### PR TITLE
[DM-34611] Secure access to Sasquatch kafka brokers

### DIFF
--- a/services/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
+++ b/services/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
@@ -8,11 +8,17 @@ spec:
     version: {{ .Values.kafka.version | quote }}
     replicas: {{ .Values.kafka.replicas }}
     listeners:
+      # plain listener without tls encryption and with scram-sha-512 authentication
+      # used by clients inside the Kubernetes cluster
       - name: plain
         port: 9092
         type: internal
         tls: false
-      - name: tls # Used by the schema registry; it has a fixed name it expects
+        authentication:
+          type: scram-sha-512
+      # tls listener with tls encryption and mutual tls authentication
+      # used by the schema registry and kafka connect clients
+      - name: tls
         port: 9093
         type: internal
         tls: true

--- a/services/sasquatch/charts/strimzi-kafka/templates/tests/test-sasl-authentication.yaml
+++ b/services/sasquatch/charts/strimzi-kafka/templates/tests/test-sasl-authentication.yaml
@@ -1,0 +1,77 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaUser
+metadata:
+  name: sasquatch-test
+  labels:
+    strimzi.io/cluster: sasquatch
+spec:
+  authentication:
+    type: scram-sha-512
+  authorization:
+    type: simple
+    acls:
+      - resource:
+          type: topic
+          name: sasquatch-test
+          patternType: literal
+        type: allow
+        host: "*"
+        operation: All
+---
+apiVersion: kafka.strimzi.io/v1beta1
+kind: KafkaTopic
+metadata:
+  name: sasquatch-test
+  labels:
+      strimzi.io/cluster: sasquatch
+spec:
+  replicas: 3
+  partitions: 12
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  labels:
+    app: sasquatch
+  name: sasquatch-test-producer
+  annotations:
+    "helm.sh/hook": test
+spec:
+  backoffLimit: 0
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        app: sasquatch
+        job-name: sasquatch-test-producer
+      name: sasquatch-test-producer
+      namespace: sasquatch
+    spec:
+      containers:
+        - env:
+            - name: BOOTSTRAP_SERVERS
+              value: sasquatch-kafka-bootstrap.sasquatch:9092
+            - name: DELAY_MS
+              value: "1000"
+            - name: TOPIC
+              value: sasquatch-test
+            - name: MESSAGE_COUNT
+              value: "100"
+            - name: MESSAGE
+              value: Hello-world
+            - name: PRODUCER_ACKS
+              value: all
+            - name: LOG_LEVEL
+              value: DEBUG
+            # Set here the password created by Strimzi for the
+            # sasquatch-test user, see the sasquatch-test secret.
+            - name: ADDITIONAL_CONFIG
+              value: |
+                sasl.mechanism=SCRAM-SHA-512
+                security.protocol=SASL_PLAINTEXT
+                sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="sasquatch-test" password="";
+          image: quay.io/strimzi-test-clients/test-client-kafka-producer:latest-kafka-3.0.0
+          imagePullPolicy: IfNotPresent
+          name: kafka-producer-client
+      restartPolicy: "Never"

--- a/services/sasquatch/charts/strimzi-kafka/templates/ts-salkafka-user.yaml
+++ b/services/sasquatch/charts/strimzi-kafka/templates/ts-salkafka-user.yaml
@@ -1,0 +1,19 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaUser
+metadata:
+  name: ts-salkafka
+  labels:
+    strimzi.io/cluster: {{ .Values.cluster.name }}
+spec:
+  authentication:
+    type: scram-sha-512
+  authorization:
+    type: simple
+    acls:
+      - resource:
+          type: topic
+          name: "lsst.sal.*"
+          patternType: literal
+        type: allow
+        host: "*"
+        operation: All

--- a/services/sasquatch/templates/vault-secret.yaml
+++ b/services/sasquatch/templates/vault-secret.yaml
@@ -10,6 +10,17 @@ spec:
 apiVersion: ricoberger.de/v1alpha1
 kind: VaultSecret
 metadata:
+  name: ts-salkafka
+  namespace: sasquatch
+spec:
+  keys:
+    - ts-salkafka-password
+  path: {{ .Values.vaultSecretsPath }}/sasquatch
+  type: Opaque
+---
+apiVersion: ricoberger.de/v1alpha1
+kind: VaultSecret
+metadata:
   name: pull-secret
 spec:
   path: {{ .Values.vaultSecretsPath }}/pull-secret


### PR DESCRIPTION
- Enable scram-sha-512 authentication for the plain listener used by clients inside the Kubernetes cluster
-  Add the `ts-salkafka` user with operations restricted to topics prefixed by `lsst.sal.*`
- The User Operator uses the `ts-salkafka` secret to set the password for the `ts-salkafka` user, that's needed otherwise the User Operator would set a random password and create the secret himself.
- Add a chart test for SASL authentication
