### PR TITLE
DM-34090: Move redis dependency to top-level chart

### DIFF
--- a/services/times-square/Chart.yaml
+++ b/services/times-square/Chart.yaml
@@ -15,3 +15,6 @@ dependencies:
     version: 1.0.0
   - name: times-square-ui
     version: 1.0.0
+  - name: redis
+    version: 16.0.1
+    repository: https://charts.bitnami.com/bitnami

--- a/services/times-square/charts/times-square/Chart.yaml
+++ b/services/times-square/charts/times-square/Chart.yaml
@@ -15,9 +15,3 @@ version: 1.0.0
 # Use times-square.image.tag to manage this from the top-level values
 # instead.
 appVersion: "1.0.0"
-
-# Additional charts that this chart uses
-dependencies:
-  - name: redis
-    version: 16.0.1
-    repository: https://charts.bitnami.com/bitnami

--- a/services/times-square/charts/times-square/templates/configmap.yaml
+++ b/services/times-square/charts/times-square/templates/configmap.yaml
@@ -11,4 +11,4 @@ data:
   TS_ENVIRONMENT_URL: {{ .Values.global.baseUrl | quote }}
   TS_PATH_PREFIX: {{ .Values.ingress.path }}
   TS_DATABASE_URL: {{ required "config.databaseUrl must be set" .Values.config.databaseUrl | quote }}
-  TS_REDIS_URL: "redis://{{ include "times-square.fullname" . }}-redis-master.{{ .Release.Namespace }}:6379/0"
+  TS_REDIS_URL: {{ required "config.redisUrl must be set" .Values.config.redusUrl | quote }}

--- a/services/times-square/charts/times-square/values.yaml
+++ b/services/times-square/charts/times-square/values.yaml
@@ -110,6 +110,10 @@ config:
   # @default -- None, must be set
   databaseUrl: ""
 
+  # -- URL for the Redis cache
+  # @default -- None, must be set
+  redisUrl: ""
+
 cloudsql:
   # -- Enable the Cloud SQL Auth Proxy sidecar, used with CloudSQL databases
   # on Google Cloud

--- a/services/times-square/values.yaml
+++ b/services/times-square/values.yaml
@@ -1,21 +1,3 @@
-times-square:
-
-  fullnameOverride: times-square
-
-  image:
-    tag: "tickets-DM-34030"
-
-    pullPolicy: "IfNotPresent"
-
-times-square-ui:
-
-  fullnameOverride: times-square-ui
-
-  image:
-    tag: "tickets-DM-34030"
-
-    pullPolicy: "IfNotPresent"
-
 # Global parameters will be set by parameters injected via the Argo CD
 # Application resource and should not be set in the individual environment
 # values files.
@@ -31,3 +13,32 @@ global:
   # -- Base path for Vault secrets
   # @default -- Set by times-square Argo CD Application
   vaultSecretsPathPrefix: ""
+
+times-square:
+
+  fullnameOverride: times-square
+
+  image:
+    tag: "tickets-DM-34030"
+
+    pullPolicy: "IfNotPresent"
+
+  config:
+    # -- Redis URL
+    # @default -- Points to embedded Redis
+    redisUrl: "redis://times-square-redis-master:6379/0"
+
+times-square-ui:
+
+  fullnameOverride: times-square-ui
+
+  image:
+    tag: "tickets-DM-34030"
+
+    pullPolicy: "IfNotPresent"
+
+redis:
+  fullnameOverride: times-square-redis
+
+  auth:
+    enabled: false


### PR DESCRIPTION
Helm was not showing the redis deployment when it was a sub-sub-chart (via the time-square subchart). Moving redis up to the top-level as a normal sub-chart should resolve this problem.

It does mean that the redis URL now needs to be hard-coded, but this shouldn't be a difficulty since the redis deployment is fully under this Helm chart's control.