### PR TITLE
[DM-35204] Set environment variables required for new Portal

### DIFF
--- a/services/portal/templates/deployment.yaml
+++ b/services/portal/templates/deployment.yaml
@@ -40,6 +40,10 @@ spec:
                   key: "ADMIN_PASSWORD"
             - name: "FIREFLY_OPTS"
               value: "-Dredis.host={{ include "portal.fullname" . }}-redis -Dsso.req.auth.hosts={{ .Values.global.host }}"
+            - name: "PROPS_redis__host"
+              value: {{ include "portal.fullname" . }}-redis
+            - name: "PROPS_sso__req__auth__hosts"
+              value: {{ .Values.global.host | quote }}
             - name: "SERVER_CONFIG_DIR"
               value: "/firefly/config"
             - name: "CLEANUP_INTERVAL"


### PR DESCRIPTION
The new version of Portal (2022.3 and later) will require setting
individual environment variables instead of FIREFLY_OPTS.  Set
the new variables now so that we can easily move back and forth
between versions solely by changing the image pin.