### PR TITLE
[DM-34430] Add test CSC and Kafka producer in sasquatch

### DIFF
--- a/services/sasquatch/Chart.yaml
+++ b/services/sasquatch/Chart.yaml
@@ -22,3 +22,9 @@ dependencies:
   - name: telegraf
     version: 1.8.18
     repository: https://helm.influxdata.com/
+  - name: csc
+    version: 0.9.2
+    repository: https://lsst-ts.github.io/charts/
+  - name: kafka-producers
+    version: 0.10.1
+    repository: https://lsst-ts.github.io/charts/

--- a/services/sasquatch/Chart.yaml
+++ b/services/sasquatch/Chart.yaml
@@ -25,6 +25,8 @@ dependencies:
   - name: csc
     version: 0.9.2
     repository: https://lsst-ts.github.io/charts/
+    condition: csc.enabled
   - name: kafka-producers
     version: 0.10.1
     repository: https://lsst-ts.github.io/charts/
+    condition: kafka-producers.enabled

--- a/services/sasquatch/Chart.yaml
+++ b/services/sasquatch/Chart.yaml
@@ -1,9 +1,10 @@
 apiVersion: v2
 name: sasquatch
 version: 1.0.0
-description: SQuaRE telemetry data service.
+description: Rubin Observatory's telemetry service.
+appVersion: 0.1.0
 dependencies:
-  - name: "strimzi-kafka"
+  - name: strimzi-kafka
     version: 1.0.0
   - name: strimzi-registry-operator
     version: 1.2.0

