### PR TITLE
[DM-28120] Enable Gafaelfawr NetworkPolicy on IDF

### DIFF
--- a/services/gafaelfawr/values-idfdev.yaml
+++ b/services/gafaelfawr/values-idfdev.yaml
@@ -15,7 +15,6 @@ gafaelfawr:
       storageClass: "standard-rwo"
 
   config:
-    loglevel: "DEBUG"
     host: "data-dev.lsst.cloud"
     databaseUrl: "postgresql://gafaelfawr@localhost/gafaelfawr"
 

--- a/services/gafaelfawr/values-idfint.yaml
+++ b/services/gafaelfawr/values-idfint.yaml
@@ -5,13 +5,16 @@ gafaelfawr:
     host: "data-int.lsst.cloud"
   vaultSecretsPath: "secret/k8s_operator/data-int.lsst.cloud/gafaelfawr"
 
+  # Enable the frontend NetworkPolicy.
+  networkPolicy:
+    enabled: true
+
   # Use the CSI storage class so that we can use snapshots.
   redis:
     persistence:
       storageClass: "standard-rwo"
 
   config:
-    loglevel: "DEBUG"
     host: "data-int.lsst.cloud"
     databaseUrl: "postgresql://gafaelfawr@localhost/gafaelfawr"
 

--- a/services/gafaelfawr/values-idfprod.yaml
+++ b/services/gafaelfawr/values-idfprod.yaml
@@ -5,6 +5,10 @@ gafaelfawr:
     host: "data.lsst.cloud"
   vaultSecretsPath: "secret/k8s_operator/data.lsst.cloud/gafaelfawr"
 
+  # Enable the frontend NetworkPolicy.
+  networkPolicy:
+    enabled: true
+
   # Use the CSI storage class so that we can use snapshots.
   redis:
     persistence:

--- a/services/gafaelfawr/values-int.yaml
+++ b/services/gafaelfawr/values-int.yaml
@@ -3,7 +3,6 @@ gafaelfawr:
     - name: "pull-secret"
   ingress:
     host: "lsst-lsp-int.ncsa.illinois.edu"
-    externalAuthUrl: true
   vaultSecretsPath: "secret/k8s_operator/lsst-lsp-int.ncsa.illinois.edu/gafaelfawr"
 
   # Use an existing, manually-managed PVC for Redis.

--- a/services/gafaelfawr/values-nts.yaml
+++ b/services/gafaelfawr/values-nts.yaml
@@ -3,7 +3,6 @@ gafaelfawr:
     - name: "pull-secret"
   ingress:
     host: "lsst-nts-k8s.ncsa.illinois.edu"
-    externalAuthUrl: true
   vaultSecretsPath: "secret/k8s_operator/lsst-nts-k8s.ncsa.illinois.edu/gafaelfawr"
 
   # Use an existing, manually-managed PVC for Redis.

--- a/services/gafaelfawr/values-stable.yaml
+++ b/services/gafaelfawr/values-stable.yaml
@@ -3,7 +3,6 @@ gafaelfawr:
     - name: "pull-secret"
   ingress:
     host: "lsst-lsp-stable.ncsa.illinois.edu"
-    externalAuthUrl: true
   vaultSecretsPath: "secret/k8s_operator/lsst-lsp-stable.ncsa.illinois.edu/gafaelfawr"
 
   # Use an existing, manually-managed PVC for Redis.


### PR DESCRIPTION
Enable creation of a frontend NetworkPolicy on IDF int and stable.
Clean up debug logging configuration that's no longer needed.
Remove pre-Gafaelfawr-2.0 ingress configuration from NCSA
deployments.