### PR TITLE
[DM-35977] Improve Argo CD application configuration

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -41,11 +41,13 @@ helm upgrade vault-secrets-operator ../services/vault-secrets-operator \
   --timeout 15m \
   --wait
 
-echo "Update / install argocd using helm3..."
+echo "Update / install argocd using helm..."
 helm dependency update ../services/argocd
 helm upgrade argocd ../services/argocd \
   --install \
+  --values ../services/argocd/values.yaml \
   --values ../services/argocd/values-$ENVIRONMENT.yaml \
+  --set global.vaultSecretsPath="$VAULT_PATH_PREFIX" \
   --create-namespace \
   --namespace argocd \
   --timeout 15m \

--- a/science-platform/templates/argocd-application.yaml
+++ b/science-platform/templates/argocd-application.yaml
@@ -1,20 +1,23 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: argocd
-  namespace: argocd
+  name: "argocd"
+  namespace: "argocd"
   finalizers:
-    - resources-finalizer.argocd.argoproj.io
+    - "resources-finalizer.argocd.argoproj.io"
 spec:
   destination:
-    namespace: argocd
-    server: https://kubernetes.default.svc
-  project: default
+    namespace: "argocd"
+    server: "https://kubernetes.default.svc"
+  project: "default"
   source:
-    path: services/argocd
-    repoURL: {{ .Values.repoURL }}
-    targetRevision: {{ .Values.revision }}
+    path: "services/argocd"
+    repoURL: {{ .Values.repoURL | quote }}
+    targetRevision: {{ .Values.revision | quote }}
     helm:
+      parameters:
+        - name: "global.vaultSecretsPath"
+          value: {{ .Values.vault_path_prefix | quote }}
       valueFiles:
-        - values.yaml
-        - values-{{ .Values.environment }}.yaml
+        - "values.yaml"
+        - "values-{{ .Values.environment }}.yaml"

--- a/services/argocd/README.md
+++ b/services/argocd/README.md
@@ -23,10 +23,10 @@
 | argo-cd.server.config."resource.compareoptions" | string | `"ignoreAggregatedRoles: true\n"` |  |
 | argo-cd.server.extraArgs[0] | string | `"--basehref=/argo-cd"` |  |
 | argo-cd.server.extraArgs[1] | string | `"--insecure=true"` |  |
-| argo-cd.server.ingress.annotations."kubernetes.io/ingress.class" | string | `"nginx"` |  |
 | argo-cd.server.ingress.annotations."nginx.ingress.kubernetes.io/rewrite-target" | string | `"/$2"` |  |
 | argo-cd.server.ingress.enabled | bool | `true` |  |
+| argo-cd.server.ingress.ingressClassName | string | `"nginx"` |  |
+| argo-cd.server.ingress.pathType | string | `"ImplementationSpecific"` |  |
 | argo-cd.server.ingress.paths[0] | string | `"/argo-cd(/|$)(.*)"` |  |
 | argo-cd.server.metrics.enabled | bool | `true` |  |
-| vault_secret.enabled | bool | `true` |  |
-| vault_secret.path | string | `""` |  |
+| global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |

--- a/services/argocd/templates/vault-secrets.yaml
+++ b/services/argocd/templates/vault-secrets.yaml
@@ -1,9 +1,7 @@
-{{ if .Values.vault_secret.enabled }}
 apiVersion: ricoberger.de/v1alpha1
 kind: VaultSecret
 metadata:
   name: argocd-secret
 spec:
-  path: {{ .Values.vault_secret.path }}
+  path: "{{ .Values.global.vaultSecretsPath }}/argocd"
   type: Opaque
-{{ end }}

--- a/services/argocd/values-base.yaml
+++ b/services/argocd/values-base.yaml
@@ -4,7 +4,7 @@ argo-cd:
       hosts:
         - "base-lsp.lsst.codes"
     config:
-      url: https://base-lsp.lsst.codes/argo-cd
+      url: "https://base-lsp.lsst.codes/argo-cd"
       dex.config: |
         connectors:
           # Auth using GitHub.
@@ -23,7 +23,3 @@ argo-cd:
       policy.csv: |
         g, lsst-sqre:friends, role:admin
         g, lsst-sqre:square, role:admin
-
-vault_secret:
-  enabled: true
-  path: secret/k8s_operator/base-lsp.lsst.codes/argocd

--- a/services/argocd/values-idfdev.yaml
+++ b/services/argocd/values-idfdev.yaml
@@ -1,12 +1,11 @@
 argo-cd:
   server:
     ingress:
-      enabled: true
       hosts:
         - "data-dev.lsst.cloud"
 
     config:
-      url: https://data-dev.lsst.cloud/argo-cd
+      url: "https://data-dev.lsst.cloud/argo-cd"
       dex.config: |
         connectors:
           # Auth using Google.
@@ -35,7 +34,3 @@ argo-cd:
         g, loi@lsst.cloud, role:admin
         g, roby@lsst.cloud, role:admin
       scopes: "[email]"
-
-vault_secret:
-  enabled: true
-  path: secret/k8s_operator/data-dev.lsst.cloud/argocd

--- a/services/argocd/values-idfint.yaml
+++ b/services/argocd/values-idfint.yaml
@@ -3,8 +3,9 @@ argo-cd:
     ingress:
       hosts:
         - "data-int.lsst.cloud"
