### PR TITLE
[DM-33241] Override name of TAP objects

### DIFF
--- a/services/tap/values-idfdev.yaml
+++ b/services/tap/values-idfdev.yaml
@@ -1,4 +1,6 @@
 cadc-tap:
+  fullnameOverride: "cadc-tap"
+
   imagePullSecrets:
     - name: "pull-secret"
   ingress:

--- a/services/tap/values-idfint.yaml
+++ b/services/tap/values-idfint.yaml
@@ -1,4 +1,6 @@
 cadc-tap:
+  fullnameOverride: "cadc-tap"
+
   imagePullSecrets:
     - name: "pull-secret"
   ingress:

--- a/services/tap/values-idfprod.yaml
+++ b/services/tap/values-idfprod.yaml
@@ -1,4 +1,6 @@
 cadc-tap:
+  fullnameOverride: "cadc-tap"
+
   imagePullSecrets:
     - name: "pull-secret"
   ingress:

--- a/services/tap/values-int.yaml
+++ b/services/tap/values-int.yaml
@@ -1,4 +1,6 @@
 cadc-tap:
+  fullnameOverride: "cadc-tap"
+
   imagePullSecrets:
     - name: "pull-secret"
   ingress:

--- a/services/tap/values-minikube.yaml
+++ b/services/tap/values-minikube.yaml
@@ -1,4 +1,6 @@
 cadc-tap:
+  fullnameOverride: "cadc-tap"
+
   imagePullSecrets:
     - name: "pull-secret"
   ingress:

--- a/services/tap/values-red-five.yaml
+++ b/services/tap/values-red-five.yaml
@@ -1,4 +1,6 @@
 cadc-tap:
+  fullnameOverride: "cadc-tap"
+
   imagePullSecrets:
     - name: "pull-secret"
   ingress:

--- a/services/tap/values-roe.yaml
+++ b/services/tap/values-roe.yaml
@@ -1,4 +1,6 @@
 cadc-tap:
+  fullnameOverride: "cadc-tap"
+
   imagePullSecrets:
     - name: "pull-secret"
   ingress:

--- a/services/tap/values-stable.yaml
+++ b/services/tap/values-stable.yaml
@@ -1,4 +1,6 @@
 cadc-tap:
+  fullnameOverride: "cadc-tap"
+
   imagePullSecrets:
     - name: "pull-secret"
   ingress:


### PR DESCRIPTION
Avoid the tap-cadc-tap naming pattern by overriding the name so
that everything will use the simpler cadc-tap base name.