### PR TITLE
[DM-33306] TAP memory to 32 GB

### DIFF
--- a/services/tap/values-idfprod.yaml
+++ b/services/tap/values-idfprod.yaml
@@ -26,9 +26,9 @@ cadc-tap:
       memory: 2G
     limits:
       cpu: 8.0
-      memory: 16G
+      memory: 32G
 
-  jvm_max_heap_size: 15G
+  jvm_max_heap_size: 31G
 
   aux_resources:
     requests:

--- a/services/tap/values-stable.yaml
+++ b/services/tap/values-stable.yaml
@@ -26,9 +26,9 @@ cadc-tap:
       memory: 2G
     limits:
       cpu: 8.0
-      memory: 16G
+      memory: 32G
 
-  jvm_max_heap_size: 15G
+  jvm_max_heap_size: 31G
 
   aux_resources:
     requests:


### PR DESCRIPTION
Up the memory because we were having issues when running too many
big queries and then running out of memory and kubernetes killing
me.