### PR TITLE
exposurelog: update base deployment for 0.8.0

### DIFF
--- a/services/exposurelog/values-base.yaml
+++ b/services/exposurelog/values-base.yaml
@@ -4,7 +4,10 @@ exposurelog:
   pull_secret: pull-secret
 
   site_id: test
-  butler_uri_1: hsc_raw
+  # Use the test butler registries.
+  # Note: exposurelog's Dockerfile copies the test repos to the top of the container
+  butler_uri_1: LSSTCam
+  butler_uri_2: LATISS
 
   ingress:
     enabled: true


### PR DESCRIPTION
Use the two test butler registries in exposurelog 0.8.0;
the old hsc registry is gone.