### PR TITLE
[DM-28900] Add GitHub Argo CD authentication configuration

### DIFF
--- a/services/argocd/values-base.yaml
+++ b/services/argocd/values-base.yaml
@@ -18,6 +18,20 @@ argo-cd:
       - "--insecure=true"
 
     config:
+      url: https://base-lsp.lsst.codes/argo-cd
+      dex.config: |
+        connectors:
+          # Auth using GitHub.
+          # See https://dexidp.io/docs/connectors/github/
+          - type: github
+            id: github
+            name: GitHub
+            config:
+              clientID: 87edeea047586c89ccc8
+              # Reference to key in argo-secret Kubernetes resource
+              clientSecret: $dex.clientSecret
+              orgs:
+                - name: lsst-sqre
       helm.repositories: |
         - url: https://lsst-sqre.github.io/charts/
           name: lsst-sqre
@@ -27,6 +41,10 @@ argo-cd:
           name: ingress-nginx
         - url: https://charts.helm.sh/stable
           name: stable
+
+    rbacConfig:
+      policy.csv: |
+        g, lsst-sqre:square, role:admin
 
   configs:
     secret:

--- a/services/argocd/values-int.yaml
+++ b/services/argocd/values-int.yaml
@@ -18,6 +18,20 @@ argo-cd:
       - "--insecure=true"
 
     config:
+      url: https://lsst-lsp-int.ncsa.illinois.edu/argo-cd
+      dex.config: |
+        connectors:
+          # Auth using GitHub.
+          # See https://dexidp.io/docs/connectors/github/
+          - type: github
+            id: github
+            name: GitHub
+            config:
+              clientID: 3f4383ff79915ace05d7
+              # Reference to key in argo-secret Kubernetes resource
+              clientSecret: $dex.clientSecret
+              orgs:
+                - name: lsst-sqre
       helm.repositories: |
         - url: https://lsst-sqre.github.io/charts/
           name: lsst-sqre
@@ -27,6 +41,10 @@ argo-cd:
           name: ingress-nginx
         - url: https://charts.helm.sh/stable
           name: stable
+
+    rbacConfig:
+      policy.csv: |
+        g, lsst-sqre:square, role:admin
 
   configs:
     secret:

--- a/services/argocd/values-nts.yaml
+++ b/services/argocd/values-nts.yaml
@@ -18,6 +18,20 @@ argo-cd:
       - "--insecure=true"
 
     config:
+      url: https://lsst-argocd-nts-efd.ncsa.illinois.edu/argo-cd
+      dex.config: |
+        connectors:
+          # Auth using GitHub.
+          # See https://dexidp.io/docs/connectors/github/
+          - type: github
+            id: github
+            name: GitHub
+            config:
+              clientID: fbd5b6ad221c4c12de9a
+              # Reference to key in argo-secret Kubernetes resource
+              clientSecret: $dex.clientSecret
+              orgs:
+                - name: lsst-sqre
       helm.repositories: |
         - url: https://lsst-sqre.github.io/charts/
           name: lsst-sqre
@@ -27,6 +41,10 @@ argo-cd:
           name: ingress-nginx
         - url: https://charts.helm.sh/stable
           name: stable
+
+    rbacConfig:
+      policy.csv: |
+        g, lsst-sqre:square, role:admin
 
   configs:
     secret:

--- a/services/argocd/values-stable.yaml
+++ b/services/argocd/values-stable.yaml
@@ -18,6 +18,20 @@ argo-cd:
       - "--insecure=true"
 
     config:
+      url: https://lsst-lsp-stable.ncsa.illinois.edu/argo-cd
+      dex.config: |
+        connectors:
+          # Auth using GitHub.
+          # See https://dexidp.io/docs/connectors/github/
+          - type: github
+            id: github
+            name: GitHub
+            config:
+              clientID: 5e20005bc8739cea5035
+              # Reference to key in argo-secret Kubernetes resource
+              clientSecret: $dex.clientSecret
+              orgs:
+                - name: lsst-sqre
       helm.repositories: |
         - url: https://lsst-sqre.github.io/charts/
           name: lsst-sqre
@@ -27,6 +41,10 @@ argo-cd:
           name: ingress-nginx
         - url: https://charts.helm.sh/stable
           name: stable
+
+    rbacConfig:
+      policy.csv: |
+        g, lsst-sqre:square, role:admin
 
   configs:
     secret:

--- a/services/argocd/values-summit.yaml
+++ b/services/argocd/values-summit.yaml
@@ -18,6 +18,20 @@ argo-cd:
       - "--insecure=true"
 
     config:
+      url: https://summit-lsp.lsst.codes/argo-cd
+      dex.config: |
+        connectors:
+          # Auth using GitHub.
+          # See https://dexidp.io/docs/connectors/github/
+          - type: github
+            id: github
+            name: GitHub
+            config:
+              clientID: 8da9b82e0da60985fb86
+              # Reference to key in argo-secret Kubernetes resource
+              clientSecret: $dex.clientSecret
+              orgs:
+                - name: lsst-sqre
       helm.repositories: |
         - url: https://lsst-sqre.github.io/charts/
           name: lsst-sqre
@@ -27,6 +41,10 @@ argo-cd:
           name: ingress-nginx
         - url: https://charts.helm.sh/stable
           name: stable
+
+    rbacConfig:
+      policy.csv: |
+        g, lsst-sqre:square, role:admin
 
   configs:
     secret:

--- a/services/argocd/values-tucson-teststand.yaml
+++ b/services/argocd/values-tucson-teststand.yaml
@@ -18,6 +18,20 @@ argo-cd:
       - "--insecure=true"
 
     config:
+      url: https://tucson-teststand.lsst.codes/argo-cd
+      dex.config: |
+        connectors:
+          # Auth using GitHub.
+          # See https://dexidp.io/docs/connectors/github/
+          - type: github
+            id: github
+            name: GitHub
+            config:
+              clientID: 7f3abd487bd532d66a6c
+              # Reference to key in argo-secret Kubernetes resource
+              clientSecret: $dex.clientSecret
+              orgs:
+                - name: lsst-sqre
       helm.repositories: |
         - url: https://lsst-sqre.github.io/charts/
           name: lsst-sqre
@@ -27,6 +41,10 @@ argo-cd:
           name: ingress-nginx
         - url: https://charts.helm.sh/stable
           name: stable
+
+    rbacConfig:
+      policy.csv: |
+        g, lsst-sqre:square, role:admin
 
   configs:
     secret:


### PR DESCRIPTION
Configure the base, summit, NCSA int and stable, NCSA teststand,
and Tucson teststand environments to use GitHub for Argo CD
authentication.  Use the square team in lsst-sqre for access
control for now.  (More will be added on at least the teststand
environments.)

Add documentation for how to set up GitHub OAuth authentication.