### PR TITLE
Use test CILogon to verify their update.

### DIFF
--- a/services/gafaelfawr/values-int.yaml
+++ b/services/gafaelfawr/values-int.yaml
@@ -23,6 +23,7 @@ gafaelfawr:
     cilogon:
       clientId: "cilogon:/client_id/6ca7b54ac075b65bccb9c885f9ba4a75"
       redirectUrl: "https://lsst-lsp-int.ncsa.illinois.edu/oauth2/callback"
+      test: true
       loginParams:
         skin: "LSST"
 


### PR DESCRIPTION
CILogon has announced an update to their service on 2021-04-13.  Test it on -int prior to then by using their test service at test.cilogon.org.