### PR TITLE
DM-35203: Add image noteburst image selection configs

### DIFF
--- a/services/noteburst/Chart.yaml
+++ b/services/noteburst/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: noteburst
 version: 1.0.0
-appVersion: "tickets-DM-35203"
+appVersion: "0.4.0"
 description: Noteburst is a notebook execution service for the Rubin Science Platform.
 type: application
 home: https://noteburst.lsst.io/

--- a/services/noteburst/Chart.yaml
+++ b/services/noteburst/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: noteburst
 version: 1.0.0
-appVersion: "tickets-DM-35205"
+appVersion: "tickets-DM-35203"
 description: Noteburst is a notebook execution service for the Rubin Science Platform.
 type: application
 home: https://noteburst.lsst.io/

--- a/services/noteburst/README.md
+++ b/services/noteburst/README.md
@@ -29,6 +29,7 @@ Noteburst is a notebook execution service for the Rubin Science Platform.
 | config.worker.imageSelector | string | `"weekly"` | Nublado image stream to select: "recommended", "weekly" or "reference" |
 | config.worker.jobTimeout | int | `300` | The default notebook execution timeout, in seconds. |
 | config.worker.tokenLifetime | int | `2419200` | Worker token lifetime, in seconds. |
+| config.worker.tokenScopes | string | `"exec:notebook,read:image,read:tap,read:alertdb"` | Nublado2 worker account's token scopes as a comma-separated list. |
 | config.worker.workerCount | int | `1` | Number of workers to run |
 | fullnameOverride | string | `""` | Override the full name for resources (includes the release name) |
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |

--- a/services/noteburst/README.md
+++ b/services/noteburst/README.md
@@ -28,7 +28,7 @@ Noteburst is a notebook execution service for the Rubin Science Platform.
 | config.worker.imageReference | string | `""` | Nublado image reference, applicable when imageSelector is "reference" |
 | config.worker.imageSelector | string | `"weekly"` | Nublado image stream to select: "recommended", "weekly" or "reference" |
 | config.worker.jobTimeout | int | `300` | The default notebook execution timeout, in seconds. |
-| config.worker.tokenLifetime | int | `2419200` | Worker token lifetime, in seconds. |
+| config.worker.tokenLifetime | string | `"2419200"` | Worker token lifetime, in seconds. |
 | config.worker.tokenScopes | string | `"exec:notebook,read:image,read:tap,read:alertdb"` | Nublado2 worker account's token scopes as a comma-separated list. |
 | config.worker.workerCount | int | `1` | Number of workers to run |
 | fullnameOverride | string | `""` | Override the full name for resources (includes the release name) |

--- a/services/noteburst/README.md
+++ b/services/noteburst/README.md
@@ -28,6 +28,7 @@ Noteburst is a notebook execution service for the Rubin Science Platform.
 | config.worker.imageReference | string | `""` | Nublado image reference, applicable when imageSelector is "reference" |
 | config.worker.imageSelector | string | `"weekly"` | Nublado image stream to select: "recommended", "weekly" or "reference" |
 | config.worker.jobTimeout | int | `300` | The default notebook execution timeout, in seconds. |
+| config.worker.keepAlive | string | `"normal"` | Worker keep alive mode: "normal", "fast", "disabled" |
 | config.worker.tokenLifetime | string | `"2419200"` | Worker token lifetime, in seconds. |
 | config.worker.tokenScopes | string | `"exec:notebook,read:image,read:tap,read:alertdb"` | Nublado2 worker account's token scopes as a comma-separated list. |
 | config.worker.workerCount | int | `1` | Number of workers to run |

--- a/services/noteburst/README.md
+++ b/services/noteburst/README.md
@@ -25,7 +25,10 @@ Noteburst is a notebook execution service for the Rubin Science Platform.
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
 | config.logLevel | string | `"INFO"` | Logging level: "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL" |
 | config.worker.identities | list | `[]` | Science Platform user identities that workers can acquire. Each item is an object with username and uuid keys |
+| config.worker.imageReference | string | `""` | Nublado image reference, applicable when imageSelector is "reference" |
+| config.worker.imageSelector | string | `"weekly"` | Nublado image stream to select: "recommended", "weekly" or "reference" |
 | config.worker.jobTimeout | int | `300` | The default notebook execution timeout, in seconds. |
+| config.worker.tokenLifetime | int | `2419200` | Worker token lifetime, in seconds. |
 | config.worker.workerCount | int | `1` | Number of workers to run |
 | fullnameOverride | string | `""` | Override the full name for resources (includes the release name) |
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |

--- a/services/noteburst/templates/worker-configmap.yaml
+++ b/services/noteburst/templates/worker-configmap.yaml
@@ -13,3 +13,4 @@ data:
   NOTEBURST_WORKER_TOKEN_LIFETIME: {{ .Values.config.worker.tokenLifetime | quote }}
   NOTEBURST_WORKER_IMAGE_SELECTOR: {{ .Values.config.worker.imageSelector | quote  }}
   NOTEBURST_WORKER_IMAGE_REFERENCE: {{ .Values.config.worker.imageReference | quote  }}
+  NOTEBURST_WORKER_TOKEN_SCOPES: {{ .Values.config.worker.tokenScopes | quote }}

