### PR TITLE
[DM-35575] Update Sasquatch news feed URLs

### DIFF
--- a/services/sasquatch/values-idfdev.yaml
+++ b/services/sasquatch/values-idfdev.yaml
@@ -31,4 +31,4 @@ chronograf:
     GENERIC_SCOPES: openid
     GENERIC_API_KEY: sub
     PUBLIC_URL: https://data-dev.lsst.cloud/
-    STATUS_FEED_URL: "https://lsst-sqre.github.io/sasquatch/feeds/idfdev.json"
+    STATUS_FEED_URL: https://raw.githubusercontent.com/lsst-sqre/rsp_broadcast/main/jsonfeeds/idfdev.json

--- a/services/sasquatch/values-summit.yaml
+++ b/services/sasquatch/values-summit.yaml
@@ -40,7 +40,7 @@ chronograf:
     GENERIC_SCOPES: openid
     GENERIC_API_KEY: sub
     PUBLIC_URL: https://summit-lsp.lsst.codes
-    STATUS_FEED_URL: https://lsst-sqre.github.io/sasquatch/feeds/summit.json
+    STATUS_FEED_URL: https://raw.githubusercontent.com/lsst-sqre/rsp_broadcast/main/jsonfeeds/summit.json
 
 kapacitor:
   persistence:

--- a/services/sasquatch/values-tucson-teststand.yaml
+++ b/services/sasquatch/values-tucson-teststand.yaml
@@ -55,7 +55,7 @@ chronograf:
     GENERIC_SCOPES: openid
     GENERIC_API_KEY: sub
     PUBLIC_URL: https://tucson-teststand.lsst.codes
-    STATUS_FEED_URL: https://lsst-sqre.github.io/argocd-efd/apps/chronograf/feeds/tucson-teststand.json
+    STATUS_FEED_URL: https://raw.githubusercontent.com/lsst-sqre/rsp_broadcast/main/jsonfeeds/tucson-teststand.json
 
 kapacitor:
   persistence:


### PR DESCRIPTION
- JSON feeds for sasquatch are now served from the rsp_broadcast repo.