### PR TITLE
[DM-30904] Increase proxy timeout for Portal

### DIFF
--- a/services/portal/values-idfint.yaml
+++ b/services/portal/values-idfint.yaml
@@ -16,6 +16,7 @@ firefly:
         proxy_set_header X-Forwarded-Proto https;
         proxy_set_header X-Forwarded-Port 443;
         proxy_set_header X-Forwarded-Path /portal/app;
+        proxy_read_timeout 300s;
 
   max_jvm_size: "7G"
 

--- a/services/portal/values-idfprod.yaml
+++ b/services/portal/values-idfprod.yaml
@@ -17,6 +17,7 @@ firefly:
         proxy_set_header X-Forwarded-Proto https;
         proxy_set_header X-Forwarded-Port 443;
         proxy_set_header X-Forwarded-Path /portal/app;
+        proxy_read_timeout 300s;
 
   max_jvm_size: "7G"
 


### PR DESCRIPTION
proxy_read_timeout for NGINX also controls the timeout on web
sockets.  We're seeing what we think is a web socket timeout showing
the results of a query in the Portal.  Try increasing the timeout
to five minutes to see if it resolves that.