### PR TITLE
DM-33595: exposurelog: update summit configuration

### DIFF
--- a/services/exposurelog/values-summit.yaml
+++ b/services/exposurelog/values-summit.yaml
@@ -2,9 +2,13 @@ exposurelog:
   pull_secret: pull-secret
 
   site_id: summit
-  nfs_path_1: /lsstdata/base/comcam  # Mounted as /volume_1
+  nfs_path_1: /repo/LSSTComCam  # Mounted as /volume_1
   nfs_server_1: comcam-arctl01.cp.lsst.org
-  butler_uri_1: /volume_1/oods/gen3butler/repo
+  butler_uri_1: /volume_1
+
+  nfs_path_2: /repo/LATISS  # Mounted as /volume_2
+  nfs_server_2: atarchiver.cp.lsst.org
+  butler_uri_2: /volume_2
 
   ingress:
     enabled: true


### PR DESCRIPTION
to use the correct ComCam repo and to include LATISS