### PR TITLE
[DM-28900] Enable Google auth to IDF dev Argo CD

### DIFF
--- a/services/argocd/values-idfdev.yaml
+++ b/services/argocd/values-idfdev.yaml
@@ -11,13 +11,26 @@ argo-cd:
         kubernetes.io/ingress.class: nginx
         nginx.ingress.kubernetes.io/rewrite-target: "/$2"
       paths:
-        - /argo-cd(/|$)(.*)
+        - /argo-cd
 
     extraArgs:
       - "--basehref=/argo-cd"
       - "--insecure=true"
 
     config:
+      dex.config: |
+        # Auth using Google.
+        # See https://dexidp.io/docs/connectors/google/
+        - type: google
+          id: google
+          name: Google
+          config:
+            clientID: 176818997517-o2tu9978r099fnsnh1acd608gkmopfhu.apps.googleusercontent.com
+            clientSecret: $dex.google.clientSecret
+            hostedDomains:
+              - lsst.cloud
+            groups:
+              - gcp-science-platform-gke-cluster-admins@lsst.cloud
       helm.repositories: |
         - url: https://lsst-sqre.github.io/charts/
           name: lsst-sqre
@@ -27,6 +40,16 @@ argo-cd:
           name: ingress-nginx
         - url: https://charts.helm.sh/stable
           name: stable
+
+    rbacConfig:
+      policy.csv: |
+        g, adam@lsst.cloud, role:admin
+        g, afausti@lsst.cloud, role:admin
+        g, christine@lsst.cloud, role:admin
+        g, frossie@lsst.cloud, role:admin
+        g, jsick@lsst.cloud, role:admin
+        g, krughoff@lsst.cloud, role:admin
+        g, rra@lsst.cloud, role:admin
 
 pull-secret:
   enabled: true


### PR DESCRIPTION
Use an OAuth client identity created via the console.

Try restricting logins by Google Group, which may not work given
that we're not using G Suite.