### PR TITLE
[DM-28900] Add Argo CD dex.clientSecret to installer

### DIFF
--- a/installer/generate_secrets.py
+++ b/installer/generate_secrets.py
@@ -239,6 +239,12 @@ class SecretGenerator:
             self._set("argocd", "admin.password", h)
             self._set("argocd", "admin.passwordMtime", now_time)
 
+        self.input_field(
+            "argocd",
+            "dex.clientSecret",
+            "OAuth client secret for ArgoCD (either GitHub or Google)?"
+        )
+
         self._set_generated("argocd", "server.secretkey", secrets.token_hex(16))
 
     def _portal(self):


### PR DESCRIPTION
This same key is used for both GitHub and Google OAuth.