### PR TITLE
[DM-30007] Pin the nublado2 chart to force an upgrade

### DIFF
--- a/services/nublado2/Chart.yaml
+++ b/services/nublado2/Chart.yaml
@@ -3,5 +3,5 @@ name: nublado2
 version: 1.0.0
 dependencies:
   - name: nublado2
-    version: ">=0.2.0"
+    version: 0.2.2
     repository: https://lsst-sqre.github.io/charts/


### PR DESCRIPTION
Even force refresh isn't picking up the new chart versions for
some reason.  Force upgrading the chart with a pin.