### PR TITLE
DM-34437: Update Squareone to 0.6.0

### DIFF
--- a/services/squareone/Chart.yaml
+++ b/services/squareone/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
     url: https://github.com/jonathansick
 
 # The default version tag of the squareone docker image
-appVersion: "0.5.0"
+appVersion: "0.6.0"
 
 dependencies:
   - name: pull-secret


### PR DESCRIPTION
This release includes handling for info banners and auto refreshing of broadcast message data.