### PR TITLE
[DM-32811] Update moneypenny configuration

### DIFF
--- a/services/moneypenny/Chart.yaml
+++ b/services/moneypenny/Chart.yaml
@@ -3,7 +3,7 @@ name: moneypenny
 version: 1.0.0
 dependencies:
   - name: moneypenny
-    version: 0.2.0
+    version: 0.2.1
     repository: https://lsst-sqre.github.io/charts/
   - name: pull-secret
     version: 0.1.2

--- a/services/moneypenny/Chart.yaml
+++ b/services/moneypenny/Chart.yaml
@@ -1,7 +1,10 @@
 apiVersion: v2
 name: moneypenny
-version: 0.1.1
+version: 1.0.0
 dependencies:
-- name: moneypenny
-  version: 0.1.2
-  repository: https://lsst-sqre.github.io/charts/
+  - name: moneypenny
+    version: 0.2.0
+    repository: https://lsst-sqre.github.io/charts/
+  - name: pull-secret
+    version: 0.1.2
+    repository: https://lsst-sqre.github.io/charts/

--- a/services/moneypenny/values-base.yaml
+++ b/services/moneypenny/values-base.yaml
@@ -1,19 +1,10 @@
 moneypenny:
-  host: "base-lsp.lsst.codes"
-
+  imagePullSecrets:
+    - name: "pull-secret"
   ingress:
-    enabled: true
-    hosts:
-      - host: base-lsp.lsst.codes
-        paths: ["/moneypenny"]
-    annotations:
-      nginx.ingress.kubernetes.io/auth-url: "https://base-lsp.lsst.codes/auth?scope=admin:provision"
+    host: "base-lsp.lsst.codes"
 
-  vault_secrets:
-    enabled: true
-    path: "secret/k8s_operator/base-lsp.lsst.codes/pull-secret"
-
-  orders: |
+  orders:
     commission:
       - name: initcommission
         image: lsstsqre/inituserhome
@@ -21,17 +12,14 @@ moneypenny:
           runAsUser: 0
           runAsNonRootUser: false
         volumeMounts:
-        - mountPath: /homedirs
-          name: homedirs
-    retire:
-      - name: farthing
-        image: lsstsqre/farthing
-        securityContext:
-          runAsUser: 1000
-          runAsNonRootUser: true
-          allowPrivilegeEscalation: false
+          - mountPath: /homedirs
+            name: homedirs
     volumes:
       - name: homedirs
         nfs:
           server: ddn-nfs.ls.lsst.org
           path: /lsstdata/user/staff/jhome
+
+pull-secret:
+  enabled: true
+  path: "secret/k8s_operator/base-lsp.lsst.codes/pull-secret"

--- a/services/moneypenny/values-idfdev.yaml
+++ b/services/moneypenny/values-idfdev.yaml
@@ -1,19 +1,12 @@
 moneypenny:
-  host: "data-dev.lsst.cloud"
-
+  imagePullSecrets:
+    - name: "pull-secret"
   ingress:
+    host: "data-dev.lsst.cloud"
+  networkPolicy:
     enabled: true
-    hosts:
-      - host: data-dev.lsst.cloud
-        paths: ["/moneypenny"]
-    annotations:
-      nginx.ingress.kubernetes.io/auth-url: "https://data-dev.lsst.cloud/auth?scope=admin:provision"
 
-  vault_secrets:
-    enabled: true
-    path: "secret/k8s_operator/data-dev.lsst.cloud/pull-secret"
-
-  orders: |
+  orders:
     commission:
       - name: initcommission
         image: lsstsqre/inituserhome
@@ -21,17 +14,14 @@ moneypenny:
           runAsUser: 0
           runAsNonRootUser: false
         volumeMounts:
-        - mountPath: /homedirs
-          name: homedirs
-    retire:
-      - name: farthing
-        image: lsstsqre/farthing
-        securityContext:
-          runAsUser: 1000
-          runAsNonRootUser: true
-          allowPrivilegeEscalation: false
+          - mountPath: /homedirs
+            name: homedirs
     volumes:
       - name: homedirs
         nfs:
           server: 10.87.86.26
           path: /share1/home
+
+pull-secret:
+  enabled: true
+  path: "secret/k8s_operator/data-dev.lsst.cloud/pull-secret"

--- a/services/moneypenny/values-idfint.yaml
+++ b/services/moneypenny/values-idfint.yaml
@@ -1,19 +1,12 @@
 moneypenny:
-  host: "data-int.lsst.cloud"
-
+  imagePullSecrets:
+    - name: "pull-secret"
   ingress:
