### PR TITLE
Add moneypenny across environments (no caller yet except in idfdev)

### DIFF
--- a/science-platform/values-base.yaml
+++ b/science-platform/values-base.yaml
@@ -23,7 +23,7 @@ logging:
 mobu:
   enabled: false
 moneypenny:
-  enabled: false
+  enabled: true
 ingress_nginx:
   enabled: true
 nublado:

--- a/science-platform/values-idfint.yaml
+++ b/science-platform/values-idfint.yaml
@@ -23,7 +23,7 @@ logging:
 mobu:
   enabled: true
 moneypenny:
-  enabled: false
+  enabled: true
 ingress_nginx:
   enabled: true
 nublado:

--- a/science-platform/values-idfprod.yaml
+++ b/science-platform/values-idfprod.yaml
@@ -23,7 +23,7 @@ logging:
 mobu:
   enabled: true
 moneypenny:
-  enabled: false
+  enabled: true
 ingress_nginx:
   enabled: true
 nublado:

--- a/science-platform/values-minikube.yaml
+++ b/science-platform/values-minikube.yaml
@@ -25,7 +25,7 @@ logging:
 mobu:
   enabled: true
 moneypenny:
-  enabled: false
+  enabled: true
 ingress_nginx:
   enabled: true
 nublado:

--- a/science-platform/values-red-five.yaml
+++ b/science-platform/values-red-five.yaml
@@ -25,7 +25,7 @@ mobu:
 ingress_nginx:
   enabled: true
 moneypenny:
-  enabled: false
+  enabled: true
 nublado:
   enabled: true
 obstap:

--- a/science-platform/values-summit.yaml
+++ b/science-platform/values-summit.yaml
@@ -23,7 +23,7 @@ logging:
 mobu:
   enabled: false
 moneypenny:
-  enabled: false
+  enabled: true
 ingress_nginx:
   enabled: true
 nublado:

--- a/science-platform/values-tucson-teststand.yaml
+++ b/science-platform/values-tucson-teststand.yaml
@@ -23,7 +23,7 @@ logging:
 mobu:
   enabled: false
 moneypenny:
-  enabled: false
+  enabled: true
 ingress_nginx:
   enabled: true
 nublado:

--- a/services/moneypenny/values-base.yaml
+++ b/services/moneypenny/values-base.yaml
@@ -1,0 +1,37 @@
+moneypenny:
+  host: "base-lsp.lsst.codes"
+
+  ingress:
+    enabled: true
+    hosts:
+      - host: base-lsp.lsst.codes
+        paths: ["/moneypenny"]
+    annotations:
+      nginx.ingress.kubernetes.io/auth-url: "https://base-lsp.lsst.codes/auth?scope=exec:admin"
+
+  vault_secrets:
+    enabled: true
+    path: "secret/k8s_operator/base-lsp.lsst.codes/pull-secret"
+
+  orders: |
+    commission:
+      - name: initcommission
+        image: lsstsqre/inituserhome
+        securityContext:
+          runAsUser: 0
+          runAsNonRootUser: false
+        volumeMounts:
+        - mountPath: /homedirs
+          name: homedirs
+    retire:
+      - name: farthing
+        image: lsstsqre/farthing
+        securityContext:
+          runAsUser: 1000
+          runAsNonRootUser: true
+          allowPrivilegeEscalation: false
+    volumes:
+      - name: homedirs
+        nfs:
+          server: ddn-nfs.ls.lsst.org
+          path: /lssr/user/staff/jhome

--- a/services/moneypenny/values-idfint.yaml
+++ b/services/moneypenny/values-idfint.yaml
@@ -1,0 +1,37 @@
+moneypenny:
+  host: "data-int.lsst.cloud"
+
+  ingress:
+    enabled: true
+    hosts:
+      - host: data-int.lsst.cloud
+        paths: ["/moneypenny"]
+    annotations:
+      nginx.ingress.kubernetes.io/auth-url: "https://data-int.lsst.cloud/auth?scope=exec:admin"
+
+  vault_secrets:
+    enabled: true
+    path: "secret/k8s_operator/data-int.lsst.cloud/pull-secret"
+
+  orders: |
+    commission:
+      - name: initcommission
+        image: lsstsqre/inituserhome
+        securityContext:
+          runAsUser: 0
+          runAsNonRootUser: false
+        volumeMounts:
+        - mountPath: /homedirs
+          name: homedirs
+    retire:
+      - name: farthing
+        image: lsstsqre/farthing
+        securityContext:
+          runAsUser: 1000
+          runAsNonRootUser: true
+          allowPrivilegeEscalation: false
+    volumes:
+      - name: homedirs
+        nfs:
+          server: 10.22.240.130
+          path: /share1/home

