### PR TITLE
DM-33930: Update times-square-ui 0.1.0-alpha.2

### DIFF
--- a/services/times-square/Chart.yaml
+++ b/services/times-square/Chart.yaml
@@ -6,5 +6,5 @@ dependencies:
     version: 0.1.8
     repository: https://lsst-sqre.github.io/charts/
   - name: times-square-ui
-    version: 0.1.0-alpha.1
+    version: 0.1.0-alpha.2
     repository: https://lsst-sqre.github.io/charts/

--- a/services/times-square/values-idfdev.yaml
+++ b/services/times-square/values-idfdev.yaml
@@ -14,8 +14,8 @@ times-square:
     serviceAccount: "times-square@science-platform-dev-7696.iam.gserviceaccount.com"
 
 times-square-ui:
+  fullnameOverride: times-square-ui
   image:
     tag: tickets-dm-33930
   ingress:
     host: "data-dev.lsst.cloud"
-    path: "/ts-ui"


### PR DESCRIPTION
- Restores ingress path to /times-square
- Adopts 0.1.0-alpha.2 chart version which fixes the network policy
- Adopt fullnameOverride to make times-square-ui resources easier to work with