### PR TITLE
[DM-32991] Bump version of ingress-nginx

### DIFF
--- a/services/ingress-nginx/Chart.yaml
+++ b/services/ingress-nginx/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: ingress-nginx
 version: 1.0.0
 dependencies:
-- name: ingress-nginx
-  version: 3.40.0
-  repository: https://kubernetes.github.io/ingress-nginx
-- name: pull-secret
-  version: ">=0.1.2"
-  repository: https://lsst-sqre.github.io/charts/
+  - name: ingress-nginx
+    version: 4.0.13
+    repository: https://kubernetes.github.io/ingress-nginx
+  - name: pull-secret
+    version: ">=0.1.2"
+    repository: https://lsst-sqre.github.io/charts/


### PR DESCRIPTION
Now that all of the Ingress resources have been switched to the
new API, we can upgrade to the new version of ingress-nginx that
drops support for the old API version.