### PR TITLE
Revert Argo CD update that introduced a bug

### DIFF
--- a/services/argocd/Chart.yaml
+++ b/services/argocd/Chart.yaml
@@ -3,5 +3,5 @@ name: argo-cd
 version: 1.0.0
 dependencies:
 - name: argo-cd
-  version: 4.10.6
+  version: 4.10.5
   repository: https://argoproj.github.io/argo-helm

--- a/services/argocd/README.md
+++ b/services/argocd/README.md
@@ -4,7 +4,7 @@
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://argoproj.github.io/argo-helm | argo-cd | 4.10.6 |
+| https://argoproj.github.io/argo-helm | argo-cd | 4.10.5 |
 
 ## Values
 


### PR DESCRIPTION
The new version doesn't show the restart menu option. Revert for now until
it's fixed upstream.