### PR TITLE
[DM-31454] Revert "Do TAP testing via mobu on data-int"

### DIFF
--- a/services/mobu/values-idfint.yaml
+++ b/services/mobu/values-idfint.yaml
@@ -2,10 +2,6 @@ mobu:
   imagePullSecrets:
     - name: "pull-secret"
 
-  image:
-    pullPolicy: Always
-    tag: "tickets-DM-31454"
-
   ingress:
     host: "data-int.lsst.cloud"
 
@@ -37,14 +33,6 @@ mobu:
         repo_url: "https://github.com/athornton/system-test.git"
         repo_branch: "prod"
         execution_idle_time: 10
-      restart: True
-    - name: "tap"
-      count: 1
-      users:
-        - username: "systemtest06"
-          uidnumber: 74773
-      scopes: ["read:tap"]
-      business: "TAPQueryRunner"
       restart: True
 
 pull-secret:


### PR DESCRIPTION
This reverts commit 87c2fa2dfa89247618f2e2399ce0b3c00e9f814e.
data-int cannot run the TAP queries.