### PR TITLE
[DM-28120] Upgrade data.lsst.cloud to current versions

### DIFF
--- a/science-platform/values-idfprod.yaml
+++ b/science-platform/values-idfprod.yaml
@@ -21,7 +21,7 @@ influxdb:
 kapacitor:
   enabled: false
 landing_page:
-  enabled: true
+  enabled: false
 logging:
   enabled: false
 mobu:
@@ -31,7 +31,7 @@ moneypenny:
 ingress_nginx:
   enabled: true
 nublado:
-  enabled: true
+  enabled: false
 nublado2:
   enabled: true
 obstap:
@@ -43,7 +43,7 @@ postgres:
 rancher_external_ip_webhook:
   enabled: true
 squareone:
-  enabled: false
+  enabled: true
 squash_api:
   enabled: false
 tap:

--- a/services/gafaelfawr/values-idfprod.yaml
+++ b/services/gafaelfawr/values-idfprod.yaml
@@ -12,12 +12,15 @@ gafaelfawr:
 
   config:
     host: "data.lsst.cloud"
+    databaseUrl: "postgresql://gafaelfawr@localhost/gafaelfawr"
 
     github:
       clientId: "65b6333a066375091548"
 
     # Allow access by GitHub team.
     groupMapping:
+      "admin:provision":
+        - "lsst-sqre-square"
       "exec:admin":
         - "lsst-sqre-square"
       "exec:notebook":
@@ -28,14 +31,37 @@ gafaelfawr:
         - "lsst-sqre-square"
         - "lsst-sqre-friends"
         - "lsst-data-management"
-      "exec:user":
-        - "lsst-sqre-square"
-        - "lsst-sqre-friends"
-        - "lsst-data-management"
       "read:tap":
         - "lsst-sqre-square"
         - "lsst-sqre-friends"
         - "lsst-data-management"
+
+    initialAdmins:
+      - "afausti"
+      - "athornton"
+      - "cbanek"
+      - "frossie"
+      - "jonathansick"
+      - "rra"
+      - "simonkrughoff"
+
+  cloudsql:
+    enabled: true
+    instanceConnectionName: "science-platform-stable-6994:us-central1:science-platform-stable-0c29612b"
+    serviceAccount: "gafaelfawr@science-platform-stable-6994.iam.gserviceaccount.com"
+
+  tokens:
+    secrets:
+      - secretName: "gafaelfawr-token"
+        secretNamespace: "mobu"
+        service: "mobu"
+        scopes:
+          - "admin:token"
+      - secretName: "gafaelfawr-token"
+        secretNamespace: "nublado2"
+        service: "nublado2"
+        scopes:
+          - "admin:provision"
 
 pull-secret:
   enabled: true

--- a/services/mobu/values-idfprod.yaml
+++ b/services/mobu/values-idfprod.yaml
@@ -1,6 +1,7 @@
 mobu:
   pull_secret: 'pull-secret'
   gafaelfawr_secrets_path: "secret/k8s_operator/data.lsst.cloud/gafaelfawr"
+  gafaelfawrSecret: "gafaelfawr-token"
   mobu_secrets_path: "secret/k8s_operator/data.lsst.cloud/mobu"
   environment_url: "https://data.lsst.cloud"
   host: "data.lsst.cloud"

--- a/services/moneypenny/values-idfprod.yaml
+++ b/services/moneypenny/values-idfprod.yaml
@@ -7,7 +7,7 @@ moneypenny:
       - host: data.lsst.cloud
         paths: ["/moneypenny"]
     annotations:
-      nginx.ingress.kubernetes.io/auth-url: "https://data.lsst.cloud/auth?scope=exec:admin"
+      nginx.ingress.kubernetes.io/auth-url: "https://data.lsst.cloud/auth?scope=admin:provision"
 
   vault_secrets:
     enabled: true

--- a/services/nublado2/values-idfprod.yaml
+++ b/services/nublado2/values-idfprod.yaml
@@ -7,6 +7,10 @@ nublado2:
       hosts: ["data.lsst.cloud"]
       annotations:
         nginx.ingress.kubernetes.io/auth-signin: "https://data.lsst.cloud/login"
+        nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr.gafaelfawr.svc.cluster.local:8080/auth?scope=exec:notebook&notebook=true"
+
+    hub:
+      baseUrl: "/nb"
 
   config:
     base_url: "https://data.lsst.cloud"

--- a/services/portal/values-idfprod.yaml
+++ b/services/portal/values-idfprod.yaml
@@ -7,9 +7,9 @@ firefly:
     host: "data.lsst.cloud"
     annotations:
       nginx.ingress.kubernetes.io/auth-method: GET
-      nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-Uid, X-Auth-Request-Token
+      nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-User,X-Auth-Request-Name,X-Auth-Request-Email,X-Auth-Request-Token
       nginx.ingress.kubernetes.io/auth-signin: "https://data.lsst.cloud/login"
-      nginx.ingress.kubernetes.io/auth-url: "https://data.lsst.cloud/auth?scope=exec:portal"
+      nginx.ingress.kubernetes.io/auth-url: "https://data.lsst.cloud/auth?scope=exec:portal&delegate_to=portal&delegate_scope=read:tap"
       nginx.ingress.kubernetes.io/configuration-snippet: |
         proxy_set_header X-Original-URI $request_uri;
         proxy_set_header X-Forwarded-Proto https;

--- a/services/squareone/values-idfprod.yaml
+++ b/services/squareone/values-idfprod.yaml
@@ -1,6 +1,12 @@
 squareone:
   ingress:
     host: "data.lsst.cloud"
+    annotations:
+      cert-manager.io/cluster-issuer: cert-issuer-letsencrypt-dns
+    tls:
+      - secretName: squareone-tls
+        hosts:
+          - "data.lsst.cloud"
   imagePullSecrets:
     - name: "pull-secret"
   config:


### PR DESCRIPTION
Upgrade to Gafaelfawr 2.0, replace the landing page with squareone,
upgrade to nublado2 as the default notebook implementation, and
make the necessary changes to the configuration of the other
applications.