### PR TITLE
[DM-28120] Unpin SUIT on IDF prod and NCSA int

### DIFF
--- a/services/portal/values-idfprod.yaml
+++ b/services/portal/values-idfprod.yaml
@@ -1,7 +1,5 @@
 firefly:
   pull_secret: 'pull-secret'
-  image:
-    tag: "rc-2.1.0-2"
 
   ingress:
     host: "data.lsst.cloud"

--- a/services/portal/values-int.yaml
+++ b/services/portal/values-int.yaml
@@ -1,8 +1,6 @@
 firefly:
   pull_secret: 'pull-secret'
   replicaCount: 2
-  image:
-    tag: "2.1.1-3"
 
   ingress:
     host: 'lsst-lsp-int.ncsa.illinois.edu'


### PR DESCRIPTION
Allows the upgrade to SUIT 2.2.0, which has fixes for Gafaelfawr
2.0 compatibility.