### PR TITLE
DM-30725: Add semaphore application for development

### DIFF
--- a/science-platform/templates/semaphore-application.yaml
+++ b/science-platform/templates/semaphore-application.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.semaphore.enabled -}}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: semaphore
+spec:
+  finalizers:
+    - kubernetes
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: semaphore
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: semaphore
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: services/squareone
+    repoURL: {{ .Values.repoURL }}
+    targetRevision: {{ .Values.revision }}
+    helm:
+      valueFiles:
+        - values-{{ .Values.environment }}.yaml
+{{- end -}}

--- a/science-platform/values-base.yaml
+++ b/science-platform/values-base.yaml
@@ -38,6 +38,8 @@ postgres:
   enabled: true
 rancher_external_ip_webhook:
   enabled: true
+semaphore:
+  enabled: false
 squareone:
   enabled: true
 squash_api:

--- a/science-platform/values-idfdev.yaml
+++ b/science-platform/values-idfdev.yaml
@@ -38,6 +38,8 @@ postgres:
   enabled: true
 rancher_external_ip_webhook:
   enabled: true
+semaphore:
+  enabled: false
 squareone:
   enabled: true
 squash_api:

--- a/science-platform/values-idfdev.yaml
+++ b/science-platform/values-idfdev.yaml
@@ -39,7 +39,7 @@ postgres:
 rancher_external_ip_webhook:
   enabled: true
 semaphore:
-  enabled: false
+  enabled: true
 squareone:
   enabled: true
 squash_api:

--- a/science-platform/values-idfint.yaml
+++ b/science-platform/values-idfint.yaml
@@ -38,6 +38,8 @@ postgres:
   enabled: true
 rancher_external_ip_webhook:
   enabled: true
+semaphore:
+  enabled: false
 squareone:
   enabled: true
 squash_api:

--- a/science-platform/values-idfprod.yaml
+++ b/science-platform/values-idfprod.yaml
@@ -38,6 +38,8 @@ postgres:
   enabled: true
 rancher_external_ip_webhook:
   enabled: true
+semaphore:
+  enabled: false
 squareone:
   enabled: true
 squash_api:

--- a/science-platform/values-int.yaml
+++ b/science-platform/values-int.yaml
@@ -38,6 +38,8 @@ postgres:
   enabled: true
 rancher_external_ip_webhook:
   enabled: false
+semaphore:
+  enabled: false
 squareone:
   enabled: true
 squash_api:

--- a/science-platform/values-minikube.yaml
+++ b/science-platform/values-minikube.yaml
@@ -38,6 +38,8 @@ postgres:
   enabled: true
 rancher_external_ip_webhook:
   enabled: true
+semaphore:
+  enabled: false
 squareone:
   enabled: true
 squash_api:

--- a/science-platform/values-minikube.yaml
+++ b/science-platform/values-minikube.yaml
@@ -39,7 +39,7 @@ postgres:
 rancher_external_ip_webhook:
   enabled: true
 semaphore:
-  enabled: false
+  enabled: true
 squareone:
   enabled: true
 squash_api:

--- a/science-platform/values-nts.yaml
+++ b/science-platform/values-nts.yaml
@@ -38,6 +38,8 @@ postgres:
   enabled: true
 rancher_external_ip_webhook:
   enabled: false
+semaphore:
+  enabled: false
 squareone:
   enabled: true
 squash_api:

--- a/science-platform/values-red-five.yaml
+++ b/science-platform/values-red-five.yaml
@@ -36,6 +36,8 @@ postgres:
   enabled: true
 rancher_external_ip_webhook:
   enabled: true
+semaphore:
+  enabled: false
 squareone:
   enabled: true
 squash_api:

--- a/science-platform/values-squash-sandbox.yaml
+++ b/science-platform/values-squash-sandbox.yaml
@@ -36,6 +36,8 @@ postgres:
   enabled: true
 rancher_external_ip_webhook:
   enabled: true
+semaphore:
+  enabled: false
 squareone:
   enabled: false
 squash_api:

--- a/science-platform/values-stable.yaml
+++ b/science-platform/values-stable.yaml
@@ -38,6 +38,8 @@ postgres:
   enabled: true
 rancher_external_ip_webhook:
   enabled: false
+semaphore:
+  enabled: false
 squareone:
   enabled: true
 squash_api:

--- a/science-platform/values-summit.yaml
+++ b/science-platform/values-summit.yaml
@@ -38,6 +38,8 @@ postgres:
   enabled: true
 rancher_external_ip_webhook:
   enabled: false
+semaphore:
+  enabled: false
 squareone:
   enabled: true
 squash_api:

--- a/science-platform/values-tucson-teststand.yaml
+++ b/science-platform/values-tucson-teststand.yaml
@@ -38,6 +38,8 @@ postgres:
   enabled: true
 rancher_external_ip_webhook:
   enabled: true
+semaphore:
+  enabled: false
 squareone:
   enabled: true
 squash_api:

