### PR TITLE
Configure NCSA -int and -stable to use 'small' Qserv instance

### DIFF
--- a/services/tap/values-int.yaml
+++ b/services/tap/values-int.yaml
@@ -1,7 +1,7 @@
 cadc-tap:
   pull_secret: 'pull-secret'
   use_mock_qserv: false
-  qserv_host: "lsst-qserv-master01:4040"
+  qserv_host: "lsst-qserv-master03:4040"
 
   host: "lsst-lsp-int.ncsa.illinois.edu"
 

--- a/services/tap/values-stable.yaml
+++ b/services/tap/values-stable.yaml
@@ -1,7 +1,7 @@
 cadc-tap:
   pull_secret: 'pull-secret'
   use_mock_qserv: false
-  qserv_host: "lsst-qserv-master01:4040"
+  qserv_host: "lsst-qserv-master03:4040"
 
   querymonkey_replicas: 1
 


### PR DESCRIPTION
The Qserv team has tracked, patched, and tested bug which we could only reproduce on the 'small' cluster.  We would now like to swap 'small' back in to production so we can resume development activities on 'large'.