### PR TITLE
[DM-28923] In-memory nublado2 database

### DIFF
--- a/services/nublado2/values-int.yaml
+++ b/services/nublado2/values-int.yaml
@@ -4,6 +4,8 @@ nublado2:
       enabled: true
 
     hub:
+      db:
+        type: sqlite-memory
       image:
         name: lsstsqre/nublado2
         tag: "master"


### PR DESCRIPTION
Okay, so since int doesn't have automatically provisioning PVs, let's
just use in memory for now.  This won't be production anyway.