### PR TITLE
[DM-29170] Improve TLS documentation

### DIFF
--- a/docs/arch/index.rst
+++ b/docs/arch/index.rst
@@ -42,3 +42,50 @@ However, for services still under development, we sometimes use a floating depen
 There is currently no mechanism to deploy different versions of a chart in different environments.
 We will probably need a mechanism to do this eventually, and have considered possible implementation strategies, but have not yet started on this work.
 In the meantime, we disable automatic deployment in Argo CD so there is a human check on whether a given chart is safe to deploy in a given environment.
+
+.. _hostnames:
+
+Hostnames and TLS
+=================
+
+The Science Platform is designed to run under a single hostname.
+All ingresses for all applications use different routes on the same external hostname.
+That hostname, in turn, is served by an NGINX proxy web server, configured via the ``ingress-nginx`` Helm chart (normally installed with the Science Platform).
+An NGINX ingress controller is required since its ``auth_request`` mechanism is used for authentication.
+
+The external hostname must have a valid TLS certificate that is trusted by the stock configuration of standard CentOS, Debian, and Alpine containers.
+There are supported two mechanisms to configure that TLS certificate:
+
+#. Purchase a commercial certificate and configure it as the ingress-nginx default certificate.
+   Do not add TLS configuration to any of the application ingresses.
+   For more information, see :doc:`../ingress-nginx/certificates`.
+   With this approach, the certificate will have to be manually renewed and replaced once per year.
+
+#. Configure Let's Encrypt to obtain a certificate via the DNS solver.
+   Once this is configured, TLS will be handled automatically without further human intervention.
+   However, this approach is far more complex to set up and has some significant prerequisites.
+   For more information, see :doc:`../cert-issuer/bootstrapping`.
+
+To use the second approach, you must have the following:
+
+* An :abbr:`AWS (Amazon Web Services)` account in which you can create two Route 53 hosted domains.
+  You must use this domain for the hostname of the Science Platform installation.
+* The ability to delegate to that Route 53 hosted domain from some public DNS domain.
+  This means either registering a domain via Amazon, registering a domain elsewhere and pointing it to Amazon's Route 53 DNS servers, or creating a subdomain of an existing public domain by adding ``NS`` records to that domain for a subdomain hosted on Route 53.
+
+If neither of those requirements sound familiar, you almost certainly want to use the first option and purchase a commercial certificate.
+
+Ingress structure
+-----------------
+
+Because all application ingresses share the same external hostname, the way the ingress configuration is structured is somewhat unusual.
+
+Nearly all of the services create an ingress without adding TLS configuration.
+Instead, they all use the same hostname, without a TLS stanza.
+The Nublado proxy ingress is the one designated ingress that has a TLS configuration and requests creation of certificates.
+Because each ingress uses the same hostname, the NGINX ingress will merge all of those ingresses into one virtual host and will set up TLS if TLS is defined on any of them.
+
+Were TLS defined on more than one ingress, only one of those TLS configurations would be used, but which one is chosen is somewhat random.
+Therefore, we designate a single application to hold the configuration to avoid any confusion from unused configurations.
+
+In the future, we are likely to move the TLS configuration to the landing page application instead of the Nublado proxy.

--- a/docs/cert-issuer/bootstrapping.rst
+++ b/docs/cert-issuer/bootstrapping.rst
@@ -6,6 +6,9 @@ The issuer defined in the ``cert-issuer`` application uses the DNS solver.
 The advantage of the DNS solver is that it works behind firewalls and can provision certificates for environments not exposed to the Internet, such as the Tucson teststand.
 The DNS solver uses an AWS service user with write access to Route 53 to answer Let's Encrypt challenges.
 
+In order to use ``cert-issuer``, you must be hosting the DNS for the external hostname of the Science Platform installation in AWS Route 53.
+See :ref:`hostnames` for more information.
+
 First, ensure that ``cert-issuer`` is set up for the domain in which the cluster will be hosted.
 If this is a new domain, follow the instructions in :doc:`route53-setup`.
 

--- a/docs/cert-issuer/index.rst
+++ b/docs/cert-issuer/index.rst
@@ -21,6 +21,9 @@ The issuer is named ``cert-issuer-letsencrypt-dns``.
 On most clusters where the Rubin Science Platform manages certificates, this is also handled by the Rubin Science Platform Argo CD, but on the base and summit clusters, cert-manager is maintained by IT and installed outside of Argo CD.
 NCSA clusters use NCSA certificates issued via an internal process.
 
+``cert-issuer`` should only be enabled in environments using Route 53 for DNS and using cert-manager with the DNS solver.
+For more information, see :ref:`hostnames`.
+
 .. rubric:: Using cert-issuer
 
 To configure an ingress to use certificates issued by it, add a ``tls`` configuration to the ingress and the annotation:
@@ -28,6 +31,10 @@ To configure an ingress to use certificates issued by it, add a ``tls`` configur
 .. code-block:: yaml
 
    cert-manager.io/cluster-issuer: cert-issuer-letsencrypt-dns
