### PR TITLE
DM-33025: Deploy noteburst 0.2.0-alpha.3 chart on idf-int

### DIFF
--- a/services/noteburst/Chart.yaml
+++ b/services/noteburst/Chart.yaml
@@ -3,7 +3,7 @@ name: noteburst
 version: 1.0.0
 dependencies:
   - name: noteburst
-    version: 0.1.3
+    version: 0.2.0-alpha.3
     repository: https://lsst-sqre.github.io/charts/
   - name: pull-secret
     version: 0.1.2

--- a/services/noteburst/values-idfdev.yaml
+++ b/services/noteburst/values-idfdev.yaml
@@ -16,6 +16,11 @@ noteburst:
   vaultSecretsPath: "secret/k8s_operator/data-dev.lsst.cloud/noteburst"
   config:
     environment_url: "https://data-dev.lsst.cloud"
+    worker:
+      workerCount: 1
+      identities:
+        - uuid: 90000
+          username: "noteburst90000"
 
 pull-secret:
   enabled: true

--- a/services/noteburst/values-minikube.yaml
+++ b/services/noteburst/values-minikube.yaml
@@ -16,6 +16,11 @@ noteburst:
   vaultSecretsPath: "secret/k8s_operator/minikube.lsst.codes/noteburst"
   config:
     environment_url: "https://minikube.lsst.cloud"
+    worker:
+      workerCount: 1
+      identities:
+        - uuid: 90000
+          username: "noteburst90000"
 
 pull-secret:
   enabled: true


### PR DESCRIPTION
This adds support for noteburst's worker queue.