### PR TITLE
[DM-31518] pull-secret for vault-secrets-operator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /installer/secrets/
+/installer/docker-creds
 /services/*/charts/
 /services-expanded/
 .DS_Store

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -21,6 +21,14 @@ kubectl create secret generic vault-secrets-operator \
   --from-literal=VAULT_TOKEN_LEASE_DURATION=31536000 \
   --dry-run -o yaml | kubectl apply -f -
 
+echo "Set up docker pull secret for vault-secrets-operator..."
+vault kv get --field=.dockerconfigjson $VAULT_PATH_PREFIX/pull-secret > docker-creds
+kubectl create secret generic pull-secret -n vault-secrets-operator \
+    --from-file=.dockerconfigjson=docker-creds \
+    --type=kubernetes.io/dockerconfigjson \
+    --dry-run -o yaml | kubectl apply -f -
+
+
 echo "Update / install vault-secrets-operator..."
 # ArgoCD depends on pull-secret, which depends on vault-secrets-operator.
 helm dependency update ../services/vault-secrets-operator


### PR DESCRIPTION
This has to be set up a bit different since we need this to exist
before vault-secrets-operator is installed.  Use the vault command
line to pull it down and kubectl to add it.