### PR TITLE
[DM-34613] Gafaelfawr Phalanx configuration cleanup

### DIFF
--- a/services/gafaelfawr/README.md
+++ b/services/gafaelfawr/README.md
@@ -45,8 +45,6 @@ Science Platform authentication and authorization system
 | config.ldap.userBaseDn | string | Get user metadata from the upstream authentication provider | Base DN for the LDAP search to find a user's entry |
 | config.ldap.userDn | string | Use anonymous binds | Bind DN for simple bind authentication. If set, `ldap-secret` must be set in the Gafaelfawr secret |
 | config.ldap.userSearchAttr | string | `"uid"` | Search attribute containing the user's username |
-| config.ldap.usernameBaseDn | string | Get the username from the upstream authentication provider | Base DN for the LDAP search to find a user's username |
-| config.ldap.usernameSearchAttr | string | `"voPersonSoRID"` | Attribute matching the `sub` claim of a token to find the record containing the username |
 | config.loglevel | string | `"INFO"` | Choose from the text form of Python logging levels |
 | config.oidc.audience | string | Value of `config.oidc.clientId` | Audience for the JWT token |
 | config.oidc.clientId | string | `""` | Client ID for generic OpenID Connect support. One and only one of this, `config.cilogon.clientId`, or `config.github.clientId` must be set. |

--- a/services/gafaelfawr/templates/configmap.yaml
+++ b/services/gafaelfawr/templates/configmap.yaml
@@ -91,8 +91,8 @@ data:
       {{- end }}
       login_url: {{ required "config.oidc.loginUrl must be set" .Values.config.oidc.loginUrl | quote }}
       token_url: {{ required "config.oidc.tokenUrl must be set" .Values.config.oidc.tokenUrl | quote }}
-      {{- if .Values.config.cilogon.enrollmentUrl }}
-      enrollment_url: {{ .Values.config.cilogon.enrollmentUrl | quote }}
+      {{- if .Values.config.oidc.enrollmentUrl }}
+      enrollment_url: {{ .Values.config.oidc.enrollmentUrl | quote }}
       {{- end }}
       issuer: {{ required "config.oidc.issuer must be set" .Values.config.oidc.issuer | quote }}
       {{- if .Values.config.oidc.redirectUrl }}

--- a/services/gafaelfawr/templates/configmap.yaml
+++ b/services/gafaelfawr/templates/configmap.yaml
@@ -141,10 +141,6 @@ data:
       name_attr: {{ .Values.config.ldap.nameAttr | quote }}
       email_attr: {{ .Values.config.ldap.emailAttr | quote }}
       {{- end }}
-      {{- if .Values.config.ldap.usernameBaseDn }}
-      username_base_dn: {{ .Values.config.ldap.usernameBaseDn | quote }}
-      username_search_attr: {{ .Values.config.ldap.usernameSearchAttr | quote }}
-      {{- end }}
     {{- end }}
 
     {{- if .Values.config.oidcServer.enabled }}

--- a/services/gafaelfawr/templates/configmap.yaml
+++ b/services/gafaelfawr/templates/configmap.yaml
@@ -52,10 +52,10 @@ data:
       {{- else }}
       login_url: "https://cilogon.org/authorize"
       token_url: "https://cilogon.org/oauth2/token"
+      issuer: "https://cilogon.org"
+      {{- end }}
       {{- if .Values.config.cilogon.enrollmentUrl }}
       enrollment_url: {{ .Values.config.cilogon.enrollmentUrl | quote }}
-      {{- end }}
-      issuer: "https://cilogon.org"
       {{- end }}
       {{- if .Values.config.cilogon.loginParams }}
       login_params:

--- a/services/gafaelfawr/values-idfdev.yaml
+++ b/services/gafaelfawr/values-idfdev.yaml
@@ -1,7 +1,3 @@
-image:
-  tag: "tickets-DM-34613"
-  pullPolicy: "Always"
-
 # Use the CSI storage class so that we can use snapshots.
 redis:
   persistence:

--- a/services/gafaelfawr/values-idfdev.yaml
+++ b/services/gafaelfawr/values-idfdev.yaml
@@ -1,5 +1,6 @@
 image:
   tag: "tickets-DM-34613"
+  pullPolicy: "Always"
 
 # Use the CSI storage class so that we can use snapshots.
 redis:

--- a/services/gafaelfawr/values-minikube.yaml
+++ b/services/gafaelfawr/values-minikube.yaml
@@ -1,6 +1,3 @@
-image:
-  tag: "tickets-DM-34613"
-
 # Reset token storage on every Redis restart.
 redis:
   persistence:

--- a/services/gafaelfawr/values.yaml
+++ b/services/gafaelfawr/values.yaml
@@ -176,14 +176,6 @@ config:
     # -- Attribute containing the user's email address
     emailAttr: "mail"
 
-    # -- Base DN for the LDAP search to find a user's username
-    # @default -- Get the username from the upstream authentication provider
-    usernameBaseDn: ""
-
-    # -- Attribute matching the `sub` claim of a token to find the record
-    # containing the username
-    usernameSearchAttr: "voPersonSoRID"
-
   influxdb:
     # -- Whether to issue tokens for InfluxDB. If set to true,
     # `influxdb-secret` must be set in the Gafaelfawr secret.


### PR DESCRIPTION
- Drop support for looking up usernames in LDAP
- Fix enrollment URL configuration for OpenID Connect
- Fix CILogon enrollment URL when test CILogon is enabled
- Switch to Gafaelfawr 5.0.0 on IDF dev and minikube