### PR TITLE
[DM-28120] Stop pinning Gafaelfawr image to a branch

### DIFF
--- a/services/gafaelfawr/values-idfdev.yaml
+++ b/services/gafaelfawr/values-idfdev.yaml
@@ -5,11 +5,6 @@ gafaelfawr:
     host: "data-dev.lsst.cloud"
   vaultSecretsPath: "secret/k8s_operator/data-dev.lsst.cloud/gafaelfawr"
 
-  # Temporarily point data-dev at the pre-release version of Gafaelfawr 2.0.
-  image:
-    tag: "tickets-DM-28120"
-    pullPolicy: "Always"
-
   # Use the CSI storage class so that we can use snapshots.
   redis:
     persistence:

--- a/services/gafaelfawr/values-idfint.yaml
+++ b/services/gafaelfawr/values-idfint.yaml
@@ -5,11 +5,6 @@ gafaelfawr:
     host: "data-int.lsst.cloud"
   vaultSecretsPath: "secret/k8s_operator/data-int.lsst.cloud/gafaelfawr"
 
-  # Temporarily point data-dev at the pre-release version of Gafaelfawr 2.0.
-  image:
-    tag: "tickets-DM-28120"
-    pullPolicy: "Always"
-
   # Use the CSI storage class so that we can use snapshots.
   redis:
     persistence:

--- a/services/gafaelfawr/values-int.yaml
+++ b/services/gafaelfawr/values-int.yaml
@@ -6,11 +6,6 @@ gafaelfawr:
     externalAuthUrl: true
   vaultSecretsPath: "secret/k8s_operator/lsst-lsp-int.ncsa.illinois.edu/gafaelfawr"
 
-  # Temporarily point minikube at the pre-release version of Gafaelfawr 2.0.
-  image:
-    tag: "tickets-DM-28120"
-    pullPolicy: "Always"
-
   # Use an existing, manually-managed PVC for Redis.
   redis:
     persistence:

--- a/services/gafaelfawr/values-minikube.yaml
+++ b/services/gafaelfawr/values-minikube.yaml
@@ -5,11 +5,6 @@ gafaelfawr:
     host: "minikube.lsst.codes"
   vaultSecretsPath: "secret/k8s_operator/minikube.lsst.codes/gafaelfawr"
 
-  # Temporarily point minikube at the pre-release version of Gafaelfawr 2.0.
-  image:
-    tag: "tickets-DM-28120"
-    pullPolicy: "Always"
-
   # Reset token storage on every Redis restart.
   redis:
     persistence:


### PR DESCRIPTION
Gafaelfawr 2.0.0 has been released, so we no longer need to pin to
a branch build and can install the official 2.0.0 release.