### PR TITLE
[DM-35872] Add Gafaelfawr config for Slack webhook

### DIFF
--- a/installer/generate_secrets.py
+++ b/installer/generate_secrets.py
@@ -42,6 +42,7 @@ class SecretGenerator:
         `regenerate` attribute is `True`.
         """
         self._pull_secret()
+        self._rsp_alerts()
         self._butler_secret()
         self._postgres()
         self._tap()
@@ -254,6 +255,10 @@ class SecretGenerator:
         else:
             raise Exception(f"Invalid auth provider {auth_type}")
 
+        slack_webhook = self.secrets["rsp-alerts"]["slack-webhook"]
+        if slack_webhook:
+            self._set("gafaelfawr", "slack-webhook", slack_webhook)
+
     def _pull_secret(self):
         self.input_file(
             "pull-secret",
@@ -358,6 +363,12 @@ class SecretGenerator:
         """This secret is for sherlock to push status to status.lsst.codes."""
         publish_key = secrets.token_hex(32)
         self._set_generated("sherlock", "publish_key", publish_key)
+
+    def _rsp_alerts(self):
+        """Shared secrets for alerting."""
+        self.input_field(
+            "rsp-alerts", "slack-webhook", "Slack webhook for alerts"
+        )
 
 
 class OnePasswordSecretGenerator(SecretGenerator):

--- a/services/gafaelfawr/README.md
+++ b/services/gafaelfawr/README.md
@@ -60,6 +60,7 @@ Science Platform authentication and authorization system
 | config.oidc.usernameClaim | string | `"sub"` | Claim from which to get the username |
 | config.oidcServer.enabled | bool | `false` | Whether to support OpenID Connect clients. If set to true, `oidc-server-secrets` must be set in the Gafaelfawr secret. |
 | config.proxies | list | [`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`] | List of netblocks used for internal Kubernetes IP addresses, used to determine the true client IP for logging |
+| config.slackAlerts | bool | `false` | Whether to send certain serious alerts to Slack. If `true`, the `slack-webhook` secret must also be set. |
 | config.tokenLifetimeMinutes | int | `43200` (30 days) | Session length and token expiration (in minutes) |
 | fullnameOverride | string | `""` | Override the full name for resources (includes the release name) |
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |

--- a/services/gafaelfawr/templates/configmap.yaml
+++ b/services/gafaelfawr/templates/configmap.yaml
@@ -14,6 +14,9 @@ data:
     database_password_file: "/etc/gafaelfawr/secrets/database-password"
     redis_url: "redis://{{ template "gafaelfawr.fullname" . }}-redis.{{ .Release.Namespace }}:6379/0"
     redis_password_file: "/etc/gafaelfawr/secrets/redis-password"
+    {{- if .Values.config.slackAlerts }}
+    slack_webhook_file: "/etc/gafaelfawr/secrets/slack-webhook"
+    {{- end }}
     token_lifetime_minutes: {{ .Values.config.tokenLifetimeMinutes }}
     {{- if .Values.config.proxies }}
     proxies:

--- a/services/gafaelfawr/values-idfdev.yaml
+++ b/services/gafaelfawr/values-idfdev.yaml
@@ -6,6 +6,7 @@ redis:
 config:
   databaseUrl: "postgresql://gafaelfawr@localhost/gafaelfawr"
   loglevel: "DEBUG"
+  slackAlerts: true
 
   # Support OpenID Connect clients like Chronograf.
   oidcServer:

--- a/services/gafaelfawr/values.yaml
+++ b/services/gafaelfawr/values.yaml
@@ -43,6 +43,10 @@ config:
   # -- Choose from the text form of Python logging levels
   loglevel: "INFO"
 
+  # -- Whether to send certain serious alerts to Slack. If `true`, the
+  # `slack-webhook` secret must also be set.
+  slackAlerts: false
+
   # -- Session length and token expiration (in minutes)
   # @default -- `43200` (30 days)
   tokenLifetimeMinutes: 43200


### PR DESCRIPTION
Add support for a general RSP alerts Slack webhook secret, and
configuration for Gafaelfawr to use it via its secret.  Currently
this is only used to report uncaught exceptions.