### PR TITLE
Bump memory limits for strimzi-cluster-operator

### DIFF
--- a/services/strimzi/values-idfdev.yaml
+++ b/services/strimzi/values-idfdev.yaml
@@ -1,4 +1,9 @@
 strimzi-kafka-operator:
+  resources:
+    limits:
+      memory: "512Mi"
+    requests:
+      memory: "512Mi"
   watchNamespaces:
     - "sasquatch"
   logLevel: "DEBUG"

--- a/services/strimzi/values-idfint.yaml
+++ b/services/strimzi/values-idfint.yaml
@@ -1,4 +1,9 @@
 strimzi-kafka-operator:
+  resources:
+    limits:
+      memory: "512Mi"
+    requests:
+      memory: "512Mi"
   watchNamespaces:
     - "alert-stream-broker"
   logLevel: "INFO"

--- a/services/strimzi/values-summit.yaml
+++ b/services/strimzi/values-summit.yaml
@@ -1,4 +1,9 @@
 strimzi-kafka-operator:
+  resources:
+    limits:
+      memory: "512Mi"
+    requests:
+      memory: "512Mi"
   watchNamespaces:
     - "sasquatch"
   logLevel: "INFO"

--- a/services/strimzi/values-tucson-teststand.yaml
+++ b/services/strimzi/values-tucson-teststand.yaml
@@ -1,4 +1,9 @@
 strimzi-kafka-operator:
+  resources:
+    limits:
+      memory: "512Mi"
+    requests:
+      memory: "512Mi"
   watchNamespaces:
     - "sasquatch"
   logLevel: "DEBUG"


### PR DESCRIPTION
It was crashing on the Tucson teststand at 384MiB with out of
memory errors.  Bump it to 512MiB everywhere.