### PR TITLE
Drop noteburst workers from minikube env

### DIFF
--- a/services/noteburst/values-minikube.yaml
+++ b/services/noteburst/values-minikube.yaml
@@ -1,6 +1,6 @@
 config:
   worker:
-    workerCount: 1
+    workerCount: 0
     identities:
       - uid: 90000
         username: "noteburst90000"


### PR DESCRIPTION
It's possible that noteburst workers can't connect to JupyterLab pods in the minikube environment; setting the worker count to 0 should prevent them from deploying.