### PR TITLE
[DM-34802] Add HiPS service and starter

### DIFF
--- a/science-platform/README.md
+++ b/science-platform/README.md
@@ -10,6 +10,7 @@
 | datalinker.enabled | bool | `false` |  |
 | exposurelog.enabled | bool | `false` |  |
 | gafaelfawr.enabled | bool | `false` |  |
+| hips.enabled | bool | `false` |  |
 | ingress_nginx.enabled | bool | `false` |  |
 | mobu.enabled | bool | `false` |  |
 | moneypenny.enabled | bool | `false` |  |

--- a/science-platform/templates/hips-application.yaml
+++ b/science-platform/templates/hips-application.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.hips.enabled -}}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "hips"
+spec:
+  finalizers:
+    - "kubernetes"
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: "hips"
+  namespace: "argocd"
+  finalizers:
+    - "resources-finalizer.argocd.argoproj.io"
+spec:
+  destination:
+    namespace: "hips"
+    server: "https://kubernetes.default.svc"
+  project: "default"
+  source:
+    path: "services/hips"
+    repoURL: {{ .Values.repoURL | quote }}
+    targetRevision: {{ .Values.revision | quote }}
+    helm:
+      parameters:
+        - name: "global.host"
+          value: {{ .Values.fqdn | quote }}
+        - name: "global.baseUrl"
+          value: "https://{{ .Values.fqdn }}"
+        - name: "global.vaultSecretsPath"
+          value: {{ .Values.vault_path_prefix | quote }}
+      valueFiles:
+        - "values.yaml"
+        - "values-{{ .Values.environment }}.yaml"
+{{- end -}}

--- a/science-platform/values-base.yaml
+++ b/science-platform/values-base.yaml
@@ -14,11 +14,13 @@ exposurelog:
   enabled: true
 gafaelfawr:
   enabled: true
+hips:
+  enabled: false
+ingress_nginx:
+  enabled: true
 mobu:
   enabled: false
 moneypenny:
-  enabled: true
-ingress_nginx:
   enabled: true
 narrativelog:
   enabled: true

--- a/science-platform/values-idfdev.yaml
+++ b/science-platform/values-idfdev.yaml
@@ -14,11 +14,13 @@ exposurelog:
   enabled: false
 gafaelfawr:
   enabled: true
+hips:
+  enabled: true
+ingress_nginx:
+  enabled: true
 mobu:
   enabled: true
 moneypenny:
-  enabled: true
-ingress_nginx:
   enabled: true
 narrativelog:
   enabled: false

--- a/science-platform/values-idfint.yaml
+++ b/science-platform/values-idfint.yaml
@@ -14,11 +14,13 @@ exposurelog:
   enabled: false
 gafaelfawr:
   enabled: true
+hips:
+  enabled: false
+ingress_nginx:
+  enabled: true
 mobu:
   enabled: true
 moneypenny:
-  enabled: true
-ingress_nginx:
   enabled: true
 narrativelog:
   enabled: false

--- a/science-platform/values-idfprod.yaml
+++ b/science-platform/values-idfprod.yaml
@@ -14,11 +14,13 @@ exposurelog:
   enabled: false
 gafaelfawr:
   enabled: true
+hips:
+  enabled: false
+ingress_nginx:
+  enabled: true
 mobu:
   enabled: true
 moneypenny:
-  enabled: true
-ingress_nginx:
   enabled: true
 narrativelog:
   enabled: false

--- a/science-platform/values-int.yaml
+++ b/science-platform/values-int.yaml
@@ -14,12 +14,14 @@ exposurelog:
   enabled: false
 gafaelfawr:
   enabled: true
+hips:
+  enabled: false
+ingress_nginx:
+  enabled: false
 mobu:
   enabled: true
 moneypenny:
   enabled: true
-ingress_nginx:
-  enabled: false
 narrativelog:
   enabled: false
 noteburst:

--- a/science-platform/values-minikube.yaml
+++ b/science-platform/values-minikube.yaml
@@ -14,11 +14,13 @@ exposurelog:
   enabled: false
 gafaelfawr:
   enabled: true
+hips:
+  enabled: true
+ingress_nginx:
+  enabled: true
 mobu:
   enabled: true
 moneypenny:
