### PR TITLE
[DM-31485] Don't reuse users for the TAP query

### DIFF
--- a/services/mobu/values-stable.yaml
+++ b/services/mobu/values-stable.yaml
@@ -39,8 +39,8 @@ mobu:
     - name: "tap"
       count: 1
       users:
-        - username: "lsptestuser01"
-          uidnumber: 60181
+        - username: "lsptestuser06"
+          uidnumber: 60186
       scopes: ["read:tap"]
       business: "TAPQueryRunner"
       restart: True


### PR DESCRIPTION
mobu currently can't handle reusing the same user for multiple
monkeys.