--- a/services/moneypenny/values-idfprod.yaml
+++ b/services/moneypenny/values-idfprod.yaml
@@ -1,0 +1,37 @@
+moneypenny:
+  host: "data.lsst.cloud"
+
+  ingress:
+    enabled: true
+    hosts:
+      - host: data.lsst.cloud
+        paths: ["/moneypenny"]
+    annotations:
+      nginx.ingress.kubernetes.io/auth-url: "https://data.lsst.cloud/auth?scope=exec:admin"
+
+  vault_secrets:
+    enabled: true
+    path: "secret/k8s_operator/data.lsst.cloud/pull-secret"
+
+  orders: |
+    commission:
+      - name: initcommission
+        image: lsstsqre/inituserhome
+        securityContext:
+          runAsUser: 0
+          runAsNonRootUser: false
+        volumeMounts:
+        - mountPath: /homedirs
+          name: homedirs
+    retire:
+      - name: farthing
+        image: lsstsqre/farthing
+        securityContext:
+          runAsUser: 1000
+          runAsNonRootUser: true
+          allowPrivilegeEscalation: false
+    volumes:
+      - name: homedirs
+        nfs:
+          server: 10.13.105.122
+          path: /share1/home

--- a/services/moneypenny/values-int.yaml
+++ b/services/moneypenny/values-int.yaml
@@ -1,0 +1,14 @@
+moneypenny:
+  host: "lsst-lsp-int.ncsa.illinois.edu"
+
+  ingress:
+    enabled: true
+    hosts:
+      - host: lsst-lsp-int.ncsa.illinois.edu
+        paths: ["/moneypenny"]
+    annotations:
+      nginx.ingress.kubernetes.io/auth-url: "https://lsst-lsp-int.ncsa.illinois.edu/auth?scope=exec:admin"
+
+  vault_secrets:
+    enabled: true
+    path: "secret/k8s_operator/lsst-lsp-int.ncsa.illinois.edu/pull-secret"

--- a/services/moneypenny/values-kueyen.yaml
+++ b/services/moneypenny/values-kueyen.yaml
@@ -1,0 +1,14 @@
+moneypenny:
+  host: "base-lsp.lsst.codes"
+
+  ingress:
+    enabled: true
+    hosts:
+      - host: base-lsp.lsst.codes
+        paths: ["/moneypenny"]
+    annotations:
+      nginx.ingress.kubernetes.io/auth-url: "https://base-lsp.lsst.codes/auth?scope=exec:admin"
+
+  vault_secrets:
+    enabled: true
+    path: "secret/k8s_operator/base-lsp.lsst.codes/pull-secret"

--- a/services/moneypenny/values-minikube.yaml
+++ b/services/moneypenny/values-minikube.yaml
@@ -1,0 +1,14 @@
+moneypenny:
+  host: "minikube.lsst.codes"
+
+  ingress:
+    enabled: true
+    hosts:
+      - host: minikube.lsst.codes
+        paths: ["/moneypenny"]
+    annotations:
+      nginx.ingress.kubernetes.io/auth-url: "https://minikube.lsst.codes/auth?scope=exec:admin"
+
+  vault_secrets:
+    enabled: true
+    path: "secret/k8s_operator/minikube.lsst.codes/pull-secret"

--- a/services/moneypenny/values-nts.yaml
+++ b/services/moneypenny/values-nts.yaml
@@ -1,0 +1,14 @@
+moneypenny:
+  host: "lsst-nts-k8s.ncsa.illinois.edu"
+
+  ingress:
+    enabled: true
+    hosts:
+      - host: lsst-nts-k8s.ncsa.illinois.edu
+        paths: ["/moneypenny"]
+    annotations:
+      nginx.ingress.kubernetes.io/auth-url: "https://lsst-nts-k8s.ncsa.illinois.edu/auth?scope=exec:admin"
+
+  vault_secrets:
+    enabled: true
+    path: "secret/k8s_operator/lsst-nts-k8s.ncsa.illinois.edu/pull-secret"