-  enabled: true
-ingress_nginx:
   enabled: true
 narrativelog:
   enabled: false

--- a/science-platform/values-roe.yaml
+++ b/science-platform/values-roe.yaml
@@ -14,11 +14,13 @@ exposurelog:
   enabled: false
 gafaelfawr:
   enabled: true
+hips:
+  enabled: false
+ingress_nginx:
+  enabled: true
 mobu:
   enabled: true
 moneypenny:
-  enabled: true
-ingress_nginx:
   enabled: true
 narrativelog:
   enabled: false

--- a/science-platform/values-stable.yaml
+++ b/science-platform/values-stable.yaml
@@ -14,12 +14,14 @@ exposurelog:
   enabled: false
 gafaelfawr:
   enabled: true
+hips:
+  enabled: false
+ingress_nginx:
+  enabled: false
 mobu:
   enabled: true
 moneypenny:
   enabled: true
-ingress_nginx:
-  enabled: false
 narrativelog:
   enabled: false
 noteburst:

--- a/science-platform/values-summit.yaml
+++ b/science-platform/values-summit.yaml
@@ -14,11 +14,13 @@ exposurelog:
   enabled: true
 gafaelfawr:
   enabled: true
+hips:
+  enabled: false
+ingress_nginx:
+  enabled: true
 mobu:
   enabled: false
 moneypenny:
-  enabled: true
-ingress_nginx:
   enabled: true
 narrativelog:
   enabled: true

--- a/science-platform/values-tucson-teststand.yaml
+++ b/science-platform/values-tucson-teststand.yaml
@@ -14,11 +14,13 @@ exposurelog:
   enabled: true
 gafaelfawr:
   enabled: true
+hips:
+  enabled: false
+ingress_nginx:
+  enabled: true
 mobu:
   enabled: false
 moneypenny:
-  enabled: true
-ingress_nginx:
   enabled: true
 narrativelog:
   enabled: true

--- a/science-platform/values.yaml
+++ b/science-platform/values.yaml
@@ -10,6 +10,8 @@ exposurelog:
   enabled: false
 gafaelfawr:
   enabled: false
+hips:
+  enabled: false
 ingress_nginx:
   enabled: false
 mobu:

--- a/services/hips/.helmignore
+++ b/services/hips/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/services/hips/Chart.yaml
+++ b/services/hips/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+appVersion: 0.1.0
+description: A Helm chart for Kubernetes
+name: hips
+type: application
+version: 0.1.0

--- a/services/hips/README.md
+++ b/services/hips/README.md
@@ -22,6 +22,7 @@ A Helm chart for Kubernetes
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | ingress.annotations | object | `{}` | Additional annotations for the ingress rule |
 | ingress.gafaelfawrAuthQuery | string | `"scope=read:image"` | Gafaelfawr auth query string |
+| ingress.path | string | `"/api/hips"` | Path at which to serve the service |
 | nodeSelector | object | `{}` | Node selection rules for the hips deployment pod |
 | podAnnotations | object | `{}` | Annotations for the hips deployment pod |
 | replicaCount | int | `1` | Number of web deployment pods to start |

--- a/services/hips/README.md
+++ b/services/hips/README.md
@@ -1,0 +1,29 @@
+# hips
+
+A Helm chart for Kubernetes
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Affinity rules for the hips deployment pod |
+| autoscaling.enabled | bool | `false` | Enable autoscaling of hips deployment |
+| autoscaling.maxReplicas | int | `100` | Maximum number of hips deployment pods |
+| autoscaling.minReplicas | int | `1` | Minimum number of hips deployment pods |
+| autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU utilization of hips deployment pods |
+| config.gcsBucket | string | None, must be set | Name of Google Cloud Storage bucket holding the HiPS files |
+| config.gcsProject | string | None, must be set | Google Cloud project in which the underlying storage is located |
+| config.serviceAccount | string | None, must be set | The Google service account that has an IAM binding to the `hips` Kubernetes service account and has access to the storage bucket |
+| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
+| global.host | string | Set by Argo CD | Host name for ingress |
+| global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
+| image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the hips image |
+| image.repository | string | `"ghcr.io/lsst-sqre/crawlspace"` | Image to use in the hips deployment |
+| image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
+| ingress.annotations | object | `{}` | Additional annotations for the ingress rule |
+| ingress.gafaelfawrAuthQuery | string | `"scope=read:image"` | Gafaelfawr auth query string |
+| nodeSelector | object | `{}` | Node selection rules for the hips deployment pod |
+| podAnnotations | object | `{}` | Annotations for the hips deployment pod |
+| replicaCount | int | `1` | Number of web deployment pods to start |
+| resources | object | `{}` | Resource limits and requests for the hips deployment pod |
+| tolerations | list | `[]` | Tolerations for the hips deployment pod |

