### PR TITLE
[DM-35764] Add external listener configuration

### DIFF
--- a/services/sasquatch/charts/strimzi-kafka/README.md
+++ b/services/sasquatch/charts/strimzi-kafka/README.md
@@ -13,6 +13,12 @@ A subchart to deploy Strimzi Kafka components for Sasquatch.
 | kafka.config."log.retention.bytes" | string | `"429496729600"` | Maximum retained number of bytes for a topic's data. |
 | kafka.config."log.retention.hours" | int | `24` | Number of days for a topic's data to be retained. |
 | kafka.config."offsets.retention.minutes" | int | `1440` | Number of minutes for a consumer group's offsets to be retained. |
+| kafka.externalListener.bootstrap.annotations | object | `{}` | Annotations that will be added to the Ingress, Route, or Service resource. |
+| kafka.externalListener.bootstrap.host | string | `""` | Name used for TLS hostname verification. |
+| kafka.externalListener.bootstrap.loadBalancerIP | string | `""` | The loadbalancer is requested with the IP address specified in this field. This feature depends on whether the underlying cloud provider supports specifying the loadBalancerIP when a load balancer is created. This field is ignored if the cloud provider does not support the feature. Once the IP address is provisioned this option make it possible to pin the IP address. We can request the same IP next time it is provisioned. This is important because it lets us configure a DNS record, associating a hostname with that pinned IP address. |
+| kafka.externalListener.brokers | list | `[]` | Borkers configuration. host is used in the brokers' advertised.brokers configuration and for TLS hostname verification. The format is a list of maps. |
+| kafka.externalListener.tls.certIssuerName | string | `"letsencrypt-dns"` | Name of a ClusterIssuer capable of provisioning a TLS certificate for the broker. |
+| kafka.externalListener.tls.enabled | bool | `false` | Whether TLS encryption is enabled. |
 | kafka.replicas | int | `3` | Number of Kafka broker replicas to run. |
 | kafka.storage.size | string | `"500Gi"` | Size of the backing storage disk for each of the Kafka brokers. |
 | kafka.storage.storageClassName | string | `""` | Name of a StorageClass to use when requesting persistent volumes. |

--- a/services/sasquatch/charts/strimzi-kafka/templates/certificates.yaml
+++ b/services/sasquatch/charts/strimzi-kafka/templates/certificates.yaml
@@ -1,0 +1,19 @@
+{{- if and (.Values.kafka.externalListener.tls.enabled) (.Values.kafka.externalListener.bootstrap.host) }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ .Values.cluster.name }}-external-tls
+
+spec:
+  secretName: {{ .Values.cluster.name }}-external-tls
+
+  issuerRef:
+    name: {{ .Values.kafka.externalListener.tls.certIssuerName }}
+    kind: ClusterIssuer
+
+  dnsNames:
+    - {{ .Values.kafka.externalListener.bootstrap.host }}
+    {{- range $broker := .Values.kafka.externalListener.brokers }}
+    - {{ $broker.host }}
+    {{- end }}
+{{- end }}

--- a/services/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
+++ b/services/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
@@ -35,9 +35,37 @@ spec:
       - name: external
         port: 9094
         type: loadbalancer
-        tls: true
+        tls: {{ .Values.kafka.externalListener.tls.enabled }}
         authentication:
           type: scram-sha-512
+        configuration:
+          bootstrap:
+            {{- if .Values.kafka.externalListener.bootstrap.loadBalancerIP }}
+            loadBalancerIP: {{ .Values.kafka.externalListener.bootstrap.loadBalancerIP }}
+            {{- end }}
+            {{- if .Values.kafka.externalListener.bootstrap.annotations }}
+            annotations: {{ .Values.kafka.externalListener.bootstrap.annotations }}
+            {{- end }}
+          {{- if .Values.kafka.externalListener.brokers }}
+          brokers:
+            {{- range $idx, $broker := .Values.kafka.externalListener.brokers }}
+            - broker: {{ $idx }}
+              loadBalancerIP: {{ $broker.loadBalancerIP }}
+              advertisedHost: {{ $broker.host }}
+              advertisedPort: 9094
+              annotations:
+                {{- range $key, $value  := $broker.annotations }}
+                {{ $key }}: {{ $value }}
+                {{- end}}
+            {{- end }}
+          {{- end }}
+          {{- if and (.Values.kafka.externalListener.tls.enabled) (.Values.kafka.externalListener.bootstrap.host) }}
+          brokerCertChainAndKey:
+            secretName: {{ .Values.cluster.name }}-external-tls
+            certificate: tls.crt
+            key: tls.key
+          {{- end }}
+
     authorization:
       type: simple
 {{- if .Values.superusers }}

--- a/services/sasquatch/charts/strimzi-kafka/values.yaml
+++ b/services/sasquatch/charts/strimzi-kafka/values.yaml
@@ -22,6 +22,40 @@ kafka:
     # -- Maximum retained number of bytes for a topic's data.
     log.retention.bytes: "429496729600"
 
+  externalListener:
+    tls:
+      # -- Whether TLS encryption is enabled.
+      enabled: false
+      # -- Name of a ClusterIssuer capable of provisioning a TLS certificate for the broker.
+      certIssuerName: "letsencrypt-dns"
+
+    bootstrap:
+      # -- The loadbalancer is requested with the IP address specified in this field.
+      # This feature depends on whether the underlying cloud provider supports specifying the loadBalancerIP when a load balancer is created.
+      # This field is ignored if the cloud provider does not support the feature.
+      # Once the IP address is provisioned this option make it possible to pin the IP address.
+      # We can request the same IP next time it is provisioned. This is important because
+      # it lets us configure a DNS record, associating a hostname with that pinned IP address.
+      loadBalancerIP: ""
+      # -- Name used for TLS hostname verification.
+      host: ""
+      # -- Annotations that will be added to the Ingress, Route, or Service resource.
+      annotations: {}
+
+    # -- Borkers configuration. host is used in the brokers' advertised.brokers configuration and for TLS hostname verification.
+    # The format is a list of maps.
+    brokers: []
+    # For example:
+    # brokers:
+    #   - loadBalancerIP: "192.168.1.1"
+    #     host: broker-0.example
+    #     annotations:
+    #       metallb.universe.tf/address-pool: sdf-dmz
+    #   - loadBalancerIP: "192.168.1.2"
+    #     host: broker-1.example
+    #     annotations:
+    #       metallb.universe.tf/address-pool: sdf-dmz
+
 zookeeper:
   # -- Number of Zookeeper replicas to run.
   replicas: 3

--- a/services/sasquatch/values-idfdev.yaml
+++ b/services/sasquatch/values-idfdev.yaml
@@ -1,4 +1,19 @@
-strimzi-kafka: {}
+strimzi-kafka:
+  kafka:
+    externalListener:
+      tls:
+        enabled: true
+      bootstrap:
+        loadBalancerIP: "34.173.210.129"
+        host: sasquatch-dev-kafka-bootstrap.lsst.cloud
+
+      brokers:
+        - loadBalancerIP: "34.173.20.18"
+          host: sasquatch-dev-kafka-0.lsst.cloud
+        - loadBalancerIP: "34.69.251.153"
+          host: sasquatch-dev-kafka-1.lsst.cloud
+        - loadBalancerIP: "35.184.86.132"
+          host: sasquatch-dev-kafka-2.lsst.cloud
 
 influxdb:
   ingress:


### PR DESCRIPTION
- If TLS is enabled use cert-manager to issue certificates for the external listener.
- Support annotations added to the Ingress, Route, or Service resource.
- Add configuration for Sasquatch on idfdev 