### PR TITLE
DM-32958: alert-stream-broker: grow disks to 1.5TB

### DIFF
--- a/services/alert-stream-broker/values-idfint.yaml
+++ b/services/alert-stream-broker/values-idfint.yaml
@@ -13,6 +13,11 @@ alert-stream-broker:
           host: alert-stream-int-broker-1.lsst.cloud
         - ip: 35.238.120.127
           host: alert-stream-int-broker-2.lsst.cloud
+    storage:
+      # "Temporarily" increased on 2021-12-13 because disks are full. Need to
+      # raise the limit to get Kafka to be able to start so we can debug
+      # further.
+      size: 1500Gi
   vaultSecretsPath: "secret/k8s_operator/data-int.lsst.cloud/alert-stream-broker"
 
   users:


### PR DESCRIPTION
This is a first step to deal with full disks - enlarge them so Kafka can start so we can see what's actually going on.