### PR TITLE
[DM-28120] Add TLS configuration to squareone for IDF int

### DIFF
--- a/services/squareone/values-idfint.yaml
+++ b/services/squareone/values-idfint.yaml
@@ -3,11 +3,16 @@ squareone:
     tag: 0.1.3
   ingress:
     host: "data-int.lsst.cloud"
+    annotations:
+      cert-manager.io/cluster-issuer: cert-issuer-letsencrypt-dns
+    tls:
+      - secretName: squareone-tls
+        hosts:
+          - "data-int.lsst.cloud"
   imagePullSecrets:
     - name: "pull-secret"
   config:
     siteName: "Rubin Science Platform @ data-int"
-
 
 pull-secret:
   enabled: true


### PR DESCRIPTION
With the removal of nublado, squareone will be taking over the TLS
configuration for the shared hostname.