### PR TITLE
[DM-33813] Deploy mobu TAP runner on IDF prod

### DIFF
--- a/services/mobu/values-idfint.yaml
+++ b/services/mobu/values-idfint.yaml
@@ -5,11 +5,6 @@ mobu:
   ingress:
     host: "data-int.lsst.cloud"
 
-  image:
-    repository: "ghcr.io/lsst-sqre/mobu"
-    pullPolicy: "Always"
-    tag: "tickets-DM-33813"
-
   cachemachineImagePolicy: "desired"
   environmentUrl: "https://data-int.lsst.cloud"
   vaultSecretsPath: "secret/k8s_operator/data-int.lsst.cloud/mobu"

--- a/services/mobu/values-idfprod.yaml
+++ b/services/mobu/values-idfprod.yaml
@@ -66,6 +66,14 @@ mobu:
         max_executions: 1
         working_directory: "notebooks/tutorial-notebooks"
       restart: true
+    - name: "tap"
+      count: 1
+      users:
+        - username: "systemtest08"
+          uidnumber: 74775
+      scopes: ["read:tap"]
+      business: "TAPQueryRunner"
+      restart: true
 
 pull-secret:
   enabled: true


### PR DESCRIPTION
Remove the image settings for IDF int since the new version of mobu
has been released, and copy the TAP runner configuration to prod.