+
+This should be done on one and only one ingress for a deployment using ``cert-issuer``.
+Currently, this is done on the proxy ingress of the ``nublado`` application.
+In the future, it will probably move to the ``landing-page`` application.
 
 .. rubric:: Guides
 

--- a/docs/cert-issuer/route53-setup.rst
+++ b/docs/cert-issuer/route53-setup.rst
@@ -13,13 +13,17 @@ Therefore, we use a strategy documented in the `cert-manager documentation for R
 To do this for a new zone, do the following.
 In these instructions, the new zone is shown as ``new.zone``.
 In practice this will be a zone like ``lsst.codes`` or ``lsst.cloud``.
+This must be a public domain served from normal Internet domain servers.
+It cannot be a private domain present only in Route 53.
 
 #. Create a new hosted zone named ``tls.new.zone`` in Route 53.
    Make a note of its zone ID.
 
 #. Add the NS glue record for ``tls.new.zone`` to ``new.zone`` in Route 53.
+   See `the Amazon documentation <https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-routing-traffic-for-subdomains.html#dns-routing-traffic-for-subdomains-creating-records>`__ for more details.
 
 #. Create a new IAM user named ``cert-manager-new-zone``.
+   (Don't forget to replace ``new-zone`` with the name of your zone.)
    Attach an inline IAM policy for that user that gives it access to the new ``tls.new.zone`` hosted zone.
 
    .. code-block:: json

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,6 +29,7 @@ Operations guide
    argo-cd/index
    cert-issuer/index
    cert-manager/index
+   ingress-nginx/index
    logging/index
    rancher-external-ip-webhook/index
    squash-api/index

--- a/docs/ingress-nginx/certificates.rst
+++ b/docs/ingress-nginx/certificates.rst
@@ -1,0 +1,33 @@
+################
+TLS certificates
+################
+
+The entire Science Platform uses the same external hostname and relies on NGINX merging all the ingresses into a single virtual host with a single TLS configuration.
+As discussed in :ref:`hostnames`, TLS for the Science Platform can be configured with either a default certificate in ``ingress-nginx`` or through Let's Encrypt with the DNS solver.
+
+If an installation is using Let's Encrypt with the DNS solver, no further configuration of the NGINX ingresss is required.
+See :doc:`../cert-issuer/bootstrapping` for setup information.
+
+When using a commercial certificate, that certificate should be configured in the ``values-*.yaml`` for ``ingress-nginx`` for that environment.
+Specifically, add the following under ``ingress-nginx.controller``:
+
+.. code-block:: yaml
+
+    extraArgs:
+      default-ssl-certificate: ingress-nginx/ingress-certificate
+
+and add, at the top level:
+
+.. code-block:: yaml
+
+   vault_certificate:
+     enabled: true
+     path: secret/k8s_operator/<environment>/ingress-nginx
+
+replacing ``<environment>`` with the hostname of the environment.
+Then, in the Vault key named by that path, store the commercial certificate.
+The Vault secret should have two keys: ``tls.crt`` and ``tls.key``.
+The first should contain the full public certificate chain.
+The second should contain the private key (without a passphrase).
+
+For an example of an environment configured this way, see `/services/ingress-nginx/values-minikube.yaml <https://github.com/lsst-sqre/phalanx/blob/master/services/ingress-nginx/values-minikube.yaml>`__

--- a/docs/ingress-nginx/index.rst
+++ b/docs/ingress-nginx/index.rst
@@ -1,0 +1,29 @@
+#############
+ingress-nginx
+#############
+
+.. list-table::
+   :widths: 10,40
+
+   * - Edit on GitHub
+     - `/services/ingress-nginx <https://github.com/lsst-sqre/phalanx/tree/master/services/ingress-nginx>`__
+   * - Type
+     - Helm_
+   * - Namespace
+     - ``ingress-nginx``
+
+.. rubric:: Overview
+
+The ``ingress-nginx`` application is an installation of `ingress-nginx <https://kubernetes.github.io/ingress-nginx/>`__ from its `Helm chart <https://github.com/kubernetes/ingress-nginx>`__.
+We use NGINX as the ingress controller for all Rubin Science Platform deployments rather than native ingress controllers because we use the NGINX ``auth_request`` feature to do authentication and authorization.
+
+NCSA clusters also use the same software, but the NGINX ingress is managed by NCSA rather than via Argo CD.
+
+Upgrading ``ingress-nginx`` is generally painless.
+A simple Argo CD sync is sufficient.
+
+.. rubric:: Guides
+
+.. toctree::
+
+   certificates


### PR DESCRIPTION
Add some architectural discussion of how TLS is configured.  Stress
that only a commercial certificate or Route 53 with the DNS solver
are supported.  Be clearer about the prerequisites for the Route 53
approach.  Add a link to more information on creating glue records.