### PR TITLE
[DM-35959] Use separate Cloud SQL Proxy pod

### DIFF
--- a/services/gafaelfawr/README.md
+++ b/services/gafaelfawr/README.md
@@ -13,12 +13,17 @@ Science Platform authentication and authorization system
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules for the Gafaelfawr frontend pod |
-| cloudsql.enabled | bool | `false` | Enable the Cloud SQL Auth Proxy sidecar, used with CloudSQL databases on Google Cloud |
+| cloudsql.affinity | object | `{}` | Affinity rules for the Cloud SQL Proxy pod |
+| cloudsql.enabled | bool | `false` | Enable the Cloud SQL Auth Proxy, used with CloudSQL databases on Google Cloud. This will be run as a sidecar for the main Gafaelfawr pods, and as a separate service (behind a `NetworkPolicy`) for other, lower-traffic services. |
 | cloudsql.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for Cloud SQL Auth Proxy images |
 | cloudsql.image.repository | string | `"gcr.io/cloudsql-docker/gce-proxy"` | Cloud SQL Auth Proxy image to use |
-| cloudsql.image.tag | string | `"1.31.2-alpine"` | Cloud SQL Auth Proxy tag to use |
-| cloudsql.instanceConnectionName | string | `""` | Instance connection name for a CloudSQL PostgreSQL instance |
-| cloudsql.serviceAccount | string | `""` | The Google service account that has an IAM binding to the `gafaelfawr` and `gafaelfawr-tokens` Kubernetes service accounts and has the `cloudsql.client` role |
+| cloudsql.image.tag | string | `"1.31.2"` | Cloud SQL Auth Proxy tag to use |
+| cloudsql.instanceConnectionName | string | None, must be set if Cloud SQL Auth Proxy is enabled | Instance connection name for a CloudSQL PostgreSQL instance |
+| cloudsql.nodeSelector | object | `{}` | Node selection rules for the Cloud SQL Proxy pod |
+| cloudsql.podAnnotations | object | `{}` | Annotations for the Cloud SQL Proxy pod |
+| cloudsql.resources | object | `{}` | Resource limits and requests for the Cloud SQL Proxy pod |
+| cloudsql.serviceAccount | string | None, must be set if Cloud SQL Auth Proxy is enabled | The Google service account that has an IAM binding to the `gafaelfawr` Kubernetes service account and has the `cloudsql.client` role |
+| cloudsql.tolerations | list | `[]` | Tolerations for the Cloud SQL Proxy pod |
 | config.cilogon.clientId | string | `""` | CILogon client ID. One and only one of this, `config.github.clientId`, or `config.oidc.clientId` must be set. |
 | config.cilogon.enrollmentUrl | string | Login fails with an error | Where to send the user if their username cannot be found in LDAP |
 | config.cilogon.loginParams | object | `{"skin":"LSST"}` | Additional parameters to add |
@@ -26,7 +31,7 @@ Science Platform authentication and authorization system
 | config.cilogon.test | bool | `false` | Whether to use the test instance of CILogon |
 | config.cilogon.uidClaim | string | `"uidNumber"` | Claim from which to get the numeric UID (only used if not retrieved from LDAP or Firestore) |
 | config.cilogon.usernameClaim | string | `"uid"` | Claim from which to get the username |
-| config.databaseUrl | string | None, must be set | URL for the PostgreSQL database |
+| config.databaseUrl | string | None, must be set if `cloudsql.enabled` is not true | URL for the PostgreSQL database |
 | config.errorFooter | string | `""` | HTML footer to add to any login error page (inside a <p> tag). |
 | config.firestore.project | string | Firestore support is disabled | If set, assign UIDs and GIDs using Google Firestore in the given project.  Cloud SQL must be enabled and the Cloud SQL service account must have read/write access to that Firestore instance. |
 | config.github.clientId | string | `""` | GitHub client ID. One and only one of this, `config.cilogon.clientId`, or `config.oidc.clientId` must be set. |