+
     config:
-      url: https://data-int.lsst.cloud/argo-cd
+      url: "https://data-int.lsst.cloud/argo-cd"
       dex.config: |
         connectors:
           # Auth using Google.
@@ -35,7 +36,3 @@ argo-cd:
         g, roby@lsst.cloud, role:admin
         g, fritzm@lsst.cloud, role:admin
       scopes: "[email]"
-
-vault_secret:
-  enabled: true
-  path: secret/k8s_operator/data-int.lsst.cloud/argocd

--- a/services/argocd/values-idfprod.yaml
+++ b/services/argocd/values-idfprod.yaml
@@ -3,8 +3,9 @@ argo-cd:
     ingress:
       hosts:
         - "data.lsst.cloud"
+
     config:
-      url: https://data.lsst.cloud/argo-cd
+      url: "https://data.lsst.cloud/argo-cd"
       dex.config: |
         connectors:
           # Auth using Google.
@@ -33,7 +34,3 @@ argo-cd:
         g, loi@lsst.cloud, role:admin
         g, roby@lsst.cloud, role:admin
       scopes: "[email]"
-
-vault_secret:
-  enabled: true
-  path: secret/k8s_operator/data.lsst.cloud/argocd

--- a/services/argocd/values-minikube.yaml
+++ b/services/argocd/values-minikube.yaml
@@ -2,11 +2,8 @@ argo-cd:
   controller:
     args:
       repoServerTimeoutSeconds: "180"
+
   server:
     ingress:
       hosts:
         - "minikube.lsst.codes"
-
-vault_secret:
-  enabled: true
-  path: secret/k8s_operator/minikube.lsst.codes/argocd

--- a/services/argocd/values-roe.yaml
+++ b/services/argocd/values-roe.yaml
@@ -5,11 +5,8 @@ argo-cd:
         - "rsp.lsst.ac.uk"
 
     config:
-      url: https://rsp.lsst.ac.uk/argo-cd
+      url: "https://rsp.lsst.ac.uk/argo-cd"
+
   configs:
     secret:
       createSecret: true
-
-vault_secret:
-  enabled: true
-  path: secret/k8s_operator/roe/argocd

--- a/services/argocd/values-summit.yaml
+++ b/services/argocd/values-summit.yaml
@@ -3,8 +3,9 @@ argo-cd:
     ingress:
       hosts:
         - "summit-lsp.lsst.codes"
+
     config:
-      url: https://summit-lsp.lsst.codes/argo-cd
+      url: "https://summit-lsp.lsst.codes/argo-cd"
       dex.config: |
         connectors:
           # Auth using GitHub.
@@ -22,7 +23,3 @@ argo-cd:
       policy.csv: |
         g, lsst-sqre:friends, role:admin
         g, lsst-sqre:square, role:admin
-
-vault_secret:
-  enabled: true
-  path: secret/k8s_operator/summit-lsp.lsst.codes/argocd

--- a/services/argocd/values-tucson-teststand.yaml
+++ b/services/argocd/values-tucson-teststand.yaml
@@ -3,8 +3,9 @@ argo-cd:
     ingress:
       hosts:
         - "tucson-teststand.lsst.codes"
+
     config:
-      url: https://tucson-teststand.lsst.codes/argo-cd
+      url: "https://tucson-teststand.lsst.codes/argo-cd"
       dex.config: |
         connectors:
           # Auth using GitHub.
@@ -22,7 +23,3 @@ argo-cd:
       policy.csv: |
         g, lsst-sqre:friends, role:admin
         g, lsst-sqre:square, role:admin
-
-vault_secret:
-  enabled: true
-  path: secret/k8s_operator/tucson-teststand.lsst.codes/argocd

--- a/services/argocd/values.yaml
+++ b/services/argocd/values.yaml
@@ -1,5 +1,5 @@
 ## Argo CD configuration
-## https://github.com/argoproj/argo-helm/blob/master/charts/argo-cd/values.yaml
+## https://github.com/argoproj/argo-helm/blob/main/charts/argo-cd/values.yaml
 argo-cd:
   redis:
     enabled: true
@@ -27,10 +27,11 @@ argo-cd:
     ingress:
       enabled: true
       annotations:
-        kubernetes.io/ingress.class: nginx
         nginx.ingress.kubernetes.io/rewrite-target: "/$2"
+      ingressClassName: "nginx"
       paths:
-        - /argo-cd(/|$)(.*)
+        - "/argo-cd(/|$)(.*)"
+      pathType: "ImplementationSpecific"
 
     extraArgs:
       - "--basehref=/argo-cd"
@@ -55,6 +56,9 @@ argo-cd:
     secret:
       createSecret: false
 
-vault_secret:
-  enabled: true
-  path: ""
+# The following will be set by parameters injected by Argo CD and should not
+# be set in the individual environment values files.
+global:
+  # -- Base path for Vault secrets
+  # @default -- Set by Argo CD
+  vaultSecretsPath: ""


### PR DESCRIPTION
Inject the Vault secrets path like we do for other applications,
and modify the installer to also inject it (and correctly pass in
both values.yaml files; I'm not sure how it was working before).
Install the Vault secret unconditionally, since it was enabled for
every environment, and remove the configuration from the individual
values files.