### PR TITLE
[DM-33513] Bump version of vo-cutouts

### DIFF
--- a/services/vo-cutouts/Chart.yaml
+++ b/services/vo-cutouts/Chart.yaml
@@ -3,7 +3,7 @@ name: vo-cutouts
 version: 1.0.0
 dependencies:
   - name: vo-cutouts
-    version: 0.2.0
+    version: 0.2.2
     repository: https://lsst-sqre.github.io/charts/
   - name: pull-secret
     version: 0.1.2


### PR DESCRIPTION
Pick up updated GCE Proxy and the change to the ConfigMap to pass
down the name of the service account.