--- a/services/gafaelfawr/templates/cloudsql-deployment.yaml
+++ b/services/gafaelfawr/templates/cloudsql-deployment.yaml
@@ -1,0 +1,63 @@
+{{- if .Values.cloudsql.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cloud-sql-proxy
+  labels:
+    {{- include "gafaelfawr.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.cloudsql.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "gafaelfawr.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: "cloud-sql-proxy"
+  template:
+    metadata:
+      {{- with .Values.cloudsql.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "gafaelfawr.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: "cloud-sql-proxy"
+    spec:
+      serviceAccountName: {{ include "gafaelfawr.fullname" . }}
+      containers:
+        - name: "cloud-sql-proxy"
+          command:
+            - "/cloud_sql_proxy"
+            - "-ip_address_types=PRIVATE"
+            - "-instances={{ required "cloudsql.instanceConnectionName must be specified" .Values.cloudsql.instanceConnectionName }}=tcp:0.0.0.0:5432"
+          image: "{{ .Values.cloudsql.image.repository }}:{{ .Values.cloudsql.image.tag }}"
+          imagePullPolicy: {{ .Values.cloudsql.image.pullPolicy | quote }}
+          ports:
+            - containerPort: 5432
+              name: "http"
+              protocol: "TCP"
+          {{- with .Values.cloudsql.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+            readOnlyRootFilesystem: true
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+      {{- with .Values.cloudsql.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.cloudsql.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.cloudsql.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/services/gafaelfawr/templates/cloudsql-networkpolicy.yaml
+++ b/services/gafaelfawr/templates/cloudsql-networkpolicy.yaml
@@ -1,0 +1,30 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: "cloud-sql-proxy"
+  labels:
+    {{- include "gafaelfawr.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    # This policy controls inbound and outbound access to the Cloud SQL Proxy.
+    matchLabels:
+      {{- include "gafaelfawr.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: "cloud-sql-proxy"
+  policyTypes:
+    - Ingress
+  ingress:
+    # Allow inbound access to the Cloud SQL Proxy from other components except
+    # the frontend.  The frontend, since it's performance-critical and gates
+    # all access to the cluster, continues running its own sidecar.
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "gafaelfawr.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: "maintenance"
+        - podSelector:
+            matchLabels:
+              {{- include "gafaelfawr.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: "tokens"
+      ports:
+        - protocol: "TCP"
+          port: 5432

--- a/services/gafaelfawr/templates/cloudsql-service.yaml
+++ b/services/gafaelfawr/templates/cloudsql-service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.cloudsql.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: "cloud-sql-proxy"
+  labels:
+    {{- include "gafaelfawr.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - protocol: "TCP"
+      port: 5432
+      targetPort: "http"
+  selector:
+    {{- include "gafaelfawr.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: "cloud-sql-proxy"
+{{- end }}

--- a/services/gafaelfawr/templates/configmap.yaml
+++ b/services/gafaelfawr/templates/configmap.yaml
@@ -1,16 +1,13 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: {{ template "gafaelfawr.fullname" . }}-config
-  labels:
-    {{- include "gafaelfawr.labels" . | nindent 4 }}
-data:
-  gafaelfawr.yaml: |
+{{/* Generate two versions of the ConfigMap, one using the sidecar proxy
+     and the other using the separate Cloud SQL Proxy service. The second
+     will be used for CronJobs and other lower-load services, avoiding the
+     difficulty with coordinating stopping the Cloud SQL Proxy sidecar when
+     a CronJob ends. */}}
+{{- define "gafaelfawr.configMap" }}
     realm: {{ required "global.host must be set" .Values.global.host | quote }}
     loglevel: {{ .Values.config.loglevel | quote }}
     session_secret_file: "/etc/gafaelfawr/secrets/session-secret"
     bootstrap_token_file: "/etc/gafaelfawr/secrets/bootstrap-token"
-    database_url: {{ required "config.databaseUrl must be set" .Values.config.databaseUrl | quote }}
     database_password_file: "/etc/gafaelfawr/secrets/database-password"
     redis_url: "redis://{{ template "gafaelfawr.fullname" . }}-redis.{{ .Release.Namespace }}:6379/0"
     redis_password_file: "/etc/gafaelfawr/secrets/redis-password"
@@ -180,3 +177,33 @@ data:
       - {{ $admin | quote }}
       {{- end }}
     {{- end }}
+{{- end }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "gafaelfawr.fullname" . }}-config
+  labels:
+    {{- include "gafaelfawr.labels" . | nindent 4 }}
+data:
+  gafaelfawr.yaml: |
+    {{- if .Values.cloudsql.enabled }}
+    database_url: "postgresql://gafaelfawr@cloud-sql-proxy/gafaelfawr"
+    {{- else }}
+    database_url: {{ required "config.databaseUrl must be set" .Values.config.databaseUrl | quote }}
+    {{- end }}
+    {{- template "gafaelfawr.configMap" . }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "gafaelfawr.fullname" . }}-config-sidecar
+  labels:
+    {{- include "gafaelfawr.labels" . | nindent 4 }}
+data:
+  gafaelfawr.yaml: |
+    {{- if .Values.cloudsql.enabled }}
+    database_url: "postgresql://gafaelfawr@localhost/gafaelfawr"
+    {{- else }}
+    database_url: {{ required "config.databaseUrl must be set" .Values.config.databaseUrl | quote }}
+    {{- end }}
+    {{- template "gafaelfawr.configMap" . }}

--- a/services/gafaelfawr/templates/cronjob-maintenance.yaml
+++ b/services/gafaelfawr/templates/cronjob-maintenance.yaml
@@ -20,59 +20,12 @@ spec:
             app.kubernetes.io/component: "maintenance"
         spec:
           restartPolicy: "Never"
-          {{- if .Values.cloudsql.enabled }}
-          serviceAccountName: {{ include "gafaelfawr.fullname" . }}
-          {{- else }}
           automountServiceAccountToken: false
-          {{- end }}
           containers:
-            {{- if .Values.cloudsql.enabled }}
-            - name: "cloud-sql-proxy"
-              # Running the sidecar as normal causes it to keep running and
-              # thus the Pod never exits, the Job never finishes, and the
-              # CronJob gets confused.  Have the main pod signal the sidecar
-              # by writing to a file on a shared emptyDir file system, and use
-              # a simple watcher loop in shell in the sidecar container to
-              # terminate the proxy when the main container finishes.
-              #
-              # Based on https://stackoverflow.com/questions/41679364/
-              command:
-                - "/bin/sh"
-                - "-c"
-              args:
-                - |
-                  /cloud_sql_proxy -ip_address_types=PRIVATE -instances={{ required "cloudsql.instanceConnectionName must be specified" .Values.cloudsql.instanceConnectionName }}=tcp:5432 &
-                  PID=$!
-                  while true; do
-                    if [[ -f "/lifecycle/main-terminated" ]]; then
-                      kill $PID
-                      exit 0
-                    fi
-                    sleep 1
-                  done
-              image: "{{ .Values.cloudsql.image.repository }}:{{ .Values.cloudsql.image.tag }}"
-              imagePullPolicy: {{ .Values.cloudsql.image.pullPolicy | quote }}
-              securityContext:
-                allowPrivilegeEscalation: false
-                capabilities:
-                  drop:
-                    - "all"
-                readOnlyRootFilesystem: true
-                runAsNonRoot: true
-                runAsUser: 65532
-                runAsGroup: 65532
-              volumeMounts:
-                - name: "lifecycle"
-                  mountPath: "/lifecycle"
-            {{- end }}
             - name: "gafaelfawr"
               command:
-                - "/bin/sh"
-                - "-c"
-              args:
-                - |
-                  gafaelfawr maintenance
-                  touch /lifecycle/main-terminated
+                - "gafaelfawr"
+                - "maintenance"
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
               imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
               {{- with .Values.maintenance.resources }}
@@ -89,8 +42,6 @@ spec:
                 - name: "config"
                   mountPath: "/etc/gafaelfawr"
                   readOnly: true
-                - name: "lifecycle"
-                  mountPath: "/lifecycle"
                 - name: "secret"
                   mountPath: "/etc/gafaelfawr/secrets"
                   readOnly: true
@@ -102,8 +53,6 @@ spec:
             - name: "config"
               configMap:
                 name: {{ template "gafaelfawr.fullname" . }}-config
-            - name: "lifecycle"
-              emptyDir: {}
             - name: "secret"
               secret:
                 secretName: {{ template "gafaelfawr.fullname" . }}-secret

--- a/services/gafaelfawr/templates/deployment-tokens.yaml
+++ b/services/gafaelfawr/templates/deployment-tokens.yaml
@@ -23,23 +23,6 @@ spec:
     spec:
       serviceAccountName: {{ include "gafaelfawr.fullname" . }}-tokens
       containers:
-        {{- if .Values.cloudsql.enabled }}
-        - name: "cloud-sql-proxy"
-          command:
-            - "/cloud_sql_proxy"
-            - "-ip_address_types=PRIVATE"
-            - "-instances={{ required "cloudsql.instanceConnectionName must be specified" .Values.cloudsql.instanceConnectionName }}=tcp:5432"
-          image: "{{ .Values.cloudsql.image.repository }}:{{ .Values.cloudsql.image.tag }}"
-          imagePullPolicy: {{ .Values.cloudsql.image.pullPolicy | quote }}
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - "all"
-            readOnlyRootFilesystem: true
-            runAsUser: 65532
-            runAsGroup: 65532
-        {{- end }}
         - name: "gafaelfawr-tokens"
           command:
             - "gafaelfawr"

--- a/services/gafaelfawr/templates/deployment.yaml
+++ b/services/gafaelfawr/templates/deployment.yaml
@@ -80,7 +80,7 @@ spec:
       volumes:
         - name: "config"
           configMap:
-            name: {{ template "gafaelfawr.fullname" . }}-config
+            name: {{ template "gafaelfawr.fullname" . }}-config-sidecar
         - name: "secret"
           secret:
             secretName: {{ template "gafaelfawr.fullname" . }}-secret

--- a/services/gafaelfawr/values-idfdev.yaml
+++ b/services/gafaelfawr/values-idfdev.yaml
@@ -4,13 +4,8 @@ redis:
     storageClass: "standard-rwo"
 
 config:
-  databaseUrl: "postgresql://gafaelfawr@localhost/gafaelfawr"
   loglevel: "DEBUG"
   slackAlerts: true
-
-  # Support OpenID Connect clients like Chronograf.
-  oidcServer:
-    enabled: true
 
   cilogon:
     clientId: "cilogon:/client_id/46f9ae932fd30e9fb1b246972a3c0720"
@@ -30,6 +25,10 @@ config:
     userBaseDn: "ou=people,o=LSST,o=CO,dc=lsst,dc=org"
     userSearchAttr: "voPersonApplicationUID"
     addUserGroup: true
+
+  # Support OpenID Connect clients like Chronograf.
+  oidcServer:
+    enabled: true
 
   groupMapping:
     "admin:provision":

--- a/services/gafaelfawr/values-idfint.yaml
+++ b/services/gafaelfawr/values-idfint.yaml
@@ -4,14 +4,12 @@ redis:
     storageClass: "standard-rwo"
 
 config:
-  databaseUrl: "postgresql://gafaelfawr@localhost/gafaelfawr"
+  github:
+    clientId: "0c4cc7eaffc0f89b9ace"
 
   # Support OpenID Connect clients like Chronograf.
   oidcServer:
     enabled: true
-
-  github:
-    clientId: "0c4cc7eaffc0f89b9ace"
 
   # Allow access by GitHub team.
   groupMapping:

--- a/services/gafaelfawr/values-idfprod.yaml
+++ b/services/gafaelfawr/values-idfprod.yaml
@@ -6,8 +6,6 @@ redis:
     storageClass: "standard-rwo"
 
 config:
-  databaseUrl: "postgresql://gafaelfawr@localhost/gafaelfawr"
-
   github:
     clientId: "65b6333a066375091548"
 

--- a/services/gafaelfawr/values-summit.yaml
+++ b/services/gafaelfawr/values-summit.yaml
@@ -7,13 +7,12 @@ redis:
 config:
   databaseUrl: "postgresql://gafaelfawr@postgres.postgres/gafaelfawr"
 
+  github:
+    clientId: "220d64cbf46f9d2b7873"
+
   # Support OpenID Connect clients like Chronograf.
   oidcServer:
     enabled: true
-
-  # Use GitHub authentication.
-  github:
-    clientId: "220d64cbf46f9d2b7873"
 
   # Allow access by GitHub team.
   groupMapping:

--- a/services/gafaelfawr/values-tucson-teststand.yaml
+++ b/services/gafaelfawr/values-tucson-teststand.yaml
@@ -7,13 +7,12 @@ redis:
 config:
   databaseUrl: "postgresql://gafaelfawr@postgres.postgres/gafaelfawr"
 
+  github:
+    clientId: "49533cbd8a8079730dcf"
+
   # Support OpenID Connect clients like Chronograf.
   oidcServer:
     enabled: true
-
-  # Use GitHub authentication.
-  github:
-    clientId: "49533cbd8a8079730dcf"
 
   # Allow access by GitHub team.
   groupMapping:

--- a/services/gafaelfawr/values.yaml
+++ b/services/gafaelfawr/values.yaml
@@ -37,7 +37,7 @@ affinity: {}
 
 config:
   # -- URL for the PostgreSQL database
-  # @default -- None, must be set
+  # @default -- None, must be set if `cloudsql.enabled` is not true
   databaseUrl: ""
 
   # -- Choose from the text form of Python logging levels
@@ -239,8 +239,10 @@ config:
   errorFooter: ""
 
 cloudsql:
-  # -- Enable the Cloud SQL Auth Proxy sidecar, used with CloudSQL databases
-  # on Google Cloud
+  # -- Enable the Cloud SQL Auth Proxy, used with CloudSQL databases on Google
+  # Cloud. This will be run as a sidecar for the main Gafaelfawr pods, and as
+  # a separate service (behind a `NetworkPolicy`) for other, lower-traffic
+  # services.
   enabled: false
 
   image:
@@ -248,18 +250,34 @@ cloudsql:
     repository: "gcr.io/cloudsql-docker/gce-proxy"
 
     # -- Cloud SQL Auth Proxy tag to use
-    tag: "1.31.2-alpine"
+    tag: "1.31.2"
 
     # -- Pull policy for Cloud SQL Auth Proxy images
     pullPolicy: "IfNotPresent"
 
   # -- Instance connection name for a CloudSQL PostgreSQL instance
+  # @default -- None, must be set if Cloud SQL Auth Proxy is enabled
   instanceConnectionName: ""
 
   # -- The Google service account that has an IAM binding to the `gafaelfawr`
-  # and `gafaelfawr-tokens` Kubernetes service accounts and has the
-  # `cloudsql.client` role
+  # Kubernetes service account and has the `cloudsql.client` role
+  # @default -- None, must be set if Cloud SQL Auth Proxy is enabled
   serviceAccount: ""
+
+  # -- Resource limits and requests for the Cloud SQL Proxy pod
+  resources: {}
+
+  # -- Annotations for the Cloud SQL Proxy pod
+  podAnnotations: {}
+
+  # -- Node selection rules for the Cloud SQL Proxy pod
+  nodeSelector: {}
+
+  # -- Tolerations for the Cloud SQL Proxy pod
+  tolerations: []
+
+  # -- Affinity rules for the Cloud SQL Proxy pod
+  affinity: {}
 
 maintenance:
   # -- Resource limits and requests for the Gafaelfawr maintenance pod


### PR DESCRIPTION
Using a Cloud SQL Proxy sidecar for CronJob resources is very
annoying, since one has to coordinate stopping the Cloud SQL Proxy
server so that the CronJob can exit, which in turn requires a bunch
of opaque shell gunk.

Since we're about to add another CronJob, add a separate Cloud SQL
Proxy service that can be used by all the non-critical, low-volume
services (the Kubernetes operator and the CronJobs to start).
Continue to use the sidecar for the main Gafaelfawr pods so that
the proxy will scale with the pods and the critical Gafaelfawr
service doesn't have a single point of failure.

Add a NetworkPolicy to keep anything else in the cluster from talking
to the Cloud SQL Proxy pod.  This will only work at Google, but this
service is only used at Google, so that should be sufficient.

This requires generating two versions of the Gafaelfawr ConfigMap,
since the database URL has to be different between the Gafaelfawr
pods (using localhost) and the other pods (using the service in the
same namespace).  Do that with multiple resources and a Helm define
inside that template.

Drop the database URL from values.yaml for environments where the
Cloud SQL Proxy is used, since we always know what it is (and have
to adjust it for the two different deployment patterns).