### PR TITLE
[DM-34335] Update Gafaelfawr chart for 4.1.0 release

### DIFF
--- a/installer/generate_secrets.py
+++ b/installer/generate_secrets.py
@@ -231,6 +231,12 @@ class SecretGenerator:
             self.input_field(
                 "gafaelfawr", "github-client-secret", "GitHub client secret"
             )
+        elif auth_type == "oidc":
+            self.input_field(
+                "gafaelfawr",
+                "oidc-client-secret",
+                "OpenID Connect client secret",
+            )
         else:
             raise Exception(f"Invalid auth provider {auth_type}")
 

--- a/installer/generate_secrets.py
+++ b/installer/generate_secrets.py
@@ -227,6 +227,11 @@ class SecretGenerator:
             self.input_field(
                 "gafaelfawr", "cilogon-client-secret", "CILogon client secret"
             )
+            use_ldap = self.secrets["gafaelfawr"]["ldap"]
+            if use_ldap == "y":
+                self.input_field(
+                    "gafaelfawr", "ldap-secret", "LDAP simple bind password"
+                )
         elif auth_type == "github":
             self.input_field(
                 "gafaelfawr", "github-client-secret", "GitHub client secret"
@@ -237,6 +242,10 @@ class SecretGenerator:
                 "oidc-client-secret",
                 "OpenID Connect client secret",
             )
+            if use_ldap == "y":
+                self.input_field(
+                    "gafaelfawr", "ldap-secret", "LDAP simple bind password"
+                )
         else:
             raise Exception(f"Invalid auth provider {auth_type}")
 

--- a/services/gafaelfawr/Chart.yaml
+++ b/services/gafaelfawr/Chart.yaml
@@ -3,4 +3,6 @@ name: gafaelfawr
 version: 1.0.0
 description: Science Platform authentication and authorization system
 home: https://gafaelfawr.lsst.io/
+sources:
+  - https://github.com/lsst-sqre/gafaelfawr
 appVersion: 4.1.0

--- a/services/gafaelfawr/Chart.yaml
+++ b/services/gafaelfawr/Chart.yaml
@@ -3,4 +3,4 @@ name: gafaelfawr
 version: 1.0.0
 description: Science Platform authentication and authorization system
 home: https://gafaelfawr.lsst.io/
-appVersion: 4.0.0
+appVersion: 4.1.0

--- a/services/gafaelfawr/README.md
+++ b/services/gafaelfawr/README.md
@@ -23,6 +23,7 @@ Science Platform authentication and authorization system
 | config.cilogon.test | bool | `false` | Whether to use the test instance of CILogon |
 | config.databaseUrl | string | None, must be set | URL for the PostgreSQL database |
 | config.errorFooter | string | `""` | HTML footer to add to any login error page (inside a <p> tag). |
+| config.firestore.project | string | Firestore support is disabled | If set, assign UIDs and GIDs using Google Firestore in the given project.  Cloud SQL must be enabled and the Cloud SQL service account must have read/write access to that Firestore instance. |
 | config.github.clientId | string | `""` | GitHub client ID. One and only one of this, `config.cilogon.clientId`, or `config.oidc.clientId` must be set. |
 | config.groupMapping | object | `{}` | Defines a mapping of scopes to groups that provide that scope. Tokens from an OpenID Connect provider such as CILogon that include groups in an `isMemberOf` claim will be granted scopes based on this mapping. |
 | config.influxdb.enabled | bool | `false` | Whether to issue tokens for InfluxDB. If set to true, `influxdb-secret` must be set in the Gafaelfawr secret. |
@@ -35,6 +36,9 @@ Science Platform authentication and authorization system
 | config.ldap.uidAttr | string | `"uidNumber"` | Attribute containing the user's UID number (only used if uidBaseDn is set) |
 | config.ldap.uidBaseDn | string | Get the UID number from the upstream authentication provider | Base DN for the LDAP search to find a user's UID number |
 | config.ldap.url | string | Do not use LDAP | LDAP server URL from which to retrieve user group information |
