### PR TITLE
Automatically reconcile VaultSecrets with Vault's state

### DIFF
--- a/docs/arch/secrets.rst
+++ b/docs/arch/secrets.rst
@@ -49,4 +49,5 @@ These 1Password objects are used by the `generate_secrets.py script <https://git
 Ephemeral secrets that can be reset when the environment is reinstalled are generated during the installation process.
 `update_secrets.sh <https://github.com/lsst-sqre/phalanx/blob/master/installer/update_secrets.sh>`__ uses the ``onepassword_uuid`` setting in `/science-platform/values.yaml <https://github.com/lsst-sqre/phalanx/blob/master/science-platform/values.yaml>`__ to locate the appropriate 1Password vault.
 
-For a step-by-step guide, see :doc:`/service-guide/add-a-onepassword-secret`.
+For a step-by-step guide on adding a 1Password-based secret, see :doc:`/service-guide/add-a-onepassword-secret`.
+For updating an existing 1Password-based secret, see :doc:`/service-guide/update-a-onepassword-secret`.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,6 +34,7 @@ General development and operations
 
    service-guide/create-service
    service-guide/add-a-onepassword-secret
+   service-guide/update-a-onepassword-secret
    service-guide/add-service
    service-guide/add-external-chart
    service-guide/sync-argo-cd

--- a/docs/service-guide/add-a-onepassword-secret.rst
+++ b/docs/service-guide/add-a-onepassword-secret.rst
@@ -12,6 +12,11 @@ This page provides steps for adding a service secret through 1Password.
    Dynamic secrets that don't have to be coordinated with external resources and only have to be consistent for a given installation of the Science Platform should be generated automatically via the ``SecretGenerator`` class in the `installer/generate_secrets.py <https://github.com/lsst-sqre/phalanx/blob/master/installer/generate_secrets.py>`__ script.
    Those secrets are not stored in 1Password since it's fine for them to change on each installation of the Science Platform.
 
+.. note::
+
+   This document only covers creating a 1Password-backed Secret for the first time for a service.
+   If you want to update a Secret, either by adding new 1Password secrets or by changing their secret values, you should follow the instructions in :doc:`/service-guide/update-a-onepassword-secret`.
+
 Part 1. Open the 1Password vault
 ================================
 
@@ -34,7 +39,7 @@ Each item in a Kubernetes ``Secret`` corresponds to either the contents of a sec
   The ``env`` can be omitted if the secret applies to all environments.
 
 - Add the secret:
-  
+
   - For a secure note, set the note's **contents** to the secret value.
   - For a login item, set the **password field** to the secret value.
 

--- a/docs/service-guide/update-a-onepassword-secret.rst
+++ b/docs/service-guide/update-a-onepassword-secret.rst
@@ -1,0 +1,30 @@
+#####################################################
+Updating a secret stored in 1Password and VaultSecret
+#####################################################
+
+Secrets that are stored in 1Password are synchronized into Vault using the `installer/generate_secrets.py <https://github.com/lsst-sqre/phalanx/blob/master/installer/generate_secrets.py>`__ script.
+Once they are in Vault, they are accessible to the Vault Secrets Operator, which responds to creation of any ``VaultSecret`` resources in Kubernetes by grabbing the current value of the secret data in Vault.
+
+The Vault Secrets Operator doesn't independently detect if there are changes to data in Vault, though.
+It only provides a snapshot of the data in Vault at the time the ``VaultSecret`` was created.
+
+So, if you want to make any changes to a ``VaultSecret``'s data, you'll need to:
+
+1. Make the changes in 1Password
+2. Run the `installer/update_secrets.sh <https://github.com/lsst-sqre/phalanx/blob/master/installer/update_secrets.sh>`__ script, as described in :doc:`/service-guide/add-a-onepassword-secret`.
+3. Delete the ``VaultSecret`` in the ArgoCD UI.
+4. Sync your application in ArgoCD, recreating the ``VaultSecret``, and triggering the Vault Secrets Operator to incorporate your changes.
+
+
+Deleting the ``VaultSecret``
+========================
+
+You can delete the ``VaultSecret`` by first navigating to your Application in ArgoCD.
+
+Find the ``VaultSecret`` resource in your application, and click on it.
+You should see a "delete" button in the top right of the dialog that pops up.
+
+Click "delete", and go through with it; a "foreground delete" is sufficient.
+Be sure not to navigate away from this page until you see the resource get deleted in the UI, since ArgoCD will delete it and the underlying Secret with background calls.
+
+Once done, you can Sync your application in order to recreate the VaultSecret.

