### PR TITLE
[DM-30888] Scale up Portal on IDF production

### DIFF
--- a/services/portal/values-idfprod.yaml
+++ b/services/portal/values-idfprod.yaml
@@ -1,5 +1,6 @@
 firefly:
   pull_secret: 'pull-secret'
+  replicaCount: 4
 
   image:
     tag: "dm-29533-2"
@@ -21,7 +22,7 @@ firefly:
 
   resources:
     limits:
-      memory: 8Gi
+      memory: 24Gi
 
   secrets:
     enabled: false


### PR DESCRIPTION
Increase the replica count to four and the memory limit for each
pod to 24GB.  The memory limit matches NCSA stable.  NCSA stable
runs two pods.