### PR TITLE
DM-29432: Add squareone service

### DIFF
--- a/science-platform/templates/squareone-application.yaml
+++ b/science-platform/templates/squareone-application.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.squareone.enabled -}}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: squareone
+spec:
+  finalizers:
+    - kubernetes
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: squareone
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: squareone
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: services/squareone
+    repoURL: {{ .Values.repoURL }}
+    targetRevision: {{ .Values.revision }}
+    helm:
+      valueFiles:
+        - values-{{ .Values.environment }}.yaml
+{{- end -}}

--- a/science-platform/values-base.yaml
+++ b/science-platform/values-base.yaml
@@ -38,6 +38,8 @@ postgres:
   enabled: true
 rancher_external_ip_webhook:
   enabled: false
+squareone:
+  enabled: false
 squash_api:
   enabled: false
 tap:

--- a/science-platform/values-idfdev.yaml
+++ b/science-platform/values-idfdev.yaml
@@ -42,6 +42,8 @@ postgres:
   enabled: true
 rancher_external_ip_webhook:
   enabled: true
+squareone:
+  enabled: false
 squash_api:
   enabled: false
 tap:

--- a/science-platform/values-idfint.yaml
+++ b/science-platform/values-idfint.yaml
@@ -21,7 +21,7 @@ influxdb:
 kapacitor:
   enabled: false
 landing_page:
-  enabled: true
+  enabled: false
 logging:
   enabled: false
 mobu:
@@ -43,7 +43,7 @@ postgres:
 rancher_external_ip_webhook:
   enabled: true
 squareone:
-  enabled: false
+  enabled: true
 squash_api:
   enabled: false
 tap:

--- a/science-platform/values-idfint.yaml
+++ b/science-platform/values-idfint.yaml
@@ -42,6 +42,8 @@ postgres:
   enabled: true
 rancher_external_ip_webhook:
   enabled: true
+squareone:
+  enabled: false
 squash_api:
   enabled: false
 tap:

--- a/science-platform/values-idfprod.yaml
+++ b/science-platform/values-idfprod.yaml
@@ -42,6 +42,8 @@ postgres:
   enabled: true
 rancher_external_ip_webhook:
   enabled: true
+squareone:
+  enabled: false
 squash_api:
   enabled: false
 tap:

--- a/science-platform/values-int.yaml
+++ b/science-platform/values-int.yaml
@@ -42,6 +42,8 @@ postgres:
   enabled: true
 rancher_external_ip_webhook:
   enabled: false
+squareone:
+  enabled: false
 squash_api:
   enabled: false
 tap:

--- a/science-platform/values-minikube.yaml
+++ b/science-platform/values-minikube.yaml
@@ -21,7 +21,7 @@ influxdb:
 kapacitor:
   enabled: false
 landing_page:
-  enabled: true
+  enabled: false
 logging:
   enabled: false
 mobu:
@@ -43,7 +43,7 @@ postgres:
 rancher_external_ip_webhook:
   enabled: true
 squareone:
-  enabled: false
+  enabled: true
 squash_api:
   enabled: false
 tap:

--- a/science-platform/values-minikube.yaml
+++ b/science-platform/values-minikube.yaml
@@ -42,6 +42,8 @@ postgres:
   enabled: true
 rancher_external_ip_webhook:
   enabled: true
+squareone:
+  enabled: false
 squash_api:
   enabled: false
 tap:

--- a/science-platform/values-nts.yaml
+++ b/science-platform/values-nts.yaml
@@ -38,6 +38,8 @@ postgres:
   enabled: true
 rancher_external_ip_webhook:
   enabled: false
+squareone:
+  enabled: false
 squash_api:
   enabled: false
 tap:

--- a/science-platform/values-red-five.yaml
+++ b/science-platform/values-red-five.yaml
@@ -38,6 +38,8 @@ postgres:
   enabled: true
 rancher_external_ip_webhook:
   enabled: true
+squareone:
+  enabled: false
 squash_api:
   enabled: false
 tap:

--- a/science-platform/values-squash-sandbox.yaml
+++ b/science-platform/values-squash-sandbox.yaml
@@ -38,6 +38,8 @@ postgres:
   enabled: false
 rancher_external_ip_webhook:
   enabled: false
+squareone:
+  enabled: false
 squash_api:
   enabled: true
 tap:

--- a/science-platform/values-stable.yaml
+++ b/science-platform/values-stable.yaml
@@ -38,6 +38,8 @@ postgres:
   enabled: true
 rancher_external_ip_webhook:
   enabled: false
+squareone:
+  enabled: false
 squash_api:
   enabled: false
 tap:

--- a/science-platform/values-summit.yaml
+++ b/science-platform/values-summit.yaml
@@ -38,6 +38,8 @@ postgres:
   enabled: true
 rancher_external_ip_webhook:
   enabled: false
+squareone:
+  enabled: false
 squash_api:
   enabled: false
 tap:

--- a/science-platform/values-tucson-teststand.yaml
+++ b/science-platform/values-tucson-teststand.yaml
@@ -38,6 +38,8 @@ postgres:
   enabled: true
 rancher_external_ip_webhook:
   enabled: true
+squareone:
+  enabled: false
 squash_api:
   enabled: false
 tap:

--- a/science-platform/values.yaml
+++ b/science-platform/values.yaml
@@ -38,6 +38,8 @@ postgres:
   enabled: false
 rancher_external_ip_webhook:
   enabled: false
+squareone:
+  enabled: false
 squash_api:
   enabled: false
 tap:

--- a/services/squareone/Chart.yaml
+++ b/services/squareone/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: squareone
+version: 1.0.0
+dependencies:
+- name: squareone
+  version: "0.1.2"
+  repository: https://lsst-sqre.github.io/charts/
+- name: pull-secret
+  version: 0.1.2
+  repository: https://lsst-sqre.github.io/charts/

