### PR TITLE
[DM-34199] Revert "Move the mobu application to a different namespace"

### DIFF
--- a/science-platform/templates/mobu-application.yaml
+++ b/science-platform/templates/mobu-application.yaml
@@ -11,7 +11,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: "mobu"
-  namespace: "mobu"
+  namespace: "argocd"
   finalizers:
     - "resources-finalizer.argocd.argoproj.io"
 spec:


### PR DESCRIPTION
This reverts commit 1abd97379dd2c72fb0b5c18ccb90822685ff3652.
Still not supported by Argo CD.