### PR TITLE
[DM-30073] Remove Portal version overrides

### DIFF
--- a/services/portal/Chart.yaml
+++ b/services/portal/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: portal
 version: 1.0.0
 dependencies:
-- name: firefly
-  version: ">=0.1.0"
-  repository: https://lsst-sqre.github.io/charts/
-- name: pull-secret
-  version: 0.1.2
-  repository: https://lsst-sqre.github.io/charts/
+  - name: firefly
+    version: ">=0.1.0"
+    repository: https://lsst-sqre.github.io/charts/
+  - name: pull-secret
+    version: 0.1.2
+    repository: https://lsst-sqre.github.io/charts/

--- a/services/portal/values-idfdev.yaml
+++ b/services/portal/values-idfdev.yaml
@@ -1,9 +1,6 @@
 firefly:
   pull_secret: 'pull-secret'
 
-  image:
-    tag: "suit-233-7-dev"
-
   ingress:
     host: "data-dev.lsst.cloud"
     annotations:

--- a/services/portal/values-idfint.yaml
+++ b/services/portal/values-idfint.yaml
@@ -1,9 +1,6 @@
 firefly:
   pull_secret: 'pull-secret'
 
-  image:
-    tag: "suit-233-7-dev"
-
   ingress:
     host: "data-int.lsst.cloud"
     annotations:

--- a/services/portal/values-idfprod.yaml
+++ b/services/portal/values-idfprod.yaml
@@ -2,9 +2,6 @@ firefly:
   pull_secret: 'pull-secret'
   replicaCount: 4
 
-  image:
-    tag: "suit-233-7-dev"
-
   ingress:
     host: "data.lsst.cloud"
     annotations:


### PR DESCRIPTION
The chart now installs suit-233-7-dev by default.