### PR TITLE
[DM-28923] Nublado2: need to override auth annotation

### DIFF
--- a/services/nublado2/values-int.yaml
+++ b/services/nublado2/values-int.yaml
@@ -41,6 +41,7 @@ nublado2:
       hosts: ["lsst-lsp-int.ncsa.illinois.edu"]
       annotations:
         nginx.ingress.kubernetes.io/auth-signin: "https://lsst-lsp-int.ncsa.illinois.edu/login"
+        nginx.ingress.kubernetes.io/auth-url: "https://lsst-lsp-int.ncsa.illinois.edu/auth?scope=exec:notebook"
 
   config:
     options_form:


### PR DESCRIPTION
For some reason on int it doesn't recognize the cluster svc DNS name?