### PR TITLE
[DM-28120] Bump Gafaelfawr version

### DIFF
--- a/services/gafaelfawr/Chart.yaml
+++ b/services/gafaelfawr/Chart.yaml
@@ -3,7 +3,7 @@ name: gafaelfawr
 version: 1.0.0
 dependencies:
   - name: gafaelfawr
-    version: 3.0.16
+    version: 3.0.17
     repository: https://lsst-sqre.github.io/charts/
   - name: pull-secret
     version: 0.1.2


### PR DESCRIPTION
Pick up revert of ingress API version to maintain compatibility with
Kubernetes versions prior to 1.19, since the conditional doesn't work
with Argo CD v2.