### PR TITLE
[DM-31490] Use small images for mobu on IDF dev

### DIFF
--- a/services/mobu/values-idfdev.yaml
+++ b/services/mobu/values-idfdev.yaml
@@ -16,6 +16,9 @@ mobu:
           uidnumber: 74768
       scopes: ["exec:notebook"]
       business: "JupyterPythonLoop"
+      options:
+        jupyter:
+          image_size: "Small"
       restart: True
 
 pull-secret:


### PR DESCRIPTION
This cluster doesn't have the resources to run large images.