--- a/services/moneypenny/values-red-five.yaml
+++ b/services/moneypenny/values-red-five.yaml
@@ -1,0 +1,14 @@
+moneypenny:
+  host: "red-five.lsst.codes"
+
+  ingress:
+    enabled: true
+    hosts:
+      - host: red-five.lsst.codes
+        paths: ["/moneypenny"]
+    annotations:
+      nginx.ingress.kubernetes.io/auth-url: "https://red-five.lsst.codes/auth?scope=exec:admin"
+
+  vault_secrets:
+    enabled: true
+    path: "secret/k8s_operator/red-five.lsst.codes/pull-secret"

--- a/services/moneypenny/values-stable.yaml
+++ b/services/moneypenny/values-stable.yaml
@@ -1,0 +1,14 @@
+moneypenny:
+  host: "lsst-lsp-stable.ncsa.illinois.edu"
+
+  ingress:
+    enabled: true
+    hosts:
+      - host: lsst-lsp-stable.ncsa.illinois.edu
+        paths: ["/moneypenny"]
+    annotations:
+      nginx.ingress.kubernetes.io/auth-url: "https://lsst-lsp-stable.ncsa.illinois.edu/auth?scope=exec:admin"
+
+  vault_secrets:
+    enabled: true
+    path: "secret/k8s_operator/lsst-lsp-stable.ncsa.illinois.edu/pull-secret"

--- a/services/moneypenny/values-summit.yaml
+++ b/services/moneypenny/values-summit.yaml
@@ -1,0 +1,37 @@
+moneypenny:
+  host: "summit-lsp.lsst.codes"
+
+  ingress:
+    enabled: true
+    hosts:
+      - host: summit-lsp.lsst.codes
+        paths: ["/moneypenny"]
+    annotations:
+      nginx.ingress.kubernetes.io/auth-url: "https://summit-lsp.lsst.codes/auth?scope=exec:admin"
+
+  vault_secrets:
+    enabled: true
+    path: "secret/k8s_operator/summit-lsp.lsst.codes/pull-secret"
+
+  orders: |
+    commission:
+      - name: initcommission
+        image: lsstsqre/inituserhome
+        securityContext:
+          runAsUser: 0
+          runAsNonRootUser: false
+        volumeMounts:
+        - mountPath: /homedirs
+          name: homedirs
+    retire:
+      - name: farthing
+        image: lsstsqre/farthing
+        securityContext:
+          runAsUser: 1000
+          runAsNonRootUser: true
+          allowPrivilegeEscalation: false
+    volumes:
+      - name: homedirs
+        nfs:
+          server: nfs1.cp.lsst.org
+          path: /jhome

--- a/services/moneypenny/values-tucson-teststand.yaml
+++ b/services/moneypenny/values-tucson-teststand.yaml
@@ -1,0 +1,37 @@
+moneypenny:
+  host: "tucson-teststand.lsst.codes"
+
+  ingress:
+    enabled: true
+    hosts:
+      - host: tucson-teststand.lsst.codes
+        paths: ["/moneypenny"]
+    annotations:
+      nginx.ingress.kubernetes.io/auth-url: "https://tucson-teststand.lsst.codes/auth?scope=exec:admin"
+
+  vault_secrets:
+    enabled: true
+    path: "secret/k8s_operator/tucson-teststand.lsst.codes/pull-secret"
+
+  orders: |
+    commission:
+      - name: initcommission
+        image: lsstsqre/inituserhome
+        securityContext:
+          runAsUser: 0
+          runAsNonRootUser: false
+        volumeMounts:
+        - mountPath: /homedirs
+          name: homedirs
+    retire:
+      - name: farthing
+        image: lsstsqre/farthing
+        securityContext:
+          runAsUser: 1000
+          runAsNonRootUser: true
+          allowPrivilegeEscalation: false
+    volumes:
+      - name: homedirs
+        nfs:
+          server: nfs01.tu.lsst.org
+          path: /data/exports-lsp/home

--- a/services/nublado/values-base.yaml
+++ b/services/nublado/values-base.yaml
@@ -3,6 +3,7 @@ nublado:
   fqdn: base-lsp.lsst.codes
   debug: 'true'
   oauth_provider: 'jwt'
+  gafaelfawr_secrets_path: 'secret/k8s_operator/base-lsp.lsst.codes/gafaelfawr'
 
   hub:
     image: 'lsstsqre/sciplat-hub:latest'

--- a/services/nublado/values-idfint.yaml
+++ b/services/nublado/values-idfint.yaml
@@ -3,6 +3,7 @@ nublado:
   fqdn: data-int.lsst.cloud
 
   oauth_provider: 'jwt'
