### PR TITLE
[DM-35482] Point Portal at new HiPS list

### DIFF
--- a/services/datalinker/values-idfint.yaml
+++ b/services/datalinker/values-idfint.yaml
@@ -1,3 +1,0 @@
-image:
-  tag: "tickets-DM-35482"
-  pullPolicy: "Always"

--- a/services/portal/templates/deployment.yaml
+++ b/services/portal/templates/deployment.yaml
@@ -42,14 +42,12 @@ spec:
                 secretKeyRef:
                   name: {{ include "portal.fullname" . }}-secret
                   key: "ADMIN_PASSWORD"
-            - name: "FIREFLY_OPTS"
-              value: "-Dredis.host={{ include "portal.fullname" . }}-redis -Dsso.req.auth.hosts={{ .Values.global.host }}"
             - name: "PROPS_redis__host"
               value: {{ include "portal.fullname" . }}-redis
             - name: "PROPS_sso__req__auth__hosts"
               value: {{ .Values.global.host | quote }}
             - name: "PROPS_lsst__hips__masterUrl"
-              value: https://irsa.ipac.caltech.edu/data/hips/list
+              value: "{{ .Values.global.baseUrl }}/api/hips/list"
             - name: "PROPS_FIREFLY_OPTIONS"
               value: >-
                 $'{


### PR DESCRIPTION
Use the in-deployment HiPS list served by datalinker.  Also delete
the old FIREFLY_OPTS setting, which is no longer used by current
Firefly.