### PR TITLE
[DM-35182] Fix spacing on datalinker annotations

### DIFF
--- a/services/datalinker/templates/ingress.yaml
+++ b/services/datalinker/templates/ingress.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- include "datalinker.labels" . | nindent 4 }}
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    {{- if .Values.ingress.gafaelfawrAuthQuery -}}
+    {{- if .Values.ingress.gafaelfawrAuthQuery }}
     nginx.ingress.kubernetes.io/auth-method: GET
     nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-User,X-Auth-Request-Email,X-Auth-Request-Token
     nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.global.baseUrl }}/login"


### PR DESCRIPTION
The conditional for datalinker ingress annotations was eating too
much whitespace.