### PR TITLE
[DM-28120] Override the cachemachine ingress annotation

### DIFF
--- a/services/cachemachine/values-nts.yaml
+++ b/services/cachemachine/values-nts.yaml
@@ -3,6 +3,8 @@ cachemachine:
 
   ingress:
     enabled: true
+    annotations:
+      nginx.ingress.kubernetes.io/auth-url: "http://lsst-nts-k8s.ncsa.illinois.edu/auth?scope=exec:admin"
     hosts:
       - host: lsst-nts-k8s.ncsa.illinois.edu
         paths: ["/cachemachine"]


### PR DESCRIPTION
The NCSA cluster doesn't support internal DNS references to services.