### PR TITLE
[DM-33248] Obstap version to 1.1

### DIFF
--- a/services/obstap/values-idfdev.yaml
+++ b/services/obstap/values-idfdev.yaml
@@ -1,6 +1,6 @@
 cadc-tap-postgres:
   pull_secret: 'pull-secret'
-  tag: "1.0"
+  tag: "1.1"
   host: "data-dev.lsst.cloud"
 
   secrets:

--- a/services/obstap/values-idfint.yaml
+++ b/services/obstap/values-idfint.yaml
@@ -1,6 +1,6 @@
 cadc-tap-postgres:
   pull_secret: 'pull-secret'
-  tag: "1.0"
+  tag: "1.1"
   host: "data-int.lsst.cloud"
 
   secrets:

--- a/services/obstap/values-idfprod.yaml
+++ b/services/obstap/values-idfprod.yaml
@@ -1,6 +1,6 @@
 cadc-tap-postgres:
   pull_secret: 'pull-secret'
-  tag: "1.0"
+  tag: "1.1"
   host: "data.lsst.cloud"
 
   secrets:

--- a/services/obstap/values-int.yaml
+++ b/services/obstap/values-int.yaml
@@ -1,6 +1,6 @@
 cadc-tap-postgres:
   pull_secret: 'pull-secret'
-  tag: "1.0"
+  tag: "1.1"
   host: "lsst-lsp-int.ncsa.illinois.edu"
 
   secrets:

--- a/services/obstap/values-minikube.yaml
+++ b/services/obstap/values-minikube.yaml
@@ -1,6 +1,6 @@
 cadc-tap-postgres:
   pull_secret: 'pull-secret'
-  tag: "1.0"
+  tag: "1.1"
   host: "minikube.lsst.codes"
 
   secrets:

--- a/services/obstap/values-red-five.yaml
+++ b/services/obstap/values-red-five.yaml
@@ -1,6 +1,6 @@
 cadc-tap-postgres:
   pull_secret: 'pull-secret'
-  tag: "1.0"
+  tag: "1.1"
   host: "red-five.lsst.codes"
 
   secrets:

--- a/services/obstap/values-roe.yaml
+++ b/services/obstap/values-roe.yaml
@@ -1,6 +1,6 @@
 cadc-tap-postgres:
   pull_secret: 'pull-secret'
-  tag: "1.0"
+  tag: "1.1"
   host: "rsp.lsst.ac.uk"
 
   secrets:

--- a/services/obstap/values-stable.yaml
+++ b/services/obstap/values-stable.yaml
@@ -1,6 +1,6 @@
 cadc-tap-postgres:
   pull_secret: 'pull-secret'
-  tag: "1.0"
+  tag: "1.1"
   host: "lsst-lsp-stable.ncsa.illinois.edu"
 
   secrets:


### PR DESCRIPTION
Push the tag to 1.1, apparently the chart doesn't default to the
app version yet, but I'll do that another time.