### PR TITLE
[DM-33244] Bump moneypenny, nublado2 version, add pull-secret

### DIFF
--- a/services/moneypenny/Chart.yaml
+++ b/services/moneypenny/Chart.yaml
@@ -3,7 +3,7 @@ name: moneypenny
 version: 1.0.0
 dependencies:
   - name: moneypenny
-    version: 0.3.3
+    version: 1.0.0
     repository: https://lsst-sqre.github.io/charts/
   - name: pull-secret
     version: 0.1.2

--- a/services/nublado2/Chart.yaml
+++ b/services/nublado2/Chart.yaml
@@ -3,5 +3,8 @@ name: nublado2
 version: 1.0.0
 dependencies:
   - name: nublado2
-    version: 0.5.8
+    version: 0.6.0
+    repository: https://lsst-sqre.github.io/charts/
+  - name: pull-secret
+    version: 0.1.2
     repository: https://lsst-sqre.github.io/charts/

--- a/services/nublado2/values-base.yaml
+++ b/services/nublado2/values-base.yaml
@@ -46,3 +46,7 @@ nublado2:
         mountPath: /scratch
 
   vault_secret_path: "secret/k8s_operator/base-lsp.lsst.codes/nublado2"
+
+pull-secret:
+  enabled: true
+  path: "secret/k8s_operator/base-lsp.lsst.codes/pull-secret"

--- a/services/nublado2/values-idfdev.yaml
+++ b/services/nublado2/values-idfdev.yaml
@@ -43,3 +43,7 @@ nublado2:
         mountPath: /scratch
 
   vault_secret_path: "secret/k8s_operator/data-dev.lsst.cloud/nublado2"
+
+pull-secret:
+  enabled: true
+  path: "secret/k8s_operator/data-dev.lsst.cloud/pull-secret"

--- a/services/nublado2/values-idfint.yaml
+++ b/services/nublado2/values-idfint.yaml
@@ -307,3 +307,7 @@ nublado2:
             limits.memory: 27Gi
 
   vault_secret_path: "secret/k8s_operator/data-int.lsst.cloud/nublado2"
+
+pull-secret:
+  enabled: true
+  path: "secret/k8s_operator/data-int.lsst.cloud/pull-secret"

--- a/services/nublado2/values-idfprod.yaml
+++ b/services/nublado2/values-idfprod.yaml
@@ -287,3 +287,7 @@ nublado2:
             limits.memory: 27Gi
 
   vault_secret_path: "secret/k8s_operator/data.lsst.cloud/nublado2"
+
+pull-secret:
+  enabled: true
+  path: "secret/k8s_operator/data.lsst.cloud/pull-secret"

--- a/services/nublado2/values-int.yaml
+++ b/services/nublado2/values-int.yaml
@@ -41,3 +41,7 @@ nublado2:
         mountPath: /scratch
 
   vault_secret_path: "secret/k8s_operator/lsst-lsp-int.ncsa.illinois.edu/nublado2"
+
+pull-secret:
+  enabled: true
+  path: "secret/k8s_operator/lsst-lsp-int.ncsa.illinois.edu/pull-secret"

--- a/services/nublado2/values-minikube.yaml
+++ b/services/nublado2/values-minikube.yaml
@@ -22,3 +22,7 @@ nublado2:
         mountPath: /home
 
   vault_secret_path: "secret/k8s_operator/minikube.lsst.codes/nublado2"
+
+pull-secret:
+  enabled: true
+  path: "secret/k8s_operator/minikube.lsst.codes/pull-secret"

--- a/services/nublado2/values-nts.yaml
+++ b/services/nublado2/values-nts.yaml
@@ -85,3 +85,7 @@ nublado2:
         readOnly: true
 
   vault_secret_path: "secret/k8s_operator/lsst-nts-k8s.ncsa.illinois.edu/nublado2"
+
+pull-secret:
+  enabled: true
+  path: "secret/k8s_operator/lsst-nts-k8s.ncsa.illinois.edu/pull-secret"

--- a/services/nublado2/values-red-five.yaml
+++ b/services/nublado2/values-red-five.yaml
@@ -44,3 +44,7 @@ nublado2:
         mountPath: /scratch
 
   vault_secret_path: "secret/k8s_operator/red-five.lsst.codes/nublado2"
+
+pull-secret:
+  enabled: true
+  path: "secret/k8s_operator/red-five.lsst.codes/pull-secret"

--- a/services/nublado2/values-roe.yaml
+++ b/services/nublado2/values-roe.yaml
@@ -41,3 +41,7 @@ nublado2:
         mountPath: /scratch
 
   vault_secret_path: "secret/k8s_operator/roe/nublado2"
+
+pull-secret:
+  enabled: true
+  path: "secret/k8s_operator/roe/pull-secret"

--- a/services/nublado2/values-stable.yaml
+++ b/services/nublado2/values-stable.yaml
@@ -55,3 +55,7 @@ nublado2:
         mountPath: /repo
 
   vault_secret_path: "secret/k8s_operator/lsst-lsp-stable.ncsa.illinois.edu/nublado2"
+
+pull-secret:
+  enabled: true
+  path: "secret/k8s_operator/lsst-lsp-stable.ncsa.illinois.edu/pull-secret"

--- a/services/nublado2/values-summit.yaml
+++ b/services/nublado2/values-summit.yaml
@@ -98,3 +98,7 @@ nublado2:
         readOnly: true
 
   vault_secret_path: "secret/k8s_operator/summit-lsp.lsst.codes/nublado2"
+
+pull-secret:
+  enabled: true
+  path: "secret/k8s_operator/summit-lsp.lsst.codes/pull-secret"

--- a/services/nublado2/values-tucson-teststand.yaml
+++ b/services/nublado2/values-tucson-teststand.yaml
@@ -80,3 +80,7 @@ nublado2:
         readOnly: true
 
   vault_secret_path: "secret/k8s_operator/tucson-teststand.lsst.codes/nublado2"
+
+pull-secret:
+  enabled: true
+  path: "secret/k8s_operator/tucson-teststand.lsst.codes/pull-secret"


### PR DESCRIPTION
Bump the version of moneypenny and nublado2 to pick up the new
Moneypenny API.  Configure pull-secret for nublado2, since our
chart was referencing it but not installing it so far as I could
see.