### PR TITLE
Support usernameClaim and uidClaim in Gafaelfawr

### DIFF
--- a/services/gafaelfawr/README.md
+++ b/services/gafaelfawr/README.md
@@ -53,6 +53,8 @@ Science Platform authentication and authorization system
 | config.oidc.loginUrl | string | None, must be set | URL to which to redirect the user for authorization |
 | config.oidc.scopes | list | `["openid"]` | Scopes to request from the OpenID Connect provider |
 | config.oidc.tokenUrl | string | None, must be set | URL from which to retrieve the token for the user |
+| config.oidc.uidClaim | string | `"uidNumber"` | Claim from which to get the numeric UID (only used if not retrieved from LDAP) |
+| config.oidc.usernameClaim | string | `"sub"` | Claim from which to get the username (only used if not retrieved from LDAP) |
 | config.oidcServer.enabled | bool | `false` | Whether to support OpenID Connect clients. If set to true, `oidc-server-secrets` must be set in the Gafaelfawr secret. |
 | config.proxies | list | [`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`] | List of netblocks used for internal Kubernetes IP addresses, used to determine the true client IP for logging |
 | config.tokenLifetimeMinutes | int | `43200` (30 days) | Session length and token expiration (in minutes) |

--- a/services/gafaelfawr/templates/configmap.yaml
+++ b/services/gafaelfawr/templates/configmap.yaml
@@ -102,6 +102,12 @@ data:
       login_params:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.config.oidc.usernameClaim }}
+      username_claim: {{ .Values.config.oidc.usernameClaim | quote }}
+      {{- end }}
+      {{- if .Values.config.oidc.uidClaim }}
+      uid_claim: {{ .Values.config.oidc.uidClaim | quote }}
+      {{- end }}
 
     {{- end }}
 

--- a/services/gafaelfawr/values.yaml
+++ b/services/gafaelfawr/values.yaml
@@ -119,6 +119,16 @@ config:
     scopes:
       - "openid"
 
+    # -- Claim from which to get the username (only used if not retrieved from
+    # LDAP)
+    # @default -- `"sub"`
+    usernameClaim: ""
+
+    # -- Claim from which to get the numeric UID (only used if not retrieved
+    # from LDAP)
+    # @default -- `"uidNumber"`
+    uidClaim: ""
+
   ldap:
     # -- LDAP server URL from which to retrieve user group information
     # @default -- Do not use LDAP


### PR DESCRIPTION
This was previously supported in an earlier iteration of the chart
but was lost.  uidClaim is used at SLAC.  Allow these to be set
for the generic OIDC provider and plumb them through to the
ConfigMap.