--- a/docs/service-guide/update-a-onepassword-secret.rst
+++ b/docs/service-guide/update-a-onepassword-secret.rst
@@ -5,26 +5,24 @@ Updating a secret stored in 1Password and VaultSecret
 Secrets that are stored in 1Password are synchronized into Vault using the `installer/generate_secrets.py <https://github.com/lsst-sqre/phalanx/blob/master/installer/generate_secrets.py>`__ script.
 Once they are in Vault, they are accessible to the Vault Secrets Operator, which responds to creation of any ``VaultSecret`` resources in Kubernetes by grabbing the current value of the secret data in Vault.
 
-The Vault Secrets Operator doesn't independently detect if there are changes to data in Vault, though.
-It only provides a snapshot of the data in Vault at the time the ``VaultSecret`` was created.
+The Vault Secrets Operator reconciles any changes as well by comparing Vault's state with that of any ``VaultSecret``s every 60 seconds.
+This reconciliation process can also take a bit of time; the net result is that you can expect changes to be reflected after a few minutes.
+
+.. note::
+
+   Note for operators: This automatic reconciliation is not enabled by default.
+   It is explicitly turned on by setting the ``vault.reconciliationTime`` key in the Helm chart, which needs to be done in every deployed environment of the Vault Secrets Operator.
 
 So, if you want to make any changes to a ``VaultSecret``'s data, you'll need to:
 
 1. Make the changes in 1Password
 2. Run the `installer/update_secrets.sh <https://github.com/lsst-sqre/phalanx/blob/master/installer/update_secrets.sh>`__ script, as described in :doc:`/service-guide/add-a-onepassword-secret`.
-3. Delete the ``VaultSecret`` in the ArgoCD UI.
-4. Sync your application in ArgoCD, recreating the ``VaultSecret``, and triggering the Vault Secrets Operator to incorporate your changes.
+3. Wait a few minutes for automatic reconciliation
 
 
-Deleting the ``VaultSecret``
-========================
+Forcing reconciliation
+======================
 
-You can delete the ``VaultSecret`` by first navigating to your Application in ArgoCD.
-
-Find the ``VaultSecret`` resource in your application, and click on it.
-You should see a "delete" button in the top right of the dialog that pops up.
-
-Click "delete", and go through with it; a "foreground delete" is sufficient.
-Be sure not to navigate away from this page until you see the resource get deleted in the UI, since ArgoCD will delete it and the underlying Secret with background calls.
-
-Once done, you can Sync your application in order to recreate the VaultSecret.
+If automatic reconciliation doesn't seem to be working, you can force it to take place by deleting the ``Secret`` that is associated with the ``VaultSecret``.
+The ``Secret`` will have the same name as its parent ``VaultSecret``.
+Once you delete the ``Secret``, the Vault Secrets Operator should detect the deletion and recreate it quickly.

--- a/services/vault-secrets-operator/values-base.yaml
+++ b/services/vault-secrets-operator/values-base.yaml
@@ -12,3 +12,4 @@ vault-secrets-operator:
           key: VAULT_TOKEN_LEASE_DURATION
   vault:
     address: "https://vault.lsst.codes"
+    reconciliationTime: 60

--- a/services/vault-secrets-operator/values-idfdev.yaml
+++ b/services/vault-secrets-operator/values-idfdev.yaml
@@ -12,3 +12,4 @@ vault-secrets-operator:
           key: VAULT_TOKEN_LEASE_DURATION
   vault:
     address: "https://vault.lsst.codes"
+    reconciliationTime: 60

