### PR TITLE
[DM-35171] Enable crawlspace HiPS server for data-int

### DIFF
--- a/science-platform/values-idfint.yaml
+++ b/science-platform/values-idfint.yaml
@@ -16,7 +16,7 @@ exposurelog:
 gafaelfawr:
   enabled: true
 hips:
-  enabled: false
+  enabled: true
 ingress_nginx:
   enabled: true
 mobu:

--- a/services/hips/values-idfint.yaml
+++ b/services/hips/values-idfint.yaml
@@ -1,0 +1,4 @@
+config:
+  gcsProject: "data-curation-prod-fbdb"
+  gcsBucket: "static-us-central1-dp02-hips"
+  serviceAccount: "crawlspace-hips@science-platform-int-dc5d.iam.gserviceaccount.com"


### PR DESCRIPTION
Point to the new DP0.2 HiPS bucket (currently empty).