--- a/services/hips/templates/_helpers.tpl
+++ b/services/hips/templates/_helpers.tpl
@@ -1,0 +1,26 @@
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "hips.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "hips.labels" -}}
+helm.sh/chart: {{ include "hips.chart" . }}
+{{ include "hips.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "hips.selectorLabels" -}}
+app.kubernetes.io/name: "hips"
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/services/hips/templates/deployment.yaml
+++ b/services/hips/templates/deployment.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "hips"
+  labels:
+    {{- include "hips.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "hips.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "hips.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          env:
+            - name: "CRAWLSPACE_PROJECT"
+              value: {{ required "config.gcsProject must be set" .Values.config.gcsProject | quote }}
+            - name: "CRAWLSPACE_BUCKET"
+              value: {{ required "config.gcsBucket must be set" .Values.config.gcsBucket | quote }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: "http"
+              containerPort: 8080
+              protocol: "TCP"
+          readinessProbe:
+            httpGet:
+              path: "/"
+              port: "http"
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+            readOnlyRootFilesystem: true
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+      serviceAccountName: "hips"
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/services/hips/templates/hpa.yaml
+++ b/services/hips/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: "hips"
+  labels:
+    {{- include "hips.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: "hips"
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: "cpu"
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: "memory"
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/services/hips/templates/ingress.yaml
+++ b/services/hips/templates/ingress.yaml
@@ -1,0 +1,29 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: "hips"
+  labels:
+    {{- include "hips.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    {{- if .Values.ingress.gafaelfawrAuthQuery }}
+    nginx.ingress.kubernetes.io/auth-method: "GET"
+    nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-User"
+    nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.global.baseUrl }}/login"
+    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.baseUrl }}/auth?{{ .Values.ingress.gafaelfawrAuthQuery }}"
+    {{- end }}
+    {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  rules:
+    - host: {{ required "global.host must be set" .Values.global.host | quote }}
+      http:
+        paths:
+          - path: "/hips"
+            pathType: "Prefix"
+            backend:
+              service:
+                name: "hips"
+                port:
+                  number: 8080

--- a/services/hips/templates/ingress.yaml
+++ b/services/hips/templates/ingress.yaml
@@ -20,7 +20,7 @@ spec:
     - host: {{ required "global.host must be set" .Values.global.host | quote }}
       http:
         paths:
-          - path: "/hips"
+          - path: {{ .Values.ingress.path | quote }}
             pathType: "Prefix"
             backend:
               service:

--- a/services/hips/templates/networkpolicy.yaml
+++ b/services/hips/templates/networkpolicy.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: "hips"
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "hips.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    # Allow inbound access from pods (in any namespace) labeled
+    # gafaelfawr.lsst.io/ingress: true.
+    - from:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              gafaelfawr.lsst.io/ingress: "true"
+      ports:
+        - protocol: "TCP"
+          port: 8080

--- a/services/hips/templates/service.yaml
+++ b/services/hips/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "hips"
+  labels:
+    {{- include "hips.labels" . | nindent 4 }}
+spec:
+  type: "ClusterIP"
+  ports:
+    - port: 8080
+      targetPort: "http"
+      protocol: "TCP"
+      name: "http"
+  selector:
+    {{- include "hips.selectorLabels" . | nindent 4 }}

--- a/services/hips/templates/serviceaccount.yaml
+++ b/services/hips/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "hips"
+  labels:
+    {{- include "hips.labels" . | nindent 4 }}
+  annotations:
+    iam.gke.io/gcp-service-account: {{ required "config.serviceAccount must be set to a valid Google service account" .Values.config.serviceAccount | quote }}

--- a/services/hips/values-idfdev.yaml
+++ b/services/hips/values-idfdev.yaml
@@ -1,0 +1,7 @@
+config:
+  gcsProject: "bogus"
+  gcsBucket: "bogus"
+  serviceAccount: "bogus"
+
+image:
+  tag: "tickets-DM-34802"

--- a/services/hips/values-minikube.yaml
+++ b/services/hips/values-minikube.yaml
@@ -1,0 +1,7 @@
+config:
+  gcsProject: "bogus"
+  gcsBucket: "bogus"
+  serviceAccount: "bogus"
+
+image:
+  tag: "tickets-DM-34802"

--- a/services/hips/values.yaml
+++ b/services/hips/values.yaml
@@ -1,0 +1,81 @@
+# Default values for hips.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# -- Number of web deployment pods to start
+replicaCount: 1
+
+config:
+  # -- Google Cloud project in which the underlying storage is located
+  # @default -- None, must be set
+  gcsProject: ""
+
+  # -- Name of Google Cloud Storage bucket holding the HiPS files
+  # @default -- None, must be set
+  gcsBucket: ""
+
+  # -- The Google service account that has an IAM binding to the `hips`
+  # Kubernetes service account and has access to the storage bucket
+  # @default -- None, must be set
+  serviceAccount: ""
+
+image:
+  # -- Image to use in the hips deployment
+  repository: "ghcr.io/lsst-sqre/crawlspace"
+
+  # -- Pull policy for the hips image
+  pullPolicy: "IfNotPresent"
+
+  # -- Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+ingress:
+  # -- Gafaelfawr auth query string
+  gafaelfawrAuthQuery: "scope=read:image"
+
+  # -- Additional annotations for the ingress rule
+  annotations: {}
+
+autoscaling:
+  # -- Enable autoscaling of hips deployment
+  enabled: false
+
+  # -- Minimum number of hips deployment pods
+  minReplicas: 1
+
+  # -- Maximum number of hips deployment pods
+  maxReplicas: 100
+
+  # -- Target CPU utilization of hips deployment pods
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+# -- Annotations for the hips deployment pod
+podAnnotations: {}
+
+# -- Resource limits and requests for the hips deployment pod
+resources: {}
+
+# -- Node selection rules for the hips deployment pod
+nodeSelector: {}
+
+# -- Tolerations for the hips deployment pod
+tolerations: []
+
+# -- Affinity rules for the hips deployment pod
+affinity: {}
+
+# The following will be set by parameters injected by Argo CD and should not
+# be set in the individual environment values files.
+global:
+  # -- Base URL for the environment
+  # @default -- Set by Argo CD
+  baseUrl: ""
+
+  # -- Host name for ingress
+  # @default -- Set by Argo CD
+  host: ""
+
+  # -- Base path for Vault secrets
+  # @default -- Set by Argo CD
+  vaultSecretsPath: ""

--- a/services/hips/values.yaml
+++ b/services/hips/values.yaml
@@ -33,6 +33,9 @@ ingress:
   # -- Gafaelfawr auth query string
   gafaelfawrAuthQuery: "scope=read:image"
 
+  # -- Path at which to serve the service
+  path: "/api/hips"
+
   # -- Additional annotations for the ingress rule
   annotations: {}
 

--- a/starters/README.md
+++ b/starters/README.md
@@ -1,0 +1,11 @@
+# Helm starters for Phalanx
+
+Each subdirectory of this directory is a Helm starter for a class of Phalanx service.
+Use the starters with the `-p` option to `helm create`.
+For example, from the `services` directory:
+
+```sh
+helm create new-service -p $(pwd)/../starters/rsp-web-service
+```
+
+The path to the starter directory must be absolute, not relative, or Helm will try to use it has a path relative to `$HOME/.local/share/helm`.

--- a/starters/web-service/.helmignore
+++ b/starters/web-service/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/starters/web-service/Chart.yaml
+++ b/starters/web-service/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: <CHARTNAME>
+version: 1.0.0
+description: |
+  Helm starter chart for a new RSP service.
+home: "https://github.com/lsst-sqre/<CHARTNAME>"
+type: application
+
+# The default version tag of the <CHARTNAME> Docker image.
+appVersion: "1.0.0"

--- a/starters/web-service/README.md
+++ b/starters/web-service/README.md
@@ -21,6 +21,7 @@ Helm starter chart for a new RSP service.
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | ingress.annotations | object | `{}` | Additional annotations for the ingress rule |
 | ingress.gafaelfawrAuthQuery | string | Unauthenticated | Gafaelfawr auth query string |
+| ingress.path | string | `"/<CHARTNAME>"` | Path at which to serve the service |
 | nodeSelector | object | `{}` | Node selection rules for the <CHARTNAME> deployment pod |
 | podAnnotations | object | `{}` | Annotations for the <CHARTNAME> deployment pod |
 | replicaCount | int | `1` | Number of web deployment pods to start |

--- a/starters/web-service/README.md
+++ b/starters/web-service/README.md
@@ -1,0 +1,28 @@
+# <CHARTNAME>
+
+Helm starter chart for a new RSP service.
+
+**Homepage:** <https://github.com/lsst-sqre/<CHARTNAME>>
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Affinity rules for the <CHARTNAME> deployment pod |
+| autoscaling.enabled | bool | `false` | Enable autoscaling of <CHARTNAME> deployment |
+| autoscaling.maxReplicas | int | `100` | Maximum number of <CHARTNAME> deployment pods |
+| autoscaling.minReplicas | int | `1` | Minimum number of <CHARTNAME> deployment pods |
+| autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU utilization of <CHARTNAME> deployment pods |
+| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
+| global.host | string | Set by Argo CD | Host name for ingress |
+| global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
+| image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the <CHARTNAME> image |
+| image.repository | string | `"ghcr.io/lsst-sqre/<CHARTNAME>"` | Image to use in the <CHARTNAME> deployment |
+| image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
+| ingress.annotations | object | `{}` | Additional annotations for the ingress rule |
+| ingress.gafaelfawrAuthQuery | string | Unauthenticated | Gafaelfawr auth query string |
+| nodeSelector | object | `{}` | Node selection rules for the <CHARTNAME> deployment pod |
+| podAnnotations | object | `{}` | Annotations for the <CHARTNAME> deployment pod |
+| replicaCount | int | `1` | Number of web deployment pods to start |
+| resources | object | `{}` | Resource limits and requests for the <CHARTNAME> deployment pod |
+| tolerations | list | `[]` | Tolerations for the <CHARTNAME> deployment pod |

--- a/starters/web-service/templates/_helpers.tpl
+++ b/starters/web-service/templates/_helpers.tpl
@@ -1,0 +1,26 @@
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "<CHARTNAME>.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "<CHARTNAME>.labels" -}}
+helm.sh/chart: {{ include "<CHARTNAME>.chart" . }}
+{{ include "<CHARTNAME>.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "<CHARTNAME>.selectorLabels" -}}
+app.kubernetes.io/name: "<CHARTNAME>"
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/starters/web-service/templates/deployment.yaml
+++ b/starters/web-service/templates/deployment.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "<CHARTNAME>"
+  labels:
+    {{- include "<CHARTNAME>.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "<CHARTNAME>.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "<CHARTNAME>.selectorLabels" . | nindent 8 }}
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+            readOnlyRootFilesystem: true
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: "http"
+              containerPort: 8080
+              protocol: "TCP"
+          readinessProbe:
+            httpGet:
+              path: "/"
+              port: "http"
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/starters/web-service/templates/hpa.yaml
+++ b/starters/web-service/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: "<CHARTNAME>"
+  labels:
+    {{- include "<CHARTNAME>.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: "<CHARTNAME>"
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: "cpu"
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: "memory"
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/starters/web-service/templates/ingress.yaml
+++ b/starters/web-service/templates/ingress.yaml
@@ -1,0 +1,29 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: "<CHARTNAME>"
+  labels:
+    {{- include "<CHARTNAME>.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    {{- if .Values.ingress.gafaelfawrAuthQuery }}
+    nginx.ingress.kubernetes.io/auth-method: "GET"
+    nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-User"
+    nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.global.baseUrl }}/login"
+    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.baseUrl }}/auth?{{ .Values.ingress.gafaelfawrAuthQuery }}"
+    {{- end }}
+    {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  rules:
+    - host: {{ required "global.host must be set" .Values.global.host | quote }}
+      http:
+        paths:
+          - path: "/<CHARTNAME>"
+            pathType: "Prefix"
+            backend:
+              service:
+                name: "<CHARTNAME>"
+                port:
+                  number: 8080

--- a/starters/web-service/templates/ingress.yaml
+++ b/starters/web-service/templates/ingress.yaml
@@ -20,7 +20,7 @@ spec:
     - host: {{ required "global.host must be set" .Values.global.host | quote }}
       http:
         paths:
-          - path: "/<CHARTNAME>"
+          - path: {{ .Values.ingress.path | quote }}
             pathType: "Prefix"
             backend:
               service:

--- a/starters/web-service/templates/networkpolicy.yaml
+++ b/starters/web-service/templates/networkpolicy.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: "<CHARTNAME>"
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "<CHARTNAME>.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    # Allow inbound access from pods (in any namespace) labeled
+    # gafaelfawr.lsst.io/ingress: true.
+    - from:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              gafaelfawr.lsst.io/ingress: "true"
+      ports:
+        - protocol: "TCP"
+          port: 8080

--- a/starters/web-service/templates/service.yaml
+++ b/starters/web-service/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "<CHARTNAME>"
+  labels:
+    {{- include "<CHARTNAME>.labels" . | nindent 4 }}
+spec:
+  type: "ClusterIP"
+  ports:
+    - port: 8080
+      targetPort: "http"
+      protocol: "TCP"
+      name: "http"
+  selector:
+    {{- include "<CHARTNAME>.selectorLabels" . | nindent 4 }}

--- a/starters/web-service/values.yaml
+++ b/starters/web-service/values.yaml
@@ -1,0 +1,70 @@
+# Default values for <CHARTNAME>.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# -- Number of web deployment pods to start
+replicaCount: 1
+
+image:
+  # -- Image to use in the <CHARTNAME> deployment
+  repository: "ghcr.io/lsst-sqre/<CHARTNAME>"
+
+  # -- Pull policy for the <CHARTNAME> image
+  pullPolicy: "IfNotPresent"
+
+  # -- Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+ingress:
+  # -- Gafaelfawr auth query string
+  # @default -- Unauthenticated
+  gafaelfawrAuthQuery: ""
+  # gafaelfawrAuthQuery: "scope=read:image"
+  # gafaelfawrAuthQuery: "scope=exec:portal&delegate_to=portal&delegate_scope=read:tap"
+
+  # -- Additional annotations for the ingress rule
+  annotations: {}
+
+autoscaling:
+  # -- Enable autoscaling of <CHARTNAME> deployment
+  enabled: false
+
+  # -- Minimum number of <CHARTNAME> deployment pods
+  minReplicas: 1
+
+  # -- Maximum number of <CHARTNAME> deployment pods
+  maxReplicas: 100
+
+  # -- Target CPU utilization of <CHARTNAME> deployment pods
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+# -- Annotations for the <CHARTNAME> deployment pod
+podAnnotations: {}
+
+# -- Resource limits and requests for the <CHARTNAME> deployment pod
+resources: {}
+
+# -- Node selection rules for the <CHARTNAME> deployment pod
+nodeSelector: {}
+
+# -- Tolerations for the <CHARTNAME> deployment pod
+tolerations: []
+
+# -- Affinity rules for the <CHARTNAME> deployment pod
+affinity: {}
+
+# The following will be set by parameters injected by Argo CD and should not
+# be set in the individual environment values files.
+global:
+  # -- Base URL for the environment
+  # @default -- Set by Argo CD
+  baseUrl: ""
+
+  # -- Host name for ingress
+  # @default -- Set by Argo CD
+  host: ""
+
+  # -- Base path for Vault secrets
+  # @default -- Set by Argo CD
+  vaultSecretsPath: ""

--- a/starters/web-service/values.yaml
+++ b/starters/web-service/values.yaml
@@ -22,6 +22,9 @@ ingress:
   # gafaelfawrAuthQuery: "scope=read:image"
   # gafaelfawrAuthQuery: "scope=exec:portal&delegate_to=portal&delegate_scope=read:tap"
 
+  # -- Path at which to serve the service
+  path: "/<CHARTNAME>"
+
   # -- Additional annotations for the ingress rule
   annotations: {}
 


### PR DESCRIPTION
Add a chart for the HiPS service using crawlspace as the underlying
container implementation.  Enable it only on IDF dev.

Add a starter for web services based on the charts starter, but with
additional simplifications.