### PR TITLE
Use new read-alertdb scope for alertdb

### DIFF
--- a/services/alert-stream-broker/values-idfint.yaml
+++ b/services/alert-stream-broker/values-idfint.yaml
@@ -113,7 +113,7 @@ alert-database:
   ingress:
     enabled: true
     host: "data-int.lsst.cloud"
-    gafaelfawrAuthQuery: "scope=read:image"
+    gafaelfawrAuthQuery: "scope=read:alertdb"
 
   storage:
     gcp:

--- a/services/gafaelfawr/values-idfint.yaml
+++ b/services/gafaelfawr/values-idfint.yaml
@@ -36,6 +36,9 @@ gafaelfawr:
         - "lsst-ops-panda"
         - "lsst-sqre-square"
         - "lsst-sqre-friends"
+      "read:alertdb":
+        - "lsst-sqre-square"
+        - "lsst-sqre-friends"
       "read:image":
         - "lsst-ops-panda"
         - "lsst-sqre-square"


### PR DESCRIPTION
This will be used by the alert database.

Just using some of the traditional GH teams for groups backing it.