### PR TITLE
[DM-30974] Rollout new versions of charts

### DIFF
--- a/services/cachemachine/Chart.yaml
+++ b/services/cachemachine/Chart.yaml
@@ -3,5 +3,5 @@ name: cachemachine
 version: 1.0.0
 dependencies:
 - name: cachemachine
-  version: 0.1.12
+  version: 0.1.13
   repository: https://lsst-sqre.github.io/charts/

--- a/services/moneypenny/Chart.yaml
+++ b/services/moneypenny/Chart.yaml
@@ -3,5 +3,5 @@ name: moneypenny
 version: 0.1.0
 dependencies:
 - name: moneypenny
-  version: '0.0.3'
+  version: '0.0.4'
   repository: https://lsst-sqre.github.io/charts/

--- a/services/squareone/Chart.yaml
+++ b/services/squareone/Chart.yaml
@@ -3,7 +3,7 @@ name: squareone
 version: 1.0.0
 dependencies:
   - name: squareone
-    version: "0.2.2"
+    version: "0.2.3"
     repository: https://lsst-sqre.github.io/charts/
   - name: pull-secret
     version: 0.1.2


### PR DESCRIPTION
Roll out a new version of these charts to add the ingress
annotation that was missing and causing some log messages.