### PR TITLE
DM-31034: Squareone 0.3.0 with config-based notifications

### DIFF
--- a/services/squareone/Chart.yaml
+++ b/services/squareone/Chart.yaml
@@ -3,7 +3,7 @@ name: squareone
 version: 1.0.0
 dependencies:
   - name: squareone
-    version: "0.2.3"
+    version: "0.3.0"
     repository: https://lsst-sqre.github.io/charts/
   - name: pull-secret
     version: 0.1.2

--- a/services/squareone/values-base.yaml
+++ b/services/squareone/values-base.yaml
@@ -11,6 +11,8 @@ squareone:
     - name: "pull-secret"
   config:
     siteName: "Rubin Science Platform @ Base"
+    # broadcastMarkdown: |
+    #   Write a markdown-formatted broadcast notification.
 
 pull-secret:
   enabled: true

--- a/services/squareone/values-idfdev.yaml
+++ b/services/squareone/values-idfdev.yaml
@@ -11,6 +11,8 @@ squareone:
     - name: "pull-secret"
   config:
     siteName: "Rubin Science Platform @ data-dev"
+    # broadcastMarkdown: |
+    #   Write a markdown-formatted broadcast notification.
 
 pull-secret:
   enabled: true

--- a/services/squareone/values-idfdev.yaml
+++ b/services/squareone/values-idfdev.yaml
@@ -11,8 +11,8 @@ squareone:
     - name: "pull-secret"
   config:
     siteName: "Rubin Science Platform @ data-dev"
-    # broadcastMarkdown: |
-    #   Write a markdown-formatted broadcast notification.
+    broadcastMarkdown: |
+      This is a broadcast notification.
 
 pull-secret:
   enabled: true

--- a/services/squareone/values-idfint.yaml
+++ b/services/squareone/values-idfint.yaml
@@ -11,6 +11,8 @@ squareone:
     - name: "pull-secret"
   config:
     siteName: "Rubin Science Platform @ data-int"
+    # broadcastMarkdown: |
+    #   Write a markdown-formatted broadcast notification.
 
 pull-secret:
   enabled: true

--- a/services/squareone/values-idfprod.yaml
+++ b/services/squareone/values-idfprod.yaml
@@ -12,6 +12,8 @@ squareone:
     - name: "pull-secret"
   config:
     siteName: "Rubin Science Platform"
+    # broadcastMarkdown: |
+    #   Write a markdown-formatted broadcast notification.
 
 pull-secret:
   enabled: true

--- a/services/squareone/values-int.yaml
+++ b/services/squareone/values-int.yaml
@@ -5,6 +5,8 @@ squareone:
     - name: "pull-secret"
   config:
     siteName: "Rubin Science Platform @ lsp-int"
+    # broadcastMarkdown: |
+    #   Write a markdown-formatted broadcast notification.
 
 pull-secret:
   enabled: true

--- a/services/squareone/values-minikube.yaml
+++ b/services/squareone/values-minikube.yaml
@@ -5,6 +5,8 @@ squareone:
     - name: "pull-secret"
   config:
     siteName: "Rubin Science Platform @ minikube"
+    # broadcastMarkdown: |
+    #   Write a markdown-formatted broadcast notification.
 
 pull-secret:
   enabled: true

--- a/services/squareone/values-minikube.yaml
+++ b/services/squareone/values-minikube.yaml
@@ -5,8 +5,8 @@ squareone:
     - name: "pull-secret"
   config:
     siteName: "Rubin Science Platform @ minikube"
-    # broadcastMarkdown: |
-    #   Write a markdown-formatted broadcast notification.
+    broadcastMarkdown: |
+      This is a broadcast notification.
 
 pull-secret:
   enabled: true

--- a/services/squareone/values-nts.yaml
+++ b/services/squareone/values-nts.yaml
@@ -5,6 +5,8 @@ squareone:
     - name: "pull-secret"
   config:
     siteName: "Rubin Science Platform @ NTS"
+    # broadcastMarkdown: |
+    #   Write a markdown-formatted broadcast notification.
 
 pull-secret:
   enabled: true

--- a/services/squareone/values-red-five.yaml
+++ b/services/squareone/values-red-five.yaml
@@ -11,6 +11,8 @@ squareone:
     - name: "pull-secret"
   config:
     siteName: "Rubin Science Platform @ red-five"
+    # broadcastMarkdown: |
+    #   Write a markdown-formatted broadcast notification.
 
 pull-secret:
   enabled: true

--- a/services/squareone/values-stable.yaml
+++ b/services/squareone/values-stable.yaml
@@ -5,6 +5,8 @@ squareone:
     - name: "pull-secret"
   config:
     siteName: "Rubin Science Platform @ lsp-stable"
+    # broadcastMarkdown: |
+    #   Write a markdown-formatted broadcast notification.
 
 pull-secret:
   enabled: true

--- a/services/squareone/values-summit.yaml
+++ b/services/squareone/values-summit.yaml
@@ -11,6 +11,8 @@ squareone:
     - name: "pull-secret"
   config:
     siteName: "Rubin Science Platform @ Summit"
+    # broadcastMarkdown: |
+    #   Write a markdown-formatted broadcast notification.
 
 pull-secret:
   enabled: true

--- a/services/squareone/values-tucson-teststand.yaml
+++ b/services/squareone/values-tucson-teststand.yaml
@@ -11,6 +11,8 @@ squareone:
     - name: "pull-secret"
   config:
     siteName: "Rubin Science Platform @ Tucson"
+    # broadcastMarkdown: |
+    #   Write a markdown-formatted broadcast notification.
 
 pull-secret:
   enabled: true


### PR DESCRIPTION
This deploys squareone 0.3.0 with support for config-based notifications (via the Squareone values files). Includes notifications enabled for the idfdev and minikube environments for testing.kj