### PR TITLE
[DM-28120] Enable Gafaelfawr network policy on IDF dev

### DIFF
--- a/services/gafaelfawr/Chart.yaml
+++ b/services/gafaelfawr/Chart.yaml
@@ -3,7 +3,7 @@ name: gafaelfawr
 version: 1.0.0
 dependencies:
   - name: gafaelfawr
-    version: 3.0.17
+    version: 3.1.0
     repository: https://lsst-sqre.github.io/charts/
   - name: pull-secret
     version: 0.1.2

--- a/services/gafaelfawr/values-idfdev.yaml
+++ b/services/gafaelfawr/values-idfdev.yaml
@@ -5,6 +5,10 @@ gafaelfawr:
     host: "data-dev.lsst.cloud"
   vaultSecretsPath: "secret/k8s_operator/data-dev.lsst.cloud/gafaelfawr"
 
+  # Enable the frontend NetworkPolicy.
+  networkPolicy:
+    enabled: true
+
   # Use the CSI storage class so that we can use snapshots.
   redis:
     persistence:

--- a/services/ingress-nginx/values-base.yaml
+++ b/services/ingress-nginx/values-base.yaml
@@ -11,6 +11,7 @@ ingress-nginx:
       externalTrafficPolicy: Local
       loadBalancerIP: "139.229.146.150"
     podLabels:
+      gafaelafwr.lsst.io/ingress: "true"
       hub.jupyter.org/network-access-proxy-http: "true"
 
 vault_certificate:

--- a/services/ingress-nginx/values-idfdev.yaml
+++ b/services/ingress-nginx/values-idfdev.yaml
@@ -11,6 +11,7 @@ ingress-nginx:
       externalTrafficPolicy: Local
       loadBalancerIP: "35.225.112.77"
     podLabels:
+      gafaelafwr.lsst.io/ingress: "true"
       hub.jupyter.org/network-access-proxy-http: "true"
 
 vault_certificate:

--- a/services/ingress-nginx/values-idfint.yaml
+++ b/services/ingress-nginx/values-idfint.yaml
@@ -10,6 +10,7 @@ ingress-nginx:
     service:
       externalTrafficPolicy: Local
     podLabels:
+      gafaelafwr.lsst.io/ingress: "true"
       hub.jupyter.org/network-access-proxy-http: "true"
 
 vault_certificate:

--- a/services/ingress-nginx/values-idfprod.yaml
+++ b/services/ingress-nginx/values-idfprod.yaml
@@ -10,6 +10,7 @@ ingress-nginx:
     service:
       externalTrafficPolicy: Local
     podLabels:
+      gafaelafwr.lsst.io/ingress: "true"
       hub.jupyter.org/network-access-proxy-http: "true"
 
 vault_certificate:

--- a/services/ingress-nginx/values-minikube.yaml
+++ b/services/ingress-nginx/values-minikube.yaml
@@ -16,6 +16,7 @@ ingress-nginx:
     extraArgs:
       default-ssl-certificate: ingress-nginx/ingress-certificate
     podLabels:
+      gafaelafwr.lsst.io/ingress: "true"
       hub.jupyter.org/network-access-proxy-http: "true"
 
 vault_certificate:

--- a/services/ingress-nginx/values-red-five.yaml
+++ b/services/ingress-nginx/values-red-five.yaml
@@ -10,6 +10,7 @@ ingress-nginx:
     service:
       externalTrafficPolicy: Local
     podLabels:
+      gafaelafwr.lsst.io/ingress: "true"
       hub.jupyter.org/network-access-proxy-http: "true"
 
 vault_certificate:

--- a/services/ingress-nginx/values-squash-sandbox.yaml
+++ b/services/ingress-nginx/values-squash-sandbox.yaml
@@ -10,6 +10,7 @@ ingress-nginx:
     service:
       externalTrafficPolicy: Local
     podLabels:
+      gafaelafwr.lsst.io/ingress: "true"
       hub.jupyter.org/network-access-proxy-http: "true"
 
 vault_certificate:

--- a/services/ingress-nginx/values-summit.yaml
+++ b/services/ingress-nginx/values-summit.yaml
@@ -11,6 +11,7 @@ ingress-nginx:
       externalTrafficPolicy: Local
       loadBalancerIP: "139.229.160.150"
     podLabels:
+      gafaelafwr.lsst.io/ingress: "true"
       hub.jupyter.org/network-access-proxy-http: "true"
 
 vault_certificate:

--- a/services/ingress-nginx/values-tucson-teststand.yaml
+++ b/services/ingress-nginx/values-tucson-teststand.yaml
@@ -11,6 +11,7 @@ ingress-nginx:
       externalTrafficPolicy: Local
       loadBalancerIP: "140.252.34.101"
     podLabels:
+      gafaelafwr.lsst.io/ingress: "true"
       hub.jupyter.org/network-access-proxy-http: "true"
 
 vault_certificate:


### PR DESCRIPTION
Add the Gafaelfawr ingress label to our managed ingress-nginx and
enable the Gafaelfawr network policy that restricts access to the
ingress on IDF dev for testing.