### PR TITLE
[DM-34385] Move the vo-cutouts chart into Phalanx

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,8 +77,8 @@ jobs:
         if: steps.filter.outputs.minikube == 'true'
         uses: manusa/actions-setup-minikube@v2.4.3
         with:
-          minikube version: 'v1.24.0'
-          kubernetes version: 'v1.22.5'
+          minikube version: 'v1.25.2'
+          kubernetes version: 'v1.22.8'
 
       - name: Test interaction with the cluster
         if: steps.filter.outputs.minikube == 'true'
@@ -87,11 +87,11 @@ jobs:
       - name: Download installer dependencies
         if: steps.filter.outputs.minikube == 'true'
         run: |
-          curl -sSL -o /tmp/vault.zip https://releases.hashicorp.com/vault/1.9.1/vault_1.9.1_linux_amd64.zip
+          curl -sSL -o /tmp/vault.zip https://releases.hashicorp.com/vault/1.9.4/vault_1.9.4_linux_amd64.zip
           unzip /tmp/vault.zip
           sudo mv vault /usr/local/bin/vault
           sudo chmod +x /usr/local/bin/vault
-          sudo curl -sSL -o /usr/local/bin/argocd https://github.com/argoproj/argo-cd/releases/download/v2.1.7/argocd-linux-amd64
+          sudo curl -sSL -o /usr/local/bin/argocd https://github.com/argoproj/argo-cd/releases/download/v2.3.3/argocd-linux-amd64
           sudo chmod +x /usr/local/bin/argocd
           sudo apt-get install socat
           sudo pip install -r installer/requirements.txt

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,6 +52,7 @@ jobs:
   minikube:
     name: Test deploy
     runs-on: ubuntu-latest
+    needs: [helm]
 
     steps:
       - name: Checkout

--- a/science-platform/templates/vo-cutouts-application.yaml
+++ b/science-platform/templates/vo-cutouts-application.yaml
@@ -2,28 +2,36 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: vo-cutouts
+  name: "vo-cutouts"
 spec:
   finalizers:
-    - kubernetes
+    - "kubernetes"
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: vo-cutouts
-  namespace: argocd
+  name: "vo-cutouts"
+  namespace: "argocd"
   finalizers:
-    - resources-finalizer.argocd.argoproj.io
+    - "resources-finalizer.argocd.argoproj.io"
 spec:
   destination:
-    namespace: vo-cutouts
-    server: https://kubernetes.default.svc
-  project: default
+    namespace: "vo-cutouts"
+    server: "https://kubernetes.default.svc"
+  project: "default"
   source:
-    path: services/vo-cutouts
-    repoURL: {{ .Values.repoURL }}
-    targetRevision: {{ .Values.revision }}
+    path: "services/vo-cutouts"
+    repoURL: {{ .Values.repoURL | quote }}
+    targetRevision: {{ .Values.revision | quote }}
     helm:
+      parameters:
+        - name: "global.host"
+          value: {{ .Values.fqdn | quote }}
+        - name: "global.baseUrl"
+          value: "https://{{ .Values.fqdn }}"
+        - name: "global.vaultSecretsPath"
+          value: {{ .Values.vault_path_prefix | quote }}
       valueFiles:
-        - values-{{ .Values.environment }}.yaml
+        - "values.yaml"
+        - "values-{{ .Values.environment }}.yaml"
 {{- end -}}

--- a/services/vo-cutouts/Chart.yaml
+++ b/services/vo-cutouts/Chart.yaml
@@ -1,10 +1,6 @@
 apiVersion: v2
 name: vo-cutouts
 version: 1.0.0
-dependencies:
-  - name: vo-cutouts
-    version: 0.3.3
-    repository: https://lsst-sqre.github.io/charts/
-  - name: pull-secret
-    version: 0.1.2
-    repository: https://lsst-sqre.github.io/charts/
+description: "Image cutout service complying with IVOA SODA"
+home: "https://github.com/lsst-sqre/vo-cutouts"
+appVersion: 0.3.0

