### PR TITLE
Update Renovate schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,9 @@
 {
   "extends": [
     "config:base"
+  ],
+  "prConcurrentLimit": 5,
+  "schedule": [
+    "before 6am on Monday"
   ]
 }


### PR DESCRIPTION
Rather than returning to a weekly schedule, which only gives
Renovate one or two runs to open its PRs, give it until 6am on Monday
morning to open its PRs.  Since it's only willing to open two an
hour, this ensures it can reach the PR limit of 5.