### PR TITLE
DM-34090: Fix bitnami repo URL in times-square chart

### DIFF
--- a/services/times-square/charts/times-square/Chart.yaml
+++ b/services/times-square/charts/times-square/Chart.yaml
@@ -1,3 +1,4 @@
+apiVersion: v2
 description: A parameterized notebook web viewer for the Rubin Science Platform.
 name: times-square
 type: application

--- a/services/times-square/charts/times-square/Chart.yaml
+++ b/services/times-square/charts/times-square/Chart.yaml
@@ -20,4 +20,4 @@ appVersion: "1.0.0"
 dependencies:
   - name: redis
     version: 16.0.1
-    repository: https://charts.bitnami.com
+    repository: https://charts.bitnami.com/bitnami

--- a/services/times-square/charts/times-square/templates/configmap.yaml
+++ b/services/times-square/charts/times-square/templates/configmap.yaml
@@ -11,4 +11,4 @@ data:
   TS_ENVIRONMENT_URL: {{ .Values.global.baseUrl | quote }}
   TS_PATH_PREFIX: {{ .Values.ingress.path }}
   TS_DATABASE_URL: {{ required "config.databaseUrl must be set" .Values.config.databaseUrl | quote }}
-  TS_REDIS_URL: "redis://{{ include "times-square.fullname" . }}-redis-master.{{ .Release.Namespace }}:6379/0"
+  TS_REDIS_URL: "redis://{{ include "times-square.fullname" . }}-redis-master.{{ .Release.Namespace }}:{{ .Values.redis.master.service.ports.redis }}/0"


### PR DESCRIPTION
This seems to be the ultimate issue with the times-square chart — that the `/bitnami` chart was left off the Helm repo.