### PR TITLE
DM-29432: Update squareone image to 0.1.1 in idfint

### DIFF
--- a/services/squareone/values-idfint.yaml
+++ b/services/squareone/values-idfint.yaml
@@ -1,4 +1,6 @@
 squareone:
+  image:
+    tag: 0.1.1
   ingress:
     host: "data-int.lsst.cloud"
   imagePullSecrets:

--- a/services/squareone/values-minikube.yaml
+++ b/services/squareone/values-minikube.yaml
@@ -1,4 +1,6 @@
 squareone:
+  image:
+    tag: 0.1.1
   ingress:
     host: "minikube.lsst.codes"
   imagePullSecrets:


### PR DESCRIPTION
Update the squareone image tag to 0.1.1 in idfint and minikube to test a solution to the squareone startup.