### PR TITLE
Deploy DM-35149 version of times-square

### DIFF
--- a/services/times-square/Chart.yaml
+++ b/services/times-square/Chart.yaml
@@ -7,7 +7,7 @@ home: https://github.com/lsst-sqre/times-square
 type: application
 
 # The default version tag of the times-square docker image
-appVersion: "0.4.0"
+appVersion: "0.5.0b1"
 
 dependencies:
   - name: redis


### PR DESCRIPTION
This adds initial GitHub Checks API support to Times Square.