### PR TITLE
[DM-29822] Use vault for portal secret

### DIFF
--- a/services/portal/values-idfdev.yaml
+++ b/services/portal/values-idfdev.yaml
@@ -23,7 +23,11 @@ firefly:
       memory: 8Gi
 
   secrets:
+    enabled: false
+
+  vault_secrets:
     enabled: true
+    path: secret/k8s_operator/data-dev.lsst.cloud/portal
 
   redis:
     resources:

--- a/services/portal/values-minikube.yaml
+++ b/services/portal/values-minikube.yaml
@@ -23,7 +23,11 @@ firefly:
       memory: 8Gi
 
   secrets:
+    enabled: false
+
+  vault_secrets:
     enabled: true
+    path: secret/k8s_operator/minikube.lsst.codes/portal
 
   redis:
     resources:


### PR DESCRIPTION
This will make argocd stop showing the portal as out of sync
when it isn't.