### PR TITLE
[DM-34859] Configure TCP keepalive for postgres

### DIFF
--- a/services/postgres/Chart.yaml
+++ b/services/postgres/Chart.yaml
@@ -1,6 +1,7 @@
 apiVersion: v2
 name: postgres
 version: 1.0.0
-appVersion: "0.0.5"
 description: Postgres RDBMS for LSP
-home: https://hub.docker.com/r/lsstsqre/lsp-postgres
+sources:
+  - https://github.com/lsst-sqre/rsp-postgres
+appVersion: 0.0.5

--- a/services/postgres/README.md
+++ b/services/postgres/README.md
@@ -14,6 +14,7 @@ Postgres RDBMS for LSP
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
+| image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the postgres image |
 | image.repository | string | `"lsstsqre/lsp-postgres"` | postgres image to use |
 | image.tag | string | The appVersion of the chart | Tag of postgres image to use |
 | postgresStorageClass | string | `"standard"` | Storage class for postgres volume.  Set to appropriate value for your deployment: at GKE, "standard" (if you want SSD, "premium-rwo", but if you want a good database maybe it's better to use a cloud database?), on Rubin Observatory Rancher, "rook-ceph-block", at NCSA, "manual", elsewhere probably "standard" |

--- a/services/postgres/README.md
+++ b/services/postgres/README.md
@@ -2,7 +2,9 @@
 
 Postgres RDBMS for LSP
 
-**Homepage:** <https://hub.docker.com/r/lsstsqre/lsp-postgres>
+## Source Code
+
+* <https://github.com/lsst-sqre/rsp-postgres>
 
 ## Values
 
@@ -14,6 +16,6 @@ Postgres RDBMS for LSP
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | image.repository | string | `"lsstsqre/lsp-postgres"` | postgres image to use |
 | image.tag | string | The appVersion of the chart | Tag of postgres image to use |
-| postgresStorageClass | string | `"standard"` | Storage class for postgres volume. Set to appropriate value for your deployment: at GKE, "standard" (if you want SSD, "premium-rwo", but if you want a good database maybe it's better to use a cloud database?), on Rubin Observatory Rancher, "rook-ceph-block", at NCSA, "manual", elsewhere probably "standard" ... |
+| postgresStorageClass | string | `"standard"` | Storage class for postgres volume.  Set to appropriate value for your deployment: at GKE, "standard" (if you want SSD, "premium-rwo", but if you want a good database maybe it's better to use a cloud database?), on Rubin Observatory Rancher, "rook-ceph-block", at NCSA, "manual", elsewhere probably "standard" |
 | postgresVolumeSize | string | `"1Gi"` | Volume size for postgres.  It can generally be very small |
 | volumeName | string | `""` | Volume name for postgres, if you use an existing volume that isn't automatically created from the PVC by the storage driver (e.g. NCSA) |

--- a/services/postgres/templates/deployment.yaml
+++ b/services/postgres/templates/deployment.yaml
@@ -86,7 +86,7 @@ spec:
                   name: "postgres"
                   key: "gafaelfawr_password"
             {{- end }}
-          imagePullPolicy: "Always"
+          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           ports:
             - name: "postgres"

--- a/services/postgres/templates/deployment.yaml
+++ b/services/postgres/templates/deployment.yaml
@@ -12,83 +12,90 @@ spec:
   template:
     metadata:
       labels:
-      {{- include "postgres.selectorLabels" . | nindent 8 }}
+        {{- include "postgres.selectorLabels" . | nindent 8 }}
     spec:
       containers:
         - name: {{ template "postgres.fullname" . }}
+          args:
+            - "-c"
+            - "tcp_keepalives_idle=600"
+            - "-c"
+            - "tcp_keepalives_interval=30"
+            - "-c"
+            - "tcp_keepalives_count=10"
+          env:
+            - name: "DEBUG"
+              value: {{ .Values.debug | quote }}
+            - name: "POSTGRES_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "postgres.fullname" . }}
+                  key: "root_password"
+            {{- with .Values.jupyterhub_db }}
+            - name: "VRO_DB_JUPYTERHUB_USER"
+              value: {{ .user | quote }}
+            - name: "VRO_DB_JUPYTERHUB_DB"
+              value: {{ .db | quote }}
+            - name: "VRO_DB_JUPYTERHUB_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  name: "postgres"
+                  key: "jupyterhub_password"
+            {{- end }}
+            {{- with .Values.lovelog_db }}
+            - name: "VRO_DB_LOVELOG_USER"
+              value: {{ .user | quote }}
+            - name: "VRO_DB_LOVELOG_DB"
+              value: {{ .db | quote }}
+            - name: "VRO_DB_LOVELOG_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  name: "postgres"
+                  key: "lovelog_password"
+            {{- end }}
+            {{- with .Values.narrativelog_db }}
+            - name: "VRO_DB_NARRATIVELOG_USER"
+              value: {{ .user | quote }}
+            - name: "VRO_DB_NARRATIVELOG_DB"
+              value: {{ .db | quote }}
+            - name: "VRO_DB_NARRATIVELOG_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  name: "postgres"
+                  key: "narrativelog_password"
+            {{- end }}
+            {{- with .Values.exposurelog_db }}
+            - name: "VRO_DB_EXPOSURELOG_USER"
+              value: {{ .user | quote }}
+            - name: "VRO_DB_EXPOSURELOG_DB"
+              value: {{ .db | quote }}
+            - name: "VRO_DB_EXPOSURELOG_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  name: "postgres"
+                  key: "exposurelog_password"
+            {{- end }}
+            {{- with .Values.gafaelfawr_db }}
+            - name: "VRO_DB_GAFAELFAWR_USER"
+              value: {{ .user | quote }}
+            - name: "VRO_DB_GAFAELFAWR_DB"
+              value: {{ .db | quote }}
+            - name: "VRO_DB_GAFAELFAWR_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  name: "postgres"
+                  key: "gafaelfawr_password"
+            {{- end }}
           imagePullPolicy: "Always"
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           ports:
-          - name: postgres
-            containerPort: 5432
+            - name: "postgres"
+              containerPort: 5432
           volumeMounts:
-            - name: storage
-              mountPath: /var/lib/postgresql
-          env:
-          - name: DEBUG
-            value: '{{ .Values.debug }}'
-          - name: POSTGRES_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "postgres.fullname" . }}
-                key: root_password
-          {{- with .Values.jupyterhub_db }}
-          - name: VRO_DB_JUPYTERHUB_USER
-            value: {{ .user }}
-          - name: VRO_DB_JUPYTERHUB_DB
-            value: {{ .db }}
-          - name: VRO_DB_JUPYTERHUB_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: postgres
-                key: jupyterhub_password
-          {{- end }}
-          {{- with .Values.lovelog_db }}
-          - name: VRO_DB_LOVELOG_USER
-            value: {{ .user }}
-          - name: VRO_DB_LOVELOG_DB
-            value: {{ .db }}
-          - name: VRO_DB_LOVELOG_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: postgres
-                key: lovelog_password
-          {{- end }}
-          {{- with .Values.narrativelog_db }}
-          - name: VRO_DB_NARRATIVELOG_USER
-            value: {{ .user }}
-          - name: VRO_DB_NARRATIVELOG_DB
-            value: {{ .db }}
-          - name: VRO_DB_NARRATIVELOG_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: postgres
-                key: narrativelog_password
-          {{- end }}
-          {{- with .Values.exposurelog_db }}
-          - name: VRO_DB_EXPOSURELOG_USER
-            value: {{ .user }}
-          - name: VRO_DB_EXPOSURELOG_DB
-            value: {{ .db }}
-          - name: VRO_DB_EXPOSURELOG_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: postgres
-                key: exposurelog_password
-          {{- end }}
-          {{- with .Values.gafaelfawr_db }}
-          - name: VRO_DB_GAFAELFAWR_USER
-            value: {{ .user }}
-          - name: VRO_DB_GAFAELFAWR_DB
-            value: {{ .db }}
-          - name: VRO_DB_GAFAELFAWR_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: postgres
-                key: gafaelfawr_password
-          {{- end }}
+            - name: "storage"
+              mountPath: "/var/lib/postgresql"
       imagePullSecrets:
-      - name: "pull-secret"
+        - name: "pull-secret"
       volumes:
         - name: storage
           persistentVolumeClaim:

--- a/services/postgres/values-int.yaml
+++ b/services/postgres/values-int.yaml
@@ -6,5 +6,3 @@ gafaelfawr_db:
   db: "gafaelfawr"
 postgresStorageClass: "manual"
 volumeName: "postgres-data-volume"
-image:
-  tag: "0.0.3"

--- a/services/postgres/values-roe.yaml
+++ b/services/postgres/values-roe.yaml
@@ -4,6 +4,4 @@ jupyterhub_db:
 gafaelfawr_db:
   user: "gafaelfawr"
   db: "gafaelfawr"
-image:
-  tag: "0.0.5"
 postgresStorageClass: "standard"

--- a/services/postgres/values-stable.yaml
+++ b/services/postgres/values-stable.yaml
@@ -6,5 +6,3 @@ gafaelfawr_db:
   db: "gafaelfawr"
 postgresStorageClass: "manual"
 volumeName: "postgres-data-volume"
-image:
-  tag: "0.0.3"

--- a/services/postgres/values.yaml
+++ b/services/postgres/values.yaml
@@ -8,18 +8,21 @@ debug: ""
 image:
   # -- postgres image to use
   repository: "lsstsqre/lsp-postgres"
+
   # -- Tag of postgres image to use
   # @default -- The appVersion of the chart
   tag: ""
 
 # -- Volume size for postgres.  It can generally be very small
 postgresVolumeSize: "1Gi"
-# -- Storage class for postgres volume.
-# Set to appropriate value for your deployment: at GKE, "standard"
-# (if you want SSD, "premium-rwo", but if you want a good database maybe
-# it's better to use a cloud database?), on Rubin Observatory Rancher,
-# "rook-ceph-block", at NCSA, "manual", elsewhere probably "standard" ...
+
+# -- Storage class for postgres volume.  Set to appropriate value for your
+# deployment: at GKE, "standard" (if you want SSD, "premium-rwo", but if you
+# want a good database maybe it's better to use a cloud database?), on Rubin
+# Observatory Rancher, "rook-ceph-block", at NCSA, "manual", elsewhere
+# probably "standard"
 postgresStorageClass: "standard"
+
 # -- Volume name for postgres, if you use an existing volume that isn't
 # automatically created from the PVC by the storage driver (e.g. NCSA)
 volumeName: ""

--- a/services/postgres/values.yaml
+++ b/services/postgres/values.yaml
@@ -9,6 +9,9 @@ image:
   # -- postgres image to use
   repository: "lsstsqre/lsp-postgres"
 
+  # -- Pull policy for the postgres image
+  pullPolicy: "IfNotPresent"
+
   # -- Tag of postgres image to use
   # @default -- The appVersion of the chart
   tag: ""


### PR DESCRIPTION
At SLAC, the network connection with the in-cluster PostgreSQL
database is dropped after too long an idle period.  Enable TCP
keep-alive on the PostgreSQL server to prevent this.

This should be harmless everywhere, so do this unconditionally.