--- a/science-platform/values.yaml
+++ b/science-platform/values.yaml
@@ -34,6 +34,8 @@ postgres:
   enabled: false
 rancher_external_ip_webhook:
   enabled: false
+semaphore:
+  enabled: false
 squareone:
   enabled: false
 squash_api:

--- a/services/semaphore/Chart.yaml
+++ b/services/semaphore/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: semaphore
+version: 1.0.0
+dependencies:
+  - name: semaphore
+    version: "0.1.0"
+    repository: https://lsst-sqre.github.io/charts/
+  - name: pull-secret
+    version: 0.1.2
+    repository: https://lsst-sqre.github.io/charts/

--- a/services/semaphore/values-base.yaml
+++ b/services/semaphore/values-base.yaml
@@ -1,6 +1,4 @@
 semaphore:
-  image:
-    tag: tickets-DM-30725
   ingress:
     enabled: true
     hosts:

--- a/services/semaphore/values-base.yaml
+++ b/services/semaphore/values-base.yaml
@@ -1,0 +1,15 @@
+semaphore:
+  image:
+    tag: tickets-DM-30725
+  ingress:
+    enabled: true
+    hosts:
+      - host: "base-lsp.lsst.codes"
+        paths:
+          - "/semaphore"
+  imagePullSecrets:
+    - name: "pull-secret"
+
+pull-secret:
+  enabled: true
+  path: secret/k8s_operator/base-lsp.lsst.codes/pull-secret

--- a/services/semaphore/values-idfdev.yaml
+++ b/services/semaphore/values-idfdev.yaml
@@ -1,0 +1,15 @@
+semaphore:
+  image:
+    tag: tickets-DM-30725
+  ingress:
+    enabled: true
+    hosts:
+      - host: "data-dev.lsst.codes"
+        paths:
+          - "/semaphore"
+  imagePullSecrets:
+    - name: "pull-secret"
+
+pull-secret:
+  enabled: true
+  path: secret/k8s_operator/data-dev.lsst.cloud/pull-secret

--- a/services/semaphore/values-idfdev.yaml
+++ b/services/semaphore/values-idfdev.yaml
@@ -1,6 +1,4 @@
 semaphore:
-  image:
-    tag: tickets-DM-30725
   ingress:
     enabled: true
     hosts:

--- a/services/semaphore/values-idfint.yaml
+++ b/services/semaphore/values-idfint.yaml
@@ -1,6 +1,4 @@
 semaphore:
-  image:
-    tag: tickets-DM-30725
   ingress:
     enabled: true
     hosts:

--- a/services/semaphore/values-idfint.yaml
+++ b/services/semaphore/values-idfint.yaml
@@ -1,0 +1,15 @@
+semaphore:
+  image:
+    tag: tickets-DM-30725
+  ingress:
+    enabled: true
+    hosts:
+      - host: "data-int.lsst.cloud"
+        paths:
+          - "/semaphore"
+  imagePullSecrets:
+    - name: "pull-secret"
+
+pull-secret:
+  enabled: true
+  path: secret/k8s_operator/data-int.lsst.cloud/pull-secret

--- a/services/semaphore/values-idfprod.yaml
+++ b/services/semaphore/values-idfprod.yaml
@@ -1,6 +1,4 @@
 semaphore:
-  image:
-    tag: tickets-DM-30725
   ingress:
     enabled: true
     hosts:

--- a/services/semaphore/values-idfprod.yaml
+++ b/services/semaphore/values-idfprod.yaml
@@ -1,0 +1,15 @@
+semaphore:
+  image:
+    tag: tickets-DM-30725
+  ingress:
+    enabled: true
+    hosts:
+      - host: "data.lsst.cloud"
+        paths:
+          - "/semaphore"
+  imagePullSecrets:
+    - name: "pull-secret"
+
+pull-secret:
+  enabled: true
+  path: secret/k8s_operator/data.lsst.cloud/pull-secret

--- a/services/semaphore/values-int.yaml
+++ b/services/semaphore/values-int.yaml
@@ -1,6 +1,4 @@
 semaphore:
-  image:
-    tag: tickets-DM-30725
   ingress:
     enabled: true
     hosts:

--- a/services/semaphore/values-int.yaml
+++ b/services/semaphore/values-int.yaml
@@ -1,0 +1,15 @@
+semaphore:
+  image:
+    tag: tickets-DM-30725
+  ingress:
+    enabled: true
+    hosts:
+      - host: "lsst-lsp-int.ncsa.illinois.edu"
+        paths:
+          - "/semaphore"
+  imagePullSecrets:
+    - name: "pull-secret"
+
+pull-secret:
+  enabled: true
+  path: secret/k8s_operator/lsst-lsp-int.ncsa.illinois.edu/pull-secret

