### PR TITLE
[DM-28120] Bump version of Gafaelfawr

### DIFF
--- a/services/gafaelfawr/Chart.yaml
+++ b/services/gafaelfawr/Chart.yaml
@@ -3,7 +3,7 @@ name: gafaelfawr
 version: 1.0.0
 dependencies:
   - name: gafaelfawr
-    version: 3.0.13
+    version: 3.0.14
     repository: https://lsst-sqre.github.io/charts/
   - name: pull-secret
     version: 0.1.2


### PR DESCRIPTION
Pick up a fix for constructing the ingress on Kubernetes 1.19 and
later.