### PR TITLE
DM-34918: exposurelog: update tucson-teststand deployment

### DIFF
--- a/services/exposurelog/values-tucson-teststand.yaml
+++ b/services/exposurelog/values-tucson-teststand.yaml
@@ -1,8 +1,9 @@
 config:
-  # WARNING: this is a "playground" deployment
-  # using exposurelog's built-in test butler registries.
-  site_id: test
-  # Use the test butler registries.
-  # Note: exposurelog's Dockerfile copies the test repos to the top of the container
-  butler_uri_1: LSSTCam
-  butler_uri_2: LATISS
+  site_id: tucson
+  nfs_path_1: /repo/LSSTComCam  # Mounted as /volume_1
+  nfs_server_1: comcam-archiver.tu.lsst.org
+  butler_uri_1: /volume_1
+
+  nfs_path_2: /repo/LATISS  # Mounted as /volume_2
+  nfs_server_2: auxtel-archiver.tu.lsst.org
+  butler_uri_2: /volume_2


### PR DESCRIPTION
to use real butler repos