### PR TITLE
[DM-34317] Add sherlock secrets, fix vo-cutouts

### DIFF
--- a/installer/generate_secrets.py
+++ b/installer/generate_secrets.py
@@ -53,6 +53,7 @@ class SecretGenerator:
         self._portal()
         self._vo_cutouts()
         self._telegraf()
+        self._sherlock()
 
         self.input_field("cert-manager", "enabled", "Use cert-manager? (y/n):")
         use_cert_manager = self.secrets["cert-manager"]["enabled"]
@@ -139,7 +140,7 @@ class SecretGenerator:
         self._set_generated("postgres", "gafaelfawr_password", secrets.token_hex(32))
         self._set_generated("postgres", "jupyterhub_password", secrets.token_hex(32))
         self._set_generated("postgres", "root_password", secrets.token_hex(64))
-        self._set_generated("postgres", "vo-cutouts_password", secrets.token_hex(32))
+        self._set_generated("postgres", "vo_cutouts_password", secrets.token_hex(32))
         self._set_generated("postgres", "narrativelog_password", secrets.token_hex(32))
 
     def _nublado2(self):
@@ -284,6 +285,11 @@ class SecretGenerator:
         self._set("vo-cutouts", "google-credentials", google)
         postgres = self.secrets["butler-secret"]["postgres-credentials.txt"]
         self._set("vo-cutouts", "postgres-credentials", postgres)
+
+    def _sherlock(self):
+        """This secret is for sherlock to push status to status.lsst.codes."""
+        publish_key = secrets.token_hex(32)
+        self._set_generated("sherlock", "publish_key", publish_key)
 
 
 class OnePasswordSecretGenerator(SecretGenerator):


### PR DESCRIPTION
So the vocutouts thing had a keyerror exception when running it,
because postgres was generating it one way, and then we tried pulling
out the wrong key.  So that's the vo-cutouts fix.

Now that we have that working, add the sherlock generated secret
for publishing.