### PR TITLE
[DM-29365] Update gafaelfawr, nublado2, and mobu

### DIFF
--- a/services/gafaelfawr/Chart.yaml
+++ b/services/gafaelfawr/Chart.yaml
@@ -3,7 +3,7 @@ name: gafaelfawr
 version: 1.0.0
 dependencies:
   - name: gafaelfawr
-    version: 3.1.1
+    version: 4.0.0
     repository: https://lsst-sqre.github.io/charts/
   - name: pull-secret
     version: 0.1.2

--- a/services/gafaelfawr/values-base.yaml
+++ b/services/gafaelfawr/values-base.yaml
@@ -49,14 +49,6 @@ gafaelfawr:
       - "rra"
       - "simonkrughoff"
 
-  tokens:
-    secrets:
-      - secretName: "gafaelfawr-token"
-        secretNamespace: "nublado2"
-        service: "nublado2"
-        scopes:
-          - "admin:provision"
-
 pull-secret:
   enabled: true
   path: "secret/k8s_operator/base-lsp.lsst.codes/pull-secret"

--- a/services/gafaelfawr/values-idfdev.yaml
+++ b/services/gafaelfawr/values-idfdev.yaml
@@ -51,19 +51,6 @@ gafaelfawr:
     instanceConnectionName: "science-platform-dev-7696:us-central1:science-platform-dev-e9e11de2"
     serviceAccount: "gafaelfawr@science-platform-dev-7696.iam.gserviceaccount.com"
 
-  tokens:
-    secrets:
-      - secretName: "gafaelfawr-token"
-        secretNamespace: "mobu"
-        service: "mobu"
-        scopes:
-          - "admin:token"
-      - secretName: "gafaelfawr-token"
-        secretNamespace: "nublado2"
-        service: "nublado2"
-        scopes:
-          - "admin:provision"
-
 pull-secret:
   enabled: true
   path: "secret/k8s_operator/data-dev.lsst.cloud/pull-secret"

--- a/services/gafaelfawr/values-idfint.yaml
+++ b/services/gafaelfawr/values-idfint.yaml
@@ -51,19 +51,6 @@ gafaelfawr:
     instanceConnectionName: "science-platform-int-dc5d:us-central1:science-platform-int-8f439af2"
     serviceAccount: "gafaelfawr@science-platform-int-dc5d.iam.gserviceaccount.com"
 
-  tokens:
-    secrets:
-      - secretName: "gafaelfawr-token"
-        secretNamespace: "mobu"
-        service: "mobu"
-        scopes:
-          - "admin:token"
-      - secretName: "gafaelfawr-token"
-        secretNamespace: "nublado2"
-        service: "nublado2"
-        scopes:
-          - "admin:provision"
-
 pull-secret:
   enabled: true
   path: "secret/k8s_operator/data-int.lsst.cloud/pull-secret"

--- a/services/gafaelfawr/values-idfprod.yaml
+++ b/services/gafaelfawr/values-idfprod.yaml
@@ -60,19 +60,6 @@ gafaelfawr:
     instanceConnectionName: "science-platform-stable-6994:us-central1:science-platform-stable-0c29612b"
     serviceAccount: "gafaelfawr@science-platform-stable-6994.iam.gserviceaccount.com"
 
-  tokens:
-    secrets:
-      - secretName: "gafaelfawr-token"
-        secretNamespace: "mobu"
-        service: "mobu"
-        scopes:
-          - "admin:token"
-      - secretName: "gafaelfawr-token"
-        secretNamespace: "nublado2"
-        service: "nublado2"
-        scopes:
-          - "admin:provision"
-
 pull-secret:
   enabled: true
   path: "secret/k8s_operator/data.lsst.cloud/pull-secret"

--- a/services/gafaelfawr/values-int.yaml
+++ b/services/gafaelfawr/values-int.yaml
@@ -44,19 +44,6 @@ gafaelfawr:
       - "krughoff"
       - "rra"
 
-  tokens:
-    secrets:
-      - secretName: "gafaelfawr-token"
-        secretNamespace: "mobu"
-        service: "mobu"
-        scopes:
-          - "admin:token"
-      - secretName: "gafaelfawr-token"
-        secretNamespace: "nublado2"
-        service: "nublado2"
-        scopes:
-          - "admin:provision"
-
 pull-secret:
   enabled: true
   path: "secret/k8s_operator/lsst-lsp-int.ncsa.illinois.edu/pull-secret"

