### PR TITLE
DM-33922: exposurelog and narrativelog: fix value namespace

### DIFF
--- a/science-platform/templates/exposurelog-application.yaml
+++ b/science-platform/templates/exposurelog-application.yaml
@@ -22,5 +22,6 @@ spec:
     targetRevision: {{ .Values.revision }}
     helm:
       valueFiles:
+      - values.yaml
       - values-{{ .Values.environment }}.yaml
 {{- end -}}

--- a/science-platform/templates/narrativelog-application.yaml
+++ b/science-platform/templates/narrativelog-application.yaml
@@ -22,5 +22,6 @@ spec:
     targetRevision: {{ .Values.revision }}
     helm:
       valueFiles:
+      - values.yaml
       - values-{{ .Values.environment }}.yaml
 {{- end -}}

--- a/services/exposurelog/Chart.yaml
+++ b/services/exposurelog/Chart.yaml
@@ -5,12 +5,10 @@ maintainers:
   - name: r-owen
 type: application
 
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.2
+# The chart version. SQuaRE convention is to use 1.0.0
+version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.9.1
+appVersion: 0.9.2

--- a/services/exposurelog/templates/deployment.yaml
+++ b/services/exposurelog/templates/deployment.yaml
@@ -54,9 +54,9 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           env:
             - name: BUTLER_URI_1
-              value: {{ .Values.butler_uri_1 | quote }}
+              value: {{ .Values.config.butler_uri_1 | quote }}
             - name: BUTLER_URI_2
-              value: {{ .Values.butler_uri_2 | quote }}
+              value: {{ .Values.config.butler_uri_2 | quote }}
             - name: EXPOSURELOG_DB_USER
               value: exposurelog
             - name: EXPOSURELOG_DB_PASSWORD
@@ -71,32 +71,32 @@ spec:
             - name: EXPOSURELOG_DB_DATABSE
               value: exposurelog
             - name: SITE_ID
-              value: {{ .Values.site_id | quote }}
+              value: {{ .Values.config.site_id | quote }}
           volumeMounts:
-            {{- if .Values.nfs_path_1 }}
+            {{- if .Values.config.nfs_path_1 }}
             - name: volume1
               mountPath: /volume_1
             {{- end }}
-            {{- if .Values.nfs_path_2 }}
+            {{- if .Values.config.nfs_path_2 }}
             - name: volume2
               mountPath: /volume_2
             {{- end }}
             - name: tmp
               mountPath: /tmp
       volumes:
-        {{- if .Values.nfs_path_1 }}
+        {{- if .Values.config.nfs_path_1 }}
         - name: volume1
           nfs:
-            path: {{ .Values.nfs_path_1 }}
+            path: {{ .Values.config.nfs_path_1 }}
             readOnly: true
-            server: {{ .Values.nfs_server_1 }} 
+            server: {{ .Values.config.nfs_server_1 }} 
         {{- end }}
-        {{- if .Values.nfs_path_2 }}
+        {{- if .Values.config.nfs_path_2 }}
         - name: volume2
           nfs:
-            path: {{ .Values.nfs_path_2 }}
+            path: {{ .Values.config.nfs_path_2 }}
             readOnly: true
-            server: {{ .Values.nfs_server_2 }}
+            server: {{ .Values.config.nfs_server_2 }}
         {{- end }}
         - name: tmp
           emptyDir: {}

--- a/services/exposurelog/values-base.yaml
+++ b/services/exposurelog/values-base.yaml
@@ -1,17 +1,15 @@
-# WARNING: this is a "playground" deployment
-# using exposurelog's built-in test butler registries.
-exposurelog:
-  imagePullSecrets:
-    - name: pull-secret
-  ingress:
-    enabled: true
-    host: base-lsp.lsst.codes
-
+config:
+  # WARNING: this is a "playground" deployment
+  # using exposurelog's built-in test butler registries.
   site_id: test
   # Use the test butler registries.
   # Note: exposurelog's Dockerfile copies the test repos to the top of the container
   butler_uri_1: LSSTCam
   butler_uri_2: LATISS
+
+ingress:
+  enabled: true
+  host: base-lsp.lsst.codes
 
 vault_path: secret/k8s_operator/base-lsp.lsst.codes/postgres
 

--- a/services/exposurelog/values-roe.yaml
+++ b/services/exposurelog/values-roe.yaml
@@ -1,17 +1,15 @@
-# WARNING: this is a "playground" deployment
-# using exposurelog's built-in test butler registries.
-exposurelog:
-  imagePullSecrets:
-    - name: pull-secret
-  ingress:
-    enabled: true
-    host: rsp.lsst.ac.uk
-
+config:
+  # WARNING: this is a "playground" deployment
+  # using exposurelog's built-in test butler registries.
   site_id: test
   # Use the test butler registries.
   # Note: exposurelog's Dockerfile copies the test repos to the top of the container
   butler_uri_1: LSSTCam
   butler_uri_2: LATISS