+  gafaelfawr_secrets_path: 'secret/k8s_operator/data-int.lsst.cloud/gafaelfawr'
 
   hub:
     image: 'lsstsqre/sciplat-hub:latest'

--- a/services/nublado/values-idfprod.yaml
+++ b/services/nublado/values-idfprod.yaml
@@ -3,6 +3,7 @@ nublado:
   fqdn: data.lsst.cloud
 
   oauth_provider: 'jwt'
+  gafaelfawr_secrets_path: 'secret/k8s_operator/data.lsst.cloud/gafaelfawr'
 
   hub:
     image: 'lsstsqre/sciplat-hub:latest'

--- a/services/nublado/values-int.yaml
+++ b/services/nublado/values-int.yaml
@@ -3,6 +3,7 @@ nublado:
   fqdn: lsst-lsp-int.ncsa.illinois.edu
 
   oauth_provider: 'jwt'
+  gafaelfawr_secrets_path: 'secret/k8s_operator/lsst-lsp-int.ncsa.illinois.edu/gafaelfawr'
 
   lab:
     restrict_nodes: 'true'

--- a/services/nublado/values-kueyen.yaml
+++ b/services/nublado/values-kueyen.yaml
@@ -3,6 +3,7 @@ nublado:
   fqdn: kueyen-lsp.lsst.codes
   debug: 'true'
   oauth_provider: 'jwt'
+  gafaelfawr_secrets_path: 'secret/k8s_operator/kueyen-lsp.lsst.codes/gafaelfawr'
 
   hub:
     image: 'lsstsqre/sciplat-hub:latest'

--- a/services/nublado/values-minikube.yaml
+++ b/services/nublado/values-minikube.yaml
@@ -3,6 +3,7 @@ nublado:
   fqdn: minikube.lsst.codes
 
   oauth_provider: 'jwt'
+  gafaelfawr_secrets_path: 'secret/k8s_operator/minikube.lsst.codes/gafaelfawr'
 
   hub:
     image: 'lsstsqre/sciplat-hub:latest'

--- a/services/nublado/values-red-five.yaml
+++ b/services/nublado/values-red-five.yaml
@@ -3,6 +3,7 @@ nublado:
   fqdn: red-five.lsst.codes
 
   oauth_provider: 'jwt'
+  gafaelfawr_secrets_path: 'secret/k8s_operator/red-five.lsst.codes/gafaelfawr'
 
   hub:
     image: 'lsstsqre/sciplat-hub:latest'

--- a/services/nublado/values-stable.yaml
+++ b/services/nublado/values-stable.yaml
@@ -3,6 +3,7 @@ nublado:
   fqdn: lsst-lsp-stable.ncsa.illinois.edu
 
   oauth_provider: 'jwt'
+  gafaelfawr_secrets_path: 'secret/k8s_operator/lsst-lsp-stable.ncsa.illinois.edu/gafaelfawr'
 
   lab:
     restrict_nodes: 'true'

--- a/services/nublado/values-summit.yaml
+++ b/services/nublado/values-summit.yaml
@@ -3,7 +3,7 @@ nublado:
   fqdn: summit-lsp.lsst.codes
   debug: 'true'
   oauth_provider: 'jwt'
-
+  gafaelfawr_secrets_path: 'secret/k8s_operator/summit-lsp.lsst.codes/gafaelfawr'
   hub:
     image: 'lsstsqre/sciplat-hub:latest'
 

--- a/services/nublado/values-tucson-teststand.yaml
+++ b/services/nublado/values-tucson-teststand.yaml
@@ -3,6 +3,7 @@ nublado:
   fqdn: tucson-teststand.lsst.codes
   debug: 'true'
   oauth_provider: 'jwt'
+  gafaelfawr_secrets_path: 'secret/k8s_operator/tucson-teststand.lsst.codes/gafaelfawr'
 
   hub:
     image: 'lsstsqre/sciplat-hub:latest'


### PR DESCRIPTION
This will install the moneypenny app (namespace and pod).  It does NOT enable any of the hubs other than idfdev to use Moneypenny, although she is configured to do FS provisioning at all the IDF instances, as well as summit, base, and tucson-teststand.

The NCSA-managed instances (int/stable/nts), kueyen, red-five, and minikube all get Moneypenny, but configured to do nothing upon receipt of orders.