### PR TITLE
[DM-33720] Fix Butler repository URL for vo-cutouts IDF prod

### DIFF
--- a/services/vo-cutouts/values-idfprod.yaml
+++ b/services/vo-cutouts/values-idfprod.yaml
@@ -10,7 +10,7 @@ vo-cutouts:
     tag: "tickets-DM-33604"
 
   config:
-    butlerRepository: "s3://butler-us-central1-panda-dev/dc2/butler-external.yaml"
+    butlerRepository: "s3://butler-us-central1-dp01"
     databaseUrl: "postgresql://vo-cutouts@localhost/vo-cutouts"
     gcsBucketUrl: "s3://rubin-cutouts-stable-us-central1-output/"
 


### PR DESCRIPTION
IDF prod uses a different Butler repository URL than IDF int.