### PR TITLE
[DM-34097] Use 4.0.0 of Gafaelfawr everywhere

### DIFF
--- a/services/gafaelfawr/values-idfdev.yaml
+++ b/services/gafaelfawr/values-idfdev.yaml
@@ -1,7 +1,3 @@
-image:
-  tag: "tickets-DM-34097"
-  pullPolicy: "Always"
-
 # Use the CSI storage class so that we can use snapshots.
 redis:
   persistence:

--- a/services/gafaelfawr/values-minikube.yaml
+++ b/services/gafaelfawr/values-minikube.yaml
@@ -1,6 +1,3 @@
-image:
-  tag: "tickets-DM-34097"
-
 # Reset token storage on every Redis restart.
 redis:
   persistence:


### PR DESCRIPTION
The new release is out, so undo the image pinning used for testing.