### PR TITLE
Debug Chronograf OIDC authentication

### DIFF
--- a/services/sasquatch/values-idfdev.yaml
+++ b/services/sasquatch/values-idfdev.yaml
@@ -23,6 +23,7 @@ chronograf:
     JWKS_URL: https://data-dev.lsst.cloud/.well-known/jwks.json
     GENERIC_API_URL: https://data-dev.lsst.cloud/auth/userinfo
     GENERIC_SCOPES: openid
+    GENERIC_API_KEY: sub
     PUBLIC_URL: https://data-dev.lsst.cloud/
     STATUS_FEED_URL: "https://lsst-sqre.github.io/sasquatch/feeds/idfdev.json"
 

--- a/services/sasquatch/values-minikube.yaml
+++ b/services/sasquatch/values-minikube.yaml
@@ -23,6 +23,7 @@ chronograf:
     JWKS_URL: https://minikube.lsst.codes/.well-known/jwks.json
     GENERIC_API_URL: https://minikube.lsst.codes/auth/userinfo
     GENERIC_SCOPES: openid
+    GENERIC_API_KEY: sub
     PUBLIC_URL: https://minikube.lsst.codes
     STATUS_FEED_URL: "https://lsst-sqre.github.io/sasquatch/feeds/minikube.json"
 


### PR DESCRIPTION
 By setting GENERIC_API_KEY=sub we use the sub token claim, which corresponds to the user's username, instead of the user's email address as Gafaelfawr does not always have an email address for a user.