### PR TITLE
DM-32646: alert-stream-broker: set service account name for db ingester

### DIFF
--- a/services/alert-stream-broker/values-idfint.yaml
+++ b/services/alert-stream-broker/values-idfint.yaml
@@ -92,6 +92,8 @@ alert-database:
 
     schemaRegistryURL: https://alert-schemas-int.lsst.cloud
 
+    serviceAccountName: alert-database-writer
+
     kafka:
       cluster: alert-broker
       port: 9092


### PR DESCRIPTION
This name needs to be synchronized exactly to a value in GCP, set via terraform.