### PR TITLE
[DM-35482] Serve /api/hips/list from datalinker

### DIFF
--- a/services/datalinker/Chart.yaml
+++ b/services/datalinker/Chart.yaml
@@ -4,4 +4,4 @@ version: 1.0.0
 description: IVOA DataLink service for Rubin Science Platform
 sources:
   - https://github.com/lsst-sqre/datalinker
-appVersion: 1.3.1
+appVersion: 1.4.0

--- a/services/datalinker/README.md
+++ b/services/datalinker/README.md
@@ -25,7 +25,6 @@ IVOA DataLink service for Rubin Science Platform
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | ingress.annotations | object | `{}` | Additional annotations for the ingress rule |
 | ingress.gafaelfawrAuthQuery | string | `"scope=read:image"` | Gafaelfawr auth query string |
-| ingress.path | string | `"/api/datalink"` | URL path to dispatch to the datalinker deployment pod |
 | nameOverride | string | `""` | Override the base name for resources |
 | nodeSelector | object | `{}` | Node selection rules for the datalinker deployment pod |
 | podAnnotations | object | `{}` | Annotations for the datalinker deployment pod |

--- a/services/datalinker/templates/deployment.yaml
+++ b/services/datalinker/templates/deployment.yaml
@@ -41,6 +41,13 @@ spec:
           env:
             - name: "DATALINKER_CUTOUT_SYNC_URL"
               value: "{{ .Values.global.baseUrl }}/api/cutout/sync"
+            - name: "DATALINKER_HIPS_BASE_URL"
+              value: "{{ .Values.global.baseUrl }}/api/hips"
+            - name: "DATALINKER_TOKEN"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "datalinker.fullname" . }}-gafaelfawr-token
+                  key: "token"
             # The following are used by Butler to retrieve its configuration
             # and authenticate to its database.
             - name: "AWS_SHARED_CREDENTIALS_FILE"

--- a/services/datalinker/templates/gafaelfawr-token.yaml
+++ b/services/datalinker/templates/gafaelfawr-token.yaml
@@ -1,0 +1,10 @@
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrServiceToken
+metadata:
+  name: {{ include "datalinker.fullname" . }}-gafaelfawr-token
+  labels:
+    {{- include "datalinker.labels" . | nindent 4 }}
+spec:
+  service: "bot-datalinker"
+  scopes:
+    - "read:image"

--- a/services/datalinker/templates/ingress-anonymous.yaml
+++ b/services/datalinker/templates/ingress-anonymous.yaml
@@ -1,16 +1,10 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ include "datalinker.fullname" . }}
+  name: {{ include "datalinker.fullname" . }}-anonymous
   labels:
     {{- include "datalinker.labels" . | nindent 4 }}
   annotations:
-    {{- if .Values.ingress.gafaelfawrAuthQuery }}
-    nginx.ingress.kubernetes.io/auth-method: "GET"
-    nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-User"
-    nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.global.baseUrl }}/login"
-    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.baseUrl }}/auth?{{ .Values.ingress.gafaelfawrAuthQuery }}"
-    {{- end }}
     {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -20,8 +14,8 @@ spec:
     - host: {{ required "global.host must be set" .Values.global.host | quote }}
       http:
         paths:
-          - path: "/api/datalink"
-            pathType: "Prefix"
+          - path: "/api/hips/list"
+            pathType: "Exact"
             backend:
               service:
                 name: {{ include "datalinker.fullname" . }}

--- a/services/datalinker/templates/ingress.yaml
+++ b/services/datalinker/templates/ingress.yaml
@@ -20,8 +20,15 @@ spec:
     - host: {{ required "global.host must be set" .Values.global.host | quote }}
       http:
         paths:
-          - path: {{ .Values.ingress.path }}
+          - path: "/api/datalink"
             pathType: "Prefix"
+            backend:
+              service:
+                name: {{ include "datalinker.fullname" . }}
+                port:
+                  number: 8080
+          - path: "/api/hips/list"
+            pathType: "Exact"
             backend:
               service:
                 name: {{ include "datalinker.fullname" . }}

--- a/services/datalinker/values-idfint.yaml
+++ b/services/datalinker/values-idfint.yaml
@@ -1,0 +1,3 @@
+image:
+  tag: "tickets-DM-35482"
+  pullPolicy: "Always"

--- a/services/datalinker/values.yaml
+++ b/services/datalinker/values.yaml
@@ -25,9 +25,6 @@ ingress:
   # -- Gafaelfawr auth query string
   gafaelfawrAuthQuery: "scope=read:image"
 
-  # -- URL path to dispatch to the datalinker deployment pod
-  path: "/api/datalink"
-
   # -- Additional annotations for the ingress rule
   annotations: {}
 

--- a/services/hips/templates/ingress.yaml
+++ b/services/hips/templates/ingress.yaml
@@ -9,7 +9,6 @@ metadata:
     {{- if .Values.ingress.gafaelfawrAuthQuery }}
     nginx.ingress.kubernetes.io/auth-method: "GET"
     nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-User"
-    nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.global.baseUrl }}/login"
     nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.baseUrl }}/auth?{{ .Values.ingress.gafaelfawrAuthQuery }}"
     {{- end }}
     {{- with .Values.ingress.annotations }}


### PR DESCRIPTION
datalinker will be the service that dynamically generates the HiPS
list based on the properties files of the HiPS data sets for a given
Science Platform deployment.