### PR TITLE
[DM-30904] Further increase Portal proxy timeout

### DIFF
--- a/services/portal/values-idfint.yaml
+++ b/services/portal/values-idfint.yaml
@@ -11,8 +11,8 @@ firefly:
       nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-User,X-Auth-Request-Name,X-Auth-Request-Email,X-Auth-Request-Token
       nginx.ingress.kubernetes.io/auth-signin: "https://data-int.lsst.cloud/login"
       nginx.ingress.kubernetes.io/auth-url: "https://data-int.lsst.cloud/auth?scope=exec:portal&delegate_to=portal&delegate_scope=read:tap"
-      nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
-      nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
+      nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+      nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
       nginx.ingress.kubernetes.io/configuration-snippet: |
         proxy_set_header X-Original-URI $request_uri;
         proxy_set_header X-Forwarded-Proto https;

--- a/services/portal/values-idfprod.yaml
+++ b/services/portal/values-idfprod.yaml
@@ -12,8 +12,8 @@ firefly:
       nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-User,X-Auth-Request-Name,X-Auth-Request-Email,X-Auth-Request-Token
       nginx.ingress.kubernetes.io/auth-signin: "https://data.lsst.cloud/login"
       nginx.ingress.kubernetes.io/auth-url: "https://data.lsst.cloud/auth?scope=exec:portal&delegate_to=portal&delegate_scope=read:tap"
-      nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
-      nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
+      nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+      nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
       nginx.ingress.kubernetes.io/configuration-snippet: |
         proxy_set_header X-Original-URI $request_uri;
         proxy_set_header X-Forwarded-Proto https;


### PR DESCRIPTION
We have some long-running queries, so increase the proxy timeout to
10m, which is as long as the Portal will keep its web socket open
for.