### PR TITLE
DM-30177: Deploy sdm_schemas 1.1.0 to NCSA-int

### DIFF
--- a/services/tap-schema/values-int.yaml
+++ b/services/tap-schema/values-int.yaml
@@ -1,7 +1,7 @@
 tap-schema:
   pull_secret: 'pull-secret'
   image: lsstsqre/tap-schema-int
-  tag: 1.0.3
+  tag: 1.1.0
 
 pull-secret:
   enabled: true


### PR DESCRIPTION
Preparation for deploying it everywhere today
This should have no tangible effect on NCSA-int; it's a change only to a schema that isn't deployed there.