--- a/services/gafaelfawr/values-minikube.yaml
+++ b/services/gafaelfawr/values-minikube.yaml
@@ -38,19 +38,6 @@ gafaelfawr:
       - "rra"
       - "simonkrughoff"
 
-  tokens:
-    secrets:
-      - secretName: "gafaelfawr-token"
-        secretNamespace: "mobu"
-        service: "mobu"
-        scopes:
-          - "admin:token"
-      - secretName: "gafaelfawr-token"
-        secretNamespace: "nublado2"
-        service: "nublado2"
-        scopes:
-          - "admin:provision"
-
 pull-secret:
   enabled: true
   path: "secret/k8s_operator/minikube.lsst.codes/pull-secret"

--- a/services/gafaelfawr/values-nts.yaml
+++ b/services/gafaelfawr/values-nts.yaml
@@ -42,14 +42,6 @@ gafaelfawr:
       - "krughoff"
       - "rra"
 
-  tokens:
-    secrets:
-      - secretName: "gafaelfawr-token"
-        secretNamespace: "nublado2"
-        service: "nublado2"
-        scopes:
-          - "admin:provision"
-
 pull-secret:
   enabled: true
   path: secret/k8s_operator/lsst-nts-k8s.ncsa.illinois.edu/pull-secret

--- a/services/gafaelfawr/values-red-five.yaml
+++ b/services/gafaelfawr/values-red-five.yaml
@@ -41,19 +41,6 @@ gafaelfawr:
       - "krughoff"
       - "rra"
 
-  tokens:
-    secrets:
-      - secretName: "gafaelfawr-token"
-        secretNamespace: "mobu"
-        service: "mobu"
-        scopes:
-          - "admin:token"
-      - secretName: "gafaelfawr-token"
-        secretNamespace: "nublado2"
-        service: "nublado2"
-        scopes:
-          - "admin:provision"
-
 pull-secret:
   enabled: true
   path: "secret/k8s_operator/red-five.lsst.codes/pull-secret"

--- a/services/gafaelfawr/values-stable.yaml
+++ b/services/gafaelfawr/values-stable.yaml
@@ -43,19 +43,6 @@ gafaelfawr:
       - "krughoff"
       - "rra"
 
-  tokens:
-    secrets:
-      - secretName: "gafaelfawr-token"
-        secretNamespace: "mobu"
-        service: "mobu"
-        scopes:
-          - "admin:token"
-      - secretName: "gafaelfawr-token"
-        secretNamespace: "nublado2"
-        service: "nublado2"
-        scopes:
-          - "admin:provision"
-
 pull-secret:
   enabled: true
   path: "secret/k8s_operator/lsst-lsp-stable.ncsa.illinois.edu/pull-secret"

--- a/services/gafaelfawr/values-summit.yaml
+++ b/services/gafaelfawr/values-summit.yaml
@@ -50,14 +50,6 @@ gafaelfawr:
       - "rra"
       - "simonkrughoff"
 
-  tokens:
-    secrets:
-      - secretName: "gafaelfawr-token"
-        secretNamespace: "nublado2"
-        service: "nublado2"
-        scopes:
-          - "admin:provision"
-
 pull-secret:
   enabled: true
   path: "secret/k8s_operator/summit-lsp.lsst.codes/pull-secret"

--- a/services/gafaelfawr/values-tucson-teststand.yaml
+++ b/services/gafaelfawr/values-tucson-teststand.yaml
@@ -50,14 +50,6 @@ gafaelfawr:
       - "rra"
       - "simonkrughoff"
 
-  tokens:
-    secrets:
-      - secretName: "gafaelfawr-token"
-        secretNamespace: "nublado2"
-        service: "nublado2"
-        scopes:
-          - "admin:provision"
-
 pull-secret:
   enabled: true
   path: "secret/k8s_operator/tucson-teststand.lsst.codes/pull-secret"

--- a/services/mobu/Chart.yaml
+++ b/services/mobu/Chart.yaml
@@ -3,7 +3,7 @@ name: mobu
 version: 1.0.0
 dependencies:
   - name: mobu
-    version: ">=0.2.0"
+    version: ">=0.3.0"
     repository: https://lsst-sqre.github.io/charts/
   - name: pull-secret
     version: 0.1.2

--- a/services/mobu/values-idfdev.yaml
+++ b/services/mobu/values-idfdev.yaml
@@ -1,7 +1,5 @@
 mobu:
   pull_secret: 'pull-secret'
