### PR TITLE
DM-30839: Update squareone to 0.2.0

### DIFF
--- a/services/squareone/Chart.yaml
+++ b/services/squareone/Chart.yaml
@@ -3,7 +3,7 @@ name: squareone
 version: 1.0.0
 dependencies:
   - name: squareone
-    version: "0.1.6"
+    version: "0.2.0"
     repository: https://lsst-sqre.github.io/charts/
   - name: pull-secret
     version: 0.1.2

--- a/services/squareone/values-idfdev.yaml
+++ b/services/squareone/values-idfdev.yaml
@@ -1,7 +1,4 @@
 squareone:
-  image:
-    pullPolicy: Always
-    tag: tickets-DM-30839
   ingress:
     host: "data-dev.lsst.cloud"
     annotations:


### PR DESCRIPTION
This release includes new documentation, support, AUP, and API aspect pages in preparation for DP0.1. See https://github.com/lsst-sqre/squareone/pull/21