### PR TITLE
[DM-33924] Always use dash in the InfluxDB configuration keys

### DIFF
--- a/services/sasquatch/README.md
+++ b/services/sasquatch/README.md
@@ -23,7 +23,7 @@ SQuaRE telemetry data service.
 | chronograf.image | object | `{"repository":"quay.io/influxdb/chronograf","tag":"1.9.3"}` | Chronograf image tag. |
 | chronograf.ingress | object | disabled | Chronograf ingress configuration. |
 | chronograf.persistence | object | `{"enabled":true,"size":"16Gi"}` | Chronograf data persistence configuration. |
-| influxdb.config | object | `{"continuous_queries":{"enabled":false},"coordinator":{"log_queries_after":"15s","max_concurrent_queries":10,"query_timeout":"900s","write_timeout":"60s"},"data":{"cache_max_memory_size":0,"trace_logging_enabled":true,"wal_fsync_delay":"100ms"},"http":{"auth_enabled":true,"enabled":true,"max_row_limit":0}}` | Override InfluxDB configuration. See https://docs.influxdata.com/influxdb/v1.8/administration/config |
+| influxdb.config | object | `{"continuous_queries":{"enabled":false},"coordinator":{"log-queries-after":"15s","max-concurrent-queries":10,"query-timeout":"900s","write-timeout":"60s"},"data":{"cache-max-memory-size":0,"trace-logging-enabled":true,"wal-fsync-delay":"100ms"},"http":{"auth-enabled":true,"enabled":true,"flux-enabled":true,"max-row-limit":0}}` | Override InfluxDB configuration. See https://docs.influxdata.com/influxdb/v1.8/administration/config |
 | influxdb.image | object | `{"tag":"1.8.10"}` | InfluxDB image tag. |
 | influxdb.ingress | object | disabled | InfluxDB ingress configuration. |
 | influxdb.initScripts | object | `{"enabled":true,"scripts":{"init.iql":"CREATE DATABASE \"telegraf\" WITH DURATION 30d REPLICATION 1 NAME \"rp_30d\"\n\n"}}` | InfluxDB Custom initialization scripts. |

--- a/services/sasquatch/values.yaml
+++ b/services/sasquatch/values.yaml
@@ -31,19 +31,19 @@ influxdb:
   # See https://docs.influxdata.com/influxdb/v1.8/administration/config
   config:
     data:
-      cache_max_memory_size: 0
-      wal_fsync_delay: "100ms"
-      trace_logging_enabled: true
+      cache-max-memory-size: 0
+      wal-fsync-delay: "100ms"
+      trace-logging-enabled: true
     http:
       enabled: true
       flux-enabled: true
-      auth_enabled: true
-      max_row_limit: 0
+      auth-enabled: true
+      max-row-limit: 0
     coordinator:
-      write_timeout: "60s"
-      max_concurrent_queries: 10
-      query_timeout: "900s"
-      log_queries_after: "15s"
+      write-timeout: "60s"
+      max-concurrent-queries: 10
+      query-timeout: "900s"
+      log-queries-after: "15s"
     continuous_queries:
       enabled: false
   # -- InfluxDB Custom initialization scripts.


### PR DESCRIPTION
The upstream InfluxDB helm chart used in sasquatch does not rewrite the configuration keys replacing "_" with "-" anymore. Glad we found this today, thanks @athornton 