### PR TITLE
[DM-33241] Bump version of TAP chart

### DIFF
--- a/services/tap/Chart.yaml
+++ b/services/tap/Chart.yaml
@@ -3,7 +3,7 @@ name: tap
 version: 1.0.0
 dependencies:
   - name: cadc-tap
-    version: 1.0.3
+    version: 1.0.4
     repository: https://lsst-sqre.github.io/charts/
   - name: pull-secret
     version: 0.1.2


### PR DESCRIPTION
Drop more security settings, since the containers currently
don't support them.