### PR TITLE
[DM-29085] Use external hostname for auth-url at NCSA

### DIFF
--- a/services/gafaelfawr/Chart.yaml
+++ b/services/gafaelfawr/Chart.yaml
@@ -3,7 +3,7 @@ name: gafaelfawr
 version: 1.0.0
 dependencies:
 - name: gafaelfawr
-  version: 2.0.2
+  version: 2.0.3
   repository: https://lsst-sqre.github.io/charts/
 - name: pull-secret
   version: 0.1.2

--- a/services/gafaelfawr/values-int.yaml
+++ b/services/gafaelfawr/values-int.yaml
@@ -3,6 +3,7 @@ gafaelfawr:
     - name: "pull-secret"
   ingress:
     host: "lsst-lsp-int.ncsa.illinois.edu"
+    externalAuthUrl: true
   vaultSecretsPath: "secret/k8s_operator/lsst-lsp-int.ncsa.illinois.edu/gafaelfawr"
 
   # Use an existing, manually-managed PVC for Redis.

--- a/services/gafaelfawr/values-nts.yaml
+++ b/services/gafaelfawr/values-nts.yaml
@@ -3,6 +3,7 @@ gafaelfawr:
     - name: "pull-secret"
   ingress:
     host: "lsst-nts-k8s.ncsa.illinois.edu"
+    externalAuthUrl: true
   vaultSecretsPath: "secret/k8s_operator/lsst-nts-k8s.ncsa.illinois.edu/gafaelfawr"
 
   # Use an existing, manually-managed PVC for Redis.

--- a/services/gafaelfawr/values-stable.yaml
+++ b/services/gafaelfawr/values-stable.yaml
@@ -3,6 +3,7 @@ gafaelfawr:
     - name: "pull-secret"
   ingress:
     host: "lsst-lsp-stable.ncsa.illinois.edu"
+    externalAuthUrl: true
   vaultSecretsPath: "secret/k8s_operator/lsst-lsp-stable.ncsa.illinois.edu/gafaelfawr"
 
   # Use an existing, manually-managed PVC for Redis.


### PR DESCRIPTION
NCSA's ingress-nginx cannot resolve the internal cluster name for
Gafaelfawr, so use the ingress hostname instead for the Gafaelfawr
token ingress in those deployments.