### PR TITLE
Delete the Portal ingress cookie on failure

### DIFF
--- a/services/portal/templates/ingress.yaml
+++ b/services/portal/templates/ingress.yaml
@@ -8,6 +8,7 @@ metadata:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/affinity: "cookie"
+    nginx.ingress.kubernetes.io/session-cookie-change-on-failure: "true"
     nginx.ingress.kubernetes.io/proxy-body-size: "0m"
     nginx.ingress.kubernetes.io/proxy-buffer-size: "24k"
     nginx.ingress.kubernetes.io/client-header-buffer-size: "24k"


### PR DESCRIPTION
See if this helps with our 504 issues after restarting the Portal.