--- a/services/vault-secrets-operator/values-idfint.yaml
+++ b/services/vault-secrets-operator/values-idfint.yaml
@@ -12,3 +12,4 @@ vault-secrets-operator:
           key: VAULT_TOKEN_LEASE_DURATION
   vault:
     address: "https://vault.lsst.codes"
+    reconciliationTime: 60

--- a/services/vault-secrets-operator/values-idfprod.yaml
+++ b/services/vault-secrets-operator/values-idfprod.yaml
@@ -12,3 +12,4 @@ vault-secrets-operator:
           key: VAULT_TOKEN_LEASE_DURATION
   vault:
     address: "https://vault.lsst.codes"
+    reconciliationTime: 60

--- a/services/vault-secrets-operator/values-int.yaml
+++ b/services/vault-secrets-operator/values-int.yaml
@@ -12,3 +12,4 @@ vault-secrets-operator:
           key: VAULT_TOKEN_LEASE_DURATION
   vault:
     address: "https://vault.lsst.codes"
+    reconciliationTime: 60

--- a/services/vault-secrets-operator/values-minikube.yaml
+++ b/services/vault-secrets-operator/values-minikube.yaml
@@ -12,3 +12,4 @@ vault-secrets-operator:
           key: VAULT_TOKEN_LEASE_DURATION
   vault:
     address: "https://vault.lsst.codes"
+    reconciliationTime: 60

--- a/services/vault-secrets-operator/values-nts.yaml
+++ b/services/vault-secrets-operator/values-nts.yaml
@@ -12,3 +12,4 @@ vault-secrets-operator:
           key: VAULT_TOKEN_LEASE_DURATION
   vault:
     address: "https://vault.lsst.codes"
+    reconciliationTime: 60

--- a/services/vault-secrets-operator/values-red-five.yaml
+++ b/services/vault-secrets-operator/values-red-five.yaml
@@ -12,3 +12,4 @@ vault-secrets-operator:
           key: VAULT_TOKEN_LEASE_DURATION
   vault:
     address: "https://vault.lsst.codes"
+    reconciliationTime: 60

--- a/services/vault-secrets-operator/values-roe.yaml
+++ b/services/vault-secrets-operator/values-roe.yaml
@@ -12,3 +12,4 @@ vault-secrets-operator:
           key: VAULT_TOKEN_LEASE_DURATION
   vault:
     address: "https://vault.lsst.codes"
+    reconciliationTime: 60

--- a/services/vault-secrets-operator/values-squash-sandbox.yaml
+++ b/services/vault-secrets-operator/values-squash-sandbox.yaml
@@ -12,3 +12,4 @@ vault-secrets-operator:
           key: VAULT_TOKEN_LEASE_DURATION
   vault:
     address: "https://vault.lsst.codes"
+    reconciliationTime: 60

--- a/services/vault-secrets-operator/values-stable.yaml
+++ b/services/vault-secrets-operator/values-stable.yaml
@@ -12,3 +12,4 @@ vault-secrets-operator:
           key: VAULT_TOKEN_LEASE_DURATION
   vault:
     address: "https://vault.lsst.codes"
+    reconciliationTime: 60

--- a/services/vault-secrets-operator/values-summit.yaml
+++ b/services/vault-secrets-operator/values-summit.yaml
@@ -12,3 +12,4 @@ vault-secrets-operator:
           key: VAULT_TOKEN_LEASE_DURATION
   vault:
     address: "https://vault.lsst.codes"
+    reconciliationTime: 60

--- a/services/vault-secrets-operator/values-tucson-teststand.yaml
+++ b/services/vault-secrets-operator/values-tucson-teststand.yaml
@@ -12,3 +12,4 @@ vault-secrets-operator:
           key: VAULT_TOKEN_LEASE_DURATION
   vault:
     address: "https://vault.lsst.codes"
+    reconciliationTime: 60


### PR DESCRIPTION
This describes what I had to do to update the alert-stream-broker's VaultSecret's child Secret.

---

Update:

After discussion, this now goes beyond just documentation. It also changes the configuration of Vault Secrets Operator in each environment, enabling automatic reconciliation.