--- a/services/squareone/values-base.yaml
+++ b/services/squareone/values-base.yaml
@@ -1,0 +1,11 @@
+squareone:
+  ingress:
+    host: "base-lsp.lsst.codes"
+  imagePullSecrets:
+    - name: "pull-secret"
+  config:
+    siteName: "Rubin Science Platform @ Base"
+
+pull-secret:
+  enabled: true
+  path: secret/k8s_operator/base-lsp.lsst.codes/pull-secret

--- a/services/squareone/values-idfdev.yaml
+++ b/services/squareone/values-idfdev.yaml
@@ -1,0 +1,11 @@
+squareone:
+  ingress:
+    host: "data-dev.lsst.cloud"
+  imagePullSecrets:
+    - name: "pull-secret"
+  config:
+    siteName: "Rubin Science Platform @ data-dev"
+
+pull-secret:
+  enabled: true
+  path: secret/k8s_operator/data-dev.lsst.cloud/pull-secret

--- a/services/squareone/values-idfint.yaml
+++ b/services/squareone/values-idfint.yaml
@@ -1,0 +1,12 @@
+squareone:
+  ingress:
+    host: "data-int.lsst.cloud"
+  imagePullSecrets:
+    - name: "pull-secret"
+  config:
+    siteName: "Rubin Science Platform @ data-int"
+
+
+pull-secret:
+  enabled: true
+  path: secret/k8s_operator/data-int.lsst.cloud/pull-secret

--- a/services/squareone/values-idfprod.yaml
+++ b/services/squareone/values-idfprod.yaml
@@ -1,0 +1,11 @@
+squareone:
+  ingress:
+    host: "data.lsst.cloud"
+  imagePullSecrets:
+    - name: "pull-secret"
+  config:
+    siteName: "Rubin Science Platform"
+
+pull-secret:
+  enabled: true
+  path: secret/k8s_operator/data.lsst.cloud/pull-secret

--- a/services/squareone/values-int.yaml
+++ b/services/squareone/values-int.yaml
@@ -1,0 +1,11 @@
+squareone:
+  ingress:
+    host: "lsst-lsp-int.ncsa.illinois.edu"
+  imagePullSecrets:
+    - name: "pull-secret"
+  config:
+    siteName: "Rubin Science Platform @ lsp-int"
+
+pull-secret:
+  enabled: true
+  path: secret/k8s_operator/lsst-lsp-int.ncsa.illinois.edu/pull-secret

--- a/services/squareone/values-minikube.yaml
+++ b/services/squareone/values-minikube.yaml
@@ -1,0 +1,11 @@
+squareone:
+  ingress:
+    host: "minikube.lsst.codes"
+  imagePullSecrets:
+    - name: "pull-secret"
+  config:
+    siteName: "Rubin Science Platform @ minikube"
+
+pull-secret:
+  enabled: true
+  path: secret/k8s_operator/minikube.lsst.codes/pull-secret

--- a/services/squareone/values-nts.yaml
+++ b/services/squareone/values-nts.yaml
@@ -1,0 +1,11 @@
+squareone:
+  ingress:
+    host: "lsst-nts-k8s.ncsa.illinois.edu"
+  imagePullSecrets:
+    - name: "pull-secret"
+  config:
+    siteName: "Rubin Science Platform @ NTS"
+
+pull-secret:
+  enabled: true
+  path: secret/k8s_operator/lsst-nts-k8s.ncsa.illinois.edu/pull-secret

--- a/services/squareone/values-red-five.yaml
+++ b/services/squareone/values-red-five.yaml
@@ -1,0 +1,11 @@
+squareone:
+  ingress:
+    host: "red-five.lsst.codes"
+  imagePullSecrets:
+    - name: "pull-secret"
+  config:
+    siteName: "Rubin Science Platform @ red-five"
+
+pull-secret:
+  enabled: true
+  path: secret/k8s_operator/red-five.lsst.codes/pull-secret

--- a/services/squareone/values-stable.yaml
+++ b/services/squareone/values-stable.yaml
@@ -1,0 +1,11 @@
+squareone:
+  ingress:
+    host: "lsst-lsp-stable.ncsa.illinois.edu"
+  imagePullSecrets:
+    - name: "pull-secret"
+  config:
+    siteName: "Rubin Science Platform @ lsp-stable"
+
+pull-secret:
+  enabled: true
+  path: secret/k8s_operator/lsst-lsp-stable.ncsa.illinois.edu/pull-secret

--- a/services/squareone/values-summit.yaml
+++ b/services/squareone/values-summit.yaml
@@ -1,0 +1,11 @@
+squareone:
+  ingress:
+    host: "summit-lsp.lsst.codes"
+  imagePullSecrets:
+    - name: "pull-secret"
+  config:
+    siteName: "Rubin Science Platform @ Summit"
+
+pull-secret:
+  enabled: true
+  path: secret/k8s_operator/summit-lsp.lsst.codes/pull-secret

--- a/services/squareone/values-tucson-teststand.yaml
+++ b/services/squareone/values-tucson-teststand.yaml
@@ -1,0 +1,11 @@
+squareone:
+  ingress:
+    host: "tucson-teststand.lsst.codes"
+  imagePullSecrets:
+    - name: "pull-secret"
+  config:
+    siteName: "Rubin Science Platform @ Tucson"
+
+pull-secret:
+  enabled: true
+  path: secret/k8s_operator/tucson-teststand.lsst.codes/pull-secret


### PR DESCRIPTION
This adds the squareone service and leaves it disabled everywhere except `idfint` (where it replaces the `landing-page` service).