### PR TITLE
Fix syntax errors in imagePullSecrets

### DIFF
--- a/services/exposurelog/templates/deployment.yaml
+++ b/services/exposurelog/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
         {{- include "exposurelog.selectorLabels" . | nindent 8 }}
     spec:
       imagePullSecrets:
-        name: pull-secret
+        - name: "pull-secret"
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/services/plot-navigator/templates/deployment.yaml
+++ b/services/plot-navigator/templates/deployment.yaml
@@ -15,7 +15,7 @@ spec:
         {{- include "plot-navigator.selectorLabels" . | nindent 8 }}
     spec:
       imagePullSecrets:
-        name: pull-secret
+        - name: "pull-secret"
       volumes:
         # butler-secrets-raw is the secrets we get from vault
         - name: "butler-secrets-raw"


### PR DESCRIPTION
In a couple of charts, this wasn't an array.  Fix it to always be
an array and use consistent quoting.