--- a/services/sasquatch/README.md
+++ b/services/sasquatch/README.md
@@ -1,8 +1,8 @@
-
+![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 # sasquatch
 
-SQuaRE telemetry data service.
+Rubin Observatory's telemetry service.
 
 ## Requirements
 
@@ -15,6 +15,8 @@ SQuaRE telemetry data service.
 | https://helm.influxdata.com/ | kapacitor | 1.4.6 |
 | https://helm.influxdata.com/ | telegraf | 1.8.18 |
 | https://lsst-sqre.github.io/charts/ | strimzi-registry-operator | 1.2.0 |
+| https://lsst-ts.github.io/charts/ | csc | 0.9.2 |
+| https://lsst-ts.github.io/charts/ | kafka-producers | 0.10.1 |
 
 ## Values
 
@@ -25,12 +27,43 @@ SQuaRE telemetry data service.
 | chronograf.image | object | `{"repository":"quay.io/influxdb/chronograf","tag":"1.9.4"}` | Chronograf image tag. |
 | chronograf.ingress | object | disabled | Chronograf ingress configuration. |
 | chronograf.persistence | object | `{"enabled":true,"size":"16Gi"}` | Chronograf data persistence configuration. |
+| csc.enabled | bool | `false` | Whether the test csc is deployed. |
+| csc.env | object | `{"LSST_DDS_PARTITION_PREFIX":"test","LSST_SITE":"test","OSPL_ERRORFILE":"/tmp/ospl-error-test.log","OSPL_INFOFILE":"/tmp/ospl-info-test.log","OSPL_URI":"file:///opt/lsst/software/stack/miniconda/lib/python3.8/config/ospl-std.xml"}` | Enviroment variables to run the Test CSC. |
+| csc.env.OSPL_URI | string | `"file:///opt/lsst/software/stack/miniconda/lib/python3.8/config/ospl-std.xml"` | Use a single process configuration for DDS OpenSplice. |
+| csc.image.nexus3 | string | `"nexus3-docker"` | The tag name for the Nexus3 Docker repository secrets if private images need to be pulled. |
+| csc.image.repository | string | `"ts-dockerhub.lsst.org/test"` | The Docker registry name of the container image to use for the CSC |
+| csc.image.tag | string | `"c0025"` | The tag of the container image to use for the CSC |
+| csc.namespace | string | `"sasquatch"` | Namespace where the Test CSC is deployed. |
+| csc.osplVersion | string | `"V6.10.4"` | DDS OpenSplice version. |
+| csc.useExternalConfig | bool | `false` | Wether to use an external configuration for DDS OpenSplice. |
 | influxdb.config | object | `{"continuous_queries":{"enabled":false},"coordinator":{"log-queries-after":"15s","max-concurrent-queries":10,"query-timeout":"900s","write-timeout":"60s"},"data":{"cache-max-memory-size":0,"trace-logging-enabled":true,"wal-fsync-delay":"100ms"},"http":{"auth-enabled":true,"enabled":true,"flux-enabled":true,"max-row-limit":0}}` | Override InfluxDB configuration. See https://docs.influxdata.com/influxdb/v1.8/administration/config |
 | influxdb.image | object | `{"tag":"1.8.10"}` | InfluxDB image tag. |
 | influxdb.ingress | object | disabled | InfluxDB ingress configuration. |
 | influxdb.initScripts | object | `{"enabled":true,"scripts":{"init.iql":"CREATE DATABASE \"telegraf\" WITH DURATION 30d REPLICATION 1 NAME \"rp_30d\"\n\n"}}` | InfluxDB Custom initialization scripts. |
 | influxdb.setDefaultUser | object | `{"enabled":true,"user":{"existingSecret":"sasquatch"}}` | Default InfluxDB user, use influxb-user and influxdb-password keys from secret. |
 | kafka-connect-manager | object | `{}` | Override strimzi-kafka configuration. |
+| kafka-producers.enabled | bool | `false` | Whether the kafka-producer for the test csc is deployed. |
+| kafka-producers.env.brokerIp | string | `"sasquatch-kafka-bootstrap.sasquatch"` | The URI for the Sasquatch Kafka broker. |
+| kafka-producers.env.brokerPort | int | `9092` | The port for the Sasquatch Kafka listener. |
+| kafka-producers.env.extras.LSST_DDS_RESPONSIVENESS_TIMEOUT | string | `"15s"` |  |
+| kafka-producers.env.extras.OSPL_ERRORFILE | string | `"/tmp/ospl-error-kafka-producers.log"` |  |
+| kafka-producers.env.extras.OSPL_INFOFILE | string | `"/tmp/ospl-info-kafka-producers.log"` |  |
+| kafka-producers.env.extras.OSPL_URI | string | `"file:///opt/lsst/software/stack/miniconda/lib/python3.8/config/ospl-std.xml"` | Use a single process configuration for DDS OpenSplice. |
+| kafka-producers.env.logLevel | int | `20` | Logging level for the Kafka producers |
+| kafka-producers.env.lsstDdsPartitionPrefix | string | `"test"` | The LSST_DDS_PARTITION_PREFIX name applied to all producer containers. |
+| kafka-producers.env.registryAddr | string | `"http://sasquatch-schema-registry.sasquatch:8081"` | The Sasquatch Schema Registry URL. |
+| kafka-producers.env.replication | int | `3` | The topic replication factor (should be the same as the number of Kafka broker in Sasquatch) |
+| kafka-producers.image.nexus3 | string | `"nexus3-docker"` | The tag name for the Nexus3 Docker repository secrets if private images need to be pulled. |
+| kafka-producers.image.repository | string | `"ts-dockerhub.lsst.org/salkafka"` | The Docker registry name of the container image to use for the producers. |
+| kafka-producers.image.tag | string | `"c0025"` | The tag of the container image to use for the producers. |
+| kafka-producers.namespace | string | `"sasquatch"` | Namespace where the Test CSC is deployed. |
+| kafka-producers.osplVersion | string | `"V6.10.4"` | DDS OpenSplice version. |
+| kafka-producers.producers | object | `{"test":{"cscs":"Test"}}` | List of producers and CSCs to get DDS samples from. |
+| kafka-producers.startupProbe.failureThreshold | int | `15` | The number of times the startup probe is allowed to fail before failing the probe |
+| kafka-producers.startupProbe.initialDelay | int | `20` | The initial delay in seconds before the first check is made |
+| kafka-producers.startupProbe.period | int | `10` | The time in seconds between subsequent checks |
+| kafka-producers.startupProbe.use | bool | `true` | Whether to use the startup probe |
+| kafka-producers.useExternalConfig | bool | `false` | Wether to use an external configuration for DDS OpenSplice. |
 | kapacitor.envVars | object | `{"KAPACITOR_SLACK_ENABLED":true}` | Kapacitor environment variables. |
 | kapacitor.existingSecret | string | `"sasquatch"` | InfluxDB credentials, use influxdb-user and influxdb-password keys from secret. |
 | kapacitor.image | object | `{"repository":"kapacitor","tag":"1.6.4"}` | Kapacitor image tag. |

--- a/services/sasquatch/README.md.gotmpl
+++ b/services/sasquatch/README.md.gotmpl
@@ -1,9 +1,0 @@
-{{ template "chart.header" . }}
-
-{{ template "chart.description" . }}
-
-{{ template "chart.requirementsSection" . }}
-
-{{ template "chart.valuesSection" . }}
-
-{{ template "helm-docs.versionFooter" . }}

--- a/services/sasquatch/charts/kafka-connect-manager/Chart.yaml
+++ b/services/sasquatch/charts/kafka-connect-manager/Chart.yaml
@@ -1,4 +1,5 @@
 apiVersion: v2
 name: kafka-connect-manager
 version: 1.0.0
-description: A sub chart to deploy the Kafka connectors used by Sasquatch.
+description: A subchart to deploy the Kafka connectors used by Sasquatch.
+appVersion: 0.9.3

--- a/services/sasquatch/charts/kafka-connect-manager/README.md
+++ b/services/sasquatch/charts/kafka-connect-manager/README.md
@@ -1,8 +1,8 @@
-
+![AppVersion: 0.9.3](https://img.shields.io/badge/AppVersion-0.9.3-informational?style=flat-square)
 
 # kafka-connect-manager
 
-A sub chart to deploy the Kafka connectors used by Sasquatch.
+A subchart to deploy the Kafka connectors used by Sasquatch.
 
 ## Values
 
@@ -10,7 +10,7 @@ A sub chart to deploy the Kafka connectors used by Sasquatch.
 |-----|------|---------|-------------|
 | env.kafkaBrokerUrl | string | `"sasquatch-kafka-bootstrap.sasquatch:9092"` | Kafka broker URL. |
 | env.kafkaConnectUrl | string | `"http://sasquatch-connect-api.sasquatch:8083"` | Kafka connnect URL. |
-| image.pullPolicy | string | `"Always"` |  |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"lsstsqre/kafkaconnect"` |  |
 | image.tag | string | `"0.9.3"` |  |
 | influxdbSink.influxdb-sink.autoUpdate | bool | `true` | If autoUpdate is enabled, check for new kafka topics. |

--- a/services/sasquatch/charts/kafka-connect-manager/README.md.gotmpl
+++ b/services/sasquatch/charts/kafka-connect-manager/README.md.gotmpl
@@ -1,7 +1,0 @@
-{{ template "chart.header" . }}
-
-{{ template "chart.description" . }}
-
-{{ template "chart.valuesSection" . }}
-
-{{ template "helm-docs.versionFooter" . }}

--- a/services/sasquatch/charts/kafka-connect-manager/values.yaml
+++ b/services/sasquatch/charts/kafka-connect-manager/values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: lsstsqre/kafkaconnect
   tag: 0.9.3
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
 
 influxdbSink:
   # Repeat this block to create multiple instances of this connector.

--- a/services/sasquatch/charts/strimzi-kafka/Chart.yaml
+++ b/services/sasquatch/charts/strimzi-kafka/Chart.yaml
@@ -1,4 +1,5 @@
 apiVersion: v2
 name: strimzi-kafka
 version: 1.0.0
-description: A sub chart to deploy Strimzi Kafka components for Sasquatch.
+description: A subchart to deploy Strimzi Kafka components for Sasquatch.
+appVersion: 3.0.0

--- a/services/sasquatch/charts/strimzi-kafka/README.md
+++ b/services/sasquatch/charts/strimzi-kafka/README.md
@@ -1,8 +1,8 @@
-
+![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
 
 # strimzi-kafka
 
-A sub chart to deploy Strimzi Kafka components for Sasquatch.
+A subchart to deploy Strimzi Kafka components for Sasquatch.
 
 ## Values
 

--- a/services/sasquatch/charts/strimzi-kafka/README.md.gotmpl
+++ b/services/sasquatch/charts/strimzi-kafka/README.md.gotmpl
@@ -1,7 +1,0 @@
-{{ template "chart.header" . }}
-
-{{ template "chart.description" . }}
-
-{{ template "chart.valuesSection" . }}
-
-{{ template "helm-docs.versionFooter" . }}

--- a/services/sasquatch/templates/vault-secret.yaml
+++ b/services/sasquatch/templates/vault-secret.yaml
@@ -14,3 +14,12 @@ metadata:
 spec:
   path: {{ .Values.vaultSecretsPath }}/pull-secret
   type: kubernetes.io/dockerconfigjson
+---
+apiVersion: ricoberger.de/v1alpha1
+kind: VaultSecret
+metadata:
+  name: sasquatch-nexus3-docker
+  namespace: sasquatch
+spec:
+  path: {{ .Values.vaultSecretsPath }}/pull-secret
+  type: kubernetes.io/dockerconfigjson

--- a/services/sasquatch/values-tucson-teststand.yaml
+++ b/services/sasquatch/values-tucson-teststand.yaml
@@ -40,4 +40,10 @@ kapacitor:
   persistence:
     storageClass: rook-ceph-block
 
+csc:
+  enabled: true
+
+kafka-producers:
+  enabled: true
+
 vaultSecretsPath: secret/k8s_operator/tucson-teststand.lsst.codes

--- a/services/sasquatch/values.yaml
+++ b/services/sasquatch/values.yaml
@@ -134,6 +134,77 @@ telegraf:
           username: "telegraf"
           password: "$TELEGRAF_PASSWORD"
 
+csc:
+  image:
+    # -- The Docker registry name of the container image to use for the CSC
+    repository: ts-dockerhub.lsst.org/test
+    # -- The tag of the container image to use for the CSC
+    tag: c0025
+    # -- The tag name for the Nexus3 Docker repository secrets if private images need to be pulled.
+    nexus3: nexus3-docker
+  # -- Enviroment variables to run the Test CSC.
+  env:
+    LSST_DDS_PARTITION_PREFIX: test
+    LSST_SITE: test
+    OSPL_INFOFILE: /tmp/ospl-info-test.log
+    OSPL_ERRORFILE: /tmp/ospl-error-test.log
+    # -- Use a single process configuration for DDS OpenSplice.
+    OSPL_URI: file:///opt/lsst/software/stack/miniconda/lib/python3.8/config/ospl-std.xml
+  # -- Wether to use an external configuration for DDS OpenSplice.
+  useExternalConfig: false
+  # -- DDS OpenSplice version.
+  osplVersion: V6.10.4
+  # -- Namespace where the Test CSC is deployed.
+  namespace: sasquatch
+
+kafka-producers:
+  image:
+    # -- The Docker registry name of the container image to use for the producers.
+    repository: ts-dockerhub.lsst.org/salkafka
+    # -- The tag of the container image to use for the producers.
+    tag: c0025
+    # -- The tag name for the Nexus3 Docker repository secrets if private images need to be pulled.
+    nexus3: nexus3-docker
+  env:
+    # -- The LSST_DDS_PARTITION_PREFIX name applied to all producer containers.
+    lsstDdsPartitionPrefix: test
+    # -- The URI for the Sasquatch Kafka broker.
+    brokerIp: sasquatch-kafka-bootstrap.sasquatch
+    # -- The port for the Sasquatch Kafka listener.
+    brokerPort: 9092
+    # -- The Sasquatch Schema Registry URL.
+    registryAddr: http://sasquatch-schema-registry.sasquatch:8081
+    # -- The topic replication factor (should be the same as the number of Kafka broker in Sasquatch)
+    replication: 3
+    # -- Logging level for the Kafka producers
+    logLevel: 20
+    extras:
+      # -- Use a single process configuration for DDS OpenSplice.
+      OSPL_URI: file:///opt/lsst/software/stack/miniconda/lib/python3.8/config/ospl-std.xml
+      LSST_DDS_RESPONSIVENESS_TIMEOUT: 15s
+      OSPL_INFOFILE: /tmp/ospl-info-kafka-producers.log
+      OSPL_ERRORFILE: /tmp/ospl-error-kafka-producers.log
+  # -- Wether to use an external configuration for DDS OpenSplice.
+  useExternalConfig: false
+  # -- DDS OpenSplice version.
+  osplVersion: V6.10.4
+  startupProbe:
+    # -- Whether to use the startup probe
+    use: true
+    # -- The number of times the startup probe is allowed to fail before failing the probe
+    failureThreshold: 15
+    # -- The initial delay in seconds before the first check is made
+    initialDelay: 20
+    # -- The time in seconds between subsequent checks
+    period: 10
+  # -- List of producers and CSCs to get DDS samples from.
+  producers:
+    test:
+      cscs: >-
+        Test
+  # -- Namespace where the Test CSC is deployed.
+  namespace: sasquatch
+
 # -- Path to the Vault secrets (`secret/k8s_operator/<hostname>/sasquatch`)
 # @default -- None, must be set
 vaultSecretsPath: ""

--- a/services/sasquatch/values.yaml
+++ b/services/sasquatch/values.yaml
@@ -135,6 +135,8 @@ telegraf:
           password: "$TELEGRAF_PASSWORD"
 
 csc:
+  # -- Whether the test csc is deployed.
+  enabled: false
   image:
     # -- The Docker registry name of the container image to use for the CSC
     repository: ts-dockerhub.lsst.org/test
@@ -158,6 +160,8 @@ csc:
   namespace: sasquatch
 
 kafka-producers:
+  # -- Whether the kafka-producer for the test csc is deployed.
+  enabled: false
   image:
     # -- The Docker registry name of the container image to use for the producers.
     repository: ts-dockerhub.lsst.org/salkafka


### PR DESCRIPTION
This PR adds the Test CSC and the Kafka Producer charts from the T&S charts repository as dependencies. The goal is to have data being produced to test new deployments of sasquatch.

Both charts are deployed in the sasquatch namespace.

It assumes the secret to pulling images from `ts-dockerhub.lsst.org` is in Vault under the `pull-secret` key for the deployment environment, and it creates the k8s secret expected by the charts in the sasquatch namespace.

