### PR TITLE
DM-30931: Fix path for semaphore science-platform app

### DIFF
--- a/science-platform/templates/semaphore-application.yaml
+++ b/science-platform/templates/semaphore-application.yaml
@@ -20,7 +20,7 @@ spec:
     server: https://kubernetes.default.svc
   project: default
   source:
-    path: services/squareone
+    path: services/semaphore
     repoURL: {{ .Values.repoURL }}
     targetRevision: {{ .Values.revision }}
     helm:

--- a/services/semaphore/values-base.yaml
+++ b/services/semaphore/values-base.yaml
@@ -4,7 +4,7 @@ semaphore:
     hosts:
       - host: "base-lsp.lsst.codes"
         paths:
-          - "/semaphore"
+          - path: "/semaphore"
   imagePullSecrets:
     - name: "pull-secret"
 

--- a/services/semaphore/values-base.yaml
+++ b/services/semaphore/values-base.yaml
@@ -5,6 +5,7 @@ semaphore:
       - host: "base-lsp.lsst.codes"
         paths:
           - path: "/semaphore"
+            pathType: Prefix
   imagePullSecrets:
     - name: "pull-secret"
 

--- a/services/semaphore/values-idfdev.yaml
+++ b/services/semaphore/values-idfdev.yaml
@@ -4,7 +4,7 @@ semaphore:
     hosts:
       - host: "data-dev.lsst.codes"
         paths:
-          - "/semaphore"
+          - path: "/semaphore"
   imagePullSecrets:
     - name: "pull-secret"
 

--- a/services/semaphore/values-idfdev.yaml
+++ b/services/semaphore/values-idfdev.yaml
@@ -5,6 +5,7 @@ semaphore:
       - host: "data-dev.lsst.codes"
         paths:
           - path: "/semaphore"
+            pathType: Prefix
   imagePullSecrets:
     - name: "pull-secret"
 

--- a/services/semaphore/values-idfint.yaml
+++ b/services/semaphore/values-idfint.yaml
@@ -4,7 +4,7 @@ semaphore:
     hosts:
       - host: "data-int.lsst.cloud"
         paths:
-          - "/semaphore"
+          - path: "/semaphore"
   imagePullSecrets:
     - name: "pull-secret"
 

--- a/services/semaphore/values-idfint.yaml
+++ b/services/semaphore/values-idfint.yaml
@@ -5,6 +5,7 @@ semaphore:
       - host: "data-int.lsst.cloud"
         paths:
           - path: "/semaphore"
+            pathType: Prefix
   imagePullSecrets:
     - name: "pull-secret"
 

--- a/services/semaphore/values-idfprod.yaml
+++ b/services/semaphore/values-idfprod.yaml
@@ -4,7 +4,7 @@ semaphore:
     hosts:
       - host: "data.lsst.cloud"
         paths:
-          - "/semaphore"
+          - path: "/semaphore"
   imagePullSecrets:
     - name: "pull-secret"
 

--- a/services/semaphore/values-idfprod.yaml
+++ b/services/semaphore/values-idfprod.yaml
@@ -5,6 +5,7 @@ semaphore:
       - host: "data.lsst.cloud"
         paths:
           - path: "/semaphore"
+            pathType: Prefix
   imagePullSecrets:
     - name: "pull-secret"
 

--- a/services/semaphore/values-int.yaml
+++ b/services/semaphore/values-int.yaml
@@ -4,7 +4,7 @@ semaphore:
     hosts:
       - host: "lsst-lsp-int.ncsa.illinois.edu"
         paths:
-          - "/semaphore"
+          - path: "/semaphore"
   imagePullSecrets:
     - name: "pull-secret"
 

--- a/services/semaphore/values-int.yaml
+++ b/services/semaphore/values-int.yaml
@@ -5,6 +5,7 @@ semaphore:
       - host: "lsst-lsp-int.ncsa.illinois.edu"
         paths:
           - path: "/semaphore"
+            pathType: Prefix
   imagePullSecrets:
     - name: "pull-secret"
 

--- a/services/semaphore/values-minikube.yaml
+++ b/services/semaphore/values-minikube.yaml
@@ -5,6 +5,7 @@ semaphore:
       - host: "minikube.lsst.codes"
         paths:
           - path: "/semaphore"
