### PR TITLE
[DM-28120] Enable squareone current applications on NCSA int

### DIFF
--- a/science-platform/values-int.yaml
+++ b/science-platform/values-int.yaml
@@ -21,7 +21,7 @@ influxdb:
 kapacitor:
   enabled: false
 landing_page:
-  enabled: true
+  enabled: false
 logging:
   enabled: true
 mobu:
@@ -41,9 +41,9 @@ portal:
 postgres:
   enabled: true
 rancher_external_ip_webhook:
-  enabled: false
+  enabled: true
 squareone:
-  enabled: false
+  enabled: true
 squash_api:
   enabled: false
 tap:


### PR DESCRIPTION
Enable squareone and rancher-external-ip-webhook on NCSA int and
disable landing-page.