### PR TITLE
[DM-32991] Bump chart versions to pick up Kubernetes 1.22 support

### DIFF
--- a/services/cachemachine/Chart.yaml
+++ b/services/cachemachine/Chart.yaml
@@ -3,5 +3,5 @@ name: cachemachine
 version: 1.0.0
 dependencies:
   - name: cachemachine
-    version: 1.1.0
+    version: 1.1.1
     repository: https://lsst-sqre.github.io/charts/

--- a/services/datalinker/Chart.yaml
+++ b/services/datalinker/Chart.yaml
@@ -3,7 +3,7 @@ name: datalinker
 version: 1.0.0
 dependencies:
   - name: datalinker
-    version: 0.1.2
+    version: 0.1.3
     repository: https://lsst-sqre.github.io/charts/
   - name: pull-secret
     version: 0.1.2

--- a/services/gafaelfawr/Chart.yaml
+++ b/services/gafaelfawr/Chart.yaml
@@ -3,7 +3,7 @@ name: gafaelfawr
 version: 1.0.0
 dependencies:
   - name: gafaelfawr
-    version: 4.4.2
+    version: 4.4.3
     repository: https://lsst-sqre.github.io/charts/
   - name: pull-secret
     version: 0.1.2

--- a/services/noteburst/Chart.yaml
+++ b/services/noteburst/Chart.yaml
@@ -3,7 +3,7 @@ name: noteburst
 version: 1.0.0
 dependencies:
   - name: noteburst
-    version: "0.1.2"
+    version: 0.1.3
     repository: https://lsst-sqre.github.io/charts/
   - name: pull-secret
     version: 0.1.2

--- a/services/portal/Chart.yaml
+++ b/services/portal/Chart.yaml
@@ -3,7 +3,7 @@ name: portal
 version: 1.0.0
 dependencies:
   - name: firefly
-    version: 0.3.6
+    version: 0.3.7
     repository: https://lsst-sqre.github.io/charts/
   - name: pull-secret
     version: 0.1.2

--- a/services/semaphore/Chart.yaml
+++ b/services/semaphore/Chart.yaml
@@ -3,7 +3,7 @@ name: semaphore
 version: 1.0.0
 dependencies:
   - name: semaphore
-    version: "0.2.1"
+    version: 0.2.2
     repository: https://lsst-sqre.github.io/charts/
   - name: pull-secret
     version: 0.1.2

--- a/services/sherlock/Chart.yaml
+++ b/services/sherlock/Chart.yaml
@@ -3,5 +3,5 @@ name: sherlock
 version: 1.0.0
 dependencies:
   - name: sherlock
-    version: 0.1.1
+    version: 0.1.2
     repository: https://lsst-sqre.github.io/charts/

--- a/services/squareone/Chart.yaml
+++ b/services/squareone/Chart.yaml
@@ -3,7 +3,7 @@ name: squareone
 version: 1.0.0
 dependencies:
   - name: squareone
-    version: "0.4.0"
+    version: 0.4.1
     repository: https://lsst-sqre.github.io/charts/
   - name: pull-secret
     version: 0.1.2

--- a/services/squash-api/Chart.yaml
+++ b/services/squash-api/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: squash-api
 version: 0.1.0
 dependencies:
-- name: squash-api
-  version: 0.1.5
-  repository: https://lsst-sqre.github.io/charts/
+  - name: squash-api
+    version: 0.1.6
+    repository: https://lsst-sqre.github.io/charts/

--- a/services/vo-cutouts/Chart.yaml
+++ b/services/vo-cutouts/Chart.yaml
@@ -3,7 +3,7 @@ name: vo-cutouts
 version: 1.0.0
 dependencies:
   - name: vo-cutouts
-    version: 0.1.1
+    version: 0.1.4
     repository: https://lsst-sqre.github.io/charts/
   - name: pull-secret
     version: 0.1.2


### PR DESCRIPTION
The latest versions of the charts add support for Kubernetes 1.22,
which deprecates the API we were using for ingress definitions.