### PR TITLE
[DM-33241] Fix gcsBucketUrl to not use https

### DIFF
--- a/services/tap/values-idfdev.yaml
+++ b/services/tap/values-idfdev.yaml
@@ -9,7 +9,7 @@ cadc-tap:
 
   config:
     gcsBucket: "async-results.lsst.codes"
-    gcsBucketUrl: "https://async-results.lsst.codes"
+    gcsBucketUrl: "http://async-results.lsst.codes"
 
 pull-secret:
   enabled: true

--- a/services/tap/values-idfint.yaml
+++ b/services/tap/values-idfint.yaml
@@ -9,7 +9,7 @@ cadc-tap:
 
   config:
     gcsBucket: "async-results.lsst.codes"
-    gcsBucketUrl: "https://async-results.lsst.codes"
+    gcsBucketUrl: "http://async-results.lsst.codes"
 
   qserv:
     host: "10.136.1.211:4040"

--- a/services/tap/values-idfprod.yaml
+++ b/services/tap/values-idfprod.yaml
@@ -17,7 +17,7 @@ cadc-tap:
 
   config:
     gcsBucket: "async-results.lsst.codes"
-    gcsBucketUrl: "https://async-results.lsst.codes"
+    gcsBucketUrl: "http://async-results.lsst.codes"
     jvmMaxHeapSize: "31G"
 
   qserv:

--- a/services/tap/values-int.yaml
+++ b/services/tap/values-int.yaml
@@ -17,7 +17,7 @@ cadc-tap:
 
   config:
     gcsBucket: "async-results.lsst.codes"
-    gcsBucketUrl: "https://async-results.lsst.codes"
+    gcsBucketUrl: "http://async-results.lsst.codes"
     jvmMaxHeapSize: "15G"
 
   qserv:

--- a/services/tap/values-minikube.yaml
+++ b/services/tap/values-minikube.yaml
@@ -9,7 +9,7 @@ cadc-tap:
 
   config:
     gcsBucket: "async-results.lsst.codes"
-    gcsBucketUrl: "https://async-results.lsst.codes"
+    gcsBucketUrl: "http://async-results.lsst.codes"
 
 pull-secret:
   enabled: true

--- a/services/tap/values-red-five.yaml
+++ b/services/tap/values-red-five.yaml
@@ -9,7 +9,7 @@ cadc-tap:
 
   config:
     gcsBucket: "async-results.lsst.codes"
-    gcsBucketUrl: "https://async-results.lsst.codes"
+    gcsBucketUrl: "http://async-results.lsst.codes"
 
 pull-secret:
   enabled: true

--- a/services/tap/values-stable.yaml
+++ b/services/tap/values-stable.yaml
@@ -17,7 +17,7 @@ cadc-tap:
 
   config:
     gcsBucket: "async-results.lsst.codes"
-    gcsBucketUrl: "https://async-results.lsst.codes"
+    gcsBucketUrl: "http://async-results.lsst.codes"
     jvmMaxHeapSize: "31G"
 
   qserv:


### PR DESCRIPTION
async-results.lsst.codes is a CNAME to a GCS bucket, so we cannot
use https for the initial access because the certificate won't
verify.  Use http, which will cause the GCS endpoint to redirect
the user to the https URL with the correct hostname for the
certificate to verify.