+    host: "data-int.lsst.cloud"
+  networkPolicy:
     enabled: true
-    hosts:
-      - host: data-int.lsst.cloud
-        paths: ["/moneypenny"]
-    annotations:
-      nginx.ingress.kubernetes.io/auth-url: "https://data-int.lsst.cloud/auth?scope=admin:provision"
 
-  vault_secrets:
-    enabled: true
-    path: "secret/k8s_operator/data-int.lsst.cloud/pull-secret"
-
-  orders: |
+  orders:
     commission:
       - name: initcommission
         image: lsstsqre/inituserhome
@@ -21,17 +14,14 @@ moneypenny:
           runAsUser: 0
           runAsNonRootUser: false
         volumeMounts:
-        - mountPath: /homedirs
-          name: homedirs
-    retire:
-      - name: farthing
-        image: lsstsqre/farthing
-        securityContext:
-          runAsUser: 1000
-          runAsNonRootUser: true
-          allowPrivilegeEscalation: false
+          - mountPath: /homedirs
+            name: homedirs
     volumes:
       - name: homedirs
         nfs:
           server: 10.22.240.130
           path: /share1/home
+
+pull-secret:
+  enabled: true
+  path: "secret/k8s_operator/data-int.lsst.cloud/pull-secret"

--- a/services/moneypenny/values-idfprod.yaml
+++ b/services/moneypenny/values-idfprod.yaml
@@ -1,19 +1,12 @@
 moneypenny:
-  host: "data.lsst.cloud"
-
+  imagePullSecrets:
+    - name: "pull-secret"
   ingress:
+    host: "data.lsst.cloud"
+  networkPolicy:
     enabled: true
-    hosts:
-      - host: data.lsst.cloud
-        paths: ["/moneypenny"]
-    annotations:
-      nginx.ingress.kubernetes.io/auth-url: "https://data.lsst.cloud/auth?scope=admin:provision"
 
-  vault_secrets:
-    enabled: true
-    path: "secret/k8s_operator/data.lsst.cloud/pull-secret"
-
-  orders: |
+  orders:
     commission:
       - name: initcommission
         image: lsstsqre/inituserhome
@@ -21,17 +14,14 @@ moneypenny:
           runAsUser: 0
           runAsNonRootUser: false
         volumeMounts:
-        - mountPath: /homedirs
-          name: homedirs
-    retire:
-      - name: farthing
-        image: lsstsqre/farthing
-        securityContext:
-          runAsUser: 1000
-          runAsNonRootUser: true
-          allowPrivilegeEscalation: false
+          - mountPath: /homedirs
+            name: homedirs
     volumes:
       - name: homedirs
         nfs:
           server: 10.13.105.122
           path: /share1/home
+
+pull-secret:
+  enabled: true
+  path: "secret/k8s_operator/data.lsst.cloud/pull-secret"

--- a/services/moneypenny/values-int.yaml
+++ b/services/moneypenny/values-int.yaml
@@ -1,30 +1,11 @@
 moneypenny:
-  host: "lsst-lsp-int.ncsa.illinois.edu"
-
+  imagePullSecrets:
+    - name: "pull-secret"
   ingress:
-    enabled: true
-    hosts:
-      - host: lsst-lsp-int.ncsa.illinois.edu
-        paths: ["/moneypenny"]
+    host: "lsst-lsp-int.ncsa.illinois.edu"
     annotations:
       nginx.ingress.kubernetes.io/auth-url: "https://lsst-lsp-int.ncsa.illinois.edu/auth?scope=admin:provision"
 
-  vault_secrets:
-    enabled: true
-    path: "secret/k8s_operator/lsst-lsp-int.ncsa.illinois.edu/pull-secret"
-
-  orders: |
-    commission:
-      - name: farthing
-        image: lsstsqre/farthing
-        securityContext:
-          runAsUser: 1000
-          runAsNonRootUser: true
-          allowPrivilegeEscalation: false
-    retire:
-      - name: farthing
-        image: lsstsqre/farthing
-        securityContext:
-          runAsUser: 1000
-          runAsNonRootUser: true
-          allowPrivilegeEscalation: false
+pull-secret:
+  enabled: true
+  path: "secret/k8s_operator/lsst-lsp-int.ncsa.illinois.edu/pull-secret"

--- a/services/moneypenny/values-minikube.yaml
+++ b/services/moneypenny/values-minikube.yaml
@@ -1,14 +1,9 @@
 moneypenny:
-  host: "minikube.lsst.codes"
-
+  imagePullSecrets:
+    - name: "pull-secret"
   ingress:
