### PR TITLE
DM-32548: strimzi-registry-operator: Update to v1.1.0 of chart

### DIFF
--- a/services/strimzi-registry-operator/Chart.yaml
+++ b/services/strimzi-registry-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: strimzi-registry-operator
-version: 1.0.0
+version: 1.1.0
 dependencies:
   - name: strimzi-registry-operator
-    version: 1.0.0
+    version: 1.1.0
     repository: https://lsst-sqre.github.io/charts/


### PR DESCRIPTION
This update runs v0.3.0 of the underlying application.