### PR TITLE
[DM-33720] Update vo-cutouts chart, install in IDF prod

### DIFF
--- a/science-platform/values-idfprod.yaml
+++ b/science-platform/values-idfprod.yaml
@@ -57,4 +57,4 @@ tap_schema:
 vault_secrets_operator:
   enabled: true
 vo_cutouts:
-  enabled: false
+  enabled: true

--- a/services/vo-cutouts/Chart.yaml
+++ b/services/vo-cutouts/Chart.yaml
@@ -3,7 +3,7 @@ name: vo-cutouts
 version: 1.0.0
 dependencies:
   - name: vo-cutouts
-    version: 0.2.2
+    version: 0.3.0
     repository: https://lsst-sqre.github.io/charts/
   - name: pull-secret
     version: 0.1.2

--- a/services/vo-cutouts/values-idfdev.yaml
+++ b/services/vo-cutouts/values-idfdev.yaml
@@ -7,7 +7,7 @@ vo-cutouts:
 
   image:
     pullPolicy: "Always"
-    tag: "tickets-DM-33513"
+    tag: "tickets-DM-33604"
 
   config:
     # There is currently no working Butler in data-dev, so this configuration
@@ -22,6 +22,10 @@ vo-cutouts:
     enabled: true
     instanceConnectionName: "science-platform-dev-7696:us-central1:science-platform-dev-e9e11de2"
     serviceAccount: "vo-cutouts@science-platform-dev-7696.iam.gserviceaccount.com"
+
+  cutoutWorker:
+    pullPolicy: "Always"
+    tag: "tickets-DM-33604"
 
 pull-secret:
   enabled: true

--- a/services/vo-cutouts/values-idfprod.yaml
+++ b/services/vo-cutouts/values-idfprod.yaml
@@ -2,8 +2,8 @@ vo-cutouts:
   imagePullSecrets:
     - name: "pull-secret"
   ingress:
-    host: "data-int.lsst.cloud"
-  vaultSecretsPath: "secret/k8s_operator/data-int.lsst.cloud/vo-cutouts"
+    host: "data.lsst.cloud"
+  vaultSecretsPath: "secret/k8s_operator/data.lsst.cloud/vo-cutouts"
 
   image:
     pullPolicy: "Always"
@@ -12,12 +12,12 @@ vo-cutouts:
   config:
     butlerRepository: "s3://butler-us-central1-panda-dev/dc2/butler-external.yaml"
     databaseUrl: "postgresql://vo-cutouts@localhost/vo-cutouts"
-    gcsBucketUrl: "s3://rubin-cutouts-int-us-central1-output/"
+    gcsBucketUrl: "s3://rubin-cutouts-stable-us-central1-output/"
 
   cloudsql:
     enabled: true
-    instanceConnectionName: "science-platform-int-dc5d:us-central1:science-platform-int-8f439af2"
-    serviceAccount: "vo-cutouts@science-platform-int-dc5d.iam.gserviceaccount.com"
+    instanceConnectionName: "science-platform-stable-6994:us-central1:science-platform-stable-0c29612b"
+    serviceAccount: "vo-cutouts@science-platform-stable-6994.iam.gserviceaccount.com"
 
   cutoutWorker:
     pullPolicy: "Always"


### PR DESCRIPTION
Update to the vo-cutouts 0.3.0 chart and adjust the data-int
configuration accordingly.  Pin to a newer ticket branch.  Add
configuration for IDF prod and enable it.  Update the configuration
for data-dev similarly.