-    enabled: true
-    hosts:
-      - host: minikube.lsst.codes
-        paths: ["/moneypenny"]
-    annotations:
-      nginx.ingress.kubernetes.io/auth-url: "https://minikube.lsst.codes/auth?scope=admin:provision"
+    host: "minikube.lsst.codes"
 
-  vault_secrets:
-    enabled: true
-    path: "secret/k8s_operator/minikube.lsst.codes/pull-secret"
+pull-secret:
+  enabled: true
+  path: "secret/k8s_operator/minikube.lsst.codes/pull-secret"

--- a/services/moneypenny/values-nts.yaml
+++ b/services/moneypenny/values-nts.yaml
@@ -1,30 +1,11 @@
 moneypenny:
-  host: "lsst-nts-k8s.ncsa.illinois.edu"
-
+  imagePullSecrets:
+    - name: "pull-secret"
   ingress:
-    enabled: true
-    hosts:
-      - host: lsst-nts-k8s.ncsa.illinois.edu
-        paths: ["/moneypenny"]
+    host: "lsst-nts-k8s.ncsa.illinois.edu"
     annotations:
       nginx.ingress.kubernetes.io/auth-url: "https://lsst-nts-k8s.ncsa.illinois.edu/auth?scope=admin:provision"
 
-  vault_secrets:
-    enabled: true
-    path: "secret/k8s_operator/lsst-nts-k8s.ncsa.illinois.edu/pull-secret"
-
-  orders: |
-    commission:
-      - name: farthing
-        image: lsstsqre/farthing
-        securityContext:
-          runAsUser: 1000
-          runAsNonRootUser: true
-          allowPrivilegeEscalation: false
-    retire:
-      - name: farthing
-        image: lsstsqre/farthing
-        securityContext:
-          runAsUser: 1000
-          runAsNonRootUser: true
-          allowPrivilegeEscalation: false
+pull-secret:
+  enabled: true
+  path: "secret/k8s_operator/lsst-nts-k8s.ncsa.illinois.edu/pull-secret"

--- a/services/moneypenny/values-red-five.yaml
+++ b/services/moneypenny/values-red-five.yaml
@@ -1,14 +1,9 @@
 moneypenny:
-  host: "red-five.lsst.codes"
-
+  imagePullSecrets:
+    - name: "pull-secret"
   ingress:
-    enabled: true
-    hosts:
-      - host: red-five.lsst.codes
-        paths: ["/moneypenny"]
-    annotations:
-      nginx.ingress.kubernetes.io/auth-url: "https://red-five.lsst.codes/auth?scope=admin:provision"
+    host: "red-five.lsst.codes"
 
-  vault_secrets:
-    enabled: true
-    path: "secret/k8s_operator/red-five.lsst.codes/pull-secret"
+pull-secret:
+  enabled: true
+  path: "secret/k8s_operator/red-five.lsst.codes/pull-secret"

--- a/services/moneypenny/values-roe.yaml
+++ b/services/moneypenny/values-roe.yaml
@@ -1,19 +1,10 @@
 moneypenny:
-  host: "rsp.lsst.ac.uk"
-
+  imagePullSecrets:
+    - name: "pull-secret"
   ingress:
-    enabled: true
-    hosts:
-      - host: rsp.lsst.ac.uk
-        paths: ["/moneypenny"]
-    annotations:
-      nginx.ingress.kubernetes.io/auth-url: "https://rsp.lsst.ac.uk/auth?scope=admin:provision"
+    host: "rsp.lsst.ac.uk"
 
-  vault_secrets:
-    enabled: true
-    path: "secret/k8s_operator/roe/pull-secret"
-
-  orders: |
+  orders:
     commission:
       - name: initcommission
         image: lsstsqre/inituserhome
@@ -21,12 +12,9 @@ moneypenny:
           runAsUser: 0
           runAsNonRootUser: false
         volumeMounts:
-        - mountPath: /homedirs
-          name: homedirs
-    retire:
-      - name: farthing
-        image: lsstsqre/farthing
-        securityContext:
-          runAsUser: 1000
-          runAsNonRootUser: true
-          allowPrivilegeEscalation: false
+          - mountPath: /homedirs
+            name: homedirs
+
+pull-secret:
+  enabled: true
+  path: "secret/k8s_operator/roe/pull-secret"

--- a/services/moneypenny/values-stable.yaml
+++ b/services/moneypenny/values-stable.yaml
@@ -1,30 +1,11 @@
 moneypenny:
-  host: "lsst-lsp-stable.ncsa.illinois.edu"
-
+  imagePullSecrets:
+    - name: "pull-secret"
   ingress:
