### PR TITLE
[DM-35182] Update datalinker to 1.3.0

### DIFF
--- a/services/datalinker/Chart.yaml
+++ b/services/datalinker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: datalinker
 version: 1.0.0
-description: IVOA datalink service for Rubin Science Platform
+description: IVOA DataLink service for Rubin Science Platform
 sources:
   - https://github.com/lsst-sqre/datalinker
-appVersion: 1.2.2
+appVersion: 1.3.0

--- a/services/datalinker/README.md
+++ b/services/datalinker/README.md
@@ -1,6 +1,6 @@
 # datalinker
 
-IVOA datalink service for Rubin Science Platform
+IVOA DataLink service for Rubin Science Platform
 
 ## Source Code
 
@@ -20,17 +20,15 @@ IVOA datalink service for Rubin Science Platform
 | global.butlerRepositoryIndex | string | Set by Argo CD | URI to the Butler configuration of available repositories |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
-| image.pullPolicy | string | `"Always"` | Pull policy for the datalinker image |
+| image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the datalinker image |
 | image.repository | string | `"ghcr.io/lsst-sqre/datalinker"` | Image to use in the datalinker deployment |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | ingress.annotations | object | `{}` | Additional annotations for the ingress rule |
-| ingress.gafaelfawrAuthQuery | string | `""` | Gafaelfawr auth query string (default, unauthenticated) |
+| ingress.gafaelfawrAuthQuery | string | `"scope=read:image"` | Gafaelfawr auth query string |
 | ingress.path | string | `"/api/datalink"` | URL path to dispatch to the datalinker deployment pod |
 | nameOverride | string | `""` | Override the base name for resources |
 | nodeSelector | object | `{}` | Node selection rules for the datalinker deployment pod |
 | podAnnotations | object | `{}` | Annotations for the datalinker deployment pod |
 | replicaCount | int | `1` | Number of web deployment pods to start |
 | resources | object | `{}` | Resource limits and requests for the datalinker deployment pod |
-| service.port | int | `8080` | Port of the service to create and map to the ingress |
-| service.type | string | `"ClusterIP"` | Type of service to create |
 | tolerations | list | `[]` | Tolerations for the datalinker deployment pod |

--- a/services/datalinker/templates/ingress.yaml
+++ b/services/datalinker/templates/ingress.yaml
@@ -6,8 +6,8 @@ metadata:
     {{- include "datalinker.labels" . | nindent 4 }}
   annotations:
     {{- if .Values.ingress.gafaelfawrAuthQuery }}
-    nginx.ingress.kubernetes.io/auth-method: GET
-    nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-User,X-Auth-Request-Email,X-Auth-Request-Token
+    nginx.ingress.kubernetes.io/auth-method: "GET"
+    nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-User"
     nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.global.baseUrl }}/login"
     nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.baseUrl }}/auth?{{ .Values.ingress.gafaelfawrAuthQuery }}"
     {{- end }}
@@ -26,4 +26,4 @@ spec:
               service:
                 name: {{ include "datalinker.fullname" . }}
                 port:
-                  number: {{ .Values.service.port }}
+                  number: 8080

--- a/services/datalinker/templates/service.yaml
+++ b/services/datalinker/templates/service.yaml
@@ -5,11 +5,11 @@ metadata:
   labels:
     {{- include "datalinker.labels" . | nindent 4 }}
 spec:
-  type: {{ .Values.service.type }}
+  type: "ClusterIP"
   ports:
-    - port: {{ .Values.service.port }}
-      targetPort: http
-      protocol: TCP
-      name: http
+    - port: 8080
+      targetPort: "http"
+      protocol: "TCP"
+      name: "http"
   selector:
     {{- include "datalinker.selectorLabels" . | nindent 4 }}

--- a/services/datalinker/values-idfint.yaml
+++ b/services/datalinker/values-idfint.yaml
@@ -1,2 +1,0 @@
-ingress:
-  gafaelfawrAuthQuery: "scope=read:image"

--- a/services/datalinker/values.yaml
+++ b/services/datalinker/values.yaml
@@ -10,7 +10,7 @@ image:
   repository: "ghcr.io/lsst-sqre/datalinker"
 
   # -- Pull policy for the datalinker image
-  pullPolicy: Always
+  pullPolicy: "IfNotPresent"
 
   # -- Overrides the image tag whose default is the chart appVersion.
   tag: ""
@@ -21,22 +21,15 @@ nameOverride: ""
 # -- Override the full name for resources (includes the release name)
 fullnameOverride: ""
 
-service:
-  # -- Type of service to create
-  type: ClusterIP
-
-  # -- Port of the service to create and map to the ingress
-  port: 8080
-
 ingress:
-  # -- Gafaelfawr auth query string (default, unauthenticated)
-  gafaelfawrAuthQuery: ""
-
-  # -- Additional annotations for the ingress rule
-  annotations: {}
+  # -- Gafaelfawr auth query string
+  gafaelfawrAuthQuery: "scope=read:image"
 
   # -- URL path to dispatch to the datalinker deployment pod
   path: "/api/datalink"
+
+  # -- Additional annotations for the ingress rule
+  annotations: {}
 
 autoscaling:
   # -- Enable autoscaling of datalinker deployment


### PR DESCRIPTION
Bump version to the latest release.  Require read:image scope for
datalinker access by default and remove the override for IDF int.
Change the pull policy to IfNotPresent to match our other services.
Remove the values.yaml configuration for service type and port,
since we never change those.