### PR TITLE
[DM-31876] Fix auth-uri setting for portal

### DIFF
--- a/services/portal/values-base.yaml
+++ b/services/portal/values-base.yaml
@@ -7,7 +7,7 @@ firefly:
       nginx.ingress.kubernetes.io/auth-method: GET
       nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-Uid, X-Auth-Request-Token
       nginx.ingress.kubernetes.io/auth-signin: "https://base-lsp.lsst.codes/login"
-      nginx.ingress.kubernetes.io/auth-url: "https://base-lsp.lsst.codes/auth?scope=exec:portal"
+      nginx.ingress.kubernetes.io/auth-url: "https://base-lsp.lsst.codes/auth?scope=exec:portal&delegate_to=portal&delegate_scope=read:tap"
       nginx.ingress.kubernetes.io/configuration-snippet: |
         proxy_set_header X-Original-URI $request_uri;
         proxy_set_header X-Forwarded-Proto https;

--- a/services/portal/values-minikube.yaml
+++ b/services/portal/values-minikube.yaml
@@ -7,7 +7,7 @@ firefly:
       nginx.ingress.kubernetes.io/auth-method: GET
       nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-Uid, X-Auth-Request-Token
       nginx.ingress.kubernetes.io/auth-signin: "https://minikube.lsst.codes/login"
-      nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr-service.gafaelfawr.svc.cluster.local:8080/auth?scope=exec:portal"
+      nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr-service.gafaelfawr.svc.cluster.local:8080/auth?scope=exec:portal&delegate_to=portal&delegate_scope=read:tap"
       nginx.ingress.kubernetes.io/configuration-snippet: |
         proxy_set_header X-Original-URI $request_uri;
         proxy_set_header X-Forwarded-Proto https;

--- a/services/portal/values-nts.yaml
+++ b/services/portal/values-nts.yaml
@@ -7,7 +7,7 @@ firefly:
       nginx.ingress.kubernetes.io/auth-method: GET
       nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-Uid, X-Auth-Request-Token
       nginx.ingress.kubernetes.io/auth-signin: "https://lsst-nts-k8s.ncsa.illinois.edu/login"
-      nginx.ingress.kubernetes.io/auth-url: "https://lsst-nts-k8s.ncsa.illinois.edu/auth?scope=exec:portal"
+      nginx.ingress.kubernetes.io/auth-url: "https://lsst-nts-k8s.ncsa.illinois.edu/auth?scope=exec:portal&delegate_to=portal&delegate_scope=read:tap"
       nginx.ingress.kubernetes.io/configuration-snippet: |
         proxy_set_header X-Original-URI $request_uri;
         proxy_set_header X-Forwarded-Proto https;

--- a/services/portal/values-red-five.yaml
+++ b/services/portal/values-red-five.yaml
@@ -7,7 +7,7 @@ firefly:
       nginx.ingress.kubernetes.io/auth-method: GET
       nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-Uid, X-Auth-Request-Token
       nginx.ingress.kubernetes.io/auth-signin: "https://red-five.lsst.codes/login"
-      nginx.ingress.kubernetes.io/auth-url: "https://red-five.lsst.codes/auth?scope=exec:portal"
+      nginx.ingress.kubernetes.io/auth-url: "https://red-five.lsst.codes/auth?scope=exec:portal&delegate_to=portal&delegate_scope=read:tap"
       nginx.ingress.kubernetes.io/configuration-snippet: |
         proxy_set_header X-Original-URI $request_uri;
         proxy_set_header X-Forwarded-Proto https;

--- a/services/portal/values-summit.yaml
+++ b/services/portal/values-summit.yaml
@@ -7,7 +7,7 @@ firefly:
       nginx.ingress.kubernetes.io/auth-method: GET
       nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-Uid, X-Auth-Request-Token
       nginx.ingress.kubernetes.io/auth-signin: "https://summit-lsp.lsst.codes/login"
-      nginx.ingress.kubernetes.io/auth-url: "https://summit-lsp.lsst.codes/auth?scope=exec:portal"
+      nginx.ingress.kubernetes.io/auth-url: "https://summit-lsp.lsst.codes/auth?scope=exec:portal&delegate_to=portal&delegate_scope=read:tap"
       nginx.ingress.kubernetes.io/configuration-snippet: |
         proxy_set_header X-Original-URI $request_uri;
         proxy_set_header X-Forwarded-Proto https;

--- a/services/portal/values-tucson-teststand.yaml
+++ b/services/portal/values-tucson-teststand.yaml
@@ -7,7 +7,7 @@ firefly:
       nginx.ingress.kubernetes.io/auth-method: GET
       nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-Uid, X-Auth-Request-Token
       nginx.ingress.kubernetes.io/auth-signin: "https://tucson-teststand.lsst.codes/login"
-      nginx.ingress.kubernetes.io/auth-url: "https://tucson-teststand.lsst.codes/auth?scope=exec:portal"
+      nginx.ingress.kubernetes.io/auth-url: "https://tucson-teststand.lsst.codes/auth?scope=exec:portal&delegate_to=portal&delegate_scope=read:tap"
       nginx.ingress.kubernetes.io/configuration-snippet: |
         proxy_set_header X-Original-URI $request_uri;
         proxy_set_header X-Forwarded-Proto https;


### PR DESCRIPTION
Add the delegate_to and delegate_scope params to the auth uri,
which were missing and causing trouble.