### PR TITLE
Drop appVersionBadge from helm-docs template

### DIFF
--- a/helm-docs.md.gotmpl
+++ b/helm-docs.md.gotmpl
@@ -1,5 +1,3 @@
-{{ template "chart.appVersionBadge" . }}
-
 {{ template "chart.header" . }}
 
 {{ template "chart.description" . }}

--- a/science-platform/README.md
+++ b/science-platform/README.md
@@ -1,5 +1,3 @@
-
-
 # science-platform
 
 ## Values

--- a/services/alert-stream-broker/README.md
+++ b/services/alert-stream-broker/README.md
@@ -1,5 +1,3 @@
-
-
 # alert-stream-broker
 
 ## Requirements

--- a/services/cachemachine/README.md
+++ b/services/cachemachine/README.md
@@ -1,5 +1,3 @@
-![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
-
 # cachemachine
 
 Service to prepull Docker images for the Science Platform

--- a/services/cert-manager/README.md
+++ b/services/cert-manager/README.md
@@ -1,5 +1,3 @@
-
-
 # cert-manager
 
 Let's Encrypt certificate management

--- a/services/exposurelog/README.md
+++ b/services/exposurelog/README.md
@@ -1,5 +1,3 @@
-![AppVersion: 0.9.2](https://img.shields.io/badge/AppVersion-0.9.2-informational?style=flat-square)
-
 # exposurelog
 
 Exposure log service

--- a/services/gafaelfawr/README.md
+++ b/services/gafaelfawr/README.md
@@ -1,5 +1,3 @@
-![AppVersion: 4.1.0](https://img.shields.io/badge/AppVersion-4.1.0-informational?style=flat-square)
-
 # gafaelfawr
 
 Science Platform authentication and authorization system

--- a/services/mobu/README.md
+++ b/services/mobu/README.md
@@ -1,5 +1,3 @@
-![AppVersion: 4.2.0](https://img.shields.io/badge/AppVersion-4.2.0-informational?style=flat-square)
-
 # mobu
 
 Generate system load by pretending to be a random scientist

--- a/services/narrativelog/README.md
+++ b/services/narrativelog/README.md
@@ -1,5 +1,3 @@
-![AppVersion: 0.2.1](https://img.shields.io/badge/AppVersion-0.2.1-informational?style=flat-square)
-
 # narrativelog
 
 Narrative log service

--- a/services/noteburst/README.md
+++ b/services/noteburst/README.md
@@ -1,5 +1,3 @@
-![AppVersion: 0.2.0](https://img.shields.io/badge/AppVersion-0.2.0-informational?style=flat-square)
-
 # noteburst
 
 Noteburst is a notebook execution service for the Rubin Science Platform.

--- a/services/nublado2/README.md
+++ b/services/nublado2/README.md
@@ -1,5 +1,3 @@
-![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
-
 # nublado2
 
 Nublado2 JupyterHub installation

--- a/services/portal/README.md
+++ b/services/portal/README.md
@@ -1,5 +1,3 @@
-![AppVersion: suit-2022.1](https://img.shields.io/badge/AppVersion-suit--2022.1-informational?style=flat-square)
-
 # portal
 
 Rubin Science Platform portal aspect

--- a/services/production-tools/README.md
+++ b/services/production-tools/README.md
@@ -1,5 +1,3 @@
-![AppVersion: 0.0.9](https://img.shields.io/badge/AppVersion-0.0.9-informational?style=flat-square)
-
 # production-tools
 
 A collection of utility pages for monitoring data processing.

--- a/services/sasquatch/README.md
+++ b/services/sasquatch/README.md
@@ -1,5 +1,3 @@
-![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
-
 # sasquatch
 
 Rubin Observatory's telemetry service.

--- a/services/sasquatch/charts/kafka-connect-manager/README.md
+++ b/services/sasquatch/charts/kafka-connect-manager/README.md
@@ -1,5 +1,3 @@
-![AppVersion: 0.9.3](https://img.shields.io/badge/AppVersion-0.9.3-informational?style=flat-square)
-
 # kafka-connect-manager
 
 A subchart to deploy the Kafka connectors used by Sasquatch.

--- a/services/sasquatch/charts/strimzi-kafka/README.md
+++ b/services/sasquatch/charts/strimzi-kafka/README.md
@@ -1,5 +1,3 @@
-![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
-
 # strimzi-kafka
 
 A subchart to deploy Strimzi Kafka components for Sasquatch.

--- a/services/semaphore/README.md
+++ b/services/semaphore/README.md
@@ -1,5 +1,3 @@
-![AppVersion: 0.3.0](https://img.shields.io/badge/AppVersion-0.3.0-informational?style=flat-square)
-
 # semaphore
 
 Semaphore is the user notification and messaging service for the Rubin Science Platform.

--- a/services/squareone/README.md
+++ b/services/squareone/README.md
@@ -1,5 +1,3 @@
-![AppVersion: 0.6.0](https://img.shields.io/badge/AppVersion-0.6.0-informational?style=flat-square)
-
 # squareone
 
 Squareone is the homepage UI for the Rubin Science Platform.

--- a/services/tap-schema/README.md
+++ b/services/tap-schema/README.md
@@ -1,5 +1,3 @@
-![AppVersion: 1.1.7](https://img.shields.io/badge/AppVersion-1.1.7-informational?style=flat-square)
-
 # tap-schema
 
 The TAP_SCHEMA database

--- a/services/telegraf-ds/README.md
+++ b/services/telegraf-ds/README.md
@@ -1,5 +1,3 @@
-
-
 # telegraf-ds
 
 SQuaRE DaemonSet (K8s) telemetry collection service

--- a/services/telegraf/README.md
+++ b/services/telegraf/README.md
@@ -1,5 +1,3 @@
-
-
 # telegraf
 
 SQuaRE telemetry collection service

--- a/services/times-square/README.md
+++ b/services/times-square/README.md
@@ -1,5 +1,3 @@
-
-
 # times-square
 
 A parameterized notebook web viewer for the Rubin Science Platform.

--- a/services/times-square/charts/times-square-ui/README.md
+++ b/services/times-square/charts/times-square-ui/README.md
@@ -1,5 +1,3 @@
-![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
-
 # times-square-ui
 
 The front-end for Times Square, a parameterized notebook web viewer for the Rubin Science Platform

--- a/services/times-square/charts/times-square/README.md
+++ b/services/times-square/charts/times-square/README.md
@@ -1,5 +1,3 @@
-![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
-
 # times-square
 
 A parameterized notebook web viewer for the Rubin Science Platform.

--- a/services/vo-cutouts/README.md
+++ b/services/vo-cutouts/README.md
@@ -1,5 +1,3 @@
-![AppVersion: 0.3.0](https://img.shields.io/badge/AppVersion-0.3.0-informational?style=flat-square)
-
 # vo-cutouts
 
 Image cutout service complying with IVOA SODA


### PR DESCRIPTION
We decided to take out the version badge in order to make it easier for version bumps from edit-on-GitHub workflows (i.e., bumping the version does not trigger a change in the README now).