--- a/services/semaphore/values-minikube.yaml
+++ b/services/semaphore/values-minikube.yaml
@@ -1,0 +1,15 @@
+semaphore:
+  image:
+    tag: tickets-DM-30725
+  ingress:
+    enabled: true
+    hosts:
+      - host: "minikube.lsst.codes"
+        paths:
+          - "/semaphore"
+  imagePullSecrets:
+    - name: "pull-secret"
+
+pull-secret:
+  enabled: true
+  path: secret/k8s_operator/minikube.lsst.codes/pull-secret

--- a/services/semaphore/values-minikube.yaml
+++ b/services/semaphore/values-minikube.yaml
@@ -1,6 +1,4 @@
 semaphore:
-  image:
-    tag: tickets-DM-30725
   ingress:
     enabled: true
     hosts:

--- a/services/semaphore/values-nts.yaml
+++ b/services/semaphore/values-nts.yaml
@@ -1,0 +1,15 @@
+semaphore:
+  image:
+    tag: tickets-DM-30725
+  ingress:
+    enabled: true
+    hosts:
+      - host: "lsst-nts-k8s.ncsa.illinois.edu"
+        paths:
+          - "/semaphore"
+  imagePullSecrets:
+    - name: "pull-secret"
+
+pull-secret:
+  enabled: true
+  path: secret/k8s_operator/lsst-nts-k8s.ncsa.illinois.edu/pull-secret

--- a/services/semaphore/values-nts.yaml
+++ b/services/semaphore/values-nts.yaml
@@ -1,6 +1,4 @@
 semaphore:
-  image:
-    tag: tickets-DM-30725
   ingress:
     enabled: true
     hosts:

--- a/services/semaphore/values-red-five.yaml
+++ b/services/semaphore/values-red-five.yaml
@@ -1,0 +1,15 @@
+semaphore:
+  image:
+    tag: tickets-DM-30725
+  ingress:
+    enabled: true
+    hosts:
+      - host: "red-five.lsst.codes"
+        paths:
+          - "/semaphore"
+  imagePullSecrets:
+    - name: "pull-secret"
+
+pull-secret:
+  enabled: true
+  path: secret/k8s_operator/red-five.lsst.codes/pull-secret

--- a/services/semaphore/values-red-five.yaml
+++ b/services/semaphore/values-red-five.yaml
@@ -1,6 +1,4 @@
 semaphore:
-  image:
-    tag: tickets-DM-30725
   ingress:
     enabled: true
     hosts:

--- a/services/semaphore/values-stable.yaml
+++ b/services/semaphore/values-stable.yaml
@@ -1,6 +1,4 @@
 semaphore:
-  image:
-    tag: tickets-DM-30725
   ingress:
     enabled: true
     hosts:

--- a/services/semaphore/values-stable.yaml
+++ b/services/semaphore/values-stable.yaml
@@ -1,0 +1,15 @@
+semaphore:
+  image:
+    tag: tickets-DM-30725
+  ingress:
+    enabled: true
+    hosts:
+      - host: "lsst-lsp-stable.ncsa.illinois.edu"
+        paths:
+          - "/semaphore"
+  imagePullSecrets:
+    - name: "pull-secret"
+
+pull-secret:
+  enabled: true
+  path: secret/k8s_operator/lsst-lsp-stable.ncsa.illinois.edu/pull-secret

--- a/services/semaphore/values-summit.yaml
+++ b/services/semaphore/values-summit.yaml
@@ -1,6 +1,4 @@
 semaphore:
-  image:
-    tag: tickets-DM-30725
   ingress:
     enabled: true
     hosts:

--- a/services/semaphore/values-summit.yaml
+++ b/services/semaphore/values-summit.yaml
@@ -1,0 +1,15 @@
+semaphore:
+  image:
+    tag: tickets-DM-30725
+  ingress:
+    enabled: true
+    hosts:
+      - host: "summit-lsp.lsst.codes"
+        paths:
+          - "/semaphore"
+  imagePullSecrets:
+    - name: "pull-secret"
+
+pull-secret:
+  enabled: true
+  path: secret/k8s_operator/summit-lsp.lsst.codes/pull-secret

--- a/services/semaphore/values-tucson-teststand.yaml
+++ b/services/semaphore/values-tucson-teststand.yaml
@@ -1,0 +1,15 @@
+semaphore:
+  image:
+    tag: tickets-DM-30725
+  ingress:
+    enabled: true
+    hosts:
+      - host: "tucson-teststand.lsst.codes"
+        paths:
+          - "/semaphore"
+  imagePullSecrets:
+    - name: "pull-secret"
+
+pull-secret:
+  enabled: true
+  path: secret/k8s_operator/tucson-teststand.lsst.codes/pull-secret

--- a/services/semaphore/values-tucson-teststand.yaml
+++ b/services/semaphore/values-tucson-teststand.yaml
@@ -1,6 +1,4 @@
 semaphore:
-  image:
-    tag: tickets-DM-30725
   ingress:
     enabled: true
     hosts:


### PR DESCRIPTION
Add the semaphore service (https://github.com/lsst-sqre/semaphore), and enable it for minikube and idf-dev environments for testing (app version 0.1.0).