### PR TITLE
DM-33930: Use unique path prefix for times-square-ui

### DIFF
--- a/services/times-square/values-idfdev.yaml
+++ b/services/times-square/values-idfdev.yaml
@@ -18,3 +18,4 @@ times-square-ui:
     tag: tickets-dm-33930
   ingress:
     host: "data-dev.lsst.cloud"
+    path: "/ts-ui"


### PR DESCRIPTION
This is to debug why access to /times-square/ was not possible.