### PR TITLE
[DM-28120] Deploy squareone on IDF dev

### DIFF
--- a/science-platform/values-idfdev.yaml
+++ b/science-platform/values-idfdev.yaml
@@ -21,7 +21,7 @@ influxdb:
 kapacitor:
   enabled: false
 landing_page:
-  enabled: true
+  enabled: false
 logging:
   enabled: false
 mobu:
@@ -43,7 +43,7 @@ postgres:
 rancher_external_ip_webhook:
   enabled: true
 squareone:
-  enabled: false
+  enabled: true
 squash_api:
   enabled: false
 tap:

--- a/services/squareone/Chart.yaml
+++ b/services/squareone/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: squareone
 version: 1.0.0
 dependencies:
-- name: squareone
-  version: "0.1.2"
-  repository: https://lsst-sqre.github.io/charts/
-- name: pull-secret
-  version: 0.1.2
-  repository: https://lsst-sqre.github.io/charts/
+  - name: squareone
+    version: "0.1.3"
+    repository: https://lsst-sqre.github.io/charts/
+  - name: pull-secret
+    version: 0.1.2
+    repository: https://lsst-sqre.github.io/charts/

--- a/services/squareone/values-idfdev.yaml
+++ b/services/squareone/values-idfdev.yaml
@@ -1,6 +1,12 @@
 squareone:
   ingress:
     host: "data-dev.lsst.cloud"
+    annotations:
+      cert-manager.io/cluster-issuer: cert-issuer-letsencrypt-dns
+    tls:
+      - secretName: squareone-tls
+        hosts:
+          - "data-dev.lsst.cloud"
   imagePullSecrets:
     - name: "pull-secret"
   config:

--- a/services/squareone/values-idfint.yaml
+++ b/services/squareone/values-idfint.yaml
@@ -1,6 +1,4 @@
 squareone:
-  image:
-    tag: 0.1.3
   ingress:
     host: "data-int.lsst.cloud"
     annotations:

--- a/services/squareone/values-minikube.yaml
+++ b/services/squareone/values-minikube.yaml
@@ -1,6 +1,4 @@
 squareone:
-  image:
-    tag: 0.1.3
   ingress:
     host: "minikube.lsst.codes"
   imagePullSecrets:


### PR DESCRIPTION
Also bump the chart version and remove the image tag pinning, since
this is now handled by the chart.