### PR TITLE
[DM-34180] Move tap-schema chart into Phalanx

### DIFF
--- a/docs/service-guide/update-tap-schema.rst
+++ b/docs/service-guide/update-tap-schema.rst
@@ -5,10 +5,9 @@ The ``TAP_SCHEMA`` table stores information about the tables available in a give
 This table is kept in sync with the felis files using the following process:
 
 #. Make a PR to the `sdm_schemas repository <https://github.com/lsst/sdm_schemas>`__ with a change to a felis YAML file.
-#. After this is merged, make a GitHub release with a new version number.
+#. After this is merged, make a GitHub release of sdm_schemas with a new semver version number.
+   (Ignore the weekly tags that are added by other processes.)
    This will create a tag and run a publishing pipeline GitHub Action.
    That publishing pipeline will run the Python felis library against the YAML files in the ``yml`` directory and make different Docker images for the different supported environments.
    It will then push the images to DockerHub.
-#. Update the version of the `tap-schema chart <https://github.com/lsst-sqre/charts/tree/master/charts/tap-schema>`__ following the instructions in :doc:`upgrade`.
-   The ``appVersion`` in ``Chart.yaml`` should be updated to match the version of the new release, and the ``version`` of the chart increased following normal semver conventions.
-#. Sync the ``tap-schema`` application in Argo CD in the relevant environment or environments (see :doc:`sync-argo-cd`).
+#. Update the ``appVersion`` version to the version of the new release in the `tap-schema Phalanx service <https://github.com/lsst-sqre/phalanx/blob/master/services/tap-schema/Chart.yaml>`__.

--- a/services/tap-schema/Chart.yaml
+++ b/services/tap-schema/Chart.yaml
@@ -1,10 +1,6 @@
 apiVersion: v2
+appVersion: 1.1.7
+description: The TAP_SCHEMA database
+home: https://github.com/lsst-sqre/lsst-tap-service
 name: tap-schema
 version: 1.0.0
-dependencies:
-- name: tap-schema
-  version: ">=0.1.0"
-  repository: https://lsst-sqre.github.io/charts/
-- name: pull-secret
-  version: 0.1.2
-  repository: https://lsst-sqre.github.io/charts/