+
+ingress:
+  enabled: true
+  host: rsp.lsst.ac.uk
 
 vault_path: secret/k8s_operator/roe/postgres
 

--- a/services/exposurelog/values-summit.yaml
+++ b/services/exposurelog/values-summit.yaml
@@ -1,11 +1,11 @@
 config:
   site_id: summit
   nfs_path_1: /repo/LSSTComCam  # Mounted as /volume_1
-  nfs_server_1: comcam-arctl01.cp.lsst.org
+  nfs_server_1: comcam-archiver.cp.lsst.org
   butler_uri_1: /volume_1
 
   nfs_path_2: /repo/LATISS  # Mounted as /volume_2
-  nfs_server_2: atarchiver.cp.lsst.org
+  nfs_server_2: auxtel-archiver.cp.lsst.org
   butler_uri_2: /volume_2
 
 ingress:

--- a/services/exposurelog/values-summit.yaml
+++ b/services/exposurelog/values-summit.yaml
@@ -1,10 +1,4 @@
-exposurelog:
-  imagePullSecrets:
-    - name: pull-secret
-  ingress:
-    enabled: true
-    host: summit-lsp.lsst.codes
-
+config:
   site_id: summit
   nfs_path_1: /repo/LSSTComCam  # Mounted as /volume_1
   nfs_server_1: comcam-arctl01.cp.lsst.org
@@ -13,6 +7,10 @@ exposurelog:
   nfs_path_2: /repo/LATISS  # Mounted as /volume_2
   nfs_server_2: atarchiver.cp.lsst.org
   butler_uri_2: /volume_2
+
+ingress:
+  enabled: true
+  host: summit-lsp.lsst.codes
 
 vault_path: secret/k8s_operator/summit-lsp.lsst.codes/postgres
 

--- a/services/exposurelog/values-tucson-teststand.yaml
+++ b/services/exposurelog/values-tucson-teststand.yaml
@@ -1,17 +1,15 @@
-# WARNING: this is a "playground" deployment
-# using exposurelog's built-in test butler registries.
-exposurelog:
-  imagePullSecrets:
-    - name: pull-secret
-  ingress:
-    enabled: true
-    host: tucson-teststand.lsst.codes
-
+config:
+  # WARNING: this is a "playground" deployment
+  # using exposurelog's built-in test butler registries.
   site_id: test
   # Use the test butler registries.
   # Note: exposurelog's Dockerfile copies the test repos to the top of the container
   butler_uri_1: LSSTCam
   butler_uri_2: LATISS
+
+ingress:
+  enabled: true
+  host: tucson-teststand.lsst.codes
 
 vault_path: secret/k8s_operator/tucson-teststand.lsst.codes/postgres
 

--- a/services/exposurelog/values.yaml
+++ b/services/exposurelog/values.yaml
@@ -10,29 +10,51 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
-# If not blank then mount the specified NFS path as internal volume /volume_1 or /volume_2, respectively.
-nfs_path_1: ""
-nfs_path_2: ""
+# Application-specific configuration
+config:
+  # NFS path to butler registry 1 and/or 2.
+  # Only specify a non-blank value if reading the registry from an NFS-mounted file.
+  # If not blank then mount the specified NFS path as internal volume /volume_1 or /volume_2, respectively.
+  nfs_path_1: ""
+  nfs_path_2: ""
 
-# Name of the NFS server that exports nfs_path_1 or nfs_path_2, respectively.
-nfs_server_1: ""
-nfs_server_2: ""
+  # Name of the NFS server that exports nfs_path_1 or nfs_path_2, respectively.
+  # Specify a non-blank value if and only if the corresponding nfs_path_1/2 is not blank.
+  nfs_server_1: ""
+  nfs_server_2: ""
 
-# URIs for butler registry 1 (required) and 2 (optional). Format:
-# * For a volume mounted using `nfs_path_1` or `nfs_path_2` (see above):
-#   An absolute path starting with `/volume_1/` or /volume_2/`.
-# * For a network URI: see the daf_butler documentation.
-# The default for butler_uri_1 is a local toy registry, because *some* value is necessary.
-# Always override that for production use.
-butler_uri_1: /home/appuser/hsc_raw
-butler_uri_2: ""
+  # URIs for butler registry 1 (required) and 2 (optional). Format:
+  # * For a volume mounted using `nfs_path_1` or `nfs_path_2` (see above):
+  #   An absolute path starting with `/volume_1/` or `/volume_2/`.
+  # * For a network URI: see the daf_butler documentation.
+  # * For a sandbox deployment: specify `LSSTCam` for butler_uri_1 and `LATISS` for butler_uri_2.
+  butler_uri_1: ""
+  butler_uri_2: ""
 
