### PR TITLE
DM-35328: Deploy noteburst 0.5.0

### DIFF
--- a/services/noteburst/Chart.yaml
+++ b/services/noteburst/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: noteburst
 version: 1.0.0
-appVersion: "0.4.0"
+appVersion: "0.5.0"
 description: Noteburst is a notebook execution service for the Rubin Science Platform.
 type: application
 home: https://noteburst.lsst.io/


### PR DESCRIPTION
This update to noteburst adds the enable_retry option to noteburst's nbexec function.