### PR TITLE
Restrict summit and base pods to labeled nodes

### DIFF
--- a/services/cachemachine/values-base.yaml
+++ b/services/cachemachine/values-base.yaml
@@ -15,7 +15,9 @@ cachemachine:
     jupyter: |
       {
         "name": "jupyter",
-        "labels": {},
+        "labels": {
+            "jupyterlab": "ok"
+        },
         "repomen": [
           {
             "type": "RubinRepoMan",

--- a/services/cachemachine/values-summit.yaml
+++ b/services/cachemachine/values-summit.yaml
@@ -15,7 +15,9 @@ cachemachine:
     jupyter: |
       {
         "name": "jupyter",
-        "labels": {},
+        "labels": {
+            "jupyterlab": "ok"
+        },
         "repomen": [
           {
             "type": "RubinRepoMan",


### PR DESCRIPTION
andes01 and andes04 are apparently cordoned, so use node labels
to stop looking at them for spawning purposes.