### PR TITLE
Unpin release on summit

### DIFF
--- a/services/cachemachine/values-summit.yaml
+++ b/services/cachemachine/values-summit.yaml
@@ -23,7 +23,7 @@ cachemachine:
             "type": "RubinRepoMan",
             "registry_url": "registry.hub.docker.com",
             "repo": "lsstsqre/summit-sal-sciplat-lab",
-            "recommended_tag": "w_2021_20",
+            "recommended_tag": "recommended",
             "num_releases": 0,
             "num_weeklies": 3,
             "num_dailies": 0

--- a/services/nublado2/values-summit.yaml
+++ b/services/nublado2/values-summit.yaml
@@ -27,9 +27,6 @@ nublado2:
     lab_environment:
       LSST_DDS_INTERFACE: net1
       LSST_DDS_PARTITION_PREFIX: summit
-    pinned_images:
-      - image_url: registry.hub.docker.com/lsstsqre/summit-sal-sciplat-lab:w_2021_20
-        name: Recommended (Weekly 2021_20)
     volumes:
       - name: home
         nfs:


### PR DESCRIPTION
Go back to using the recommended tag and unpin the release in
nublado2 now that we've fixed which nodes are inspected.