### PR TITLE
[DM-28120] Fix authentication annotations for TAP

### DIFF
--- a/services/tap/values-idfdev.yaml
+++ b/services/tap/values-idfdev.yaml
@@ -11,6 +11,14 @@ cadc-tap:
     enabled: true
     path: 'secret/k8s_operator/data-dev.lsst.cloud/tap'
 
+  ingress:
+    authenticated_annotations:
+      nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-Uid, X-Auth-Request-Token
+      nginx.ingress.kubernetes.io/auth-url: "https://data-dev.lsst.cloud/auth?scope=read:tap&auth_type=basic&delegate_to=tap"
+      nginx.ingress.kubernetes.io/configuration-snippet: |
+        auth_request_set $auth_token $upstream_http_x_auth_request_token;
+        proxy_set_header Authorization "Bearer $auth_token";
+
   gcs_bucket: 'async-results.lsst.codes'
   gcs_bucket_url: 'http://async-results.lsst.codes'
 

--- a/services/tap/values-idfint.yaml
+++ b/services/tap/values-idfint.yaml
@@ -12,6 +12,14 @@ cadc-tap:
     enabled: true
     path: 'secret/k8s_operator/data-int.lsst.cloud/tap'
 
+  ingress:
+    authenticated_annotations:
+      nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-Uid, X-Auth-Request-Token
+      nginx.ingress.kubernetes.io/auth-url: "https://data-int.lsst.cloud/auth?scope=read:tap&auth_type=basic&delegate_to=tap"
+      nginx.ingress.kubernetes.io/configuration-snippet: |
+        auth_request_set $auth_token $upstream_http_x_auth_request_token;
+        proxy_set_header Authorization "Bearer $auth_token";
+
   gcs_bucket: 'async-results.lsst.codes'
   gcs_bucket_url: 'http://async-results.lsst.codes'
 

--- a/services/tap/values-idfprod.yaml
+++ b/services/tap/values-idfprod.yaml
@@ -12,6 +12,14 @@ cadc-tap:
     enabled: true
     path: 'secret/k8s_operator/data.lsst.cloud/tap'
 
+  ingress:
+    authenticated_annotations:
+      nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-Uid, X-Auth-Request-Token
+      nginx.ingress.kubernetes.io/auth-url: "https://data.lsst.cloud/auth?scope=read:tap&auth_type=basic&delegate_to=tap"
+      nginx.ingress.kubernetes.io/configuration-snippet: |
+        auth_request_set $auth_token $upstream_http_x_auth_request_token;
+        proxy_set_header Authorization "Bearer $auth_token";
+
   gcs_bucket: 'async-results.lsst.codes'
   gcs_bucket_url: 'http://async-results.lsst.codes'
 

--- a/services/tap/values-int.yaml
+++ b/services/tap/values-int.yaml
@@ -15,7 +15,7 @@ cadc-tap:
   ingress:
     authenticated_annotations:
       nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-Uid, X-Auth-Request-Token
-      nginx.ingress.kubernetes.io/auth-url: "https://lsst-lsp-int.ncsa.illinois.edu/auth?scope=read:tap&auth_type=basic"
+      nginx.ingress.kubernetes.io/auth-url: "https://lsst-lsp-int.ncsa.illinois.edu/auth?scope=read:tap&auth_type=basic&delegate_to=tap"
       nginx.ingress.kubernetes.io/configuration-snippet: |
         auth_request_set $auth_token $upstream_http_x_auth_request_token;
         proxy_set_header Authorization "Bearer $auth_token";

--- a/services/tap/values-minikube.yaml
+++ b/services/tap/values-minikube.yaml
@@ -11,6 +11,14 @@ cadc-tap:
     enabled: true
     path: 'secret/k8s_operator/minikube.lsst.codes/tap'
 
+  ingress:
+    authenticated_annotations:
+      nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-Uid, X-Auth-Request-Token
+      nginx.ingress.kubernetes.io/auth-url: "https://minikube.lsst.codes/auth?scope=read:tap&auth_type=basic&delegate_to=tap"
+      nginx.ingress.kubernetes.io/configuration-snippet: |
+        auth_request_set $auth_token $upstream_http_x_auth_request_token;
+        proxy_set_header Authorization "Bearer $auth_token";
+
   gcs_bucket: 'async-results.lsst.codes'
   gcs_bucket_url: 'http://async-results.lsst.codes'
 

--- a/services/tap/values-red-five.yaml
+++ b/services/tap/values-red-five.yaml
@@ -11,6 +11,14 @@ cadc-tap:
     enabled: true
     path: 'secret/k8s_operator/red-five.lsst.codes/tap'
 
+  ingress:
+    authenticated_annotations:
+      nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-Uid, X-Auth-Request-Token
+      nginx.ingress.kubernetes.io/auth-url: "https://red-five.lsst.codes/auth?scope=read:tap&auth_type=basic&delegate_to=tap"
+      nginx.ingress.kubernetes.io/configuration-snippet: |
+        auth_request_set $auth_token $upstream_http_x_auth_request_token;
+        proxy_set_header Authorization "Bearer $auth_token";
+
   gcs_bucket: 'async-results.lsst.codes'
   gcs_bucket_url: 'http://async-results.lsst.codes'
 


### PR DESCRIPTION
The chart doesn't configure authentication, so it needs to be done
in Phalanx, at least for now.  Request a delegated token and lift
it into the Authorization header, since TAP uses that internally.