### PR TITLE
DM-29432: Update squareone image to 0.1.2

### DIFF
--- a/services/squareone/values-idfint.yaml
+++ b/services/squareone/values-idfint.yaml
@@ -1,6 +1,6 @@
 squareone:
   image:
-    tag: 0.1.1
+    tag: 0.1.2
   ingress:
     host: "data-int.lsst.cloud"
   imagePullSecrets:

--- a/services/squareone/values-minikube.yaml
+++ b/services/squareone/values-minikube.yaml
@@ -1,6 +1,6 @@
 squareone:
   image:
-    tag: 0.1.1
+    tag: 0.1.2
   ingress:
     host: "minikube.lsst.codes"
   imagePullSecrets:


### PR DESCRIPTION
On idfint and minikube.

This image should further fix the configuration path issue.