### PR TITLE
[DM-28993] Pin mobu and cachemachine charts and remove tags

### DIFF
--- a/services/cachemachine/Chart.yaml
+++ b/services/cachemachine/Chart.yaml
@@ -3,5 +3,5 @@ name: cachemachine
 version: 1.0.0
 dependencies:
 - name: cachemachine
-  version: ">=0.1.0"
+  version: 0.1.5
   repository: https://lsst-sqre.github.io/charts/

--- a/services/cachemachine/values-bleed.yaml
+++ b/services/cachemachine/values-bleed.yaml
@@ -1,9 +1,6 @@
 cachemachine:
   host: "bleed.lsst.codes"
 
-  image:
-    tag: "1.0.4"
-
   ingress:
     enabled: true
     hosts:

--- a/services/cachemachine/values-idfdev.yaml
+++ b/services/cachemachine/values-idfdev.yaml
@@ -1,9 +1,6 @@
 cachemachine:
   host: "data-dev.lsst.cloud"
 
-  image:
-    tag: "1.0.4"
-
   ingress:
     enabled: true
     hosts:

--- a/services/cachemachine/values-int.yaml
+++ b/services/cachemachine/values-int.yaml
@@ -1,9 +1,6 @@
 cachemachine:
   host: "lsst-lsp-int.ncsa.illinois.edu"
 
-  image:
-    tag: "1.0.4"
-
   ingress:
     enabled: true
     hosts:

--- a/services/cachemachine/values-minikube.yaml
+++ b/services/cachemachine/values-minikube.yaml
@@ -1,9 +1,6 @@
 cachemachine:
   host: "minikube.lsst.codes"
 
-  image:
-    tag: "1.0.4"
-
   ingress:
     enabled: true
     hosts:

--- a/services/mobu/Chart.yaml
+++ b/services/mobu/Chart.yaml
@@ -3,7 +3,7 @@ name: mobu
 version: 1.0.0
 dependencies:
 - name: mobu
-  version: ">=0.1.0"
+  version: 0.1.6
   repository: https://lsst-sqre.github.io/charts/
 - name: pull-secret
   version: 0.1.2

--- a/services/mobu/values-idfdev.yaml
+++ b/services/mobu/values-idfdev.yaml
@@ -5,9 +5,6 @@ mobu:
   environment_url: "https://data-dev.lsst.cloud"
   host: "data-dev.lsst.cloud"
 
-  image:
-    tag: 1.0.5
-
 pull-secret:
   enabled: true
   path: secret/k8s_operator/data-dev.lsst.cloud/pull-secret

--- a/services/mobu/values-idfint.yaml
+++ b/services/mobu/values-idfint.yaml
@@ -5,9 +5,6 @@ mobu:
   environment_url: "https://data-int.lsst.cloud"
   host: "data-int.lsst.cloud"
 
-  image:
-    tag: 1.0.5
-
 pull-secret:
   enabled: true
   path: secret/k8s_operator/data-int.lsst.cloud/pull-secret

--- a/services/mobu/values-idfprod.yaml
+++ b/services/mobu/values-idfprod.yaml
@@ -5,9 +5,6 @@ mobu:
   environment_url: "https://data.lsst.cloud"
   host: "data.lsst.cloud"
 
-  image:
-    tag: 1.0.5
-
 pull-secret:
   enabled: true
   path: secret/k8s_operator/data.lsst.cloud/pull-secret

--- a/services/mobu/values-int.yaml
+++ b/services/mobu/values-int.yaml
@@ -5,9 +5,6 @@ mobu:
   environment_url: "https://lsst-lsp-int.ncsa.illinois.edu"
   host: "lsst-lsp-int.ncsa.illinois.edu"
 
-  image:
-    tag: 1.0.5
-
   ingress:
     annotations:
       nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-Uid, X-Auth-Request-Token

--- a/services/mobu/values-minikube.yaml
+++ b/services/mobu/values-minikube.yaml
@@ -5,9 +5,6 @@ mobu:
   environment_url: "https://minikube.lsst.codes"
   host: "minikube.lsst.codes"
 
-  image:
-    tag: 1.0.5
-
 pull-secret:
   enabled: true
   path: secret/k8s_operator/minikube.lsst.codes/pull-secret

--- a/services/mobu/values-red-five.yaml
+++ b/services/mobu/values-red-five.yaml
@@ -5,9 +5,6 @@ mobu:
   environment_url: "https://red-five.lsst.codes"
   host: "red-five.lsst.codes"
 
-  image:
-    tag: 1.0.5
-
 pull-secret:
   enabled: true
   path: secret/k8s_operator/red-five.lsst.codes/pull-secret

--- a/services/mobu/values-stable.yaml
+++ b/services/mobu/values-stable.yaml
@@ -5,9 +5,6 @@ mobu:
   environment_url: "https://lsst-lsp-stable.ncsa.illinois.edu"
   host: "lsst-lsp-stable.ncsa.illinois.edu"
 
-  image:
-    tag: 1.0.5
-
   ingress:
     annotations:
       nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-Uid, X-Auth-Request-Token


### PR DESCRIPTION
Rather than pinning the Docker image tag, pin the version of the
chart for mobu and cachemachine.  The chart now pins the Docker
image.  This works correctly with Renovate's automatic PR
generation: it will now create PRs for new Docker image versions
in the charts repo and then create PRs for new chart versions in
the Phalanx repo.