-  gafaelfawr_secrets_path: "secret/k8s_operator/data-dev.lsst.cloud/gafaelfawr"
-  gafaelfawrSecret: "gafaelfawr-token"
   mobu_secrets_path: "secret/k8s_operator/data-dev.lsst.cloud/mobu"
   environment_url: "https://data-dev.lsst.cloud"
   host: "data-dev.lsst.cloud"

--- a/services/mobu/values-idfint.yaml
+++ b/services/mobu/values-idfint.yaml
@@ -1,7 +1,5 @@
 mobu:
   pull_secret: 'pull-secret'
-  gafaelfawr_secrets_path: "secret/k8s_operator/data-int.lsst.cloud/gafaelfawr"
-  gafaelfawrSecret: "gafaelfawr-token"
   mobu_secrets_path: "secret/k8s_operator/data-int.lsst.cloud/mobu"
   environment_url: "https://data-int.lsst.cloud"
   host: "data-int.lsst.cloud"

--- a/services/mobu/values-idfprod.yaml
+++ b/services/mobu/values-idfprod.yaml
@@ -1,7 +1,5 @@
 mobu:
   pull_secret: 'pull-secret'
-  gafaelfawr_secrets_path: "secret/k8s_operator/data.lsst.cloud/gafaelfawr"
-  gafaelfawrSecret: "gafaelfawr-token"
   mobu_secrets_path: "secret/k8s_operator/data.lsst.cloud/mobu"
   environment_url: "https://data.lsst.cloud"
   host: "data.lsst.cloud"

--- a/services/mobu/values-int.yaml
+++ b/services/mobu/values-int.yaml
@@ -1,7 +1,5 @@
 mobu:
   pull_secret: 'pull-secret'
-  gafaelfawr_secrets_path: "secret/k8s_operator/lsst-lsp-int.ncsa.illinois.edu/gafaelfawr"
-  gafaelfawrSecret: "gafaelfawr-token"
   mobu_secrets_path: "secret/k8s_operator/lsst-lsp-int.ncsa.illinois.edu/mobu"
   environment_url: "https://lsst-lsp-int.ncsa.illinois.edu"
   host: "lsst-lsp-int.ncsa.illinois.edu"

--- a/services/mobu/values-minikube.yaml
+++ b/services/mobu/values-minikube.yaml
@@ -1,7 +1,5 @@
 mobu:
   pull_secret: 'pull-secret'
-  gafaelfawr_secrets_path: "secret/k8s_operator/minikube.lsst.codes/gafaelfawr"
-  gafaelfawrSecret: "gafaelfawr-token"
   mobu_secrets_path: "secret/k8s_operator/minikube.lsst.codes/mobu"
   environment_url: "https://minikube.lsst.codes"
   host: "minikube.lsst.codes"

--- a/services/mobu/values-red-five.yaml
+++ b/services/mobu/values-red-five.yaml
@@ -1,7 +1,5 @@
 mobu:
   pull_secret: 'pull-secret'
-  gafaelfawr_secrets_path: "secret/k8s_operator/red-five.lsst.codes/gafaelfawr"
-  gafaelfawrSecret: "gafaelfawr-token"
   mobu_secrets_path: "secret/k8s_operator/red-five.lsst.codes/mobu"
   environment_url: "https://red-five.lsst.codes"
   host: "red-five.lsst.codes"

--- a/services/mobu/values-stable.yaml
+++ b/services/mobu/values-stable.yaml
@@ -1,8 +1,6 @@
 mobu:
   pull_secret: 'pull-secret'
-  gafaelfawr_secrets_path: "secret/k8s_operator/lsst-lsp-stable.ncsa.illinois.edu/gafaelfawr"
   mobu_secrets_path: "secret/k8s_operator/lsst-lsp-stable.ncsa.illinois.edu/mobu"
-  gafaelfawrSecret: "gafaelfawr-token"
   environment_url: "https://lsst-lsp-stable.ncsa.illinois.edu"
   host: "lsst-lsp-stable.ncsa.illinois.edu"
 

--- a/services/nublado2/Chart.yaml
+++ b/services/nublado2/Chart.yaml
@@ -3,5 +3,5 @@ name: nublado2
 version: 1.0.0
 dependencies:
   - name: nublado2
-    version: 0.2.6
+    version: 0.3.0
     repository: https://lsst-sqre.github.io/charts/

--- a/services/nublado2/values-base.yaml
+++ b/services/nublado2/values-base.yaml
@@ -49,4 +49,3 @@ nublado2:
         mountPath: /scratch
 
   vault_secret_path: "secret/k8s_operator/base-lsp.lsst.codes/nublado2"
-  gafaelfawr_secret_path: "secret/k8s_operator/base-lsp.lsst.codes/gafaelfawr"

