### PR TITLE
[DM-35849] Exclude Kafka PVCs from the app sync status

### DIFF
--- a/services/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
+++ b/services/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
@@ -5,6 +5,12 @@ metadata:
   name: {{ .Values.cluster.name }}
 spec:
   kafka:
+    template:
+      persistentVolumeClaim:
+        metadata:
+          annotations:
+            argocd.argoproj.io/compare-options: IgnoreExtraneous
+            argocd.argoproj.io/sync-options: Prune=false
     version: {{ .Values.kafka.version | quote }}
     replicas: {{ .Values.kafka.replicas }}
     listeners:
@@ -64,6 +70,12 @@ spec:
         {{- end}}
         deleteClaim: false
   zookeeper:
+    template:
+      persistentVolumeClaim:
+        metadata:
+          annotations:
+            argocd.argoproj.io/compare-options: IgnoreExtraneous
+            argocd.argoproj.io/sync-options: Prune=false
     replicas: {{ .Values.zookeeper.replicas }}
     storage:
       # Note that storage is configured per replica. If there are 3 replicas,

--- a/services/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
+++ b/services/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
@@ -40,7 +40,6 @@ spec:
         - {{ . }}
 {{- end }}
 {{- end }}
-
     config:
       offsets.topic.replication.factor:  {{ .Values.kafka.replicas }}
       transaction.state.log.replication.factor:  {{ .Values.kafka.replicas }}


### PR DESCRIPTION
In Strimzi operator 0.30.0 Kafka `PersistenVolumeClaim` resources show up as `OutOfSync (requires prune)` in Argo CD, affecting the overall app sync status. 

Strimzi provides a mechanism for [customizing k8s resources](https://strimzi.io/docs/operators/latest/configuring.html#assembly-customizing-kubernetes-resources-str).  Use that to add annotations to [exclude the PVCs from the app sync status](https://argo-cd.readthedocs.io/en/stable/user-guide/compare-options/#ignoring-resources-that-are-extraneous) and to [prevent them from being pruned](https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/#no-prune-resources).