### PR TITLE
[DM-35495] Bump version of Portal on data-int

### DIFF
--- a/services/portal/values-idfdev.yaml
+++ b/services/portal/values-idfdev.yaml
@@ -1,15 +1,14 @@
 replicaCount: 2
 
-resources:
-  limits:
-    memory: "2Gi"
-
 image:
   tag: "suit-2022.4"
 
 config:
-  hipsUrl: "https://irsa.ipac.caltech.edu/data/hips/CDS/DSS2/color/"
   volumes:
     workareaNfs:
       path: "/share1/home/firefly/shared-workarea"
       server: "10.87.86.26"
+
+resources:
+  limits:
+    memory: "2Gi"

--- a/services/portal/values-idfint.yaml
+++ b/services/portal/values-idfint.yaml
@@ -1,5 +1,8 @@
 replicaCount: 4
 
+image:
+  tag: "suit-2022.4"
+
 config:
   volumes:
     workareaNfs:


### PR DESCRIPTION
Switch to the same version as data-dev.  Also switch data-dev to
the DP0.2 HiPS service.