### PR TITLE
[DM-31056] Update to Gafaelfawr 4.2.0

### DIFF
--- a/services/gafaelfawr/Chart.yaml
+++ b/services/gafaelfawr/Chart.yaml
@@ -3,7 +3,7 @@ name: gafaelfawr
 version: 1.0.0
 dependencies:
   - name: gafaelfawr
-    version: 4.1.0
+    version: 4.2.0
     repository: https://lsst-sqre.github.io/charts/
   - name: pull-secret
     version: 0.1.2

--- a/services/gafaelfawr/values-idfdev.yaml
+++ b/services/gafaelfawr/values-idfdev.yaml
@@ -46,6 +46,11 @@ gafaelfawr:
       - "rra"
       - "simonkrughoff"
 
+    errorFooter: |
+      To report problems or ask for help, please open an issue in the
+      <a href="https://github.com/rubin-dp0/Support/issues">GitHub
+      rubin-dp0/Support project</a>.
+
   cloudsql:
     enabled: true
     instanceConnectionName: "science-platform-dev-7696:us-central1:science-platform-dev-e9e11de2"

--- a/services/gafaelfawr/values-idfint.yaml
+++ b/services/gafaelfawr/values-idfint.yaml
@@ -5,11 +5,6 @@ gafaelfawr:
     host: "data-int.lsst.cloud"
   vaultSecretsPath: "secret/k8s_operator/data-int.lsst.cloud/gafaelfawr"
 
-  # Use a hot-fix branch to test the Unicode name workaround.
-  image:
-    pullPolicy: "Always"
-    tag: "tickets-DM-31056"
-
   # Enable the frontend NetworkPolicy.
   networkPolicy:
     enabled: true
@@ -52,6 +47,11 @@ gafaelfawr:
       - "jonathansick"
       - "rra"
       - "simonkrughoff"
+
+    errorFooter: |
+      To report problems or ask for help, please open an issue in the
+      <a href="https://github.com/rubin-dp0/Support/issues">GitHub
+      rubin-dp0/Support project</a>.
 
   cloudsql:
     enabled: true

--- a/services/gafaelfawr/values-idfprod.yaml
+++ b/services/gafaelfawr/values-idfprod.yaml
@@ -5,11 +5,6 @@ gafaelfawr:
     host: "data.lsst.cloud"
   vaultSecretsPath: "secret/k8s_operator/data.lsst.cloud/gafaelfawr"
 
-  # Use a hot-fix branch to test the Unicode name workaround.
-  image:
-    pullPolicy: "Always"
-    tag: "tickets-DM-31056"
-
   # Enable the frontend NetworkPolicy.
   networkPolicy:
     enabled: true
@@ -60,6 +55,11 @@ gafaelfawr:
       - "jonathansick"
       - "rra"
       - "simonkrughoff"
+
+    errorFooter: |
+      To report problems or ask for help, please open an issue in the
+      <a href="https://github.com/rubin-dp0/Support/issues">GitHub
+      rubin-dp0/Support project</a>.
 
   cloudsql:
     enabled: true

--- a/services/portal/values-idfdev.yaml
+++ b/services/portal/values-idfdev.yaml
@@ -8,7 +8,7 @@ firefly:
     host: "data-dev.lsst.cloud"
     annotations:
       nginx.ingress.kubernetes.io/auth-method: GET
-      nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-User,X-Auth-Request-Name,X-Auth-Request-Email,X-Auth-Request-Token
+      nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-User,X-Auth-Request-Email,X-Auth-Request-Token
       nginx.ingress.kubernetes.io/auth-signin: "https://data-dev.lsst.cloud/login"
       nginx.ingress.kubernetes.io/auth-url: "https://data-dev.lsst.cloud/auth?scope=exec:portal&delegate_to=portal&delegate_scope=read:tap"
       nginx.ingress.kubernetes.io/configuration-snippet: |

--- a/services/portal/values-idfprod.yaml
+++ b/services/portal/values-idfprod.yaml
@@ -9,7 +9,7 @@ firefly:
     host: "data.lsst.cloud"
     annotations:
       nginx.ingress.kubernetes.io/auth-method: GET
-      nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-User,X-Auth-Request-Name,X-Auth-Request-Email,X-Auth-Request-Token
+      nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-User,X-Auth-Request-Email,X-Auth-Request-Token
       nginx.ingress.kubernetes.io/auth-signin: "https://data.lsst.cloud/login"
       nginx.ingress.kubernetes.io/auth-url: "https://data.lsst.cloud/auth?scope=exec:portal&delegate_to=portal&delegate_scope=read:tap"
       nginx.ingress.kubernetes.io/proxy-read-timeout: "600"

--- a/services/portal/values-int.yaml
+++ b/services/portal/values-int.yaml
@@ -6,7 +6,7 @@ firefly:
     host: 'lsst-lsp-int.ncsa.illinois.edu'
     annotations:
       nginx.ingress.kubernetes.io/auth-method: GET
-      nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-User,X-Auth-Request-Name,X-Auth-Request-Email,X-Auth-Request-Token
+      nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-User,X-Auth-Request-Email,X-Auth-Request-Token
       nginx.ingress.kubernetes.io/auth-signin: "https://lsst-lsp-int.ncsa.illinois.edu/login"
       nginx.ingress.kubernetes.io/auth-url: "https://lsst-lsp-int.ncsa.illinois.edu/auth?scope=exec:portal&delegate_to=portal&delegate_scope=read:tap"
       nginx.ingress.kubernetes.io/configuration-snippet: |

--- a/services/portal/values-stable.yaml
+++ b/services/portal/values-stable.yaml
@@ -6,7 +6,7 @@ firefly:
     host: 'lsst-lsp-stable.ncsa.illinois.edu'
     annotations:
       nginx.ingress.kubernetes.io/auth-method: GET
-      nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-User,X-Auth-Request-Name,X-Auth-Request-Email,X-Auth-Request-Token
+      nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-User,X-Auth-Request-Email,X-Auth-Request-Token
       nginx.ingress.kubernetes.io/auth-signin: "https://lsst-lsp-stable.ncsa.illinois.edu/login"
       nginx.ingress.kubernetes.io/auth-url: "https://lsst-lsp-stable.ncsa.illinois.edu/auth?scope=exec:portal&delegate_to=portal&delegate_scope=read:tap"
       nginx.ingress.kubernetes.io/configuration-snippet: |


### PR DESCRIPTION
Stop passing name to the Portal in headers.  Upgrade Gafaelfawr to
4.2.0, which drops support for name in HTTP headers due to Unicode
issues and checks that the user is a member of a valid group.  Add
an error footer to the IDF environments pointing to the GitHub
project for issues (this is also on int and dev so that we can test
it more easily, not because those users should use that channel).