### PR TITLE
DM-33922: exposurelog: add a writable /tmp dir

### DIFF
--- a/services/exposurelog/Chart.yaml
+++ b/services/exposurelog/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.1
+version: 0.3.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/services/exposurelog/README.md
+++ b/services/exposurelog/README.md
@@ -1,0 +1,6 @@
+# exposurelog
+
+Deployment of the exposurelog service, which manages a database of log messages associated with exposures.
+Similar to narrativelog, but narrativelog messages are not associated with exposures.
+
+exposurelog is developed at https://github.com/lsst-sqre/exposurelog and uses OpenAPI to document the API.

--- a/services/exposurelog/templates/deployment.yaml
+++ b/services/exposurelog/templates/deployment.yaml
@@ -74,13 +74,15 @@ spec:
               value: {{ .Values.site_id | quote }}
           volumeMounts:
             {{- if .Values.nfs_path_1 }}
-            - mountPath: /volume_1
-              name: volume1
+            - name: volume1
+              mountPath: /volume_1
             {{- end }}
             {{- if .Values.nfs_path_2 }}
-            - mountPath: /volume_2
-              name: volume2
+            - name: volume2
+              mountPath: /volume_2
             {{- end }}
+            - name: tmp
+              mountPath: /tmp
       volumes:
         {{- if .Values.nfs_path_1 }}
         - name: volume1
@@ -96,6 +98,8 @@ spec:
             readOnly: true
             server: {{ .Values.nfs_server_2 }}
         {{- end }}
+        - name: tmp
+          emptyDir: {}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/services/narrativelog/README.md
+++ b/services/narrativelog/README.md
@@ -1,0 +1,6 @@
+# narrativelog
+
+Deployment of the narrativelog service, which manages a database of log messages.
+Similar to exposurelog, but exposurelog messages are associated with exposures.
+
+narrativelog is developed at https://github.com/lsst-sqre/narrativelog and uses OpenAPI to document the API.


### PR DESCRIPTION
in order to make matplotlib happy.
Also tweak existing volumeMount entries to put the name first, for consistency with other deployments.
Also add README files for exposurelog and narrativelog.