### PR TITLE
tickets/DM-33827: Enable Flux in IDF dev

### DIFF
--- a/services/sasquatch/values-idfdev.yaml
+++ b/services/sasquatch/values-idfdev.yaml
@@ -4,9 +4,6 @@ influxdb:
   ingress:
     enabled: true
     hostname: data-dev.lsst.cloud
-  config:
-    http:
-      flux-enabled: true
 
 kafka-connect-manager:
   influxdbSink:

--- a/services/sasquatch/values-idfdev.yaml
+++ b/services/sasquatch/values-idfdev.yaml
@@ -4,6 +4,9 @@ influxdb:
   ingress:
     enabled: true
     hostname: data-dev.lsst.cloud
+  config:
+    http:
+      flux-enabled: true
 
 kafka-connect-manager:
   influxdbSink:

--- a/services/sasquatch/values.yaml
+++ b/services/sasquatch/values.yaml
@@ -36,6 +36,7 @@ influxdb:
       trace_logging_enabled: true
     http:
       enabled: true
+      flux_enabled: true
       auth_enabled: true
       max_row_limit: 0
     coordinator:


### PR DESCRIPTION
I'm sure this is conceptually correct.  Whether it's `flux-enabled`, `flux-enable`, `flux_enabled`, `fluxEnabled`, or some other permutation isn't totally clear to me, but it'd be flux-enabled in the config file.  I don't quite understand mapping that to the Helm chart to the Phalanx config yet.