-# Site ID; a non-empty string of up to 16 characters.
-# This must be different for each deployment, in order to support
-# synchronization of records from one message database to another.
-site_id: ""
+  # Site ID; a non-empty string of up to 16 characters.
+  # This should be different for each non-sandbox deployment.
+  # Sandboxes should use `test`.
+  site_id: ""
 
-imagePullSecrets: []
+# Site-specific values files should specify:
+#
+# ingress:
+#   enabled: true
+#   host: ...
+#
+# vault-path: secret/k8s_operator/.../postgres
+#
+# pull-secret:
+#   enabled: true
+#   path: secret/k8s_operator/.../pull-secret
+
+# This is needed for the CI job to run
+ingress:
+  enabled: false
+
+imagePullSecrets:
+  - name: pull-secret
+
 nameOverride: ""
 fullnameOverride: ""
 
@@ -52,19 +74,6 @@ securityContext: {}
 service:
   type: ClusterIP
   port: 8080
-
-ingress:
-  enabled: false
-  annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
-  hosts:
-    - host: bleed.lsst.codes
-      paths: ["/exposurelog"]
-  tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/services/narrativelog/Chart.yaml
+++ b/services/narrativelog/Chart.yaml
@@ -5,10 +5,8 @@ maintainers:
   - name: r-owen
 type: application
 
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+# The chart version. SQuaRE convention is to use 1.0.0
+version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/services/narrativelog/templates/deployment.yaml
+++ b/services/narrativelog/templates/deployment.yaml
@@ -67,7 +67,7 @@ spec:
             - name: NARRATIVELOG_DB_DATABSE
               value: narrativelog
             - name: SITE_ID
-              value: {{ .Values.site_id | quote }}
+              value: {{ .Values.config.site_id | quote }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/services/narrativelog/values-base.yaml
+++ b/services/narrativelog/values-base.yaml
@@ -1,11 +1,9 @@
-narrativelog:
-  imagePullSecrets:
-    - name: pull-secret
-  ingress:
-    enabled: true
-    host: base-lsp.lsst.codes
-
+config:
   site_id: base
+
+ingress:
+  enabled: true
+  host: base-lsp.lsst.codes
 
 vault_path: secret/k8s_operator/base-lsp.lsst.codes/postgres
 

--- a/services/narrativelog/values-summit.yaml
+++ b/services/narrativelog/values-summit.yaml
@@ -1,11 +1,9 @@
-narrativelog:
-  imagePullSecrets:
-    - name: pull-secret
-  ingress:
-    enabled: true
-    host: summit-lsp.lsst.codes
-
+config:
   site_id: summit
+
+ingress:
+  enabled: true
+  host: summit-lsp.lsst.codes
 
 vault_path: secret/k8s_operator/summit-lsp.lsst.codes/postgres
 

--- a/services/narrativelog/values-tucson-teststand.yaml
+++ b/services/narrativelog/values-tucson-teststand.yaml
@@ -1,11 +1,9 @@
-narrativelog:
-  imagePullSecrets:
-    - name: pull-secret
-  ingress:
-    enabled: true
-    host: tucson-teststand.lsst.codes
-
+config:
   site_id: tucson
+
+ingress:
+  enabled: true
+  host: tucson-teststand.lsst.codes
 
 vault_path: secret/k8s_operator/tucson-teststand.lsst.codes/postgres
 

--- a/services/narrativelog/values.yaml
+++ b/services/narrativelog/values.yaml
@@ -10,12 +10,33 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
-# Site ID; a non-empty string of up to 16 characters.
-# This must be different for each deployment, in order to support
-# synchronization of records from one message database to another.
-site_id: ""
+# Application-specific configuration
+config:
+  # Site ID; a non-empty string of up to 16 characters.
+  # This should be different for each non-sandbox deployment.
+  # Sandboxes should use `test`.
+  site_id: ""
 
-imagePullSecrets: []
+
+# Site-specific values files should specify:
+#
+# ingress:
+#   enabled: true
+#   host: ...
+#
+# vault-path: secret/k8s_operator/.../postgres
+#
+# pull-secret:
+#   enabled: true
+#   path: secret/k8s_operator/.../pull-secret
+
+# This is needed for the CI job to run
+ingress:
+  enabled: false
+
+imagePullSecrets:
+  - name: pull-secret
+
 nameOverride: ""
 fullnameOverride: ""
 
@@ -35,19 +56,6 @@ securityContext: {}
 service:
   type: ClusterIP
   port: 8080
-
-ingress:
-  enabled: false
-  annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
-  hosts:
-    - host: bleed.lsst.codes
-      paths: ["/narrativelog"]
-  tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
Moving the charts from charts to this package broke value namespaces.
Rather than move the some of the names up a level, I put
application-specific values into namespace "config".

I also removed some values from values.yaml, replacing them with
comments, so that the site-specific file MUST override some values
in order for deployment to work. This is to avoid the current situation
where the service may run with incorrect default values.