### PR TITLE
DM-34941: Squareone and Times Square UI development

### DIFF
--- a/services/squareone/Chart.yaml
+++ b/services/squareone/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
     url: https://github.com/jonathansick
 
 # The default version tag of the squareone docker image
-appVersion: "0.7.0b1"
+appVersion: "tickets-DM-34789"

--- a/services/squareone/Chart.yaml
+++ b/services/squareone/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
     url: https://github.com/jonathansick
 
 # The default version tag of the squareone docker image
-appVersion: "tickets-DM-34789"
+appVersion: "tickets-DM-34941"

--- a/services/times-square/Chart.yaml
+++ b/services/times-square/Chart.yaml
@@ -7,7 +7,7 @@ home: https://github.com/lsst-sqre/times-square
 type: application
 
 # The default version tag of the times-square docker image
-appVersion: 0.4.0b1
+appVersion: "tickets-DM-34823"
 
 dependencies:
   - name: redis


### PR DESCRIPTION
This deploys development versions of Squareone and Times Square.

Superscedes #1442