### PR TITLE
Drop vaultsecret for noteburst

### DIFF
--- a/services/noteburst/templates/vaultsecret.yaml
+++ b/services/noteburst/templates/vaultsecret.yaml
@@ -1,9 +1,0 @@
-apiVersion: ricoberger.de/v1alpha1
-kind: VaultSecret
-metadata:
-  name: {{ include "noteburst.fullname" . }}
-  labels:
-    {{- include "noteburst.labels" . | nindent 4 }}
-spec:
-  path: "{{ .Values.global.vaultSecretsPathPrefix }}/noteburst"
-  type: Opaque


### PR DESCRIPTION
Noteburst isn't using secrets as the moment, so having an empty VaultSecret resource is actually causing errors.