--- a/services/vo-cutouts/README.md
+++ b/services/vo-cutouts/README.md
@@ -1,0 +1,67 @@
+# vo-cutouts
+
+Image cutout service complying with IVOA SODA
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Affinity rules for the vo-cutouts frontend pod |
+| cloudsql.enabled | bool | `false` | Enable the Cloud SQL Auth Proxy sidecar, used with CloudSQL databases on Google Cloud |
+| cloudsql.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for Cloud SQL Auth Proxy images |
+| cloudsql.image.repository | string | `"gcr.io/cloudsql-docker/gce-proxy"` | Cloud SQL Auth Proxy image to use |
+| cloudsql.image.tag | string | `"1.30.0"` | Cloud SQL Auth Proxy tag to use |
+| cloudsql.instanceConnectionName | string | `""` | Instance connection name for a CloudSQL PostgreSQL instance |
+| cloudsql.serviceAccount | string | None, must be set | The Google service account that has an IAM binding to the `vo-cutouts` Kubernetes service accounts and has the `cloudsql.client` role, access to the GCS bucket, and ability to sign URLs as itself |
+| config.butlerRepository | string | None, must be set | Configuration for the Butler repository to use |
+| config.databaseUrl | string | None, must be set | URL for the PostgreSQL database |
+| config.gcsBucketUrl | string | None, must be set | URL for the GCS bucket into which to store cutouts (must start with `s3`) |
+| config.lifetime | string | 2592000 (30 days) | Lifetime of job results in seconds (quote so that Helm doesn't turn it into a floating point number) |
+| config.loglevel | string | `"INFO"` | Choose from the text form of Python logging levels |
+| config.syncTimeout | int | 60 (1 minute) | Timeout for results from a sync cutout in seconds |
+| config.timeout | int | 600 (10 minutes) | Timeout for a single cutout job in seconds |
+| cutoutWorker.affinity | object | `{}` | Affinity rules for the cutout worker pod |
+| cutoutWorker.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for cutout workers |
+| cutoutWorker.image.repository | string | `"lsstsqre/vo-cutouts-worker"` | Stack image to use for cutouts |
+| cutoutWorker.image.tag | string | The appVersion of the chart | Tag of vo-cutouts worker image to use |
+| cutoutWorker.nodeSelector | object | `{}` | Node selection rules for the cutout worker pod |
+| cutoutWorker.podAnnotations | object | `{}` | Annotations for the cutout worker pod |
+| cutoutWorker.replicaCount | int | `2` | Number of cutout worker pods to start |
+| cutoutWorker.resources | object | `{}` | Resource limits and requests for the cutout worker pod |
+| cutoutWorker.tolerations | list | `[]` | Tolerations for the cutout worker pod |
+| databaseWorker.affinity | object | `{}` | Affinity rules for the database worker pod |
+| databaseWorker.nodeSelector | object | `{}` | Node selection rules for the database worker pod |
+| databaseWorker.podAnnotations | object | `{}` | Annotations for the database worker pod |
+| databaseWorker.replicaCount | int | `1` | Number of database worker pods to start |
+| databaseWorker.resources | object | `{}` | Resource limits and requests for the database worker pod |
+| databaseWorker.tolerations | list | `[]` | Tolerations for the database worker pod |
+| fullnameOverride | string | `""` | Override the full name for resources (includes the release name) |
+| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
+| global.host | string | Set by Argo CD | Host name for ingress |
+| global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
+| image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the vo-cutouts image |
+| image.repository | string | `"lsstsqre/vo-cutouts"` | vo-cutouts image to use |
+| image.tag | string | The appVersion of the chart | Tag of vo-cutouts image to use |
+| ingress.annotations | object | `{}` | Additional annotations to add to the ingress |
+| ingress.gafaelfawrAuthQuery | string | `"scope=read:image"` | Gafaelfawr auth query string |
+| nameOverride | string | `""` | Override the base name for resources |
+| nodeSelector | object | `{}` | Node selector rules for the vo-cutouts frontend pod |
+| podAnnotations | object | `{}` | Annotations for the vo-cutouts frontend pod |
+| redis.affinity | object | `{}` | Affinity rules for the Redis pod |
+| redis.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the Redis image |
+| redis.image.repository | string | `"redis"` | Redis image to use |
+| redis.image.tag | string | `"6.2.6"` | Redis image tag to use |
+| redis.nodeSelector | object | `{}` | Node selection rules for the Redis pod |
+| redis.persistence.accessMode | string | `"ReadWriteOnce"` | Access mode of storage to request |
+| redis.persistence.enabled | bool | `true` | Whether to persist Redis storage and thus tokens. Setting this to false will use `emptyDir` and reset all tokens on every restart. Only use this for a test deployment. |
+| redis.persistence.size | string | `"100Mi"` | Amount of persistent storage to request |
+| redis.persistence.storageClass | string | `""` | Class of storage to request |
+| redis.persistence.volumeClaimName | string | `""` | Use an existing PVC, not dynamic provisioning. If this is set, the size, storageClass, and accessMode settings are ignored. |
+| redis.podAnnotations | object | `{}` | Pod annotations for the Redis pod |
+| redis.tolerations | list | `[]` | Tolerations for the Redis pod |
+| replicaCount | int | `1` | Number of web frontend pods to start |
+| resources | object | `{}` | Resource limits and requests for the vo-cutouts frontend pod |
+| tolerations | list | `[]` | Tolerations for the vo-cutouts frontend pod |
+
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.5.0](https://github.com/norwoodj/helm-docs/releases/v1.5.0)

--- a/services/vo-cutouts/README.md.gotmpl
+++ b/services/vo-cutouts/README.md.gotmpl
@@ -1,0 +1,9 @@
+{{ template "chart.header" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesSection" . }}
+
+{{ template "helm-docs.versionFooter" . }}

--- a/services/vo-cutouts/templates/_helpers.tpl
+++ b/services/vo-cutouts/templates/_helpers.tpl
@@ -1,0 +1,52 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "vo-cutouts.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "vo-cutouts.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "vo-cutouts.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "vo-cutouts.labels" -}}
+helm.sh/chart: {{ include "vo-cutouts.chart" . }}
+{{ include "vo-cutouts.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "vo-cutouts.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "vo-cutouts.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/services/vo-cutouts/templates/configmap.yaml
+++ b/services/vo-cutouts/templates/configmap.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "vo-cutouts.fullname" . }}-config
+  labels:
+    {{- include "vo-cutouts.labels" . | nindent 4 }}
+data:
+  CUTOUT_BUTLER_REPOSITORY: {{ required "config.butlerRepository must be set" .Values.config.butlerRepository | quote }}
+  CUTOUT_DATABASE_URL: {{ required "config.databaseUrl must be set" .Values.config.databaseUrl | quote }}
+  CUTOUT_SERVICE_ACCOUNT: {{ required "cloudsql.serviceAccount must be set" .Values.cloudsql.serviceAccount | quote }}
+  CUTOUT_STORAGE_URL: {{ required "config.gcsBucketUrl must be set" .Values.config.gcsBucketUrl | quote }}
+  CUTOUT_TIMEOUT: {{ .Values.config.timeout | quote }}
+  CUTOUT_LIFETIME: {{ .Values.config.lifetime | quote }}
+  CUTOUT_REDIS_HOST: "{{ template "vo-cutouts.fullname" . }}-redis.{{ .Release.Namespace }}"
+  CUTOUT_SYNC_TIMEOUT: {{ .Values.config.syncTimeout | quote }}
+  SAFIR_LOG_LEVEL: {{ .Values.config.loglevel | quote }}
+  SAFIR_PROFILE: "production"

--- a/services/vo-cutouts/templates/db-worker-deployment.yaml
+++ b/services/vo-cutouts/templates/db-worker-deployment.yaml
@@ -1,0 +1,107 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "vo-cutouts.fullname" . }}-db-worker
+  labels:
+    {{- include "vo-cutouts.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.databaseWorker.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "vo-cutouts.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: "db-worker"
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.databaseWorker.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "vo-cutouts.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: "db-worker"
+    spec:
+      {{- if .Values.cloudsql.enabled }}
+      serviceAccountName: {{ include "vo-cutouts.fullname" . }}
+      {{- else }}
+      automountServiceAccountToken: false
+      {{- end }}
+      containers:
+        {{- if .Values.cloudsql.enabled }}
+        - name: "cloud-sql-proxy"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+          image: "{{ .Values.cloudsql.image.repository }}:{{ .Values.cloudsql.image.tag }}"
+          imagePullPolicy: {{ .Values.cloudsql.image.pullPolicy | quote }}
+          command:
+            - "/cloud_sql_proxy"
+            - "-ip_address_types=PRIVATE"
+            - "-instances={{ required "cloudsql.instanceConnectionName must be specified" .Values.cloudsql.instanceConnectionName }}=tcp:5432"
+        {{- end }}
+        - name: "db-worker"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+            readOnlyRootFilesystem: true
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          command:
+            - "dramatiq"
+            - "vocutouts.actors"
+            - "-Q"
+            - "uws"
+            - "-p"
+            - "1"
+          env:
+            - name: "CUTOUT_DATABASE_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "vo-cutouts.fullname" . }}-secret
+                  key: "database-password"
+            - name: "CUTOUT_REDIS_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "vo-cutouts.fullname" . }}-secret
+                  key: "redis-password"
+          envFrom:
+            - configMapRef:
+                name: {{ template "vo-cutouts.fullname" . }}-config
+          {{- with .Values.databaseWorker.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: "tmp"
+              mountPath: "/tmp"
+      imagePullSecrets:
+        - name: "pull-secret"
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+      volumes:
+        # Dramatiq enables its Prometheus middleware by default, which
+        # requires writable /tmp.
+        - name: "tmp"
+          emptyDir: {}
+      {{- with .Values.databaseWorker.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.databaseWorker.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.databaseWorker.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/services/vo-cutouts/templates/db-worker-networkpolicy.yaml
+++ b/services/vo-cutouts/templates/db-worker-networkpolicy.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ template "vo-cutouts.fullname" . }}-db-worker
+  labels:
+    {{- include "vo-cutouts.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    # This policy controls inbound and outbound access to the database workers.
+    matchLabels:
+      {{- include "vo-cutouts.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: "db-worker"
+  policyTypes:
+    # Block all inbound access.
+    - Ingress

--- a/services/vo-cutouts/templates/deployment.yaml
+++ b/services/vo-cutouts/templates/deployment.yaml
@@ -1,0 +1,108 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "vo-cutouts.fullname" . }}
+  labels:
+    {{- include "vo-cutouts.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "vo-cutouts.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: "frontend"
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "vo-cutouts.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: "frontend"
+    spec:
+      {{- if .Values.cloudsql.enabled }}
+      serviceAccountName: {{ include "vo-cutouts.fullname" . }}
+      {{- else }}
+      automountServiceAccountToken: false
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+      containers:
+        {{- if .Values.cloudsql.enabled }}
+        - name: "cloud-sql-proxy"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+          image: "{{ .Values.cloudsql.image.repository }}:{{ .Values.cloudsql.image.tag }}"
+          imagePullPolicy: {{ .Values.cloudsql.image.pullPolicy | quote }}
+          command:
+            - "/cloud_sql_proxy"
+            - "-ip_address_types=PRIVATE"
+            - "-instances={{ required "cloudsql.instanceConnectionName must be specified" .Values.cloudsql.instanceConnectionName }}=tcp:5432"
+        {{- end }}
+        - name: "vo-cutouts"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+            readOnlyRootFilesystem: true
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          ports:
+            - containerPort: 8080
+              name: "http"
+              protocol: "TCP"
+          env:
+            - name: "CUTOUT_DATABASE_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "vo-cutouts.fullname" . }}-secret
+                  key: "database-password"
+            - name: "CUTOUT_REDIS_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "vo-cutouts.fullname" . }}-secret
+                  key: "redis-password"
+          envFrom:
+            - configMapRef:
+                name: {{ template "vo-cutouts.fullname" . }}-config
+          readinessProbe:
+            httpGet:
+              path: "/api/cutout/availability"
+              port: "http"
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: "tmp"
+              mountPath: "/tmp"
+      imagePullSecrets:
+        - name: "pull-secret"
+      volumes:
+        # Dramatiq enables its Prometheus middleware by default, which
+        # requires writable /tmp.
+        - name: "tmp"
+          emptyDir: {}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/services/vo-cutouts/templates/ingress.yaml
+++ b/services/vo-cutouts/templates/ingress.yaml
@@ -1,0 +1,29 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    {{- if .Values.ingress.gafaelfawrAuthQuery }}
+    nginx.ingress.kubernetes.io/auth-method: "GET"
+    nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-User
+    nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.global.baseUrl }}/login"
+    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.baseUrl }}/auth?{{ .Values.ingress.gafaelfawrAuthQuery }}"
+    {{- end }}
+    {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  name: {{ template "vo-cutouts.fullname" . }}
+  labels:
+    {{- include "vo-cutouts.labels" . | nindent 4 }}
+spec:
+  rules:
+    - host: {{ required "global.host must be set" .Values.global.host | quote }}
+      http:
+        paths:
+          - path: "/api/cutout"
+            pathType: "Prefix"
+            backend:
+              service:
+                name: {{ template "vo-cutouts.fullname" . }}
+                port:
+                  number: 8080

--- a/services/vo-cutouts/templates/networkpolicy.yaml
+++ b/services/vo-cutouts/templates/networkpolicy.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ template "vo-cutouts.fullname" . }}
+  labels:
+    {{- include "vo-cutouts.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    # This policy controls inbound access to the frontend component.
+    matchLabels:
+      {{- include "vo-cutouts.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: "frontend"
+  policyTypes:
+    - Ingress
+  ingress:
+    # Allow inbound access from pods (in any namespace) labeled
+    # gafaelfawr.lsst.io/ingress: true.
+    - from:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              gafaelfawr.lsst.io/ingress: "true"
+      ports:
+        - protocol: "TCP"
+          port: 8080

--- a/services/vo-cutouts/templates/redis-networkpolicy.yaml
+++ b/services/vo-cutouts/templates/redis-networkpolicy.yaml
@@ -1,0 +1,34 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ template "vo-cutouts.fullname" . }}-redis
+  labels:
+    {{- include "vo-cutouts.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    # This policy controls inbound and outbound access to the Redis component.
+    matchLabels:
+      {{- include "vo-cutouts.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: "redis"
+  policyTypes:
+    - Ingress
+    # Deny all outbound access; Redis doesn't need to talk to anything.
+    - Egress
+  ingress:
+    # Allow inbound access to Redis from all other components.
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "vo-cutouts.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: "frontend"
+        - podSelector:
+            matchLabels:
+              {{- include "vo-cutouts.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: "worker"
+        - podSelector:
+            matchLabels:
+              {{- include "vo-cutouts.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: "db-worker"
+      ports:
+        - protocol: "TCP"
+          port: 6379

--- a/services/vo-cutouts/templates/redis-service.yml
+++ b/services/vo-cutouts/templates/redis-service.yml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "vo-cutouts.fullname" . }}-redis
+  labels:
+    {{- include "vo-cutouts.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 6379
+      protocol: "TCP"
+      targetPort: 6379
+  selector:
+    {{- include "vo-cutouts.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: "redis"
+  sessionAffinity: None

--- a/services/vo-cutouts/templates/redis-statefulset.yaml
+++ b/services/vo-cutouts/templates/redis-statefulset.yaml
@@ -1,0 +1,107 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ template "vo-cutouts.fullname" . }}-redis
+  labels:
+    {{- include "vo-cutouts.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "vo-cutouts.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: "redis"
+  serviceName: "redis"
+  template:
+    metadata:
+      {{- with .Values.redis.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "vo-cutouts.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: "redis"
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - name: "redis"
+          image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
+          imagePullPolicy: {{ .Values.redis.image.pullPolicy | quote }}
+          args:
+            - "redis-server"
+            - "--appendonly"
+            - "yes"
+            - "--requirepass"
+            - "$(REDIS_PASSWORD)"
+          env:
+            - name: "REDIS_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "vo-cutouts.fullname" . }}-secret
+                  key: "redis-password"
+          livenessProbe:
+            exec:
+              command:
+                - "sh"
+                - "-c"
+                - "redis-cli -h $(hostname) incr health:counter"
+            initialDelaySeconds: 15
+            periodSeconds: 30
+          ports:
+            - containerPort: 6379
+          resources:
+            limits:
+              cpu: "1"
+            requests:
+              cpu: "100m"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: {{ template "vo-cutouts.fullname" . }}-redis-data
+              mountPath: "/data"
+      imagePullSecrets:
+        - name: "pull-secret"
+      securityContext:
+        fsGroup: 999
+        runAsNonRoot: true
+        runAsUser: 999
+        runAsGroup: 999
+      {{- if (not .Values.redis.persistence.enabled) }}
+      volumes:
+        - name: {{ template "vo-cutouts.fullname" . }}-redis-data
+          emptyDir: {}
+      {{- else if .Values.redis.persistence.volumeClaimName }}
+      volumes:
+        - name: {{ template "vo-cutouts.fullname" . }}-redis-data
+          persistentVolumeClaim:
+            claimName: {{ .Values.redis.persistence.volumeClaimName | quote }}
+      {{- end }}
+      {{- with .Values.redis.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.redis.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.redis.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- if (and .Values.redis.persistence.enabled (not .Values.redis.persistence.volumeClaimName)) }}
+  volumeClaimTemplates:
+    - metadata:
+        name: {{ template "vo-cutouts.fullname" . }}-redis-data
+      spec:
+        accessModes:
+          - {{ .Values.redis.persistence.accessMode | quote }}
+        resources:
+          requests:
+            storage: {{ .Values.redis.persistence.size | quote }}
+        {{- if .Values.redis.persistence.storageClass }}
+        storageClassName: {{ .Values.redis.persistence.storageClass | quote }}
+        {{- end }}
+  {{- end }}

--- a/services/vo-cutouts/templates/service.yaml
+++ b/services/vo-cutouts/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "vo-cutouts.fullname" . }}
+  labels:
+    {{- include "vo-cutouts.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - protocol: "TCP"
+      port: 8080
+      targetPort: "http"
+  selector:
+    {{- include "vo-cutouts.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: "frontend"
+  sessionAffinity: None

--- a/services/vo-cutouts/templates/serviceaccount.yaml
+++ b/services/vo-cutouts/templates/serviceaccount.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.cloudsql.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "vo-cutouts.fullname" . }}
+  labels:
+    {{- include "vo-cutouts.labels" . | nindent 4 }}
+  annotations:
+    iam.gke.io/gcp-service-account: {{ required "cloudsql.serviceAccount must be set to a valid Google service account" .Values.cloudsql.serviceAccount | quote }}
+{{- end }}

--- a/services/vo-cutouts/templates/vault-secrets.yaml
+++ b/services/vo-cutouts/templates/vault-secrets.yaml
@@ -1,0 +1,19 @@
+apiVersion: ricoberger.de/v1alpha1
+kind: VaultSecret
+metadata:
+  name: {{ template "vo-cutouts.fullname" . }}-secret
+  labels:
+    {{- include "vo-cutouts.labels" . | nindent 4 }}
+spec:
+  path: "{{ .Values.global.vaultSecretsPath }}/vo-cutouts"
+  type: Opaque
+---
+apiVersion: ricoberger.de/v1alpha1
+kind: VaultSecret
+metadata:
+  name: "pull-secret"
+  labels:
+    {{- include "vo-cutouts.labels" . | nindent 4 }}
+spec:
+  path: "{{ .Values.global.vaultSecretsPath }}/pull-secret"
+  type: "kubernetes.io/dockerconfigjson"

--- a/services/vo-cutouts/templates/worker-deployment.yaml
+++ b/services/vo-cutouts/templates/worker-deployment.yaml
@@ -1,0 +1,123 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "vo-cutouts.fullname" . }}-worker
+  labels:
+    {{- include "vo-cutouts.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.databaseWorker.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "vo-cutouts.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: "worker"
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.databaseWorker.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "vo-cutouts.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: "worker"
+    spec:
+      automountServiceAccountToken: false
+
+      # Butler uses a pgpass file to authenticate to its database, and
+      # PostgreSQL unfortunately requires its pgpass file be owned by the
+      # current user and mode 0600, but Kubernetes has no way of controlling
+      # the ownership of a mounted secret.  We therefore use a privileged init
+      # container to copy the secrets into a shared emptyDir and change their
+      # ownership and permissions.
+      initContainers:
+        - name: "fix-secret-permissions"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          command:
+            - "/bin/bash"
+            - "-c"
+            - |
+              cp -RL /etc/vo-cutouts/secrets-raw/* /etc/vo-cutouts/secrets
+              chmod 0400 /etc/vo-cutouts/secrets/*
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+          volumeMounts:
+            - name: "secrets"
+              mountPath: "/etc/vo-cutouts/secrets"
+            - name: "secrets-raw"
+              mountPath: "/etc/vo-cutouts/secrets-raw"
+              readOnly: true
+      containers:
+        - name: "worker"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+          image: "{{ .Values.cutoutWorker.image.repository }}:{{ .Values.cutoutWorker.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.cutoutWorker.image.pullPolicy | quote }}
+          env:
+            # The following are used by Butler to retrieve its configuration
+            # and authenticate to its database.
+            - name: "AWS_SHARED_CREDENTIALS_FILE"
+              value: "/etc/vo-cutouts/secrets/aws-credentials"
+            - name: "PGPASSFILE"
+              value: "/etc/vo-cutouts/secrets/postgres-credentials"
+            - name: "S3_ENDPOINT_URL"
+              value: "https://storage.googleapis.com"
+
+            # Authentication to the Redis queue for Dramatiq.
+            - name: "CUTOUT_REDIS_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "vo-cutouts.fullname" . }}-secret
+                  key: "redis-password"
+
+            # URL of the bucket into which to store the cutouts.
+            - name: "CUTOUT_STORAGE_URL"
+              value: {{ required "config.gcsBucketUrl must be set" .Values.config.gcsBucketUrl | quote }}
+
+            # Temporary directory into which to stage cutouts before uploading.
+            - name: "CUTOUT_TMPDIR"
+              value: "/tmp/cutouts"
+          envFrom:
+            - configMapRef:
+                name: {{ template "vo-cutouts.fullname" . }}-config
+          {{- with .Values.cutoutWorker.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: "secrets"
+              mountPath: "/etc/vo-cutouts/secrets"
+            - name: "tmp"
+              mountPath: "/tmp"
+      imagePullSecrets:
+        - name: "pull-secret"
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+      volumes:
+        - name: "secrets"
+          emptyDir: {}
+        - name: "secrets-raw"
+          secret:
+            secretName: {{ template "vo-cutouts.fullname" . }}-secret
+        - name: "tmp"
+          emptyDir: {}
+      {{- with .Values.cutoutWorker.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.cutoutWorker.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.cutoutWorker.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/services/vo-cutouts/templates/worker-networkpolicy.yaml
+++ b/services/vo-cutouts/templates/worker-networkpolicy.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ template "vo-cutouts.fullname" . }}-worker
+  labels:
+    {{- include "vo-cutouts.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    # This policy controls inbound and outbound access to the database workers.
+    matchLabels:
+      {{- include "vo-cutouts.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: "worker"
+  policyTypes:
+    # Block all inbound access.
+    - Ingress

--- a/services/vo-cutouts/values-idfdev.yaml
+++ b/services/vo-cutouts/values-idfdev.yaml
@@ -1,24 +1,12 @@
-vo-cutouts:
-  imagePullSecrets:
-    - name: "pull-secret"
-  ingress:
-    host: "data-dev.lsst.cloud"
-  vaultSecretsPath: "secret/k8s_operator/data-dev.lsst.cloud/vo-cutouts"
+config:
+  # There is currently no working Butler in data-dev, so this configuration
+  # won't work.  Leaving it here anyway since it has the correct configuration
+  # otherwise should we later get a Butler for that environment.
+  butlerRepository: "TBD"
+  databaseUrl: "postgresql://vo-cutouts@localhost/vo-cutouts"
+  gcsBucketUrl: "s3://rubin-cutouts-dev-us-central1-output/"
 
-  config:
-    # There is currently no working Butler in data-dev, so this configuration
-    # won't work.  Leaving it here anyway since it has the correct
-    # configuration otherwise should we later get a Butler for that
-    # environment.
-    butlerRepository: "TBD"
-    databaseUrl: "postgresql://vo-cutouts@localhost/vo-cutouts"
-    gcsBucketUrl: "s3://rubin-cutouts-dev-us-central1-output/"
-
-  cloudsql:
-    enabled: true
-    instanceConnectionName: "science-platform-dev-7696:us-central1:science-platform-dev-e9e11de2"
-    serviceAccount: "vo-cutouts@science-platform-dev-7696.iam.gserviceaccount.com"
-
-pull-secret:
+cloudsql:
   enabled: true
-  path: "secret/k8s_operator/data-dev.lsst.cloud/pull-secret"
+  instanceConnectionName: "science-platform-dev-7696:us-central1:science-platform-dev-e9e11de2"
+  serviceAccount: "vo-cutouts@science-platform-dev-7696.iam.gserviceaccount.com"

--- a/services/vo-cutouts/values-idfint.yaml
+++ b/services/vo-cutouts/values-idfint.yaml
@@ -1,20 +1,9 @@
-vo-cutouts:
-  imagePullSecrets:
-    - name: "pull-secret"
-  ingress:
-    host: "data-int.lsst.cloud"
-  vaultSecretsPath: "secret/k8s_operator/data-int.lsst.cloud/vo-cutouts"
+config:
+  butlerRepository: "s3://butler-us-central1-panda-dev/dc2/butler-external.yaml"
+  databaseUrl: "postgresql://vo-cutouts@localhost/vo-cutouts"
+  gcsBucketUrl: "s3://rubin-cutouts-int-us-central1-output/"
 
-  config:
-    butlerRepository: "s3://butler-us-central1-panda-dev/dc2/butler-external.yaml"
-    databaseUrl: "postgresql://vo-cutouts@localhost/vo-cutouts"
-    gcsBucketUrl: "s3://rubin-cutouts-int-us-central1-output/"
-
-  cloudsql:
-    enabled: true
-    instanceConnectionName: "science-platform-int-dc5d:us-central1:science-platform-int-8f439af2"
-    serviceAccount: "vo-cutouts@science-platform-int-dc5d.iam.gserviceaccount.com"
-
-pull-secret:
+cloudsql:
   enabled: true
-  path: "secret/k8s_operator/data-int.lsst.cloud/pull-secret"
+  instanceConnectionName: "science-platform-int-dc5d:us-central1:science-platform-int-8f439af2"
+  serviceAccount: "vo-cutouts@science-platform-int-dc5d.iam.gserviceaccount.com"

--- a/services/vo-cutouts/values-idfprod.yaml
+++ b/services/vo-cutouts/values-idfprod.yaml
@@ -1,20 +1,9 @@
-vo-cutouts:
-  imagePullSecrets:
-    - name: "pull-secret"
-  ingress:
-    host: "data.lsst.cloud"
-  vaultSecretsPath: "secret/k8s_operator/data.lsst.cloud/vo-cutouts"
+config:
+  butlerRepository: "s3://butler-us-central1-dp01"
+  databaseUrl: "postgresql://vo-cutouts@localhost/vo-cutouts"
+  gcsBucketUrl: "s3://rubin-cutouts-stable-us-central1-output/"
 
-  config:
-    butlerRepository: "s3://butler-us-central1-dp01"
-    databaseUrl: "postgresql://vo-cutouts@localhost/vo-cutouts"
-    gcsBucketUrl: "s3://rubin-cutouts-stable-us-central1-output/"
-
-  cloudsql:
-    enabled: true
-    instanceConnectionName: "science-platform-stable-6994:us-central1:science-platform-stable-0c29612b"
-    serviceAccount: "vo-cutouts@science-platform-stable-6994.iam.gserviceaccount.com"
-
-pull-secret:
+cloudsql:
   enabled: true
-  path: "secret/k8s_operator/data.lsst.cloud/pull-secret"
+  instanceConnectionName: "science-platform-stable-6994:us-central1:science-platform-stable-0c29612b"
+  serviceAccount: "vo-cutouts@science-platform-stable-6994.iam.gserviceaccount.com"

--- a/services/vo-cutouts/values.yaml
+++ b/services/vo-cutouts/values.yaml
@@ -1,0 +1,203 @@
+# Default values for vo-cutouts.
+
+# -- Number of web frontend pods to start
+replicaCount: 1
+
+# -- Override the base name for resources
+nameOverride: ""
+
+# -- Override the full name for resources (includes the release name)
+fullnameOverride: ""
+
+image:
+  # -- vo-cutouts image to use
+  repository: "lsstsqre/vo-cutouts"
+
+  # -- Pull policy for the vo-cutouts image
+  pullPolicy: "IfNotPresent"
+
+  # -- Tag of vo-cutouts image to use
+  # @default -- The appVersion of the chart
+  tag: ""
+
+ingress:
+  # -- Gafaelfawr auth query string
+  gafaelfawrAuthQuery: "scope=read:image"
+
+  # -- Additional annotations to add to the ingress
+  annotations: {}
+
+# -- Resource limits and requests for the vo-cutouts frontend pod
+resources: {}
+
+# -- Annotations for the vo-cutouts frontend pod
+podAnnotations: {}
+
+# -- Node selector rules for the vo-cutouts frontend pod
+nodeSelector: {}
+
+# -- Tolerations for the vo-cutouts frontend pod
+tolerations: []
+
+# -- Affinity rules for the vo-cutouts frontend pod
+affinity: {}
+
+config:
+  # -- Choose from the text form of Python logging levels
+  loglevel: "INFO"
+
+  # -- Configuration for the Butler repository to use
+  # @default -- None, must be set
+  butlerRepository: ""
+
+  # -- URL for the PostgreSQL database
+  # @default -- None, must be set
+  databaseUrl: ""
+
+  # -- URL for the GCS bucket into which to store cutouts (must start with
+  # `s3`)
+  # @default -- None, must be set
+  gcsBucketUrl: ""
+
+  # -- Timeout for a single cutout job in seconds
+  # @default -- 600 (10 minutes)
+  timeout: 600
+
+  # -- Lifetime of job results in seconds (quote so that Helm doesn't turn it
+  # into a floating point number)
+  # @default -- 2592000 (30 days)
+  lifetime: "2592000"
+
+  # -- Timeout for results from a sync cutout in seconds
+  # @default -- 60 (1 minute)
+  syncTimeout: 60
+
+cloudsql:
+  # -- Enable the Cloud SQL Auth Proxy sidecar, used with CloudSQL databases
+  # on Google Cloud
+  enabled: false
+
+  image:
+    # -- Cloud SQL Auth Proxy image to use
+    repository: "gcr.io/cloudsql-docker/gce-proxy"
+
+    # -- Cloud SQL Auth Proxy tag to use
+    tag: "1.30.0"
+
+    # -- Pull policy for Cloud SQL Auth Proxy images
+    pullPolicy: "IfNotPresent"
+
+  # -- Instance connection name for a CloudSQL PostgreSQL instance
+  instanceConnectionName: ""
+
+  # -- The Google service account that has an IAM binding to the `vo-cutouts`
+  # Kubernetes service accounts and has the `cloudsql.client` role, access
+  # to the GCS bucket, and ability to sign URLs as itself
+  # @default -- None, must be set
+  serviceAccount: ""
+
+cutoutWorker:
+  # -- Number of cutout worker pods to start
+  replicaCount: 2
+
+  image:
+    # -- Stack image to use for cutouts
+    repository: "lsstsqre/vo-cutouts-worker"
+
+    # -- Tag of vo-cutouts worker image to use
+    # @default -- The appVersion of the chart
+    tag: ""
+
+    # -- Pull policy for cutout workers
+    pullPolicy: "IfNotPresent"
+
+  # -- Resource limits and requests for the cutout worker pod
+  resources: {}
+
+  # -- Annotations for the cutout worker pod
+  podAnnotations: {}
+
+  # -- Node selection rules for the cutout worker pod
+  nodeSelector: {}
+
+  # -- Tolerations for the cutout worker pod
+  tolerations: []
+
+  # -- Affinity rules for the cutout worker pod
+  affinity: {}
+
+databaseWorker:
+  # -- Number of database worker pods to start
+  replicaCount: 1
+
+  # -- Resource limits and requests for the database worker pod
+  resources: {}
+
+  # -- Annotations for the database worker pod
+  podAnnotations: {}
+
+  # -- Node selection rules for the database worker pod
+  nodeSelector: {}
+
+  # -- Tolerations for the database worker pod
+  tolerations: []
+
+  # -- Affinity rules for the database worker pod
+  affinity: {}
+
+redis:
+  image:
+    # -- Redis image to use
+    repository: "redis"
+
+    # -- Redis image tag to use
+    tag: "6.2.6"
+
+    # -- Pull policy for the Redis image
+    pullPolicy: "IfNotPresent"
+
+  persistence:
+    # -- Whether to persist Redis storage and thus tokens. Setting this to
+    # false will use `emptyDir` and reset all tokens on every restart. Only
+    # use this for a test deployment.
+    enabled: true
+
+    # -- Amount of persistent storage to request
+    size: "100Mi"
+
+    # -- Class of storage to request
+    storageClass: ""
+
+    # -- Access mode of storage to request
+    accessMode: "ReadWriteOnce"
+
+    # -- Use an existing PVC, not dynamic provisioning. If this is set, the
+    # size, storageClass, and accessMode settings are ignored.
+    volumeClaimName: ""
+
+  # -- Pod annotations for the Redis pod
+  podAnnotations: {}
+
+  # -- Node selection rules for the Redis pod
+  nodeSelector: {}
+
+  # -- Tolerations for the Redis pod
+  tolerations: []
+
+  # -- Affinity rules for the Redis pod
+  affinity: {}
+
+# The following will be set by parameters injected by Argo CD and should not
+# be set in the individual environment values files.
+global:
+  # -- Base URL for the environment
+  # @default -- Set by Argo CD
+  baseUrl: ""
+
+  # -- Host name for ingress
+  # @default -- Set by Argo CD
+  host: ""
+
+  # -- Base path for Vault secrets
+  # @default -- Set by Argo CD
+  vaultSecretsPath: ""


### PR DESCRIPTION
Move the chart from charts, add the global variable settings in
the Argo CD application configuration, and simplify the chart to
make use of them.  Update the version of the GCE Proxy to match
the other applications in Phalanx.