### PR TITLE
[DM-28120] Fix TLS configuration for squareone

### DIFF
--- a/services/squareone/values-base.yaml
+++ b/services/squareone/values-base.yaml
@@ -6,7 +6,7 @@ squareone:
     tls:
       - secretName: squareone-tls
         hosts:
-          - "base-lsp.lsst.cloud"
+          - "base-lsp.lsst.codes"
   imagePullSecrets:
     - name: "pull-secret"
   config:

--- a/services/squareone/values-red-five.yaml
+++ b/services/squareone/values-red-five.yaml
@@ -6,7 +6,7 @@ squareone:
     tls:
       - secretName: squareone-tls
         hosts:
-          - "red-five.lsst.cloud"
+          - "red-five.lsst.codes"
   imagePullSecrets:
     - name: "pull-secret"
   config:

--- a/services/squareone/values-summit.yaml
+++ b/services/squareone/values-summit.yaml
@@ -6,7 +6,7 @@ squareone:
     tls:
       - secretName: squareone-tls
         hosts:
-          - "summit-lsp.lsst.cloud"
+          - "summit-lsp.lsst.codes"
   imagePullSecrets:
     - name: "pull-secret"
   config:

--- a/services/squareone/values-tucson-teststand.yaml
+++ b/services/squareone/values-tucson-teststand.yaml
@@ -6,7 +6,7 @@ squareone:
     tls:
       - secretName: squareone-tls
         hosts:
-          - "tucson-teststand.lsst.cloud"
+          - "tucson-teststand.lsst.codes"
   imagePullSecrets:
     - name: "pull-secret"
   config:


### PR DESCRIPTION
The T&S sites and red-five had .lsst.cloud instead of .lsst.codes.