### PR TITLE
[DM-31490] Update configuration for mobu 4.0.0

### DIFF
--- a/services/mobu/Chart.yaml
+++ b/services/mobu/Chart.yaml
@@ -3,7 +3,7 @@ name: mobu
 version: 1.0.0
 dependencies:
   - name: mobu
-    version: ">=1.0.0"
+    version: ">=3.0.0"
     repository: https://lsst-sqre.github.io/charts/
   - name: pull-secret
     version: 0.1.2

--- a/services/mobu/values-idfdev.yaml
+++ b/services/mobu/values-idfdev.yaml
@@ -16,12 +16,6 @@ mobu:
           uidnumber: 74768
       scopes: ["exec:notebook"]
       business: "JupyterPythonLoop"
-      options:
-        jupyter_options_form:
-          image: "registry.hub.docker.com/lsstsqre/sciplat-lab:recommended"
-          image_list: "registry.hub.docker.com/lsstsqre/sciplat-lab:recommended|Recommended|"
-          image_dropdown: "use_image_from_dropdown"
-          size: "Small"
       restart: True
 
 pull-secret:

--- a/services/mobu/values-idfint.yaml
+++ b/services/mobu/values-idfint.yaml
@@ -9,30 +9,30 @@ mobu:
   vaultSecretsPath: "secret/k8s_operator/data-int.lsst.cloud/mobu"
 
   autostart:
-    - name: "system-test"
-      count: 5
+    - name: "firefighter"
+      count: 1
       users:
         - username: "systemtest01"
           uidnumber: 74768
-        - username: "systemtest02"
-          uidnumber: 74769
-        - username: "systemtest03"
-          uidnumber: 74770
-        - username: "systemtest04"
-          uidnumber: 74771
-        - username: "systemtest05"
-          uidnumber: 74772
       scopes: ["exec:notebook", "exec:portal", "read:tap"]
       business: "NotebookRunner"
       options:
-        jupyter_options_form:
-          image: "registry.hub.docker.com/lsstsqre/sciplat-lab:recommended"
-          image_list: "registry.hub.docker.com/lsstsqre/sciplat-lab:recommended|Recommended|"
-          image_dropdown: "use_image_from_dropdown"
-          size: "Small"
         repo_url: "https://github.com/SimonKrughoff/system-test.git"
         repo_branch: "prod"
-        execution_idle_time: 10
+        max_executions: 1
+      restart: True
+    - name: "weekly"
+      count: 1
+      users:
+        - username: "systemtest02"
+          uidnumber: 74769
+      scopes: ["exec:notebook", "exec:portal", "read:tap"]
+      business: "NotebookRunner"
+      options:
+        jupyter:
+          image_class: "latest-weekly"
+        repo_url: "https://github.com/SimonKrughoff/system-test.git"
+        repo_branch: "prod"
       restart: True
 
 pull-secret:

--- a/services/mobu/values-idfprod.yaml
+++ b/services/mobu/values-idfprod.yaml
@@ -25,11 +25,6 @@ mobu:
       scopes: ["exec:notebook", "exec:portal", "read:tap"]
       business: "NotebookRunner"
       options:
-        jupyter_options_form:
-          image: "registry.hub.docker.com/lsstsqre/sciplat-lab:recommended"
-          image_list: "registry.hub.docker.com/lsstsqre/sciplat-lab:recommended|Recommended|"
-          image_dropdown: "use_image_from_dropdown"
-          size: "Large"
         repo_url: "https://github.com/SimonKrughoff/system-test.git"
         repo_branch: "prod"
         max_executions: 1

--- a/services/mobu/values-int.yaml
+++ b/services/mobu/values-int.yaml
@@ -19,11 +19,6 @@ mobu:
       scopes: ["exec:notebook", "exec:portal", "read:tap"]
       business: "NotebookRunner"
       options:
-        jupyter_options_form:
-          image: "registry.hub.docker.com/lsstsqre/sciplat-lab:recommended"
-          image_list: "registry.hub.docker.com/lsstsqre/sciplat-lab:recommended|Recommended|"
-          image_dropdown: "use_image_from_dropdown"
-          size: "Large"
         repo_url: "https://github.com/lsst-sqre/notebook-demo.git"
         repo_branch: "robo-simon"
         max_executions: 1

--- a/services/mobu/values-stable.yaml
+++ b/services/mobu/values-stable.yaml
@@ -27,11 +27,6 @@ mobu:
       scopes: ["exec:notebook", "exec:portal", "read:tap"]
       business: "NotebookRunner"
       options:
-        jupyter_options_form:
-          image: "registry.hub.docker.com/lsstsqre/sciplat-lab:recommended"
-          image_list: "registry.hub.docker.com/lsstsqre/sciplat-lab:recommended|Recommended|"
-          image_dropdown: "use_image_from_dropdown"
-          size: "Large"
         repo_url: "https://github.com/lsst-sqre/notebook-demo.git"
         repo_branch: "robo-simon"
         max_executions: 1


### PR DESCRIPTION
The next release of mobu will not require specifying all the values
to submit to the options form and will default to a Large image.
It also supports testing the latest weekly instead of the recommended
image, so use that on IDF int to test the latest weekly image before
we promote it.