### PR TITLE
[DM-35243] Disable query-timeout limit temporarily

### DIFF
--- a/services/sasquatch/README.md
+++ b/services/sasquatch/README.md
@@ -35,7 +35,7 @@ Rubin Observatory's telemetry service.
 | csc.osplVersion | string | `"V6.10.4"` | DDS OpenSplice version. |
 | csc.useExternalConfig | bool | `false` | Wether to use an external configuration for DDS OpenSplice. |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
-| influxdb.config | object | `{"continuous_queries":{"enabled":false},"coordinator":{"log-queries-after":"15s","max-concurrent-queries":10,"query-timeout":"900s","write-timeout":"60s"},"data":{"cache-max-memory-size":0,"trace-logging-enabled":true,"wal-fsync-delay":"100ms"},"http":{"auth-enabled":true,"enabled":true,"flux-enabled":true,"max-row-limit":0}}` | Override InfluxDB configuration. See https://docs.influxdata.com/influxdb/v1.8/administration/config |
+| influxdb.config | object | `{"continuous_queries":{"enabled":false},"coordinator":{"log-queries-after":"15s","max-concurrent-queries":10,"query-timeout":"0s","write-timeout":"60s"},"data":{"cache-max-memory-size":0,"trace-logging-enabled":true,"wal-fsync-delay":"100ms"},"http":{"auth-enabled":true,"enabled":true,"flux-enabled":true,"max-row-limit":0}}` | Override InfluxDB configuration. See https://docs.influxdata.com/influxdb/v1.8/administration/config |
 | influxdb.image | object | `{"tag":"1.8.10"}` | InfluxDB image tag. |
 | influxdb.ingress | object | disabled | InfluxDB ingress configuration. |
 | influxdb.initScripts | object | `{"enabled":true,"scripts":{"init.iql":"CREATE DATABASE \"telegraf\" WITH DURATION 30d REPLICATION 1 NAME \"rp_30d\"\n\n"}}` | InfluxDB Custom initialization scripts. |

--- a/services/sasquatch/values.yaml
+++ b/services/sasquatch/values.yaml
@@ -48,7 +48,7 @@ influxdb:
     coordinator:
       write-timeout: "60s"
       max-concurrent-queries: 10
-      query-timeout: "900s"
+      query-timeout: "0s"
       log-queries-after: "15s"
     continuous_queries:
       enabled: false


### PR DESCRIPTION
- In DM-35243 we are running a side load query as part of a database restore which usually takes a long time to complete, so we need to disable the query-timeout limit in InfluxDB temporarily.