### PR TITLE
alert-stream-broker: add alert-db server

### DIFF
--- a/services/alert-stream-broker/Chart.yaml
+++ b/services/alert-stream-broker/Chart.yaml
@@ -24,5 +24,5 @@ dependencies:
     repository: https://lsst-sqre.github.io/charts/
 
   - name: alert-database
-    version: 1.1.0
+    version: 2.0.0
     repository: https://lsst-sqre.github.io/charts/

--- a/services/alert-stream-broker/values-idfint.yaml
+++ b/services/alert-stream-broker/values-idfint.yaml
@@ -111,7 +111,7 @@ alert-database:
   ingress:
     enabled: true
     host: "data-int.lsst.cloud"
-    gafaelfawrAuthQuery: "scope=read:alertdb"
+    gafaelfawrAuthQuery: "scope=read:image"
 
   storage:
     gcp:

--- a/services/alert-stream-broker/values-idfint.yaml
+++ b/services/alert-stream-broker/values-idfint.yaml
@@ -103,6 +103,16 @@ alert-database:
       serviceAccountName: alertdb-writer
       projectID: science-platform-int-dc5d
 
+  server:
+    gcp:
+      serviceAccountName: alertdb-reader
+      projectID: science-platform-int-dc5d
+
+  ingress:
+    enabled: true
+    host: "data-int.lsst.cloud"
+    gafaelfawrAuthQuery: "scope=read:alertdb"
+
   storage:
     gcp:
       project: science-platform-int-dc5d

--- a/services/gafaelfawr/values-idfint.yaml
+++ b/services/gafaelfawr/values-idfint.yaml
@@ -44,9 +44,6 @@ gafaelfawr:
         - "lsst-ops-panda"
         - "lsst-sqre-square"
         - "lsst-sqre-friends"
-      "read:alertdb":
-        - "lsst-sqre-square"
-        - "lsst-sqre-friends"
 
     initialAdmins:
       - "afausti"

--- a/services/gafaelfawr/values-idfint.yaml
+++ b/services/gafaelfawr/values-idfint.yaml
@@ -44,6 +44,9 @@ gafaelfawr:
         - "lsst-ops-panda"
         - "lsst-sqre-square"
         - "lsst-sqre-friends"
+      "read:alertdb":
+        - "lsst-sqre-square"
+        - "lsst-sqre-friends"
 
     initialAdmins:
       - "afausti"


### PR DESCRIPTION
The server is the entrypoint allowing HTTP-based access to archival alert packet and schema data.