### PR TITLE
[DM-28120] Fix secret paths on NCSA teststand

### DIFF
--- a/services/nublado2/values-nts.yaml
+++ b/services/nublado2/values-nts.yaml
@@ -94,5 +94,5 @@ nublado2:
         mountPath: /readonly/repo
         readOnly: true
 
-  vault_secret_path: "secret/k8s_operator/lsst-lsp-int.ncsa.illinois.edu/nublado2"
-  gafaelfawr_secret_path: "secret/k8s_operator/lsst-lsp-int.ncsa.illinois.edu/gafaelfawr"
+  vault_secret_path: "secret/k8s_operator/lsst-nts-k8s.ncsa.illinois.edu/nublado2"
+  gafaelfawr_secret_path: "secret/k8s_operator/lsst-nts-k8s.ncsa.illinois.edu/gafaelfawr"


### PR DESCRIPTION
This was accidentally pointing to NCSA int.