### PR TITLE
[DM-33804] Add Telegraf to Sasquatch

### DIFF
--- a/services/sasquatch/Chart.yaml
+++ b/services/sasquatch/Chart.yaml
@@ -19,3 +19,6 @@ dependencies:
   - name: kapacitor
     version: 1.4.3
     repository: https://helm.influxdata.com/
+  - name: telegraf
+    version: 1.8.14
+    repository: https://helm.influxdata.com/

--- a/services/sasquatch/README.md
+++ b/services/sasquatch/README.md
@@ -11,6 +11,7 @@ SQuaRE telemetry data service.
 | https://helm.influxdata.com/ | chronograf | 1.2.3 |
 | https://helm.influxdata.com/ | influxdb | 4.10.6 |
 | https://helm.influxdata.com/ | kapacitor | 1.4.3 |
+| https://helm.influxdata.com/ | telegraf | 1.8.14 |
 | https://lsst-sqre.github.io/charts/ | strimzi-registry-operator | 1.2.0 |
 
 ## Values
@@ -35,6 +36,12 @@ SQuaRE telemetry data service.
 | kapacitor.persistence | object | `{"enabled":true,"size":"16Gi"}` | Chronograf data persistence configuration. |
 | strimzi-kafka | object | `{}` | Override strimzi-kafka configuration. |
 | strimzi-registry-operator | object | `{"clusterName":"sasquatch","operatorNamespace":"sasquatch","watchNamespace":"sasquatch"}` | strimzi-registry-operator configuration. |
+| telegraf.config.inputs | list | `[{"prometheus":{"metric_version":2,"urls":["http://hub.nublado2:8081/nb/hub/metrics"]}}]` | Telegraf input plugins. Collect JupyterHub Prometheus metrics by dedault. See https://jupyterhub.readthedocs.io/en/stable/reference/metrics.html |
+| telegraf.config.outputs | list | `[{"influxdb":{"database":"telegraf","password":"$TELEGRAF_PASSWORD","urls":["http://sasquatch-influxdb.sasquatch:8086"],"username":"telegraf"}}]` | Telegraf default output destination. |
+| telegraf.config.processors | object | `{}` | Telegraf processor plugins. |
+| telegraf.env[0] | object | `{"name":"TELEGRAF_PASSWORD","valueFrom":{"secretKeyRef":{"key":"telegraf-password","name":"sasquatch"}}}` | Telegraf password. |
+| telegraf.podLabels | object | `{"hub.jupyter.org/network-access-hub":"true"}` | Allow network access to JupyterHub pod. |
+| telegraf.service.enabled | bool | `false` | Telegraf service. |
 | vaultSecretsPath | string | None, must be set | Path to the Vault secrets (`secret/k8s_operator/<hostname>/sasquatch`) |
 
 ----------------------------------------------

--- a/services/sasquatch/values.yaml
+++ b/services/sasquatch/values.yaml
@@ -99,6 +99,7 @@ kapacitor:
     KAPACITOR_SLACK_ENABLED: true
 
 telegraf:
+  # -- Allow network access to JupyterHub pod.
   podLabels:
     hub.jupyter.org/network-access-hub: "true"
   env:
@@ -114,7 +115,9 @@ telegraf:
   config:
     # -- Telegraf processor plugins.
     processors: {}
-    # -- Telegraf input plugins. Must be set.
+    # -- Telegraf input plugins.
+    # Collect JupyterHub Prometheus metrics by dedault.
+    # See https://jupyterhub.readthedocs.io/en/stable/reference/metrics.html
     inputs:
       - prometheus:
           urls:

--- a/services/sasquatch/values.yaml
+++ b/services/sasquatch/values.yaml
@@ -98,6 +98,36 @@ kapacitor:
   envVars:
     KAPACITOR_SLACK_ENABLED: true
 
+telegraf:
+  env:
+    # -- Telegraf password.
+    - name: TELEGRAF_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: sasquatch
+          key: telegraf-password
+  service:
+    # -- Telegraf service.
+    enabled: false
+  config:
+    # -- Telegraf processor plugins.
+    processors: {}
+    # -- Telegraf input plugins. Must be set.
+    inputs:
+      - prometheus:
+          urls:
+            - http://hub.nublado2:8081/nb/hub/metrics
+          # See https://docs.influxdata.com/influxdb/v2.1/reference/prometheus-metrics/
+          metric_version: 2
+    # -- Telegraf default output destination.
+    outputs:
+      - influxdb:
+          urls:
+            - "http://sasquatch-influxdb.sasquatch:8086"
+          database: "telegraf"
+          username: "telegraf"
+          password: "$TELEGRAF_PASSWORD"
+
 # -- Path to the Vault secrets (`secret/k8s_operator/<hostname>/sasquatch`)
 # @default -- None, must be set
 vaultSecretsPath: ""

--- a/services/sasquatch/values.yaml
+++ b/services/sasquatch/values.yaml
@@ -99,6 +99,8 @@ kapacitor:
     KAPACITOR_SLACK_ENABLED: true
 
 telegraf:
+  podLabels:
+    hub.jupyter.org/network-access-hub: "true"
   env:
     # -- Telegraf password.
     - name: TELEGRAF_PASSWORD


### PR DESCRIPTION
- Add InfluxData Telegraf chart as a dependency to Sasquatch
- Configure the Telegraf Prometheus input plugin to collect [JupyterHub metrics](https://jupyterhub.readthedocs.io/en/stable/reference/metrics.html) and write them to InfluxDB.