### PR TITLE
[DM-31965] Stop using parser improvements image

### DIFF
--- a/services/tap/values-idfint.yaml
+++ b/services/tap/values-idfint.yaml
@@ -1,5 +1,4 @@
 cadc-tap:
-  tag: "parser-improvements"
   pull_secret: 'pull-secret'
   use_mock_qserv: false
   qserv_host: "10.136.1.211:4040"

--- a/services/tap/values-idfprod.yaml
+++ b/services/tap/values-idfprod.yaml
@@ -1,5 +1,4 @@
 cadc-tap:
-  tag: "parser-improvements"
   pull_secret: 'pull-secret'
   use_mock_qserv: false
   qserv_host: "10.140.1.211:4040"


### PR DESCRIPTION
Now that is just built into the normal image through putting in a
patched jar file from the tap service.