### PR TITLE
[DM-34385] Ignore nublado2 secret differences

### DIFF
--- a/science-platform/templates/nublado2-application.yaml
+++ b/science-platform/templates/nublado2-application.yaml
@@ -2,29 +2,41 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: nublado2
+  name: "nublado2"
 spec:
   finalizers:
-    - kubernetes
+    - "kubernetes"
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: nublado2
-  namespace: argocd
+  name: "nublado2"
+  namespace: "argocd"
   finalizers:
-    - resources-finalizer.argocd.argoproj.io
+    - "resources-finalizer.argocd.argoproj.io"
 spec:
   destination:
-    namespace: nublado2
-    server: https://kubernetes.default.svc
-  project: default
+    namespace: "nublado2"
+    server: "https://kubernetes.default.svc"
+  project: "default"
   source:
-    path: services/nublado2
-    repoURL: {{ .Values.repoURL }}
-    targetRevision: {{ .Values.revision }}
+    path: "services/nublado2"
+    repoURL: {{ .Values.repoURL | quote }}
+    targetRevision: {{ .Values.revision | quote }}
     helm:
       valueFiles:
-        - values.yaml
-        - values-{{ .Values.environment }}.yaml
+        - "values.yaml"
+        - "values-{{ .Values.environment }}.yaml"
+  ignoreDifferences:
+    - group: ""
+      kind: "Secret"
+      jsonPointers:
+        - "/data/hub.config.ConfigurableHTTPProxy.auth_token"
+        - "/data/hub.config.CryptKeeper.keys"
+        - "/data/hub.config.JupyterHub.cookie_secret"
+    - group: "apps"
+      kind: "Deployment"
+      jsonPointers:
+        - "/spec/template/metadata/annotations/checksum~1secret"
+        - "/spec/template/metadata/annotations/checksum~1auth-token"
 {{- end -}}


### PR DESCRIPTION
nublado2 does automatic secret rotation, which means that it always
shows as out of date.  Configure Argo CD to ignore the secret changes
and the associated checksum changes on the deployment objects.