### PR TITLE
[DM-29612] Stop pinning SUIT versions for the Portal Aspect

### DIFF
--- a/services/portal/values-base.yaml
+++ b/services/portal/values-base.yaml
@@ -1,7 +1,5 @@
 firefly:
   pull_secret: 'pull-secret'
-  image:
-    tag: "1.1.1"
 
   ingress:
     host: 'base-lsp.lsst.codes'

--- a/services/portal/values-minikube.yaml
+++ b/services/portal/values-minikube.yaml
@@ -1,7 +1,5 @@
 firefly:
   pull_secret: 'pull-secret'
-  image:
-    tag: "1.1.1"
 
   ingress:
     host: "minikube.lsst.codes"

--- a/services/portal/values-nts.yaml
+++ b/services/portal/values-nts.yaml
@@ -1,7 +1,5 @@
 firefly:
   pull_secret: 'pull-secret'
-  image:
-    tag: "2.1.1-3"
 
   ingress:
     host: 'lsst-nts-k8s.ncsa.illinois.edu'

--- a/services/portal/values-red-five.yaml
+++ b/services/portal/values-red-five.yaml
@@ -1,7 +1,5 @@
 firefly:
   pull_secret: 'pull-secret'
-  image:
-    tag: "1.1.1"
 
   ingress:
     host: "red-five.lsst.codes"

--- a/services/portal/values-stable.yaml
+++ b/services/portal/values-stable.yaml
@@ -1,8 +1,6 @@
 firefly:
   pull_secret: 'pull-secret'
   replicaCount: 2
-  image:
-    tag: "rc-2.1.0-2"
 
   ingress:
     host: 'lsst-lsp-stable.ncsa.illinois.edu'

--- a/services/portal/values-summit.yaml
+++ b/services/portal/values-summit.yaml
@@ -1,7 +1,5 @@
 firefly:
   pull_secret: 'pull-secret'
-  image:
-    tag: "1.1.1"
 
   ingress:
     host: 'summit-lsp.lsst.codes'


### PR DESCRIPTION
Use the default version from the upstream chart, which currently
will install 2.2.0 via its appVersion setting.  The T&S installations
don't have TAP and therefore should get Firefly rather than SUIT, but
this will be handled as part of a later cleanup.