### PR TITLE
DM-32568: alert-stream-broker: run on kafka node pool

### DIFF
--- a/services/alert-stream-broker/Chart.yaml
+++ b/services/alert-stream-broker/Chart.yaml
@@ -3,7 +3,7 @@ name: alert-stream-broker
 version: "2"
 dependencies:
   - name: alert-stream-broker
-    version: 2.4.0
+    version: 2.5.0
     repository: https://lsst-sqre.github.io/charts/
 
   # The schema registry is bundled together in the same application as the

--- a/services/alert-stream-broker/values-idfint.yaml
+++ b/services/alert-stream-broker/values-idfint.yaml
@@ -15,6 +15,16 @@ alert-stream-broker:
           host: alert-stream-int-broker-2.lsst.cloud
     storage:
       size: 1500Gi
+
+    nodePool:
+      affinities:
+        - key: kafka
+          value: ok
+
+      tolerations:
+        - key: kafka
+          value: ok
+          effect: NoSchedule
   vaultSecretsPath: "secret/k8s_operator/data-int.lsst.cloud/alert-stream-broker"
 
   users:


### PR DESCRIPTION
This merely requests `kafka` nodes (and tolerates their taints), it doesn't hard-require them, so it's safe to deploy even before taints are established.