### PR TITLE
[DM-35495] Give SQuaRE friends exec:admin scope on IDF dev/int

### DIFF
--- a/services/gafaelfawr/values-idfdev.yaml
+++ b/services/gafaelfawr/values-idfdev.yaml
@@ -22,6 +22,7 @@ config:
       - "lsst-sqre-square"
     "exec:admin":
       - "lsst-sqre-square"
+      - "lsst-sqre-friends"
     "exec:notebook":
       - "lsst-sqre-square"
       - "lsst-sqre-friends"

--- a/services/gafaelfawr/values-idfint.yaml
+++ b/services/gafaelfawr/values-idfint.yaml
@@ -15,6 +15,7 @@ config:
       - "lsst-sqre-square"
     "exec:admin":
       - "lsst-sqre-square"
+      - "lsst-sqre-friends"
     "exec:notebook":
       - "lsst-ops-panda"
       - "lsst-ops"


### PR DESCRIPTION
This is now required for access to the Portal admin status URL,
so include the Portal folks.