### PR TITLE
Revert "Fix Argo CD Redis metrics container"

### DIFF
--- a/services/argocd/values-base.yaml
+++ b/services/argocd/values-base.yaml
@@ -3,8 +3,6 @@ argo-cd:
     enabled: true
     metrics:
       enabled: true
-      image:
-        repository: "bitnami/redis-exporter"
 
   controller:
     metrics:

--- a/services/argocd/values-idfdev.yaml
+++ b/services/argocd/values-idfdev.yaml
@@ -3,8 +3,6 @@ argo-cd:
     enabled: true
     metrics:
       enabled: true
-      image:
-        repository: "bitnami/redis-exporter"
 
   controller:
     metrics:

--- a/services/argocd/values-idfint.yaml
+++ b/services/argocd/values-idfint.yaml
@@ -3,8 +3,6 @@ argo-cd:
     enabled: true
     metrics:
       enabled: true
-      image:
-        repository: "bitnami/redis-exporter"
 
   controller:
     metrics:

--- a/services/argocd/values-idfprod.yaml
+++ b/services/argocd/values-idfprod.yaml
@@ -3,8 +3,6 @@ argo-cd:
     enabled: true
     metrics:
       enabled: true
-      image:
-        repository: "bitnami/redis-exporter"
 
   controller:
     metrics:

--- a/services/argocd/values-int.yaml
+++ b/services/argocd/values-int.yaml
@@ -3,8 +3,6 @@ argo-cd:
     enabled: true
     metrics:
       enabled: true
-      image:
-        repository: "bitnami/redis-exporter"
 
   controller:
     metrics:

--- a/services/argocd/values-minikube.yaml
+++ b/services/argocd/values-minikube.yaml
@@ -12,8 +12,6 @@ argo-cd:
     enabled: true
     metrics:
       enabled: true
-      image:
-        repository: "bitnami/redis-exporter"
 
   repoServer:
     metrics:

--- a/services/argocd/values-roe.yaml
+++ b/services/argocd/values-roe.yaml
@@ -3,8 +3,6 @@ argo-cd:
     enabled: true
     metrics:
       enabled: true
-      image:
-        repository: "bitnami/redis-exporter"
 
   controller:
     metrics:

--- a/services/argocd/values-stable.yaml
+++ b/services/argocd/values-stable.yaml
@@ -3,8 +3,6 @@ argo-cd:
     enabled: true
     metrics:
       enabled: true
-      image:
-        repository: "bitnami/redis-exporter"
 
   controller:
     metrics:

--- a/services/argocd/values-summit.yaml
+++ b/services/argocd/values-summit.yaml
@@ -3,8 +3,6 @@ argo-cd:
     enabled: true
     metrics:
       enabled: true
-      image:
-        repository: "bitnami/redis-exporter"
 
   controller:
     metrics:

--- a/services/argocd/values-tucson-teststand.yaml
+++ b/services/argocd/values-tucson-teststand.yaml
@@ -3,8 +3,6 @@ argo-cd:
     enabled: true
     metrics:
       enabled: true
-      image:
-        repository: "bitnami/redis-exporter"
 
   controller:
     metrics:


### PR DESCRIPTION
This reverts commit bf3547642eef4ae976468ee53ce1e3a0b8bc1ae5.
This has now been fixed by a subsequent Argo CD chart release.