-    enabled: true
-    hosts:
-      - host: lsst-lsp-stable.ncsa.illinois.edu
-        paths: ["/moneypenny"]
+    host: "lsst-lsp-stable.ncsa.illinois.edu"
     annotations:
       nginx.ingress.kubernetes.io/auth-url: "https://lsst-lsp-stable.ncsa.illinois.edu/auth?scope=admin:provision"
 
-  vault_secrets:
-    enabled: true
-    path: "secret/k8s_operator/lsst-lsp-stable.ncsa.illinois.edu/pull-secret"
-
-  orders: |
-    commission:
-      - name: farthing
-        image: lsstsqre/farthing
-        securityContext:
-          runAsUser: 1000
-          runAsNonRootUser: true
-          allowPrivilegeEscalation: false
-    retire:
-      - name: farthing
-        image: lsstsqre/farthing
-        securityContext:
-          runAsUser: 1000
-          runAsNonRootUser: true
-          allowPrivilegeEscalation: false
+pull-secret:
+  enabled: true
+  path: "secret/k8s_operator/lsst-lsp-stable.ncsa.illinois.edu/pull-secret"

--- a/services/moneypenny/values-summit.yaml
+++ b/services/moneypenny/values-summit.yaml
@@ -1,19 +1,10 @@
 moneypenny:
-  host: "summit-lsp.lsst.codes"
-
+  imagePullSecrets:
+    - name: "pull-secret"
   ingress:
-    enabled: true
-    hosts:
-      - host: summit-lsp.lsst.codes
-        paths: ["/moneypenny"]
-    annotations:
-      nginx.ingress.kubernetes.io/auth-url: "https://summit-lsp.lsst.codes/auth?scope=admin:provision"
+    host: "summit-lsp.lsst.codes"
 
-  vault_secrets:
-    enabled: true
-    path: "secret/k8s_operator/summit-lsp.lsst.codes/pull-secret"
-
-  orders: |
+  orders:
     commission:
       - name: initcommission
         image: lsstsqre/inituserhome
@@ -21,17 +12,14 @@ moneypenny:
           runAsUser: 0
           runAsNonRootUser: false
         volumeMounts:
-        - mountPath: /homedirs
-          name: homedirs
-    retire:
-      - name: farthing
-        image: lsstsqre/farthing
-        securityContext:
-          runAsUser: 1000
-          runAsNonRootUser: true
-          allowPrivilegeEscalation: false
+          - mountPath: /homedirs
+            name: homedirs
     volumes:
       - name: homedirs
         nfs:
           server: nfs1.cp.lsst.org
           path: /jhome
+
+pull-secret:
+  enabled: true
+  path: "secret/k8s_operator/summit-lsp.lsst.codes/pull-secret"

--- a/services/moneypenny/values-tucson-teststand.yaml
+++ b/services/moneypenny/values-tucson-teststand.yaml
@@ -1,19 +1,10 @@
 moneypenny:
-  host: "tucson-teststand.lsst.codes"
-
+  imagePullSecrets:
+    - name: "pull-secret"
   ingress:
-    enabled: true
-    hosts:
-      - host: tucson-teststand.lsst.codes
-        paths: ["/moneypenny"]
-    annotations:
-      nginx.ingress.kubernetes.io/auth-url: "https://tucson-teststand.lsst.codes/auth?scope=admin:provision"
+    host: "tucson-teststand.lsst.codes"
 
-  vault_secrets:
-    enabled: true
-    path: "secret/k8s_operator/tucson-teststand.lsst.codes/pull-secret"
-
-  orders: |
+  orders:
     commission:
       - name: initcommission
         image: lsstsqre/inituserhome
@@ -21,17 +12,14 @@ moneypenny:
           runAsUser: 0
           runAsNonRootUser: false
         volumeMounts:
-        - mountPath: /homedirs
-          name: homedirs
-    retire:
-      - name: farthing
-        image: lsstsqre/farthing
-        securityContext:
-          runAsUser: 1000
-          runAsNonRootUser: true
-          allowPrivilegeEscalation: false
+          - mountPath: /homedirs
+            name: homedirs
     volumes:
       - name: homedirs
         nfs:
           server: nfs-jhome.tu.lsst.org
           path: /jhome
+
+pull-secret:
+  enabled: true
+  path: "secret/k8s_operator/tucson-teststand.lsst.codes/pull-secret"


### PR DESCRIPTION
Use the pull-secret chart to install pull-secret instead of a
separate VaultSecret that came with the old moneypenny chart.
Update values-*.yaml for the new configuration options and remove
boilerplate that's now handled by the chart.  Remove the retire
configuration, since we currently don't use it anywhere.

Enable the network policy on the IDF.