--- a/services/nublado2/values-idfdev.yaml
+++ b/services/nublado2/values-idfdev.yaml
@@ -47,4 +47,3 @@ nublado2:
         mountPath: /scratch
 
   vault_secret_path: "secret/k8s_operator/data-dev.lsst.cloud/nublado2"
-  gafaelfawr_secret_path: "secret/k8s_operator/data-dev.lsst.cloud/gafaelfawr"

--- a/services/nublado2/values-idfint.yaml
+++ b/services/nublado2/values-idfint.yaml
@@ -47,4 +47,3 @@ nublado2:
         mountPath: /scratch
 
   vault_secret_path: "secret/k8s_operator/data-int.lsst.cloud/nublado2"
-  gafaelfawr_secret_path: "secret/k8s_operator/data-int.lsst.cloud/gafaelfawr"

--- a/services/nublado2/values-idfprod.yaml
+++ b/services/nublado2/values-idfprod.yaml
@@ -47,4 +47,3 @@ nublado2:
         mountPath: /scratch
 
   vault_secret_path: "secret/k8s_operator/data.lsst.cloud/nublado2"
-  gafaelfawr_secret_path: "secret/k8s_operator/data.lsst.cloud/gafaelfawr"

--- a/services/nublado2/values-int.yaml
+++ b/services/nublado2/values-int.yaml
@@ -44,4 +44,3 @@ nublado2:
         mountPath: /scratch
 
   vault_secret_path: "secret/k8s_operator/lsst-lsp-int.ncsa.illinois.edu/nublado2"
-  gafaelfawr_secret_path: "secret/k8s_operator/lsst-lsp-int.ncsa.illinois.edu/gafaelfawr"

--- a/services/nublado2/values-minikube.yaml
+++ b/services/nublado2/values-minikube.yaml
@@ -20,4 +20,3 @@ nublado2:
         mountPath: /home
 
   vault_secret_path: "secret/k8s_operator/minikube.lsst.codes/nublado2"
-  gafaelfawr_secret_path: "secret/k8s_operator/minikube.lsst.codes/gafaelfawr"

--- a/services/nublado2/values-nts.yaml
+++ b/services/nublado2/values-nts.yaml
@@ -89,4 +89,3 @@ nublado2:
         readOnly: true
 
   vault_secret_path: "secret/k8s_operator/lsst-nts-k8s.ncsa.illinois.edu/nublado2"
-  gafaelfawr_secret_path: "secret/k8s_operator/lsst-nts-k8s.ncsa.illinois.edu/gafaelfawr"

--- a/services/nublado2/values-red-five.yaml
+++ b/services/nublado2/values-red-five.yaml
@@ -40,4 +40,3 @@ nublado2:
         mountPath: /scratch
 
   vault_secret_path: "secret/k8s_operator/red-five.lsst.codes/nublado2"
-  gafaelfawr_secret_path: "secret/k8s_operator/red-five.lsst.codes/gafaelfawr"

--- a/services/nublado2/values-stable.yaml
+++ b/services/nublado2/values-stable.yaml
@@ -68,4 +68,3 @@ nublado2:
         mountPath: /repo
 
   vault_secret_path: "secret/k8s_operator/lsst-lsp-stable.ncsa.illinois.edu/nublado2"
-  gafaelfawr_secret_path: "secret/k8s_operator/lsst-lsp-stable.ncsa.illinois.edu/gafaelfawr"

--- a/services/nublado2/values-summit.yaml
+++ b/services/nublado2/values-summit.yaml
@@ -101,4 +101,3 @@ nublado2:
         readOnly: true
 
   vault_secret_path: "secret/k8s_operator/summit-lsp.lsst.codes/nublado2"
-  gafaelfawr_secret_path: "secret/k8s_operator/summit-lsp.lsst.codes/gafaelfawr"

--- a/services/nublado2/values-tucson-teststand.yaml
+++ b/services/nublado2/values-tucson-teststand.yaml
@@ -55,4 +55,3 @@ nublado2:
         mountPath: /scratch
 
   vault_secret_path: "secret/k8s_operator/tucson-teststand.lsst.codes/nublado2"
-  gafaelfawr_secret_path: "secret/k8s_operator/tucson-teststand.lsst.codes/gafaelfawr"


### PR DESCRIPTION
Switch to Gafaelfawr 3.0.0 with its new support for custom
resources.  Remove obsolete configuration for the nublado2 and
mobu charts, and delete the obsolete secret configuration in the
Gafaelfawr chart.