### PR TITLE
[DM-33121] Bump version of Gafaelfawr

### DIFF
--- a/services/gafaelfawr/Chart.yaml
+++ b/services/gafaelfawr/Chart.yaml
@@ -3,7 +3,7 @@ name: gafaelfawr
 version: 1.0.0
 dependencies:
   - name: gafaelfawr
-    version: 4.4.3
+    version: 4.5.0
     repository: https://lsst-sqre.github.io/charts/
   - name: pull-secret
     version: 0.1.2


### PR DESCRIPTION
Pick up additional scope, new Google Cloud Proxy version, and new
Gafaelfawr 3.5.0 release with LDAP support and async Kubernetes.