### PR TITLE
DM-31395: Update semaphore to 0.2.1

### DIFF
--- a/services/semaphore/Chart.yaml
+++ b/services/semaphore/Chart.yaml
@@ -3,7 +3,7 @@ name: semaphore
 version: 1.0.0
 dependencies:
   - name: semaphore
-    version: "0.2.0"
+    version: "0.2.1"
     repository: https://lsst-sqre.github.io/charts/
   - name: pull-secret
     version: 0.1.2


### PR DESCRIPTION
This fixes the /v1/broadcasts endpoint, which was showing disabled messages.