### PR TITLE
[DM-28120] Fix auth-url for cachemachine at NCSA int

### DIFF
--- a/services/cachemachine/values-int.yaml
+++ b/services/cachemachine/values-int.yaml
@@ -3,6 +3,8 @@ cachemachine:
 
   ingress:
     enabled: true
+    annotations:
+      nginx.ingress.kubernetes.io/auth-url: "https://lsst-lsp-int.ncsa.illinois.edu/auth?scope=exec:admin"
     hosts:
       - host: lsst-lsp-int.ncsa.illinois.edu
         paths: ["/cachemachine"]


### PR DESCRIPTION
NCSA int's ingress can't resolve in-cluster names, so we have to
use the external name for auth-url settings.