### PR TITLE
[DM-35029] Bump crawlspace version to 0.1.1

### DIFF
--- a/science-platform/templates/hips-application.yaml
+++ b/science-platform/templates/hips-application.yaml
@@ -29,8 +29,6 @@ spec:
           value: {{ .Values.fqdn | quote }}
         - name: "global.baseUrl"
           value: "https://{{ .Values.fqdn }}"
-        - name: "global.vaultSecretsPath"
-          value: {{ .Values.vault_path_prefix | quote }}
       valueFiles:
         - "values.yaml"
         - "values-{{ .Values.environment }}.yaml"

--- a/services/hips/Chart.yaml
+++ b/services/hips/Chart.yaml
@@ -4,4 +4,4 @@ version: 1.0.0
 description: HiPS web server backed by Google Cloud Storage
 sources:
   - https://github.com/lsst-sqre/crawlspace
-appVersion: 0.1.0
+appVersion: 0.1.1

--- a/services/hips/README.md
+++ b/services/hips/README.md
@@ -20,7 +20,6 @@ HiPS web server backed by Google Cloud Storage
 | config.serviceAccount | string | None, must be set | The Google service account that has an IAM binding to the `hips` Kubernetes service account and has access to the storage bucket |
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
-| global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the hips image |
 | image.repository | string | `"ghcr.io/lsst-sqre/crawlspace"` | Image to use in the hips deployment |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |

--- a/services/hips/values.yaml
+++ b/services/hips/values.yaml
@@ -78,7 +78,3 @@ global:
   # -- Host name for ingress
   # @default -- Set by Argo CD
   host: ""
-
-  # -- Base path for Vault secrets
-  # @default -- Set by Argo CD
-  vaultSecretsPath: ""


### PR DESCRIPTION
Update the hips service for the new crawlspace release.  Stop
plumbing through vaultSecretsPath for that service, since it has
no secrets (it uses workload identity).