### PR TITLE
DM-35150: Deploy Times Square 0.5.0

### DIFF
--- a/services/times-square/Chart.yaml
+++ b/services/times-square/Chart.yaml
@@ -7,7 +7,7 @@ home: https://github.com/lsst-sqre/times-square
 type: application
 
 # The default version tag of the times-square docker image
-appVersion: "0.5.0b1"
+appVersion: "0.5.0"
 
 dependencies:
   - name: redis


### PR DESCRIPTION
This update adds GitHub checks for notebooks.