--- a/services/tap-schema/README.md.gotmpl
+++ b/services/tap-schema/README.md.gotmpl
@@ -1,0 +1,9 @@
+{{ template "chart.header" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesSection" . }}
+
+{{ template "helm-docs.versionFooter" . }}

--- a/services/tap-schema/templates/_helpers.tpl
+++ b/services/tap-schema/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "tap-schema.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "tap-schema.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "tap-schema.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "tap-schema.labels" -}}
+helm.sh/chart: {{ include "tap-schema.chart" . }}
+{{ include "tap-schema.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "tap-schema.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "tap-schema.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/services/tap-schema/templates/tap-schema-db-deployment.yaml
+++ b/services/tap-schema/templates/tap-schema-db-deployment.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "tap-schema.fullname" . }}-db
+  labels:
+    {{- include "tap-schema.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "tap-schema.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "tap-schema.selectorLabels" . | nindent 8 }}
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - name: {{ .Chart.Name }}
+          env:
+            - name: MYSQL_DATABASE
+              value: "TAP_SCHEMA"
+            - name: MYSQL_USER
+              value: "TAP_SCHEMA"
+            - name: MYSQL_PASSWORD
+              value: "TAP_SCHEMA"
+            - name: MYSQL_ROOT_HOST
+              value: "%"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          ports:
+            - containerPort: 3306
+              protocol: "TCP"
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      imagePullSecrets:
+        - name: "pull-secret"
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/services/tap-schema/templates/tap-schema-db-service.yaml
+++ b/services/tap-schema/templates/tap-schema-db-service.yaml
@@ -1,0 +1,14 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{ template "tap-schema.fullname" . }}-db
+  labels:
+    {{- include "tap-schema.labels" . | nindent 4 }}
+spec:
+  type: "ClusterIP"
+  ports:
+    - protocol: "TCP"
+      port: 3306
+      targetPort: 3306
+  selector:
+    {{- include "tap-schema.selectorLabels" . | nindent 4 }}

--- a/services/tap-schema/templates/vault-secrets.yaml
+++ b/services/tap-schema/templates/vault-secrets.yaml
@@ -1,0 +1,9 @@
+apiVersion: ricoberger.de/v1alpha1
+kind: VaultSecret
+metadata:
+  name: "pull-secret"
+  labels:
+    {{- include "tap-schema.labels" . | nindent 4 }}
+spec:
+  path: "{{ .Values.globals.vaultSecretsPath }}/pull-secret"
+  type: "kubernetes.io/dockerconfigjson"

--- a/services/tap-schema/values-idfdev.yaml
+++ b/services/tap-schema/values-idfdev.yaml
@@ -1,7 +1,0 @@
-tap-schema:
-  pull_secret: 'pull-secret'
-  image: lsstsqre/tap-schema-mock
-
-pull-secret:
-  enabled: true
-  path: secret/k8s_operator/data-dev.lsst.cloud/pull-secret

--- a/services/tap-schema/values-idfint.yaml
+++ b/services/tap-schema/values-idfint.yaml
@@ -1,7 +1,2 @@
-tap-schema:
-  pull_secret: 'pull-secret'
-  image: lsstsqre/tap-schema-idfint
-
-pull-secret:
-  enabled: true
-  path: secret/k8s_operator/data-int.lsst.cloud/pull-secret
+image:
+  repository: "lsstsqre/tap-schema-idfint"

--- a/services/tap-schema/values-idfprod.yaml
+++ b/services/tap-schema/values-idfprod.yaml
@@ -1,7 +1,2 @@
-tap-schema:
-  pull_secret: 'pull-secret'
-  image: lsstsqre/tap-schema-idfprod
-
-pull-secret:
-  enabled: true
-  path: secret/k8s_operator/data.lsst.cloud/pull-secret
+image:
+  repository: "lsstsqre/tap-schema-idfprod"

--- a/services/tap-schema/values-int.yaml
+++ b/services/tap-schema/values-int.yaml
@@ -1,7 +1,2 @@
-tap-schema:
-  pull_secret: 'pull-secret'
-  image: lsstsqre/tap-schema-int
-
-pull-secret:
-  enabled: true
-  path: secret/k8s_operator/lsst-lsp-int.ncsa.illinois.edu/pull-secret
+image:
+  repository: "lsstsqre/tap-schema-int"

--- a/services/tap-schema/values-minikube.yaml
+++ b/services/tap-schema/values-minikube.yaml
@@ -1,7 +1,0 @@
-tap-schema:
-  pull_secret: 'pull-secret'
-  image: lsstsqre/tap-schema-mock
-
-pull-secret:
-  enabled: true
-  path: secret/k8s_operator/minikube.lsst.codes/pull-secret

--- a/services/tap-schema/values-red-five.yaml
+++ b/services/tap-schema/values-red-five.yaml
@@ -1,7 +1,0 @@
-tap-schema:
-  pull_secret: 'pull-secret'
-  image: lsstsqre/tap-schema-mock
-
-pull-secret:
-  enabled: true
-  path: secret/k8s_operator/red-five.lsst.codes/pull-secret

--- a/services/tap-schema/values-roe.yaml
+++ b/services/tap-schema/values-roe.yaml
@@ -1,7 +1,0 @@
-tap-schema:
-  pull_secret: 'pull-secret'
-  image: lsstsqre/tap-schema-mock
-
-pull-secret:
-  enabled: true
-  path: secret/k8s_operator/roe/pull-secret

--- a/services/tap-schema/values-stable.yaml
+++ b/services/tap-schema/values-stable.yaml
@@ -1,7 +1,2 @@
-tap-schema:
-  pull_secret: 'pull-secret'
-  image: lsstsqre/tap-schema-stable
-
-pull-secret:
-  enabled: true
-  path: secret/k8s_operator/lsst-lsp-stable.ncsa.illinois.edu/pull-secret
+image:
+  repository: "lsstsqre/tap-schema-stable"

--- a/services/tap-schema/values.yaml
+++ b/services/tap-schema/values.yaml
@@ -1,0 +1,48 @@
+# Default values for tap-schema.
+
+# -- Override the base name for resources
+nameOverride: ""
+
+# -- Override the full name for resources (includes the release name)
+fullnameOverride: ""
+
+image:
+  # -- tap-schema image to use
+  repository: "lsstdax/tap-schema-mock"
+
+  # -- Pull policy for the tap-schema image
+  pullPolicy: "IfNotPresent"
+
+  # -- Tag of tap-schema image to use
+  # @default -- The appVersion of the chart
+  tag: ""
+
+# -- Resource limits and requests for the MySQL pod
+resources: {}
+
+# -- Annotations for the MySQL pod
+podAnnotations: {}
+
+# -- Node selector rules for the MySQL pod
+nodeSelector: {}
+
+# -- Tolerations for the MySQL pod
+tolerations: []
+
+# -- Affinity rules for the MySQL pod
+affinity: {}
+
+# The following will be set by parameters injected by Argo CD and should not
+# be set in the individual environment values files.
+globals:
+  # -- Base URL for the environment
+  # @default -- Set by Argo CD
+  baseUrl: ""
+
+  # -- Host name for ingress
+  # @default -- Set by Argo CD
+  host: ""
+
+  # -- Base path for Vault secrets
+  # @default -- Set by Argo CD
+  vaultSecretsPath: ""


### PR DESCRIPTION
Simplify the configuration and update the Helm resources to match
our current standards.  Update the documentation for how to push
out a new TAP schema.