### PR TITLE
[DM-29799] Restrict cachemachine nodes by label

### DIFF
--- a/services/cachemachine/values-int.yaml
+++ b/services/cachemachine/values-int.yaml
@@ -17,7 +17,9 @@ cachemachine:
     jupyter: |
       {
         "name": "jupyter",
-        "labels": {},
+        "labels": {
+            "jupyterlab": "ok"
+        },
         "repomen": [
           {
             "type": "RubinRepoMan",

--- a/services/cachemachine/values-stable.yaml
+++ b/services/cachemachine/values-stable.yaml
@@ -17,7 +17,9 @@ cachemachine:
     jupyter: |
       {
         "name": "jupyter",
-        "labels": {},
+        "labels": {
+            "jupyterlab": "ok"
+        },
         "repomen": [
           {
             "type": "RubinRepoMan",


### PR DESCRIPTION
We weren't setting jupyterlab:ok, so that was running on all the
nodes, and we want to restrict the nodes down to just what jupyterlab
nodes are running on.  This will also restrict what nodes we look
at.