### PR TITLE
added annotation for workload identity to authenticate with gar

### DIFF
--- a/services/cachemachine/values-idfdev.yaml
+++ b/services/cachemachine/values-idfdev.yaml
@@ -4,6 +4,11 @@ ingress:
 
 vaultSecretsPath: "secret/k8s_operator/data-dev.lsst.cloud/pull-secret"
 
+serviceAccount:
+  annotations: {
+    iam.gke.io/gcp-service-account: cachemachine-wi@science-platform-dev-7696.iam.gserviceaccount.com
+  }
+
 autostart:
   jupyter: |
     {


### PR DESCRIPTION
added annotation.  The SA name defaults to the namespace name so did not add that value.