+| config.ldap.userDn | string | Use anonymous binds | Bind DN for simple bind authentication. If set, `ldap-secret` must be set in the Gafaelfawr secret |
+| config.ldap.usernameBaseDn | string | Get the username from the upstream authentication provider | Base DN for the LDAP search to find a user's username |
+| config.ldap.usernameSearchAttr | string | `"voPersonSoRID"` | Attribute matching the `sub` claim of a token to find the record containing the username |
 | config.loglevel | string | `"INFO"` | Choose from the text form of Python logging levels |
 | config.oidc.audience | string | Value of `config.oidc.clientId` | Audience for the JWT token |
 | config.oidc.clientId | string | `""` | Client ID for generic OpenID Connect support. One and only one of this, `config.cilogon.clientId`, or `config.github.clientId` must be set. |
@@ -51,7 +55,7 @@ Science Platform authentication and authorization system
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the Gafaelfawr image |
-| image.repository | string | `"lsstsqre/gafaelfawr"` | Gafaelfawr image to use |
+| image.repository | string | `"ghcr.io/lsst-sqre/gafaelfawr"` | Gafaelfawr image to use |
 | image.tag | string | The appVersion of the chart | Tag of Gafaelfawr image to use |
 | nameOverride | string | `""` | Override the base name for resources |
 | nodeSelector | object | `{}` | Node selector rules for the Gafaelfawr frontend pod |

--- a/services/gafaelfawr/README.md
+++ b/services/gafaelfawr/README.md
@@ -6,6 +6,10 @@ Science Platform authentication and authorization system
 
 **Homepage:** <https://gafaelfawr.lsst.io/>
 
+## Source Code
+
+* <https://github.com/lsst-sqre/gafaelfawr>
+
 ## Values
 
 | Key | Type | Default | Description |

