### PR TITLE
[DM-35204] Reintroduce HiPS NetworkPolicy

### DIFF
--- a/services/hips/templates/networkpolicy.yaml
+++ b/services/hips/templates/networkpolicy.yaml
@@ -1,0 +1,31 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: "hips"
+  labels:
+    {{- include "hips.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "hips.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        # Allow inbound access from pods (in any namespace) labeled
+        # gafaelfawr.lsst.io/ingress: true.
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              gafaelfawr.lsst.io/ingress: "true"
+        # Temporarily also allow inbound access from the Portal because the
+        # current version of the Portal doesn't support passing authentication
+        # credentials to HiPS requests.
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: "portal"
+              app.kubernetes.io/component: "firefly"
+      ports:
+        - protocol: "TCP"
+          port: 8080


### PR DESCRIPTION
Re-add the NetworkPolicy for the HiPS service, but make an exception
for the Portal so that it can use the internal cluster address.  It
doesn't yet know how to send authentication on HiPS requests.