### PR TITLE
[DM-35495] Protect Portal admin URLs with Gafaelfawr

### DIFF
--- a/services/portal/README.md
+++ b/services/portal/README.md
@@ -25,6 +25,7 @@ Rubin Science Platform portal aspect
 | image.repository | string | `"ipac/suit"` | Portal image to use |
 | image.tag | string | The appVersion of the chart | Tag of Portal image to use |
 | ingress.annotations | object | `{}` | Additional annotations to add to the ingress |
+| ingress.gafaelfawrAdminAuthQuery | string | `"scope=exec:admin"` | Gafaelfawr auth query string for the admin API |
 | ingress.gafaelfawrAuthQuery | string | `"scope=exec:portal&delegate_to=portal&delegate_scope=read:image,read:tap"` | Gafaelfawr auth query string |
 | nameOverride | string | `""` | Override the base name for resources |
 | nodeSelector | object | `{}` | Node selector rules for the Portal pod |

--- a/services/portal/templates/deployment.yaml
+++ b/services/portal/templates/deployment.yaml
@@ -33,6 +33,10 @@ spec:
                 secretKeyRef:
                   name: {{ include "portal.fullname" . }}-secret
                   key: "ADMIN_PASSWORD"
+            {{- if .Values.ingress.gafaelfawrAdminAuthQuery }}
+            - name: "USE_ADMIN_AUTH"
+              value: "false"
+            {{- end }}
             - name: "REDIS_PASSWORD"
               valueFrom:
                 secretKeyRef:

--- a/services/portal/templates/ingress-admin.yaml
+++ b/services/portal/templates/ingress-admin.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.ingress.gafaelfawrAdminAuthQuery -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "portal.fullname" . }}
+  labels:
+    {{- include "portal.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/affinity: "cookie"
+    nginx.ingress.kubernetes.io/session-cookie-change-on-failure: "true"
+    nginx.ingress.kubernetes.io/proxy-body-size: "0m"
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "24k"
+    nginx.ingress.kubernetes.io/client-header-buffer-size: "24k"
+    nginx.ingress.kubernetes.io/rewrite-target: "/suit$1$2"
+    nginx.ingress.kubernetes.io/proxy-redirect-from: "/suit/"
+    nginx.ingress.kubernetes.io/proxy-redirect-to: "/portal/app/"
+    nginx.ingress.kubernetes.io/proxy-cookie-path: "/suit /portal/app"
+    nginx.ingress.kubernetes.io/session-cookie-path: "/portal/app"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      proxy_set_header X-Original-URI $request_uri;
+      proxy_set_header X-Forwarded-Proto https;
+      proxy_set_header X-Forwarded-Port 443;
+      proxy_set_header X-Forwarded-Path /portal/app;
+    nginx.ingress.kubernetes.io/auth-method: "GET"
+    nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-User,X-Auth-Request-Email"
+    nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.global.baseUrl }}/login"
+    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.baseUrl }}/auth?{{ .Values.ingress.gafaelfawrAdminAuthQuery }}"
+    {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  rules:
+    - host: {{ required "global.host must be set" .Values.global.host | quote }}
+      http:
+        paths:
+          - path: "/portal/app/admin(/|$)(.*)"
+            pathType: "ImplementationSpecific"
+            backend:
+              service:
+                name: {{ include "portal.fullname" . }}
+                port:
+                  number: 8080
+{{- end }}

--- a/services/portal/values.yaml
+++ b/services/portal/values.yaml
@@ -24,6 +24,9 @@ ingress:
   # -- Gafaelfawr auth query string
   gafaelfawrAuthQuery: "scope=exec:portal&delegate_to=portal&delegate_scope=read:image,read:tap"
 
+  # -- Gafaelfawr auth query string for the admin API
+  gafaelfawrAdminAuthQuery: "scope=exec:admin"
+
   # -- Additional annotations to add to the ingress
   annotations: {}
 


### PR DESCRIPTION
Disable Portal's internal admin authentication and instead protect
the admin endpoints with Gafaelfawr using a different scope
(exec:admin).  This will work with Portal 2022.4 or later, which
is still being deployed, but should be harmless to apply to earlier
versions (just not effective).