### PR TITLE
[DM-35058] Update vo-cutouts to 0.4.1

### DIFF
--- a/services/vo-cutouts/Chart.yaml
+++ b/services/vo-cutouts/Chart.yaml
@@ -4,4 +4,4 @@ version: 1.0.0
 description: "Image cutout service complying with IVOA SODA"
 sources:
   - "https://github.com/lsst-sqre/vo-cutouts"
-appVersion: 0.4.0
+appVersion: 0.4.1

--- a/services/vo-cutouts/README.md
+++ b/services/vo-cutouts/README.md
@@ -25,7 +25,7 @@ Image cutout service complying with IVOA SODA
 | config.timeout | int | 600 (10 minutes) | Timeout for a single cutout job in seconds |
 | cutoutWorker.affinity | object | `{}` | Affinity rules for the cutout worker pod |
 | cutoutWorker.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for cutout workers |
-| cutoutWorker.image.repository | string | `"lsstsqre/vo-cutouts-worker"` | Stack image to use for cutouts |
+| cutoutWorker.image.repository | string | `"ghcr.io/lsst-sqre/vo-cutouts-worker"` | Stack image to use for cutouts |
 | cutoutWorker.image.tag | string | The appVersion of the chart | Tag of vo-cutouts worker image to use |
 | cutoutWorker.nodeSelector | object | `{}` | Node selection rules for the cutout worker pod |
 | cutoutWorker.podAnnotations | object | `{}` | Annotations for the cutout worker pod |
@@ -44,7 +44,7 @@ Image cutout service complying with IVOA SODA
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the vo-cutouts image |
-| image.repository | string | `"lsstsqre/vo-cutouts"` | vo-cutouts image to use |
+| image.repository | string | `"ghcr.io/lsst-sqre/vo-cutouts"` | vo-cutouts image to use |
 | image.tag | string | The appVersion of the chart | Tag of vo-cutouts image to use |
 | ingress.annotations | object | `{}` | Additional annotations to add to the ingress |
 | ingress.gafaelfawrAuthQuery | string | `"scope=read:image"` | Gafaelfawr auth query string |

--- a/services/vo-cutouts/templates/db-worker-deployment.yaml
+++ b/services/vo-cutouts/templates/db-worker-deployment.yaml
@@ -82,8 +82,6 @@ spec:
           volumeMounts:
             - name: "tmp"
               mountPath: "/tmp"
-      imagePullSecrets:
-        - name: "pull-secret"
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/services/vo-cutouts/templates/deployment.yaml
+++ b/services/vo-cutouts/templates/deployment.yaml
@@ -87,8 +87,6 @@ spec:
           volumeMounts:
             - name: "tmp"
               mountPath: "/tmp"
-      imagePullSecrets:
-        - name: "pull-secret"
       volumes:
         # Dramatiq enables its Prometheus middleware by default, which
         # requires writable /tmp.

--- a/services/vo-cutouts/templates/redis-statefulset.yaml
+++ b/services/vo-cutouts/templates/redis-statefulset.yaml
@@ -62,8 +62,6 @@ spec:
           volumeMounts:
             - name: {{ template "vo-cutouts.fullname" . }}-redis-data
               mountPath: "/data"
-      imagePullSecrets:
-        - name: "pull-secret"
       securityContext:
         fsGroup: 999
         runAsNonRoot: true

--- a/services/vo-cutouts/templates/vault-secrets.yaml
+++ b/services/vo-cutouts/templates/vault-secrets.yaml
@@ -7,13 +7,3 @@ metadata:
 spec:
   path: "{{ .Values.global.vaultSecretsPath }}/vo-cutouts"
   type: Opaque
----
-apiVersion: ricoberger.de/v1alpha1
-kind: VaultSecret
-metadata:
-  name: "pull-secret"
-  labels:
-    {{- include "vo-cutouts.labels" . | nindent 4 }}
-spec:
-  path: "{{ .Values.global.vaultSecretsPath }}/pull-secret"
-  type: "kubernetes.io/dockerconfigjson"

--- a/services/vo-cutouts/templates/worker-deployment.yaml
+++ b/services/vo-cutouts/templates/worker-deployment.yaml
@@ -97,8 +97,6 @@ spec:
               mountPath: "/etc/vo-cutouts/secrets"
             - name: "tmp"
               mountPath: "/tmp"
-      imagePullSecrets:
-        - name: "pull-secret"
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/services/vo-cutouts/values.yaml
+++ b/services/vo-cutouts/values.yaml
@@ -11,7 +11,7 @@ fullnameOverride: ""
 
 image:
   # -- vo-cutouts image to use
-  repository: "lsstsqre/vo-cutouts"
+  repository: "ghcr.io/lsst-sqre/vo-cutouts"
 
   # -- Pull policy for the vo-cutouts image
   pullPolicy: "IfNotPresent"
@@ -98,7 +98,7 @@ cutoutWorker:
 
   image:
     # -- Stack image to use for cutouts
-    repository: "lsstsqre/vo-cutouts-worker"
+    repository: "ghcr.io/lsst-sqre/vo-cutouts-worker"
 
     # -- Tag of vo-cutouts worker image to use
     # @default -- The appVersion of the chart


### PR DESCRIPTION
Update the version and pull from GitHub Container Registry instead
of Docker Hub.  Drop the pull-secret, since the only remaining image
we pull from Docker Hub is the first-party redis image, which
should be cached and shouldn't cause rate-limiting issues.