### PR TITLE
[DM-34998] Inject butlerRepositoryIndex

### DIFF
--- a/science-platform/templates/datalinker-application.yaml
+++ b/science-platform/templates/datalinker-application.yaml
@@ -2,33 +2,35 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: datalinker
+  name: "datalinker"
 spec:
   finalizers:
-    - kubernetes
+    - "kubernetes"
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: datalinker
-  namespace: argocd
+  name: "datalinker"
+  namespace: "argocd"
   finalizers:
-    - resources-finalizer.argocd.argoproj.io
+    - "resources-finalizer.argocd.argoproj.io"
 spec:
   destination:
-    namespace: datalinker
-    server: https://kubernetes.default.svc
-  project: default
+    namespace: "datalinker"
+    server: "https://kubernetes.default.svc"
+  project: "default"
   source:
-    path: services/datalinker
-    repoURL: {{ .Values.repoURL }}
-    targetRevision: {{ .Values.revision }}
+    path: "services/datalinker"
+    repoURL: {{ .Values.repoURL | quote }}
+    targetRevision: {{ .Values.revision | quote }}
     helm:
       parameters:
-        - name: "global.host"
-          value: {{ .Values.fqdn | quote }}
         - name: "global.baseUrl"
           value: "https://{{ .Values.fqdn }}"
+        - name: "global.butlerRepositoryIndex"
+          value: {{ .Values.butlerRepositoryIndex | quote }}
+        - name: "global.host"
+          value: {{ .Values.fqdn | quote }}
         - name: "global.vaultSecretsPath"
           value: {{ .Values.vault_path_prefix | quote }}
       valueFiles:

--- a/science-platform/templates/vo-cutouts-application.yaml
+++ b/science-platform/templates/vo-cutouts-application.yaml
@@ -25,10 +25,12 @@ spec:
     targetRevision: {{ .Values.revision | quote }}
     helm:
       parameters:
-        - name: "global.host"
-          value: {{ .Values.fqdn | quote }}
         - name: "global.baseUrl"
           value: "https://{{ .Values.fqdn }}"
+        - name: "global.butlerRepositoryIndex"
+          value: {{ .Values.butlerRepositoryIndex | quote }}
+        - name: "global.host"
+          value: {{ .Values.fqdn | quote }}
         - name: "global.vaultSecretsPath"
           value: {{ .Values.vault_path_prefix | quote }}
       valueFiles:

--- a/science-platform/values-idfint.yaml
+++ b/science-platform/values-idfint.yaml
@@ -1,6 +1,7 @@
 environment: idfint
 fqdn: data-int.lsst.cloud
 vault_path_prefix: secret/k8s_operator/data-int.lsst.cloud
+butlerRepositoryIndex: "s3://butler-us-central1-repo-locations/data-int-repos.yaml"
 
 alert_stream_broker:
   enabled: false

--- a/science-platform/values-idfprod.yaml
+++ b/science-platform/values-idfprod.yaml
@@ -1,6 +1,7 @@
 environment: idfprod
 fqdn: data.lsst.cloud
 vault_path_prefix: secret/k8s_operator/data.lsst.cloud
+butlerRepositoryIndex: "s3://butler-us-central1-repo-locations/data-repos.yaml"
 
 alert_stream_broker:
   enabled: false

--- a/services/datalinker/README.md
+++ b/services/datalinker/README.md
@@ -13,6 +13,7 @@ A Helm chart for Kubernetes
 | autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU utilization of datalinker deployment pods |
 | fullnameOverride | string | `""` | Override the full name for resources (includes the release name) |
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |
+| global.butlerRepositoryIndex | string | Set by Argo CD | URI to the Butler configuration of available repositories |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | image.pullPolicy | string | `"Always"` | Pull policy for the datalinker image |

--- a/services/datalinker/templates/deployment.yaml
+++ b/services/datalinker/templates/deployment.yaml
@@ -43,6 +43,8 @@ spec:
             # and authenticate to its database.
             - name: "AWS_SHARED_CREDENTIALS_FILE"
               value: "/tmp/secrets/aws-credentials.ini"
+            - name: "DAF_BUTLER_REPOSITORY_INDEX"
+              value: {{ .Values.global.butlerRepositoryIndex | quote }}
             - name: "PGPASSFILE"
               value: "/tmp/secrets/postgres-credentials.txt"
             - name: "S3_ENDPOINT_URL"

--- a/services/datalinker/values.yaml
+++ b/services/datalinker/values.yaml
@@ -83,6 +83,10 @@ global:
   # @default -- Set by Argo CD
   baseUrl: ""
 
+  # -- URI to the Butler configuration of available repositories
+  # @default -- Set by Argo CD
+  butlerRepositoryIndex: ""
+
   # -- Host name for ingress
   # @default -- Set by Argo CD
   host: ""

--- a/services/vo-cutouts/README.md
+++ b/services/vo-cutouts/README.md
@@ -15,7 +15,6 @@ Image cutout service complying with IVOA SODA
 | cloudsql.image.tag | string | `"1.30.1"` | Cloud SQL Auth Proxy tag to use |
 | cloudsql.instanceConnectionName | string | `""` | Instance connection name for a CloudSQL PostgreSQL instance |
 | cloudsql.serviceAccount | string | None, must be set | The Google service account that has an IAM binding to the `vo-cutouts` Kubernetes service accounts and has the `cloudsql.client` role, access to the GCS bucket, and ability to sign URLs as itself |
