### PR TITLE
[DM-31201] Disable running tutorial notebooks on IDF prod

### DIFF
--- a/services/mobu/values-idfprod.yaml
+++ b/services/mobu/values-idfprod.yaml
@@ -52,23 +52,23 @@ mobu:
         idle_time: 900
         delete_lab: false
       restart: true
-    - name: "tutorial"
-      count: 1
-      users:
-        - username: "systemtest07"
-          uidnumber: 74774
-      scopes: ["exec:notebook", "exec:portal", "read:tap"]
-      business: "NotebookRunner"
-      options:
-        jupyter_options_form:
-          image: "registry.hub.docker.com/lsstsqre/sciplat-lab:recommended"
-          image_list: "registry.hub.docker.com/lsstsqre/sciplat-lab:recommended|Recommended|"
-          image_dropdown: "use_image_from_dropdown"
-          size: "Large"
-        repo_url: "https://github.com/rubin-dp0/tutorial-notebooks.git"
-        repo_branch: "prod"
-        max_executions: 1
-      restart: true
+    # - name: "tutorial"
+    #   count: 1
+    #   users:
+    #     - username: "systemtest07"
+    #       uidnumber: 74774
+    #   scopes: ["exec:notebook", "exec:portal", "read:tap"]
+    #   business: "NotebookRunner"
+    #   options:
+    #     jupyter_options_form:
+    #       image: "registry.hub.docker.com/lsstsqre/sciplat-lab:recommended"
+    #       image_list: "registry.hub.docker.com/lsstsqre/sciplat-lab:recommended|Recommended|"
+    #       image_dropdown: "use_image_from_dropdown"
+    #       size: "Large"
+    #     repo_url: "https://github.com/rubin-dp0/tutorial-notebooks.git"
+    #     repo_branch: "prod"
+    #     max_executions: 1
+    #   restart: true
 
 pull-secret:
   enabled: true


### PR DESCRIPTION
For now, disable the mobu tutorial notebook runner, since it doesn't
work correctly with a notebook that requires an external file.