### PR TITLE
DM-35317: Deploy squareone 0.7.1

### DIFF
--- a/services/squareone/Chart.yaml
+++ b/services/squareone/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
     url: https://github.com/jonathansick
 
 # The default version tag of the squareone docker image
-appVersion: "0.7.0"
+appVersion: "0.7.1"


### PR DESCRIPTION
This update to Squareone includes documentation link updates for DP0.2.