### PR TITLE
[DM-33813] Update mobu type, enable NetworkPolicy

### DIFF
--- a/services/mobu/templates/deployment.yaml
+++ b/services/mobu/templates/deployment.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: {{ include "mobu.fullname" . }}
   labels:
@@ -9,7 +9,8 @@ spec:
   selector:
     matchLabels:
       {{- include "mobu.selectorLabels" . | nindent 6 }}
-  serviceName: "mobu"
+  strategy:
+    type: "Recreate"
   template:
     metadata:
       {{- with .Values.podAnnotations }}

--- a/services/mobu/templates/networkpolicy.yaml
+++ b/services/mobu/templates/networkpolicy.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.ingress.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -20,4 +19,3 @@ spec:
       ports:
         - protocol: "TCP"
           port: 8080
-{{- end }}


### PR DESCRIPTION
Change the StatefulSet back to a Deployment, but use a Recreate
strategy so that only one will be running at a time.  Remove the
conditional around NetworkPolicy now that there's no boolean
setting whether to create an ingress.