### PR TITLE
[DM-28120] Clean up Gafaelfawr configuration

### DIFF
--- a/services/gafaelfawr/values-idfint.yaml
+++ b/services/gafaelfawr/values-idfint.yaml
@@ -16,6 +16,7 @@ gafaelfawr:
       storageClass: "standard-rwo"
 
   config:
+    loglevel: "DEBUG"
     host: "data-int.lsst.cloud"
     databaseUrl: "postgresql://gafaelfawr@localhost/gafaelfawr"
 
@@ -30,9 +31,6 @@ gafaelfawr:
         - "lsst-sqre-square"
         - "lsst-sqre-friends"
       "exec:portal":
-        - "lsst-sqre-square"
-        - "lsst-sqre-friends"
-      "exec:user":
         - "lsst-sqre-square"
         - "lsst-sqre-friends"
       "read:tap":

--- a/services/portal/values-idfdev.yaml
+++ b/services/portal/values-idfdev.yaml
@@ -9,7 +9,7 @@ firefly:
       nginx.ingress.kubernetes.io/auth-method: GET
       nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-User,X-Auth-Request-Name,X-Auth-Request-Email,X-Auth-Request-Token
       nginx.ingress.kubernetes.io/auth-signin: "https://data-dev.lsst.cloud/login"
-      nginx.ingress.kubernetes.io/auth-url: "https://data-dev.lsst.cloud/auth?scope=exec:portal&delegate_to=portal"
+      nginx.ingress.kubernetes.io/auth-url: "https://data-dev.lsst.cloud/auth?scope=exec:portal&delegate_to=portal&delegate_scope=read:tap"
       nginx.ingress.kubernetes.io/configuration-snippet: |
         proxy_set_header X-Original-URI $request_uri;
         proxy_set_header X-Forwarded-Proto https;

--- a/services/portal/values-idfint.yaml
+++ b/services/portal/values-idfint.yaml
@@ -7,9 +7,9 @@ firefly:
     host: "data-int.lsst.cloud"
     annotations:
       nginx.ingress.kubernetes.io/auth-method: GET
-      nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-Uid, X-Auth-Request-Token
+      nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-User,X-Auth-Request-Name,X-Auth-Request-Email,X-Auth-Request-Token
       nginx.ingress.kubernetes.io/auth-signin: "https://data-int.lsst.cloud/login"
-      nginx.ingress.kubernetes.io/auth-url: "https://data-int.lsst.cloud/auth?scope=exec:portal"
+      nginx.ingress.kubernetes.io/auth-url: "https://data-int.lsst.cloud/auth?scope=exec:portal&delegate_to=portal&delegate_scope=read:tap"
       nginx.ingress.kubernetes.io/configuration-snippet: |
         proxy_set_header X-Original-URI $request_uri;
         proxy_set_header X-Forwarded-Proto https;

--- a/services/portal/values-int.yaml
+++ b/services/portal/values-int.yaml
@@ -8,9 +8,9 @@ firefly:
     host: 'lsst-lsp-int.ncsa.illinois.edu'
     annotations:
       nginx.ingress.kubernetes.io/auth-method: GET
-      nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-Uid, X-Auth-Request-Token
+      nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-User,X-Auth-Request-Name,X-Auth-Request-Email,X-Auth-Request-Token
       nginx.ingress.kubernetes.io/auth-signin: "https://lsst-lsp-int.ncsa.illinois.edu/login"
-      nginx.ingress.kubernetes.io/auth-url: "https://lsst-lsp-int.ncsa.illinois.edu/auth?scope=exec:portal"
+      nginx.ingress.kubernetes.io/auth-url: "https://lsst-lsp-int.ncsa.illinois.edu/auth?scope=exec:portal&delegate_to=portal&delegate_scope=read:tap"
       nginx.ingress.kubernetes.io/configuration-snippet: |
         proxy_set_header X-Original-URI $request_uri;
         proxy_set_header X-Forwarded-Proto https;


### PR DESCRIPTION
Use the right /auth parameters for the portal and pass more headers
in the environments with Gafaelfawr 2.0.  Enable debug logging in
data-int for Gafaelfawr to try to understand why connections are
timing out.