### PR TITLE
[DM-31454] Replace TAP querymonkey with mobu

### DIFF
--- a/installer/generate_secrets.py
+++ b/installer/generate_secrets.py
@@ -102,9 +102,6 @@ class SecretGenerator:
             self._set(component, name, new_value)
 
     def _tap(self):
-        self.input_field(
-            "tap", "slack_webhook_url", "slack webhook url for querymonkey"
-        )
         self.input_file(
             "tap",
             "google_creds.json",

--- a/services/mobu/values-int.yaml
+++ b/services/mobu/values-int.yaml
@@ -32,14 +32,6 @@ mobu:
         repo_branch: "robo-simon"
         max_executions: 1
       restart: True
-    - name: "tap"
-      count: 1
-      users:
-        - username: "lsptestuser02"
-          uidnumber: 60182
-      scopes: ["read:tap"]
-      business: "TAPQueryRunner"
-      restart: True
 
 pull-secret:
   enabled: true

--- a/services/mobu/values-stable.yaml
+++ b/services/mobu/values-stable.yaml
@@ -36,6 +36,14 @@ mobu:
         repo_branch: "robo-simon"
         max_executions: 1
       restart: true
+    - name: "tap"
+      count: 1
+      users:
+        - username: "lsptestuser01"
+          uidnumber: 60181
+      scopes: ["read:tap"]
+      business: "TAPQueryRunner"
+      restart: True
 
 pull-secret:
   enabled: true

--- a/services/tap/values-stable.yaml
+++ b/services/tap/values-stable.yaml
@@ -3,8 +3,6 @@ cadc-tap:
   use_mock_qserv: false
   qserv_host: "lsst-qserv-master03:4040"
 
-  querymonkey_replicas: 1
-
   host: "lsst-lsp-stable.ncsa.illinois.edu"
 
   secrets:


### PR DESCRIPTION
Enable TAP query monitoring with mobu on NCSA stable.  Disable it
for now on NCSA int because we're getting errors that we don't
understand and that are not useful to keep reporting.  Remove the
old querymonkey configuration for NCSA stable and for secrets.