### PR TITLE
DM-32958: alert-stream-broker: update to alert-stream-simulator 1.6.0

### DIFF
--- a/services/alert-stream-broker/Chart.yaml
+++ b/services/alert-stream-broker/Chart.yaml
@@ -20,5 +20,5 @@ dependencies:
   # namespace - and the alert-stream-simulator needs those credentials to
   # connect.
   - name: alert-stream-simulator
-    version: 1.5.0
+    version: 1.6.0
     repository: https://lsst-sqre.github.io/charts/

--- a/services/alert-stream-broker/values-idfint.yaml
+++ b/services/alert-stream-broker/values-idfint.yaml
@@ -14,9 +14,6 @@ alert-stream-broker:
         - ip: 35.238.120.127
           host: alert-stream-int-broker-2.lsst.cloud
     storage:
-      # "Temporarily" increased on 2021-12-13 because disks are full. Need to
-      # raise the limit to get Kafka to be able to start so we can debug
-      # further.
       size: 1500Gi
   vaultSecretsPath: "secret/k8s_operator/data-int.lsst.cloud/alert-stream-broker"
 


### PR DESCRIPTION
This version sets a max bytes retention policy on the alerts-simulated topic.