### PR TITLE
[DM-31529] Bump version of cachemachine

### DIFF
--- a/services/cachemachine/Chart.yaml
+++ b/services/cachemachine/Chart.yaml
@@ -3,5 +3,5 @@ name: cachemachine
 version: 1.0.0
 dependencies:
   - name: cachemachine
-    version: 1.0.1
+    version: 1.1.0
     repository: https://lsst-sqre.github.io/charts/


### PR DESCRIPTION
Pick up a fix to automatically exclude cordoned nodes.