--- a/services/gafaelfawr/README.md
+++ b/services/gafaelfawr/README.md
@@ -1,4 +1,4 @@
-![AppVersion: 4.0.0](https://img.shields.io/badge/AppVersion-4.0.0-informational?style=flat-square)
+![AppVersion: 4.1.0](https://img.shields.io/badge/AppVersion-4.1.0-informational?style=flat-square)
 
 # gafaelfawr
 
@@ -18,6 +18,7 @@ Science Platform authentication and authorization system
 | cloudsql.instanceConnectionName | string | `""` | Instance connection name for a CloudSQL PostgreSQL instance |
 | cloudsql.serviceAccount | string | `""` | The Google service account that has an IAM binding to the `gafaelfawr` and `gafaelfawr-tokens` Kubernetes service accounts and has the `cloudsql.client` role |
 | config.cilogon.clientId | string | `""` | CILogon client ID. One and only one of this, `config.github.clientId`, or `config.oidc.clientId` must be set. |
+| config.cilogon.enrollmentUrl | string | Login fails with an error | Where to send the user if their username cannot be found in LDAP |
 | config.cilogon.loginParams | object | `{"skin":"LSST"}` | Additional parameters to add |
 | config.cilogon.redirectUrl | string | `/login` at the value of config.host | Return URL given to CILogon (must match the CILogon configuration) |
 | config.cilogon.test | bool | `false` | Whether to use the test instance of CILogon |
@@ -42,6 +43,7 @@ Science Platform authentication and authorization system
 | config.loglevel | string | `"INFO"` | Choose from the text form of Python logging levels |
 | config.oidc.audience | string | Value of `config.oidc.clientId` | Audience for the JWT token |
 | config.oidc.clientId | string | `""` | Client ID for generic OpenID Connect support. One and only one of this, `config.cilogon.clientId`, or `config.github.clientId` must be set. |
+| config.oidc.enrollmentUrl | string | Login fails with an error | Where to send the user if their username cannot be found in LDAP |
 | config.oidc.issuer | string | None, must be set | Issuer for the JWT token |
 | config.oidc.loginParams | object | `{}` | Additional parameters to add to the login request |
 | config.oidc.loginUrl | string | None, must be set | URL to which to redirect the user for authorization |

--- a/services/gafaelfawr/README.md.gotmpl
+++ b/services/gafaelfawr/README.md.gotmpl
@@ -1,9 +1,0 @@
-{{ template "chart.header" . }}
-
-{{ template "chart.description" . }}
-
-{{ template "chart.requirementsSection" . }}
-
-{{ template "chart.valuesSection" . }}
-
-{{ template "helm-docs.versionFooter" . }}

--- a/services/gafaelfawr/templates/configmap.yaml
+++ b/services/gafaelfawr/templates/configmap.yaml
@@ -101,8 +101,15 @@ data:
     ldap:
       url: {{ .Values.config.ldap.url | quote }}
       base_dn: {{ required "config.ldap.baseDn must be set" .Values.config.ldap.baseDn | quote }}
+      {{- if .Values.config.ldap.userDn }}
+      user_dn: {{ .Values.config.ldap.userDn | quote }}
+      {{- end }}
       group_object_class: {{ .Values.config.ldap.groupObjectClass | quote }}
       group_member_attr: {{ .Values.config.ldap.groupMemberAttr | quote }}
+      {{- if .Values.config.ldap.usernameBaseDn }}
+      username_base_dn: {{ .Values.config.ldap.usernameBaseDn | quote }}
+      username_search_attr: {{ .Values.config.ldap.usernameSearchAttr | quote }}
+      {{- end }}
       {{- if .Values.config.ldap.uidBaseDn }}
       uid_base_dn: {{ .Values.config.ldap.uidBaseDn | quote }}
       uid_attr: {{ .Values.config.ldap.uidAttr | quote }}

--- a/services/gafaelfawr/templates/configmap.yaml
+++ b/services/gafaelfawr/templates/configmap.yaml
@@ -97,6 +97,11 @@ data:
 
     {{- end }}
 
+    {{- if .Values.config.firestore.project }}
+    firestore:
+      project: {{ .Values.config.firestore.project | quote }}
+    {{- end }}
+
     {{- if .Values.config.ldap.url }}
     ldap:
       url: {{ .Values.config.ldap.url | quote }}

--- a/services/gafaelfawr/templates/configmap.yaml
+++ b/services/gafaelfawr/templates/configmap.yaml
@@ -50,6 +50,9 @@ data:
       {{- else }}
       login_url: "https://cilogon.org/authorize"
       token_url: "https://cilogon.org/oauth2/token"
+      {{- if .Values.config.cilogon.enrollmentUrl }}
+      enrollment_url: {{ .Values.config.cilogon.enrollmentUrl | quote }}
+      {{- end }}
       issuer: "https://cilogon.org"
       {{- end }}
       {{- if .Values.config.cilogon.loginParams }}
@@ -80,6 +83,9 @@ data:
       {{- end }}
       login_url: {{ required "config.oidc.loginUrl must be set" .Values.config.oidc.loginUrl | quote }}
       token_url: {{ required "config.oidc.tokenUrl must be set" .Values.config.oidc.tokenUrl | quote }}
+      {{- if .Values.config.cilogon.enrollmentUrl }}
+      enrollment_url: {{ .Values.config.cilogon.enrollmentUrl | quote }}
+      {{- end }}
       issuer: {{ required "config.oidc.issuer must be set" .Values.config.oidc.issuer | quote }}
       {{- if .Values.config.oidc.redirectUrl }}
       redirect_url: {{ .Values.config.oidc.redirectUrl | quote }}

--- a/services/gafaelfawr/templates/configmap.yaml
+++ b/services/gafaelfawr/templates/configmap.yaml
@@ -103,9 +103,9 @@ data:
       base_dn: {{ required "config.ldap.baseDn must be set" .Values.config.ldap.baseDn | quote }}
       group_object_class: {{ .Values.config.ldap.groupObjectClass | quote }}
       group_member_attr: {{ .Values.config.ldap.groupMemberAttr | quote }}
-      {{- if .Values.config.uidBaseDn }}
-      uid_base_dn: {{ .Values.config.uidBaseDn | quote }}
-      uid_attr: {{ .Values.config.uidAttr | quote }}
+      {{- if .Values.config.ldap.uidBaseDn }}
+      uid_base_dn: {{ .Values.config.ldap.uidBaseDn | quote }}
+      uid_attr: {{ .Values.config.ldap.uidAttr | quote }}
       {{- end }}
     {{- end }}
 

--- a/services/gafaelfawr/templates/deployment.yaml
+++ b/services/gafaelfawr/templates/deployment.yaml
@@ -57,6 +57,13 @@ spec:
                 secretKeyRef:
                   name: {{ template "gafaelfawr.fullname" . }}-secret
                   key: "database-password"
+            {{- if .Values.config.ldap.userDn }}
+            - name: "GAFAELFAWR_LDAP_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "gafaelfawr.fullname" . }}-secret
+                  key: "ldap-password"
+            {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
           ports:

--- a/services/gafaelfawr/templates/vault-secrets.yaml
+++ b/services/gafaelfawr/templates/vault-secrets.yaml
@@ -7,13 +7,3 @@ metadata:
 spec:
   path: "{{ .Values.global.vaultSecretsPath }}/gafaelfawr"
   type: Opaque
----
-apiVersion: ricoberger.de/v1alpha1
-kind: VaultSecret
-metadata:
-  name: "pull-secret"
-  labels:
-    {{- include "gafaelfawr.labels" . | nindent 4 }}
-spec:
-  path: "{{ .Values.global.vaultSecretsPath }}/pull-secret"
-  type: "kubernetes.io/dockerconfigjson"

--- a/services/gafaelfawr/values-idfdev.yaml
+++ b/services/gafaelfawr/values-idfdev.yaml
@@ -1,3 +1,6 @@
+image:
+  tag: "tickets-DM-34335"
+
 # Use the CSI storage class so that we can use snapshots.
 redis:
   persistence:

--- a/services/gafaelfawr/values-minikube.yaml
+++ b/services/gafaelfawr/values-minikube.yaml
@@ -1,3 +1,6 @@
+image:
+  tag: "tickets-DM-34335"
+
 # Reset token storage on every Redis restart.
 redis:
   persistence:

--- a/services/gafaelfawr/values.yaml
+++ b/services/gafaelfawr/values.yaml
@@ -11,7 +11,7 @@ replicaCount: 1
 
 image:
   # -- Gafaelfawr image to use
-  repository: "lsstsqre/gafaelfawr"
+  repository: "ghcr.io/lsst-sqre/gafaelfawr"
 
   # -- Pull policy for the Gafaelfawr image
   pullPolicy: "IfNotPresent"

--- a/services/gafaelfawr/values.yaml
+++ b/services/gafaelfawr/values.yaml
@@ -64,6 +64,10 @@ config:
     # @default -- `/login` at the value of config.host
     redirectUrl: ""
 
+    # -- Where to send the user if their username cannot be found in LDAP
+    # @default -- Login fails with an error
+    enrollmentUrl: ""
+
     # -- Whether to use the test instance of CILogon
     test: false
 
@@ -102,6 +106,10 @@ config:
     # -- URL from which to retrieve the token for the user
     # @default -- None, must be set
     tokenUrl: ""
+
+    # -- Where to send the user if their username cannot be found in LDAP
+    # @default -- Login fails with an error
+    enrollmentUrl: ""
 
     # -- Issuer for the JWT token
     # @default -- None, must be set

--- a/services/gafaelfawr/values.yaml
+++ b/services/gafaelfawr/values.yaml
@@ -71,6 +71,13 @@ config:
     loginParams:
       skin: "LSST"
 
+  firestore:
+    # -- If set, assign UIDs and GIDs using Google Firestore in the given
+    # project.  Cloud SQL must be enabled and the Cloud SQL service account
+    # must have read/write access to that Firestore instance.
+    # @default -- Firestore support is disabled
+    project: ""
+
   github:
     # -- GitHub client ID. One and only one of this, `config.cilogon.clientId`,
     # or `config.oidc.clientId` must be set.

--- a/services/gafaelfawr/values.yaml
+++ b/services/gafaelfawr/values.yaml
@@ -113,12 +113,25 @@ config:
     # @default -- None, must be set
     baseDn: ""
 
+    # -- Bind DN for simple bind authentication. If set, `ldap-secret` must be
+    # set in the Gafaelfawr secret
+    # @default -- Use anonymous binds
+    userDn: ""
+
     # -- Object class containing group information
     groupObjectClass: "posixGroup"
 
     # -- Member attribute of the object class. Values must match the username
     # returned in the token from the OpenID Connect authentication server.
     groupMemberAttr: "member"
+
+    # -- Base DN for the LDAP search to find a user's username
+    # @default -- Get the username from the upstream authentication provider
+    usernameBaseDn: ""
+
+    # -- Attribute matching the `sub` claim of a token to find the record
+    # containing the username
+    usernameSearchAttr: "voPersonSoRID"
 
     # -- Base DN for the LDAP search to find a user's UID number
     # @default -- Get the UID number from the upstream authentication provider


### PR DESCRIPTION
- Add configuration support for getting the UID from LDAP
- Add installer support for generic OpenID Connect
- Switch the Gafaelfawr image to GitHub Container Registry
- Add configuration support for Google Firestore
- Add configuration support for enrollment URLs
- Update Gafaelfawr to 4.1.0