### PR TITLE
[DM-33720] Remove container pins for vo-cutouts

### DIFF
--- a/services/vo-cutouts/values-idfdev.yaml
+++ b/services/vo-cutouts/values-idfdev.yaml
@@ -5,10 +5,6 @@ vo-cutouts:
     host: "data-dev.lsst.cloud"
   vaultSecretsPath: "secret/k8s_operator/data-dev.lsst.cloud/vo-cutouts"
 
-  image:
-    pullPolicy: "Always"
-    tag: "tickets-DM-33604"
-
   config:
     # There is currently no working Butler in data-dev, so this configuration
     # won't work.  Leaving it here anyway since it has the correct
@@ -22,11 +18,6 @@ vo-cutouts:
     enabled: true
     instanceConnectionName: "science-platform-dev-7696:us-central1:science-platform-dev-e9e11de2"
     serviceAccount: "vo-cutouts@science-platform-dev-7696.iam.gserviceaccount.com"
-
-  cutoutWorker:
-    image:
-      pullPolicy: "Always"
-      tag: "tickets-DM-33604"
 
 pull-secret:
   enabled: true

--- a/services/vo-cutouts/values-idfint.yaml
+++ b/services/vo-cutouts/values-idfint.yaml
@@ -5,10 +5,6 @@ vo-cutouts:
     host: "data-int.lsst.cloud"
   vaultSecretsPath: "secret/k8s_operator/data-int.lsst.cloud/vo-cutouts"
 
-  image:
-    pullPolicy: "Always"
-    tag: "tickets-DM-33604"
-
   config:
     butlerRepository: "s3://butler-us-central1-panda-dev/dc2/butler-external.yaml"
     databaseUrl: "postgresql://vo-cutouts@localhost/vo-cutouts"
@@ -18,11 +14,6 @@ vo-cutouts:
     enabled: true
     instanceConnectionName: "science-platform-int-dc5d:us-central1:science-platform-int-8f439af2"
     serviceAccount: "vo-cutouts@science-platform-int-dc5d.iam.gserviceaccount.com"
-
-  cutoutWorker:
-    image:
-      pullPolicy: "Always"
-      tag: "tickets-DM-33604"
 
 pull-secret:
   enabled: true

--- a/services/vo-cutouts/values-idfprod.yaml
+++ b/services/vo-cutouts/values-idfprod.yaml
@@ -5,10 +5,6 @@ vo-cutouts:
     host: "data.lsst.cloud"
   vaultSecretsPath: "secret/k8s_operator/data.lsst.cloud/vo-cutouts"
 
-  image:
-    pullPolicy: "Always"
-    tag: "tickets-DM-33604"
-
   config:
     butlerRepository: "s3://butler-us-central1-dp01"
     databaseUrl: "postgresql://vo-cutouts@localhost/vo-cutouts"
@@ -18,11 +14,6 @@ vo-cutouts:
     enabled: true
     instanceConnectionName: "science-platform-stable-6994:us-central1:science-platform-stable-0c29612b"
     serviceAccount: "vo-cutouts@science-platform-stable-6994.iam.gserviceaccount.com"
-
-  cutoutWorker:
-    image:
-      pullPolicy: "Always"
-      tag: "tickets-DM-33604"
 
 pull-secret:
   enabled: true


### PR DESCRIPTION
0.3.0 has been released, so we can now go back to using the
default images.