--- a/services/noteburst/templates/worker-configmap.yaml
+++ b/services/noteburst/templates/worker-configmap.yaml
@@ -14,3 +14,4 @@ data:
   NOTEBURST_WORKER_IMAGE_SELECTOR: {{ .Values.config.worker.imageSelector | quote  }}
   NOTEBURST_WORKER_IMAGE_REFERENCE: {{ .Values.config.worker.imageReference | quote  }}
   NOTEBURST_WORKER_TOKEN_SCOPES: {{ .Values.config.worker.tokenScopes | quote }}
+  NOTEBURST_WORKER_KEEPALIVE: {{ .Values.config.worker.keepAlive | quote }}

--- a/services/noteburst/templates/worker-configmap.yaml
+++ b/services/noteburst/templates/worker-configmap.yaml
@@ -10,3 +10,6 @@ data:
   NOTEBURST_REDIS_URL: "redis://{{ include "noteburst.fullname" . }}-redis-master.{{ .Release.Namespace }}:{{ .Values.redis.master.service.ports.redis }}/0"
   NOTEBURST_WORKER_LOCK_REDIS_URL: "redis://{{ include "noteburst.fullname" . }}-redis-master.{{ .Release.Namespace }}:{{ .Values.redis.master.service.ports.redis }}/1"
   NOTEBURST_WORKER_JOB_TIMEOUT: {{ .Values.config.worker.jobTimeout | quote }}
+  NOTEBURST_WORKER_TOKEN_LIFETIME: {{ .Values.config.worker.tokenLifetime | quote }}
+  NOTEBURST_WORKER_IMAGE_SELECTOR: {{ .Values.config.worker.imageSelector | quote  }}
+  NOTEBURST_WORKER_IMAGE_REFERENCE: {{ .Values.config.worker.imageReference | quote  }}

--- a/services/noteburst/templates/worker-deployment.yaml
+++ b/services/noteburst/templates/worker-deployment.yaml
@@ -42,8 +42,8 @@ spec:
                 - "arq"
                 - "--check"
                 - "noteburst.worker.main.WorkerSettings"
-            initialDelaySeconds: 5
-            periodSeconds: 5
+            initialDelaySeconds: 360
+            periodSeconds: 15
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           envFrom:

--- a/services/noteburst/values-idfdev.yaml
+++ b/services/noteburst/values-idfdev.yaml
@@ -8,14 +8,14 @@ config:
     workerCount: 1
     identities:
       - uid: 90000
-        username: "noteburst90000"
+        username: "bot-noteburst90000"
       - uid: 90001
-        username: "noteburst90001"
+        username: "bot-noteburst90001"
       - uid: 90002
-        username: "noteburst90002"
+        username: "bot-noteburst90002"
       - uid: 90003
-        username: "noteburst90003"
+        username: "bot-noteburst90003"
       - uid: 90004
-        username: "noteburst90004"
+        username: "bot-noteburst90004"
       - uid: 90005
-        username: "noteburst90005"
+        username: "bot-noteburst90005"

--- a/services/noteburst/values.yaml
+++ b/services/noteburst/values.yaml
@@ -114,6 +114,15 @@ config:
     # -- The default notebook execution timeout, in seconds.
     jobTimeout: 300
 
+    # -- Worker token lifetime, in seconds.
+    tokenLifetime: 2419200
+
+    # -- Nublado image stream to select: "recommended", "weekly" or "reference"
+    imageSelector: "weekly"
+
+    # -- Nublado image reference, applicable when imageSelector is "reference"
+    imageReference: ""
+
 redis:
   auth:
     enabled: false

--- a/services/noteburst/values.yaml
+++ b/services/noteburst/values.yaml
@@ -117,6 +117,9 @@ config:
     # -- Worker token lifetime, in seconds.
     tokenLifetime: 2419200
 
+    # -- Nublado2 worker account's token scopes as a comma-separated list.
+    tokenScopes: "exec:notebook,read:image,read:tap,read:alertdb"
+
     # -- Nublado image stream to select: "recommended", "weekly" or "reference"
     imageSelector: "weekly"
 

--- a/services/noteburst/values.yaml
+++ b/services/noteburst/values.yaml
@@ -115,7 +115,7 @@ config:
     jobTimeout: 300
 
     # -- Worker token lifetime, in seconds.
-    tokenLifetime: 2419200
+    tokenLifetime: "2419200"
 
     # -- Nublado2 worker account's token scopes as a comma-separated list.
     tokenScopes: "exec:notebook,read:image,read:tap,read:alertdb"

--- a/services/noteburst/values.yaml
+++ b/services/noteburst/values.yaml
@@ -126,6 +126,9 @@ config:
     # -- Nublado image reference, applicable when imageSelector is "reference"
     imageReference: ""
 
+    # -- Worker keep alive mode: "normal", "fast", "disabled"
+    keepAlive: "normal"
+
 redis:
   auth:
     enabled: false

--- a/services/times-square/templates/worker-deployment.yaml
+++ b/services/times-square/templates/worker-deployment.yaml
@@ -70,8 +70,8 @@ spec:
                 - "arq"
                 - "--check"
                 - "timessquare.worker.main.WorkerSettings"
-            initialDelaySeconds: 5
-            periodSeconds: 5
+            initialDelaySeconds: 360
+            periodSeconds: 15
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           envFrom:


### PR DESCRIPTION
 New configurations for noteburst workers:

- `NOTEBURST_WORKER_TOKEN_LIFETIME`
- `NOTEBURST_WORKER_IMAGE_SELECTOR`
- `NOTEBURST_WORKER_IMAGE_REFERENCE`
