### PR TITLE
DM-30931: Update semaphore chart to 0.2.0-alpha.2

### DIFF
--- a/services/semaphore/Chart.yaml
+++ b/services/semaphore/Chart.yaml
@@ -3,7 +3,7 @@ name: semaphore
 version: 1.0.0
 dependencies:
   - name: semaphore
-    version: "0.1.0"
+    version: "0.2.0-alpha.2"
     repository: https://lsst-sqre.github.io/charts/
   - name: pull-secret
     version: 0.1.2

--- a/services/semaphore/values-base.yaml
+++ b/services/semaphore/values-base.yaml
@@ -10,6 +10,7 @@ semaphore:
             pathType: Prefix
   imagePullSecrets:
     - name: "pull-secret"
+  vaultSecretsPath: "secret/k8s_operator/base-lsp.lsst.codes/semaphore"
 
 pull-secret:
   enabled: true

--- a/services/semaphore/values-idfdev.yaml
+++ b/services/semaphore/values-idfdev.yaml
@@ -10,6 +10,7 @@ semaphore:
             pathType: Prefix
   imagePullSecrets:
     - name: "pull-secret"
+  vaultSecretsPath: "secret/k8s_operator/data-dev.lsst.cloud/semaphore"
 
 pull-secret:
   enabled: true

--- a/services/semaphore/values-idfint.yaml
+++ b/services/semaphore/values-idfint.yaml
@@ -10,6 +10,7 @@ semaphore:
             pathType: Prefix
   imagePullSecrets:
     - name: "pull-secret"
+  vaultSecretsPath: "secret/k8s_operator/data-int.lsst.cloud/semaphore"
 
 pull-secret:
   enabled: true

--- a/services/semaphore/values-idfprod.yaml
+++ b/services/semaphore/values-idfprod.yaml
@@ -10,6 +10,7 @@ semaphore:
             pathType: Prefix
   imagePullSecrets:
     - name: "pull-secret"
+  vaultSecretsPath: "secret/k8s_operator/data.lsst.cloud/semaphore"
 
 pull-secret:
   enabled: true

--- a/services/semaphore/values-int.yaml
+++ b/services/semaphore/values-int.yaml
@@ -10,6 +10,7 @@ semaphore:
             pathType: Prefix
   imagePullSecrets:
     - name: "pull-secret"
+  vaultSecretsPath: "secret/k8s_operator/lsst-lsp-int.ncsa.illinois.edu/semaphore"
 
 pull-secret:
   enabled: true

--- a/services/semaphore/values-minikube.yaml
+++ b/services/semaphore/values-minikube.yaml
@@ -10,6 +10,7 @@ semaphore:
             pathType: Prefix
   imagePullSecrets:
     - name: "pull-secret"
+  vaultSecretsPath: "secret/k8s_operator/minikube.lsst.codes/semaphore"
 
 pull-secret:
   enabled: true

--- a/services/semaphore/values-nts.yaml
+++ b/services/semaphore/values-nts.yaml
@@ -10,6 +10,7 @@ semaphore:
             pathType: Prefix
   imagePullSecrets:
     - name: "pull-secret"
+  vaultSecretsPath: "secret/k8s_operator/lsst-nts-k8s.ncsa.illinois.edu/semaphore"
 
 pull-secret:
   enabled: true

--- a/services/semaphore/values-red-five.yaml
+++ b/services/semaphore/values-red-five.yaml
@@ -10,6 +10,7 @@ semaphore:
             pathType: Prefix
   imagePullSecrets:
     - name: "pull-secret"
+  vaultSecretsPath: "secret/k8s_operator/red-five.lsst.codes/semaphore"
 
 pull-secret:
   enabled: true

--- a/services/semaphore/values-stable.yaml
+++ b/services/semaphore/values-stable.yaml
@@ -10,6 +10,7 @@ semaphore:
             pathType: Prefix
   imagePullSecrets:
     - name: "pull-secret"
+  vaultSecretsPath: "secret/k8s_operator/lsst-lsp-stable.ncsa.illinois.edu/semaphore"
 
 pull-secret:
   enabled: true

--- a/services/semaphore/values-summit.yaml
+++ b/services/semaphore/values-summit.yaml
@@ -10,6 +10,7 @@ semaphore:
             pathType: Prefix
   imagePullSecrets:
     - name: "pull-secret"
+  vaultSecretsPath: "secret/k8s_operator/summit-lsp.lsst.codes/semaphore"
 
 pull-secret:
   enabled: true

--- a/services/semaphore/values-tucson-teststand.yaml
+++ b/services/semaphore/values-tucson-teststand.yaml
@@ -10,6 +10,7 @@ semaphore:
             pathType: Prefix
   imagePullSecrets:
     - name: "pull-secret"
+  vaultSecretsPath: "secret/k8s_operator/tucson-teststand.lsst.codes/semaphore"
 
 pull-secret:
   enabled: true


### PR DESCRIPTION
- Update chart to 0.2.0-alpha.2 (enable development testing to semaphore (lsst-sqre/semaphore#3)
- Set vaultSecretsPath value