### PR TITLE
[DM-30904] Update TAP application for 0.2.0 chart

### DIFF
--- a/services/tap/Chart.yaml
+++ b/services/tap/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: tap
 version: 1.0.0
 dependencies:
-- name: cadc-tap
-  version: ">=0.1.0"
-  repository: https://lsst-sqre.github.io/charts/
-- name: pull-secret
-  version: 0.1.2
-  repository: https://lsst-sqre.github.io/charts/
+  - name: cadc-tap
+    version: ">=0.2.0"
+    repository: https://lsst-sqre.github.io/charts/
+  - name: pull-secret
+    version: 0.1.2
+    repository: https://lsst-sqre.github.io/charts/

--- a/services/tap/values-idfdev.yaml
+++ b/services/tap/values-idfdev.yaml
@@ -3,7 +3,6 @@ cadc-tap:
   use_mock_qserv: true
 
   host: "data-dev.lsst.cloud"
-  tap_schema_address: "tap-schema-db.tap-schema.svc.cluster.local:3306"
 
   secrets:
     enabled: false

--- a/services/tap/values-idfint.yaml
+++ b/services/tap/values-idfint.yaml
@@ -4,7 +4,6 @@ cadc-tap:
   qserv_host: "10.136.1.211:4040"
 
   host: "data-int.lsst.cloud"
-  tap_schema_address: "tap-schema-db.tap-schema.svc.cluster.local:3306"
 
   secrets:
     enabled: false

--- a/services/tap/values-idfprod.yaml
+++ b/services/tap/values-idfprod.yaml
@@ -4,7 +4,6 @@ cadc-tap:
   qserv_host: "10.140.1.211:4040"
 
   host: "data.lsst.cloud"
-  tap_schema_address: "tap-schema-db.tap-schema.svc.cluster.local:3306"
 
   secrets:
     enabled: false

--- a/services/tap/values-int.yaml
+++ b/services/tap/values-int.yaml
@@ -4,7 +4,6 @@ cadc-tap:
   qserv_host: "lsst-qserv-master03:4040"
 
   host: "lsst-lsp-int.ncsa.illinois.edu"
-  tap_schema_address: "tap-schema-db.tap-schema.svc.cluster.local:3306"
 
   secrets:
     enabled: false

--- a/services/tap/values-minikube.yaml
+++ b/services/tap/values-minikube.yaml
@@ -3,7 +3,6 @@ cadc-tap:
   use_mock_qserv: true
 
   host: "minikube.lsst.codes"
-  tap_schema_address: "tap-schema-db.tap-schema.svc.cluster.local:3306"
 
   secrets:
     enabled: false

--- a/services/tap/values-red-five.yaml
+++ b/services/tap/values-red-five.yaml
@@ -3,7 +3,6 @@ cadc-tap:
   use_mock_qserv: true
 
   host: "red-five.lsst.codes"
-  tap_schema_address: "tap-schema-db.tap-schema.svc.cluster.local:3306"
 
   secrets:
     enabled: false

--- a/services/tap/values-stable.yaml
+++ b/services/tap/values-stable.yaml
@@ -6,7 +6,6 @@ cadc-tap:
   querymonkey_replicas: 1
 
   host: "lsst-lsp-stable.ncsa.illinois.edu"
-  tap_schema_address: "tap-schema-db.tap-schema.svc.cluster.local:3306"
 
   secrets:
     enabled: false


### PR DESCRIPTION
Depend on 0.2.0 and remove the now-unnecessary override of the
address of the TAP schema database.