### PR TITLE
Increase write timeout in the query coordinator

### DIFF
--- a/services/sasquatch/README.md
+++ b/services/sasquatch/README.md
@@ -35,7 +35,7 @@ Rubin Observatory's telemetry service.
 | csc.osplVersion | string | `"V6.10.4"` | DDS OpenSplice version. |
 | csc.useExternalConfig | bool | `false` | Wether to use an external configuration for DDS OpenSplice. |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
-| influxdb.config | object | `{"continuous_queries":{"enabled":false},"coordinator":{"log-queries-after":"15s","max-concurrent-queries":0,"query-timeout":"0s","write-timeout":"60s"},"data":{"cache-max-memory-size":0,"trace-logging-enabled":true,"wal-fsync-delay":"100ms"},"http":{"auth-enabled":true,"enabled":true,"flux-enabled":true,"max-row-limit":0},"logging":{"level":"debug"}}` | Override InfluxDB configuration. See https://docs.influxdata.com/influxdb/v1.8/administration/config |
+| influxdb.config | object | `{"continuous_queries":{"enabled":false},"coordinator":{"log-queries-after":"15s","max-concurrent-queries":0,"query-timeout":"0s","write-timeout":"1h"},"data":{"cache-max-memory-size":0,"trace-logging-enabled":true,"wal-fsync-delay":"100ms"},"http":{"auth-enabled":true,"enabled":true,"flux-enabled":true,"max-row-limit":0},"logging":{"level":"debug"}}` | Override InfluxDB configuration. See https://docs.influxdata.com/influxdb/v1.8/administration/config |
 | influxdb.image | object | `{"tag":"1.8.10"}` | InfluxDB image tag. |
 | influxdb.ingress | object | disabled | InfluxDB ingress configuration. |
 | influxdb.initScripts | object | `{"enabled":true,"scripts":{"init.iql":"CREATE DATABASE \"telegraf\" WITH DURATION 30d REPLICATION 1 NAME \"rp_30d\"\n\n"}}` | InfluxDB Custom initialization scripts. |

--- a/services/sasquatch/values.yaml
+++ b/services/sasquatch/values.yaml
@@ -46,7 +46,7 @@ influxdb:
       auth-enabled: true
       max-row-limit: 0
     coordinator:
-      write-timeout: "60s"
+      write-timeout: "1h"
       max-concurrent-queries: 0
       query-timeout: "0s"
       log-queries-after: "15s"


### PR DESCRIPTION
- We are seeing "ClientPayloadError: Response payload is not completed"  and long async queries being killed. Try to get around that by increasing the write timeout in the query coordinator.