-| config.butlerRepository | string | None, must be set | Configuration for the Butler repository to use |
 | config.databaseUrl | string | None, must be set | URL for the PostgreSQL database |
 | config.gcsBucketUrl | string | None, must be set | URL for the GCS bucket into which to store cutouts (must start with `s3`) |
 | config.lifetime | string | 2592000 (30 days) | Lifetime of job results in seconds (quote so that Helm doesn't turn it into a floating point number) |
@@ -39,6 +38,7 @@ Image cutout service complying with IVOA SODA
 | databaseWorker.tolerations | list | `[]` | Tolerations for the database worker pod |
 | fullnameOverride | string | `""` | Override the full name for resources (includes the release name) |
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |
+| global.butlerRepositoryIndex | string | Set by Argo CD | URI to the Butler configuration of available repositories |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the vo-cutouts image |

--- a/services/vo-cutouts/templates/configmap.yaml
+++ b/services/vo-cutouts/templates/configmap.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "vo-cutouts.labels" . | nindent 4 }}
 data:
-  CUTOUT_BUTLER_REPOSITORY: {{ required "config.butlerRepository must be set" .Values.config.butlerRepository | quote }}
   CUTOUT_DATABASE_URL: {{ required "config.databaseUrl must be set" .Values.config.databaseUrl | quote }}
   CUTOUT_SERVICE_ACCOUNT: {{ required "cloudsql.serviceAccount must be set" .Values.cloudsql.serviceAccount | quote }}
   CUTOUT_STORAGE_URL: {{ required "config.gcsBucketUrl must be set" .Values.config.gcsBucketUrl | quote }}

--- a/services/vo-cutouts/templates/worker-deployment.yaml
+++ b/services/vo-cutouts/templates/worker-deployment.yaml
@@ -64,6 +64,8 @@ spec:
             # and authenticate to its database.
             - name: "AWS_SHARED_CREDENTIALS_FILE"
               value: "/etc/vo-cutouts/secrets/aws-credentials"
+            - name: "DAF_BUTLER_REPOSITORY_INDEX"
+              value: {{ .Values.global.butlerRepositoryIndex | quote }}
             - name: "PGPASSFILE"
               value: "/etc/vo-cutouts/secrets/postgres-credentials"
             - name: "S3_ENDPOINT_URL"

--- a/services/vo-cutouts/values-idfdev.yaml
+++ b/services/vo-cutouts/values-idfdev.yaml
@@ -1,8 +1,4 @@
 config:
-  # There is currently no working Butler in data-dev, so this configuration
-  # won't work.  Leaving it here anyway since it has the correct configuration
-  # otherwise should we later get a Butler for that environment.
-  butlerRepository: "TBD"
   databaseUrl: "postgresql://vo-cutouts@localhost/vo-cutouts"
   gcsBucketUrl: "s3://rubin-cutouts-dev-us-central1-output/"
 

--- a/services/vo-cutouts/values-idfint.yaml
+++ b/services/vo-cutouts/values-idfint.yaml
@@ -1,5 +1,4 @@
 config:
-  butlerRepository: "s3://butler-us-central1-panda-dev/dc2/butler-external.yaml"
   databaseUrl: "postgresql://vo-cutouts@localhost/vo-cutouts"
   gcsBucketUrl: "s3://rubin-cutouts-int-us-central1-output/"
 

--- a/services/vo-cutouts/values-idfprod.yaml
+++ b/services/vo-cutouts/values-idfprod.yaml
@@ -1,5 +1,4 @@
 config:
-  butlerRepository: "s3://butler-us-central1-dp01"
   databaseUrl: "postgresql://vo-cutouts@localhost/vo-cutouts"
   gcsBucketUrl: "s3://rubin-cutouts-stable-us-central1-output/"
 

--- a/services/vo-cutouts/values.yaml
+++ b/services/vo-cutouts/values.yaml
@@ -46,10 +46,6 @@ config:
   # -- Choose from the text form of Python logging levels
   loglevel: "INFO"
 
-  # -- Configuration for the Butler repository to use
-  # @default -- None, must be set
-  butlerRepository: ""
-
   # -- URL for the PostgreSQL database
   # @default -- None, must be set
   databaseUrl: ""
@@ -193,6 +189,10 @@ global:
   # -- Base URL for the environment
   # @default -- Set by Argo CD
   baseUrl: ""
+
+  # -- URI to the Butler configuration of available repositories
+  # @default -- Set by Argo CD
+  butlerRepositoryIndex: ""
 
   # -- Host name for ingress
   # @default -- Set by Argo CD


### PR DESCRIPTION
Both vo-cutouts and datalinker need DAF_BUTLER_REPOSITORY_INDEX to
resolve Butler locations.  This is a per-site configuration that
should also eventually be injected into nublado2, so add it to the
deployment values file and inject it via Argo CD.  Adjust datalinker
and vo-cutouts charts accordingly, and set the environment variable
on the relevant deployments.

For vo-cutouts, we can now drop CUTOUT_BUTLER_REPOSITORY, since this
replaces that setting.