### PR TITLE
DM-30931: Deploy semaphore chart 0.2.0-alpha.3 onto idfdev

### DIFF
--- a/services/semaphore/Chart.yaml
+++ b/services/semaphore/Chart.yaml
@@ -3,7 +3,7 @@ name: semaphore
 version: 1.0.0
 dependencies:
   - name: semaphore
-    version: "0.2.0-alpha.2"
+    version: "0.2.0-alpha.3"
     repository: https://lsst-sqre.github.io/charts/
   - name: pull-secret
     version: 0.1.2

--- a/services/semaphore/values-base.yaml
+++ b/services/semaphore/values-base.yaml
@@ -1,4 +1,6 @@
 semaphore:
+  config:
+    phalanx_env: "base"
   ingress:
     enabled: true
     annotations:

--- a/services/semaphore/values-idfdev.yaml
+++ b/services/semaphore/values-idfdev.yaml
@@ -4,6 +4,7 @@ semaphore:
   config:
     github_app_id: "127943"
     enable_github_app: "True"
+    phalanx_env: "idfdev"
   ingress:
     enabled: true
     annotations:

--- a/services/semaphore/values-idfdev.yaml
+++ b/services/semaphore/values-idfdev.yaml
@@ -5,6 +5,7 @@ semaphore:
     github_app_id: "127943"
     enable_github_app: "True"
     phalanx_env: "idfdev"
+    log_level: "debug"
   ingress:
     enabled: true
     annotations:

--- a/services/semaphore/values-idfint.yaml
+++ b/services/semaphore/values-idfint.yaml
@@ -1,4 +1,6 @@
 semaphore:
+  config:
+    phalanx_env: "idfint"
   ingress:
     enabled: true
     annotations:

--- a/services/semaphore/values-idfprod.yaml
+++ b/services/semaphore/values-idfprod.yaml
@@ -1,4 +1,6 @@
 semaphore:
+  config:
+    phalanx_env: "idfprod"
   ingress:
     enabled: true
     annotations:

--- a/services/semaphore/values-int.yaml
+++ b/services/semaphore/values-int.yaml
@@ -1,4 +1,6 @@
 semaphore:
+  config:
+    phalanx_env: "int"
   ingress:
     enabled: true
     annotations:

--- a/services/semaphore/values-minikube.yaml
+++ b/services/semaphore/values-minikube.yaml
@@ -1,4 +1,6 @@
 semaphore:
+  config:
+    phalanx_env: "minikube"
   ingress:
     enabled: true
     annotations:

--- a/services/semaphore/values-nts.yaml
+++ b/services/semaphore/values-nts.yaml
@@ -1,4 +1,6 @@
 semaphore:
+  config:
+    phalanx_env: "nts"
   ingress:
     enabled: true
     annotations:

--- a/services/semaphore/values-red-five.yaml
+++ b/services/semaphore/values-red-five.yaml
@@ -1,4 +1,6 @@
 semaphore:
+  config:
+    phalanx_env: "red-five"
   ingress:
     enabled: true
     annotations:

--- a/services/semaphore/values-stable.yaml
+++ b/services/semaphore/values-stable.yaml
@@ -1,4 +1,6 @@
 semaphore:
+  config:
+    phalanx_env: "stable"
   ingress:
     enabled: true
     annotations:

--- a/services/semaphore/values-summit.yaml
+++ b/services/semaphore/values-summit.yaml
@@ -1,4 +1,6 @@
 semaphore:
+  config:
+    phalanx_env: "summit"
   ingress:
     enabled: true
     annotations:

--- a/services/semaphore/values-tucson-teststand.yaml
+++ b/services/semaphore/values-tucson-teststand.yaml
@@ -1,4 +1,6 @@
 semaphore:
+  config:
+    phalanx_env: "tucson-teststand"
   ingress:
     enabled: true
     annotations:


### PR DESCRIPTION
This chart update adds the phalanx_env configuration for semaphore, which is needed for ingesting messages from a shared GitHub repository.