### PR TITLE
DM-34090: Times Square: hard code redis port

### DIFF
--- a/services/times-square/charts/times-square/templates/configmap.yaml
+++ b/services/times-square/charts/times-square/templates/configmap.yaml
@@ -11,4 +11,4 @@ data:
   TS_ENVIRONMENT_URL: {{ .Values.global.baseUrl | quote }}
   TS_PATH_PREFIX: {{ .Values.ingress.path }}
   TS_DATABASE_URL: {{ required "config.databaseUrl must be set" .Values.config.databaseUrl | quote }}
-  TS_REDIS_URL: "redis://{{ include "times-square.fullname" . }}-redis-master.{{ .Release.Namespace }}:{{ .Values.redis.master.service.ports.redis }}/0"
+  TS_REDIS_URL: "redis://{{ include "times-square.fullname" . }}-redis-master.{{ .Release.Namespace }}:6379/0"


### PR DESCRIPTION
Helm / Argo CD is having trouble resolving the pointer to the port; so we'll hard code it for now.