### PR TITLE
DM-30887: Update squareone to 0.2.2

### DIFF
--- a/services/squareone/Chart.yaml
+++ b/services/squareone/Chart.yaml
@@ -3,7 +3,7 @@ name: squareone
 version: 1.0.0
 dependencies:
   - name: squareone
-    version: "0.2.1"
+    version: "0.2.2"
     repository: https://lsst-sqre.github.io/charts/
   - name: pull-secret
     version: 0.1.2


### PR DESCRIPTION
Includes a typo fix for the terms of service.

https://github.com/lsst-sqre/squareone/pull/23