### PR TITLE
Remove TAP monkey for NCSA stable for now

### DIFF
--- a/services/mobu/values-stable.yaml
+++ b/services/mobu/values-stable.yaml
@@ -31,14 +31,6 @@ mobu:
         repo_branch: "NCSA-prod"
         max_executions: 1
       restart: true
-    - name: "tap"
-      count: 1
-      users:
-        - username: "lsptestuser06"
-          uidnumber: 60186
-      scopes: ["read:tap"]
-      business: "TAPQueryRunner"
-      restart: True
 
 pull-secret:
   enabled: true


### PR DESCRIPTION
This is causing serious problems with qserv because it can't
handle one of the queries well.  Ensure it doesn't restart if
mobu is restarted.