### PR TITLE
[DM-30007] Set Butler environment variables only on IDF

### DIFF
--- a/services/nublado2/Chart.yaml
+++ b/services/nublado2/Chart.yaml
@@ -3,5 +3,5 @@ name: nublado2
 version: 1.0.0
 dependencies:
   - name: nublado2
-    version: ">=0.1.4"
+    version: ">=0.2.0"
     repository: https://lsst-sqre.github.io/charts/

--- a/services/nublado2/values-base.yaml
+++ b/services/nublado2/values-base.yaml
@@ -14,6 +14,7 @@ nublado2:
 
   config:
     base_url: "https://base-lsp.lsst.cloud"
+    butler_secret_path: "secret/k8s_operator/base-lsp.lsst.codes/butler-secret"
     volumes:
       - name: home
         nfs:

--- a/services/nublado2/values-idfdev.yaml
+++ b/services/nublado2/values-idfdev.yaml
@@ -15,6 +15,10 @@ nublado2:
   config:
     base_url: "https://data-dev.lsst.cloud"
     butler_secret_path: "secret/k8s_operator/data-dev.lsst.cloud/butler-secret"
+    lab_environment:
+      PGPASSFILE: "/opt/lsst/software/jupyterlab/butler-secret/postgres-credentials.txt"
+      AWS_SHARED_CREDENTIALS_FILE: "/opt/lsst/software/jupyterlab/butler-secret/aws-credentials.ini"
+      S3_ENDPOINT_URL: "https://storage.googleapis.com"
     volumes:
       - name: datasets
         nfs:

--- a/services/nublado2/values-idfint.yaml
+++ b/services/nublado2/values-idfint.yaml
@@ -15,6 +15,10 @@ nublado2:
   config:
     base_url: "https://data-int.lsst.cloud"
     butler_secret_path: "secret/k8s_operator/data-int.lsst.cloud/butler-secret"
+    lab_environment:
+      PGPASSFILE: "/opt/lsst/software/jupyterlab/butler-secret/postgres-credentials.txt"
+      AWS_SHARED_CREDENTIALS_FILE: "/opt/lsst/software/jupyterlab/butler-secret/aws-credentials.ini"
+      S3_ENDPOINT_URL: "https://storage.googleapis.com"
     volumes:
       - name: datasets
         nfs:

--- a/services/nublado2/values-idfprod.yaml
+++ b/services/nublado2/values-idfprod.yaml
@@ -15,6 +15,10 @@ nublado2:
   config:
     base_url: "https://data.lsst.cloud"
     butler_secret_path: "secret/k8s_operator/data.lsst.cloud/butler-secret"
+    lab_environment:
+      PGPASSFILE: "/opt/lsst/software/jupyterlab/butler-secret/postgres-credentials.txt"
+      AWS_SHARED_CREDENTIALS_FILE: "/opt/lsst/software/jupyterlab/butler-secret/aws-credentials.ini"
+      S3_ENDPOINT_URL: "https://storage.googleapis.com"
     volumes:
       - name: datasets
         nfs:

--- a/services/nublado2/values-nts.yaml
+++ b/services/nublado2/values-nts.yaml
@@ -16,6 +16,7 @@ nublado2:
 
   config:
     base_url: "https://lsst-nts-k8s.ncsa.illinois.edu"
+    butler_secret_path: "secret/k8s_operator/lsst-nts-k8s.ncsa.illinois.edu/butler-secret"
     pinned_images:
       - image_url: registry.hub.docker.com/lsstsqre/sciplat-lab:recommended
         name: Recommended

--- a/services/nublado2/values-red-five.yaml
+++ b/services/nublado2/values-red-five.yaml
@@ -11,6 +11,7 @@ nublado2:
 
   config:
     base_url: "https://red-five.lsst.codes"
+    butler_secret_path: "secret/k8s_operator/red-five.lsst.codes/butler-secret"
     volumes:
       - name: home
         nfs:

--- a/services/nublado2/values-summit.yaml
+++ b/services/nublado2/values-summit.yaml
@@ -14,6 +14,7 @@ nublado2:
 
   config:
     base_url: "https://summit-lsp.lsst.cloud"
+    butler_secret_path: "secret/k8s_operator/summit-lsp.lsst.codes/butler-secret"
     volumes:
       - name: home
         nfs:

--- a/services/nublado2/values-tucson-teststand.yaml
+++ b/services/nublado2/values-tucson-teststand.yaml
@@ -14,6 +14,7 @@ nublado2:
 
   config:
     base_url: "https://tucson-teststand.lsst.cloud"
+    butler_secret_path: "secret/k8s_operator/tucson-teststand.lsst.codes/butler-secret"
     volumes:
       - name: home
         nfs:


### PR DESCRIPTION
- Move the Butler credential environment variables to per-environment configuration
- Set `butler_secret_path` on every environment since it's currently mandatory