### PR TITLE
[DM-34737] Datalinker 1.1.0 version

### DIFF
--- a/services/datalinker/Chart.yaml
+++ b/services/datalinker/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 1.0.0
+appVersion: 1.1.0
 description: A Helm chart for Kubernetes
 name: datalinker
 type: application
-version: 0.1.8
+version: 0.1.9
 maintainers:
   - name: cbanek


### PR DESCRIPTION
Use the new datalinker released version that has the links endpoint.