### PR TITLE
Added a new suit deployment, fixed the proxy in ingress.yaml

### DIFF
--- a/services/portal/templates/ingress.yaml
+++ b/services/portal/templates/ingress.yaml
@@ -20,7 +20,7 @@ metadata:
       proxy_set_header X-Original-URI $request_uri;
       proxy_set_header X-Forwarded-Proto https;
       proxy_set_header X-Forwarded-Port 443;
-      proxy_set_header X-Forwarded-Path /firefly;
+      proxy_set_header X-Forwarded-Path /portal/app;
     {{- if .Values.ingress.gafaelfawrAuthQuery }}
     nginx.ingress.kubernetes.io/auth-method: "GET"
     nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-User,X-Auth-Request-Email,X-Auth-Request-Token"

--- a/services/portal/values-idfdev.yaml
+++ b/services/portal/values-idfdev.yaml
@@ -1,6 +1,5 @@
 resources:
   limits:
     memory: "8Gi"
-
 image:
   tag: "suit-2022.1"

--- a/services/portal/values-idfint.yaml
+++ b/services/portal/values-idfint.yaml
@@ -9,6 +9,5 @@ config:
 resources:
   limits:
     memory: "30Gi"
-
 image:
   tag: "suit-2022.1"


### PR DESCRIPTION
  - updates to suit version 2022.1
  - _fixes_:  when firefly is proxied, we need to know where it’s proxied from