+            pathType: Prefix
   imagePullSecrets:
     - name: "pull-secret"
 

--- a/services/semaphore/values-minikube.yaml
+++ b/services/semaphore/values-minikube.yaml
@@ -4,7 +4,7 @@ semaphore:
     hosts:
       - host: "minikube.lsst.codes"
         paths:
-          - "/semaphore"
+          - path: "/semaphore"
   imagePullSecrets:
     - name: "pull-secret"
 

--- a/services/semaphore/values-nts.yaml
+++ b/services/semaphore/values-nts.yaml
@@ -5,6 +5,7 @@ semaphore:
       - host: "lsst-nts-k8s.ncsa.illinois.edu"
         paths:
           - path: "/semaphore"
+            pathType: Prefix
   imagePullSecrets:
     - name: "pull-secret"
 

--- a/services/semaphore/values-nts.yaml
+++ b/services/semaphore/values-nts.yaml
@@ -4,7 +4,7 @@ semaphore:
     hosts:
       - host: "lsst-nts-k8s.ncsa.illinois.edu"
         paths:
-          - "/semaphore"
+          - path: "/semaphore"
   imagePullSecrets:
     - name: "pull-secret"
 

--- a/services/semaphore/values-red-five.yaml
+++ b/services/semaphore/values-red-five.yaml
@@ -5,6 +5,7 @@ semaphore:
       - host: "red-five.lsst.codes"
         paths:
           - path: "/semaphore"
+            pathType: Prefix
   imagePullSecrets:
     - name: "pull-secret"
 

--- a/services/semaphore/values-red-five.yaml
+++ b/services/semaphore/values-red-five.yaml
@@ -4,7 +4,7 @@ semaphore:
     hosts:
       - host: "red-five.lsst.codes"
         paths:
-          - "/semaphore"
+          - path: "/semaphore"
   imagePullSecrets:
     - name: "pull-secret"
 

--- a/services/semaphore/values-stable.yaml
+++ b/services/semaphore/values-stable.yaml
@@ -5,6 +5,7 @@ semaphore:
       - host: "lsst-lsp-stable.ncsa.illinois.edu"
         paths:
           - path: "/semaphore"
+            pathType: Prefix
   imagePullSecrets:
     - name: "pull-secret"
 

--- a/services/semaphore/values-stable.yaml
+++ b/services/semaphore/values-stable.yaml
@@ -4,7 +4,7 @@ semaphore:
     hosts:
       - host: "lsst-lsp-stable.ncsa.illinois.edu"
         paths:
-          - "/semaphore"
+          - path: "/semaphore"
   imagePullSecrets:
     - name: "pull-secret"
 

--- a/services/semaphore/values-summit.yaml
+++ b/services/semaphore/values-summit.yaml
@@ -4,7 +4,7 @@ semaphore:
     hosts:
       - host: "summit-lsp.lsst.codes"
         paths:
-          - "/semaphore"
+          - path: "/semaphore"
   imagePullSecrets:
     - name: "pull-secret"
 

--- a/services/semaphore/values-summit.yaml
+++ b/services/semaphore/values-summit.yaml
@@ -5,6 +5,7 @@ semaphore:
       - host: "summit-lsp.lsst.codes"
         paths:
           - path: "/semaphore"
+            pathType: Prefix
   imagePullSecrets:
     - name: "pull-secret"
 

--- a/services/semaphore/values-tucson-teststand.yaml
+++ b/services/semaphore/values-tucson-teststand.yaml
@@ -5,6 +5,7 @@ semaphore:
       - host: "tucson-teststand.lsst.codes"
         paths:
           - path: "/semaphore"
+            pathType: Prefix
   imagePullSecrets:
     - name: "pull-secret"
 

--- a/services/semaphore/values-tucson-teststand.yaml
+++ b/services/semaphore/values-tucson-teststand.yaml
@@ -4,7 +4,7 @@ semaphore:
     hosts:
       - host: "tucson-teststand.lsst.codes"
         paths:
-          - "/semaphore"
+          - path: "/semaphore"
   imagePullSecrets:
     - name: "pull-secret"
 


### PR DESCRIPTION
Semaphore's application source path was incorrectly left as services/squareone when bootstrapping. This left some errors in the semaphore configuration unchecked. This PR should resolve those issues.