### PR TITLE
[DM-31056] Stop sending the name to the Portal on IDF int

### DIFF
--- a/services/portal/values-idfint.yaml
+++ b/services/portal/values-idfint.yaml
@@ -8,7 +8,7 @@ firefly:
     host: "data-int.lsst.cloud"
     annotations:
       nginx.ingress.kubernetes.io/auth-method: GET
-      nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-User,X-Auth-Request-Name,X-Auth-Request-Email,X-Auth-Request-Token
+      nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-User,X-Auth-Request-Email,X-Auth-Request-Token
       nginx.ingress.kubernetes.io/auth-signin: "https://data-int.lsst.cloud/login"
       nginx.ingress.kubernetes.io/auth-url: "https://data-int.lsst.cloud/auth?scope=exec:portal&delegate_to=portal&delegate_scope=read:tap"
       nginx.ingress.kubernetes.io/proxy-read-timeout: "600"


### PR DESCRIPTION
This should trigger the Portal fallback of showing the username,
which is what we want anyway.