### PR TITLE
Enable telegraf and telegraf-ds at TTS

### DIFF
--- a/science-platform/values-tucson-teststand.yaml
+++ b/science-platform/values-tucson-teststand.yaml
@@ -54,11 +54,10 @@ tap:
   enabled: false
 tap_schema:
   enabled: false
-# EFD already provides telegraf namespace.  Gotta work that out.
 telegraf:
-  enabled: false
+  enabled: true
 telegraf-ds:
-  enabled: false
+  enabled: true
 times_square:
   enabled: false
 vault_secrets_operator:


### PR DESCRIPTION
- Now that Sasquatch is running at TTS we can tear down the old EFD deployment and deploy telegraf and telegraf-ds as part of the monitoring infrastructure.