### PR TITLE
DM-30727: Squareone 0.4 and Semaphore 0.2 (idfint and idfdev)

### DIFF
--- a/science-platform/values-idfint.yaml
+++ b/science-platform/values-idfint.yaml
@@ -39,7 +39,7 @@ postgres:
 rancher_external_ip_webhook:
   enabled: true
 semaphore:
-  enabled: false
+  enabled: true
 squareone:
   enabled: true
 squash_api:

--- a/services/semaphore/values-idfint.yaml
+++ b/services/semaphore/values-idfint.yaml
@@ -1,6 +1,8 @@
 semaphore:
   config:
     phalanx_env: "idfint"
+    github_app_id: "131457"
+    enable_github_app: "True"
   ingress:
     enabled: true
     annotations:

--- a/services/squareone/Chart.yaml
+++ b/services/squareone/Chart.yaml
@@ -3,7 +3,7 @@ name: squareone
 version: 1.0.0
 dependencies:
   - name: squareone
-    version: "0.3.1"
+    version: "0.4.0"
     repository: https://lsst-sqre.github.io/charts/
   - name: pull-secret
     version: 0.1.2

--- a/services/squareone/values-base.yaml
+++ b/services/squareone/values-base.yaml
@@ -11,8 +11,6 @@ squareone:
     - name: "pull-secret"
   config:
     siteName: "Rubin Science Platform @ Base"
-    # broadcastMarkdown: |
-    #   Write a markdown-formatted broadcast notification.
 
 pull-secret:
   enabled: true

--- a/services/squareone/values-idfdev.yaml
+++ b/services/squareone/values-idfdev.yaml
@@ -11,8 +11,7 @@ squareone:
     - name: "pull-secret"
   config:
     siteName: "Rubin Science Platform @ data-dev"
-    broadcastMarkdown: |
-      This is a broadcast notification.
+    semaphoreUrl: "https://data-dev.lsst.cloud/semaphore"
 
 pull-secret:
   enabled: true

--- a/services/squareone/values-idfint.yaml
+++ b/services/squareone/values-idfint.yaml
@@ -11,9 +11,6 @@ squareone:
     - name: "pull-secret"
   config:
     siteName: "Rubin Science Platform @ data-int"
-    # broadcastMarkdown: >
-    #   Patch Thursday **today** 3pm-5pm Pacific / 22:00-00:00 UT
-    #   [(*what is RSP Patch Thursday?)*](https://community.lsst.org/t/what-is-rsp-patch-thursday/5647)
 
 pull-secret:
   enabled: true

--- a/services/squareone/values-idfint.yaml
+++ b/services/squareone/values-idfint.yaml
@@ -11,6 +11,7 @@ squareone:
     - name: "pull-secret"
   config:
     siteName: "Rubin Science Platform @ data-int"
+    semaphoreUrl: "https://data-int.lsst.cloud/semaphore"
 
 pull-secret:
   enabled: true

--- a/services/squareone/values-idfprod.yaml
+++ b/services/squareone/values-idfprod.yaml
@@ -12,9 +12,6 @@ squareone:
     - name: "pull-secret"
   config:
     siteName: "Rubin Science Platform"
-#    broadcastMarkdown: >
-#      Patch Thursday **today** 3pm-5pm Pacific / 22:00-00:00 UT
-#      [(*what is RSP Patch Thursday?)*](https://community.lsst.org/t/what-is-rsp-patch-thursday/5647)
 
 pull-secret:
   enabled: true

--- a/services/squareone/values-int.yaml
+++ b/services/squareone/values-int.yaml
@@ -5,8 +5,6 @@ squareone:
     - name: "pull-secret"
   config:
     siteName: "Rubin Science Platform @ lsp-int"
-    # broadcastMarkdown: |
-    #   Write a markdown-formatted broadcast notification.
 
 pull-secret:
   enabled: true

--- a/services/squareone/values-minikube.yaml
+++ b/services/squareone/values-minikube.yaml
@@ -5,8 +5,6 @@ squareone:
     - name: "pull-secret"
   config:
     siteName: "Rubin Science Platform @ minikube"
-    broadcastMarkdown: |
-      This is a broadcast notification.
 
 pull-secret:
   enabled: true

--- a/services/squareone/values-nts.yaml
+++ b/services/squareone/values-nts.yaml
@@ -5,8 +5,6 @@ squareone:
     - name: "pull-secret"
   config:
     siteName: "Rubin Science Platform @ NTS"
-    # broadcastMarkdown: |
-    #   Write a markdown-formatted broadcast notification.
 
 pull-secret:
   enabled: true

--- a/services/squareone/values-red-five.yaml
+++ b/services/squareone/values-red-five.yaml
@@ -11,8 +11,6 @@ squareone:
     - name: "pull-secret"
   config:
     siteName: "Rubin Science Platform @ red-five"
-    # broadcastMarkdown: |
-    #   Write a markdown-formatted broadcast notification.
 
 pull-secret:
   enabled: true

--- a/services/squareone/values-stable.yaml
+++ b/services/squareone/values-stable.yaml
@@ -5,8 +5,6 @@ squareone:
     - name: "pull-secret"
   config:
     siteName: "Rubin Science Platform @ lsp-stable"
-    # broadcastMarkdown: |
-    #   Write a markdown-formatted broadcast notification.
 
 pull-secret:
   enabled: true

--- a/services/squareone/values-summit.yaml
+++ b/services/squareone/values-summit.yaml
@@ -11,8 +11,6 @@ squareone:
     - name: "pull-secret"
   config:
     siteName: "Rubin Science Platform @ Summit"
-    # broadcastMarkdown: |
-    #   Write a markdown-formatted broadcast notification.
 
 pull-secret:
   enabled: true

--- a/services/squareone/values-tucson-teststand.yaml
+++ b/services/squareone/values-tucson-teststand.yaml
@@ -11,8 +11,6 @@ squareone:
     - name: "pull-secret"
   config:
     siteName: "Rubin Science Platform @ Tucson"
-    # broadcastMarkdown: |
-    #   Write a markdown-formatted broadcast notification.
 
 pull-secret:
   enabled: true


### PR DESCRIPTION
This is for the integration of squareone 0.4 and semaphore 0.2 to source broadcast messages and user notifications from semaphore.

Enables semaphore on idfint and idfdev.