### PR TITLE
[DM-34613] Fix LDAP configuration for IDF dev

### DIFF
--- a/services/gafaelfawr/README.md
+++ b/services/gafaelfawr/README.md
@@ -24,6 +24,8 @@ Science Platform authentication and authorization system
 | config.cilogon.loginParams | object | `{"skin":"LSST"}` | Additional parameters to add |
 | config.cilogon.redirectUrl | string | `/login` at the value of config.host | Return URL given to CILogon (must match the CILogon configuration) |
 | config.cilogon.test | bool | `false` | Whether to use the test instance of CILogon |
+| config.cilogon.uidClaim | string | `"uidNumber"` | Claim from which to get the numeric UID (only used if not retrieved from LDAP or Firestore) |
+| config.cilogon.usernameClaim | string | `"uid"` | Claim from which to get the username |
 | config.databaseUrl | string | None, must be set | URL for the PostgreSQL database |
 | config.errorFooter | string | `""` | HTML footer to add to any login error page (inside a <p> tag). |
 | config.firestore.project | string | Firestore support is disabled | If set, assign UIDs and GIDs using Google Firestore in the given project.  Cloud SQL must be enabled and the Cloud SQL service account must have read/write access to that Firestore instance. |
@@ -54,8 +56,8 @@ Science Platform authentication and authorization system
 | config.oidc.loginUrl | string | None, must be set | URL to which to redirect the user for authorization |
 | config.oidc.scopes | list | `["openid"]` | Scopes to request from the OpenID Connect provider |
 | config.oidc.tokenUrl | string | None, must be set | URL from which to retrieve the token for the user |
-| config.oidc.uidClaim | string | `"uidNumber"` | Claim from which to get the numeric UID (only used if not retrieved from LDAP) |
-| config.oidc.usernameClaim | string | `"sub"` | Claim from which to get the username (only used if not retrieved from LDAP) |
+| config.oidc.uidClaim | string | `"uidNumber"` | Claim from which to get the numeric UID (only used if not retrieved from LDAP or Firestore) |
+| config.oidc.usernameClaim | string | `"sub"` | Claim from which to get the username |
 | config.oidcServer.enabled | bool | `false` | Whether to support OpenID Connect clients. If set to true, `oidc-server-secrets` must be set in the Gafaelfawr secret. |
 | config.proxies | list | [`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`] | List of netblocks used for internal Kubernetes IP addresses, used to determine the true client IP for logging |
 | config.tokenLifetimeMinutes | int | `43200` (30 days) | Session length and token expiration (in minutes) |

--- a/services/gafaelfawr/templates/configmap.yaml
+++ b/services/gafaelfawr/templates/configmap.yaml
@@ -72,6 +72,12 @@ data:
         - "email"
         - "org.cilogon.userinfo"
       audience: {{ .Values.config.cilogon.clientId | quote }}
+      {{- if .Values.config.cilogon.usernameClaim }}
+      username_claim: {{ .Values.config.oidc.usernameClaim | quote }}
+      {{- end }}
+      {{- if .Values.config.cilogon.uidClaim }}
+      uid_claim: {{ .Values.config.oidc.uidClaim | quote }}
+      {{- end }}
 
     {{- else if .Values.config.oidc.clientId }}
 
@@ -129,7 +135,9 @@ data:
       {{- if .Values.config.ldap.userBaseDn }}
       user_base_dn: {{ .Values.config.ldap.userBaseDn | quote }}
       user_search_attr: {{ .Values.config.ldap.userSearchAttr | quote }}
+      {{- if .Values.config.ldap.uidAttr }}
       uid_attr: {{ .Values.config.ldap.uidAttr | quote }}
+      {{- end }}
       name_attr: {{ .Values.config.ldap.nameAttr | quote }}
       email_attr: {{ .Values.config.ldap.emailAttr | quote }}
       {{- end }}

--- a/services/gafaelfawr/values-idfdev.yaml
+++ b/services/gafaelfawr/values-idfdev.yaml
@@ -17,6 +17,7 @@ config:
     clientId: "cilogon:/client_id/46f9ae932fd30e9fb1b246972a3c0720"
     enrollmentUrl: "https://registry-test.lsst.codes/registry/co_petitions/start/coef:6"
     test: true
+    usernameClaim: "username"
 
   firestore:
     project: "rsp-firestore-dev-31c4"
@@ -25,7 +26,10 @@ config:
     url: "ldaps://ldap-test.cilogon.org"
     userDn: "uid=readonly_user,ou=system,o=LSST,o=CO,dc=lsst,dc=org"
     groupBaseDn: "ou=groups,o=LSST,o=CO,dc=lsst,dc=org"
+    groupObjectClass: "eduMember"
+    groupMemberAttr: "hasMember"
     userBaseDn: "ou=people,o=LSST,o=CO,dc=lsst,dc=org"
+    userSearchAttr: "voPersonApplicationUID"
 
   groupMapping:
     "admin:provision":

--- a/services/gafaelfawr/values.yaml
+++ b/services/gafaelfawr/values.yaml
@@ -75,6 +75,15 @@ config:
     loginParams:
       skin: "LSST"
 
+    # -- Claim from which to get the username
+    # @default -- `"uid"`
+    usernameClaim: ""
+
+    # -- Claim from which to get the numeric UID (only used if not retrieved
+    # from LDAP or Firestore)
+    # @default -- `"uidNumber"`
+    uidClaim: ""
+
   firestore:
     # -- If set, assign UIDs and GIDs using Google Firestore in the given
     # project.  Cloud SQL must be enabled and the Cloud SQL service account
@@ -119,13 +128,12 @@ config:
     scopes:
       - "openid"
 
-    # -- Claim from which to get the username (only used if not retrieved from
-    # LDAP)
+    # -- Claim from which to get the username
     # @default -- `"sub"`
     usernameClaim: ""
 
     # -- Claim from which to get the numeric UID (only used if not retrieved
-    # from LDAP)
+    # from LDAP or Firestore)
     # @default -- `"uidNumber"`
     uidClaim: ""
 


### PR DESCRIPTION
COmanage needed some different LDAP configuration and to change
the username claim attribute in the OpenID Connect token.  Also
suppress the uid_attr config parameter if none is set to avoid
sending the empty string.