### PR TITLE
[DM-28120] Add admin:provision to int environments

### DIFF
--- a/services/gafaelfawr/values-idfint.yaml
+++ b/services/gafaelfawr/values-idfint.yaml
@@ -25,6 +25,8 @@ gafaelfawr:
 
     # Allow access by GitHub team.
     groupMapping:
+      "admin:provision":
+        - "lsst-sqre-square"
       "exec:admin":
         - "lsst-sqre-square"
       "exec:notebook":

--- a/services/gafaelfawr/values-int.yaml
+++ b/services/gafaelfawr/values-int.yaml
@@ -35,10 +35,10 @@ gafaelfawr:
 
     # Use NCSA groups to determine token scopes.
     groupMapping:
+      "admin:provision": ["lsst_int_lsp_admin"]
       "exec:admin": ["lsst_int_lsp_admin"]
       "exec:notebook": ["lsst_int_lspdev"]
       "exec:portal": ["lsst_int_lspdev"]
-      "exec:user": ["lsst_int_lspdev"]
       "read:tap": ["lsst_int_lspdev"]
 
     initialAdmins:

--- a/services/gafaelfawr/values-int.yaml
+++ b/services/gafaelfawr/values-int.yaml
@@ -43,12 +43,12 @@ gafaelfawr:
 
     initialAdmins:
       - "afausti"
-      - "athornton"
+      - "athornto"
       - "cbanek"
       - "frossie"
-      - "jonathansick"
+      - "jsick"
+      - "krughoff"
       - "rra"
-      - "simonkrughoff"
 
   tokens:
     secrets:


### PR DESCRIPTION
Add the new admin:provision scope to the int environments.  Remove
the now-unused exec:user scope from NCSA int.