### PR TITLE
[DM-28900] Use Google OAuth for Argo CD in prod

### DIFF
--- a/services/argocd/values-idfprod.yaml
+++ b/services/argocd/values-idfprod.yaml
@@ -18,6 +18,20 @@ argo-cd:
       - "--insecure=true"
 
     config:
+      url: https://data.lsst.cloud/argo-cd
+      dex.config: |
+        connectors:
+          # Auth using Google.
+          # See https://dexidp.io/docs/connectors/google/
+          - type: google
+            id: google
+            name: Google
+            config:
+              clientID: 14801011072-0m55hc1pdak9h6srsa5na01vcommjk7d.apps.googleusercontent.com
+              clientSecret: $dex.clientSecret
+              hostedDomains:
+                - lsst.cloud
+              redirectURI: https://data.lsst.cloud/argo-cd/api/dex/callback
       helm.repositories: |
         - url: https://lsst-sqre.github.io/charts/
           name: lsst-sqre
@@ -27,6 +41,17 @@ argo-cd:
           name: ingress-nginx
         - url: https://charts.helm.sh/stable
           name: stable
+
+    rbacConfig:
+      policy.csv: |
+        g, adam@lsst.cloud, role:admin
+        g, afausti@lsst.cloud, role:admin
+        g, christine@lsst.cloud, role:admin
+        g, frossie@lsst.cloud, role:admin
+        g, jsick@lsst.cloud, role:admin
+        g, krughoff@lsst.cloud, role:admin
+        g, rra@lsst.cloud, role:admin
+      scopes: "[email]"
 
   configs:
     secret:


### PR DESCRIPTION
Enable Google OAuth authentication for Argo CD in data.lsst.cloud
with an enumerated list of administrators.  This matches the
configuration from data-int with different URLs and a new client
ID corresponding to an OAuth application in the same GCP project.