### PR TITLE
[DM-35977] Use ingressClassName instead of an annotation

### DIFF
--- a/services/cachemachine/README.md
+++ b/services/cachemachine/README.md
@@ -18,7 +18,6 @@ Service to prepull Docker images for the Science Platform
 | ingress.annotations | object | `{}` | Additional annotations to add for endpoints that are authenticated. |
 | ingress.anonymousAnnotations | object | `{}` | Additional annotations to add for endpoints that allow anonymous access, such as `/*/available`. |
 | ingress.gafaelfawrAuthQuery | string | `"scope=exec:admin"` | Gafaelfawr auth query string |
-| ingress.tls | list | `[]` | Configures TLS for the ingress if needed. If multiple ingresses share the same hostname, only one of them needs a TLS configuration. |
 | nameOverride | string | `""` | Override the base name for resources |
 | nodeSelector | object | `{}` | Node selector rules for the cachemachine frontend pod |
 | podAnnotations | object | `{}` | Annotations for the cachemachine frontend pod |

--- a/services/cachemachine/templates/ingress-anonymous.yaml
+++ b/services/cachemachine/templates/ingress-anonymous.yaml
@@ -2,7 +2,6 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/use-regex: "true"
     {{- with .Values.ingress.anonymousAnnotations }}
     {{- toYaml . | nindent 4 }}
@@ -11,18 +10,12 @@ metadata:
   labels:
     {{- include "cachemachine.labels" . | nindent 4 }}
 spec:
+  ingressClassName: "nginx"
   rules:
     - host: {{ required "global.host must be set" .Values.global.host | quote }}
       http:
         paths:
-          - path: "/cachemachine/.*/available"
-            pathType: "ImplementationSpecific"
-            backend:
-              service:
-                name: {{ template "cachemachine.fullname" . }}
-                port:
-                  number: 80
-          - path: "/cachemachine/.*/desired"
+          - path: "/cachemachine/.*/(available|desired)"
             pathType: "ImplementationSpecific"
             backend:
               service:

--- a/services/cachemachine/templates/ingress.yaml
+++ b/services/cachemachine/templates/ingress.yaml
@@ -2,7 +2,6 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     {{- if .Values.ingress.gafaelfawrAuthQuery }}
     nginx.ingress.kubernetes.io/auth-method: "GET"
     nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-User"
@@ -16,6 +15,7 @@ metadata:
   labels:
     {{- include "cachemachine.labels" . | nindent 4 }}
 spec:
+  ingressClassName: "nginx"
   rules:
     - host: {{ required "global.host must be set" .Values.global.host | quote }}
       http:
@@ -27,13 +27,3 @@ spec:
                 name: {{ template "cachemachine.fullname" . }}
                 port:
                   number: 80
-  {{- if .Values.ingress.tls }}
-  tls:
-    {{- range .Values.ingress.tls }}
-    - hosts:
-        {{- range .hosts }}
-        - {{ . | quote }}
-        {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
-  {{- end }}

--- a/services/cachemachine/values.yaml
+++ b/services/cachemachine/values.yaml
@@ -37,10 +37,6 @@ ingress:
   # access, such as `/*/available`.
   anonymousAnnotations: {}
 
-  # -- Configures TLS for the ingress if needed. If multiple ingresses share
-  # the same hostname, only one of them needs a TLS configuration.
-  tls: []
-
 # -- Resource limits and requests for the cachemachine frontend pod
 resources: {}
 

--- a/services/exposurelog/templates/ingress.yaml
+++ b/services/exposurelog/templates/ingress.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "exposurelog.labels" . | nindent 4 }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     {{- if .Values.ingress.gafaelfawrAuthQuery }}
     nginx.ingress.kubernetes.io/auth-method: "GET"
     nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-User,X-Auth-Request-Email,X-Auth-Request-Token"
@@ -16,6 +15,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  ingressClassName: "nginx"
   rules:
     - host: {{ required "global.host must be set" .Values.global.host | quote }}
       http:

--- a/services/gafaelfawr/templates/ingress-rewrite.yaml
+++ b/services/gafaelfawr/templates/ingress-rewrite.yaml
@@ -2,13 +2,13 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/rewrite-target: "/auth/tokens/"
     nginx.ingress.kubernetes.io/use-regex: "true"
   name: {{ template "gafaelfawr.fullname" . }}-rewrite
   labels:
     {{- include "gafaelfawr.labels" . | nindent 4 }}
 spec:
+  ingressClassName: "nginx"
   rules:
     - host: {{ required "global.host must be set" .Values.global.host | quote }}
       http:

--- a/services/gafaelfawr/templates/ingress.yaml
+++ b/services/gafaelfawr/templates/ingress.yaml
@@ -1,12 +1,11 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  annotations:
-    kubernetes.io/ingress.class: "nginx"
   name: {{ template "gafaelfawr.fullname" . }}
   labels:
     {{- include "gafaelfawr.labels" . | nindent 4 }}
 spec:
+  ingressClassName: "nginx"
   rules:
     - host: {{ required "global.host must be set" .Values.global.host | quote }}
       http:
@@ -39,6 +38,7 @@ spec:
                 name: {{ template "gafaelfawr.fullname" . }}
                 port:
                   number: 8080
+          {{- if .Values.config.oidcServer.enabled }}
           - path: "/.well-known/jwks.json"
             pathType: Exact
             backend:
@@ -46,7 +46,6 @@ spec:
                 name: {{ template "gafaelfawr.fullname" . }}
                 port:
                   number: 8080
-          {{- if .Values.config.oidcServer.enabled }}
           - path: "/.well-known/openid-configuration"
             pathType: Exact
             backend:

--- a/services/hips/templates/ingress.yaml
+++ b/services/hips/templates/ingress.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "hips.labels" . | nindent 4 }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     {{- if .Values.ingress.gafaelfawrAuthQuery }}
     nginx.ingress.kubernetes.io/auth-method: "GET"
     nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-User"
@@ -15,6 +14,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  ingressClassName: "nginx"
   rules:
     - host: {{ required "global.host must be set" .Values.global.host | quote }}
       http:

--- a/services/mobu/templates/ingress.yaml
+++ b/services/mobu/templates/ingress.yaml
@@ -2,7 +2,6 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     {{- if .Values.ingress.gafaelfawrAuthQuery }}
     nginx.ingress.kubernetes.io/auth-method: "GET"
     nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-User"
@@ -16,6 +15,7 @@ metadata:
   labels:
     {{- include "mobu.labels" . | nindent 4 }}
 spec:
+  ingressClassName: "nginx"
   rules:
     - host: {{ required "global.host must be set" .Values.global.host | quote }}
       http:

--- a/services/moneypenny/templates/ingress.yaml
+++ b/services/moneypenny/templates/ingress.yaml
@@ -2,7 +2,6 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/auth-method: "GET"
     nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.baseUrl }}/auth?{{ required "ingress.gafaelfawrAuthQuery must be set" .Values.ingress.gafaelfawrAuthQuery }}"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "310"
@@ -13,6 +12,7 @@ metadata:
   labels:
     {{- include "moneypenny.labels" . | nindent 4 }}
 spec:
+  ingressClassName: "nginx"
   rules:
     - host: {{ required "global.host must be set" .Values.global.host | quote }}
       http:

--- a/services/narrativelog/templates/ingress.yaml
+++ b/services/narrativelog/templates/ingress.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "narrativelog.labels" . | nindent 4 }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     {{- if .Values.ingress.gafaelfawrAuthQuery }}
     nginx.ingress.kubernetes.io/auth-method: "GET"
     nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-User,X-Auth-Request-Email,X-Auth-Request-Token"
@@ -16,6 +15,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  ingressClassName: "nginx"
   rules:
     - host: {{ required "global.host must be set" .Values.global.host | quote }}
       http:

--- a/services/noteburst/templates/ingress.yaml
+++ b/services/noteburst/templates/ingress.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     {{- include "noteburst.labels" . | nindent 4 }}
   annotations:
-    kubernetes.io/ingress.class: nginx
     {{- if .Values.ingress.gafaelfawrAuthQuery }}
     nginx.ingress.kubernetes.io/auth-method: "GET"
     nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-User,X-Auth-Request-Email,X-Auth-Request-Token
@@ -17,6 +16,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  ingressClassName: "nginx"
   rules:
     - host: {{ required "global.host must be set" .Values.global.host | quote }}
       http:

--- a/services/nublado2/README.md
+++ b/services/nublado2/README.md
@@ -70,12 +70,12 @@ Kubernetes: `>=1.20.0-0`
 | jupyterhub.hub.resources.limits.cpu | string | `"900m"` |  |
 | jupyterhub.hub.resources.limits.memory | string | `"1Gi"` |  |
 | jupyterhub.imagePullSecrets[0].name | string | `"pull-secret"` |  |
-| jupyterhub.ingress.annotations."kubernetes.io/ingress.class" | string | `"nginx"` |  |
 | jupyterhub.ingress.annotations."nginx.ingress.kubernetes.io/auth-method" | string | `"GET"` |  |
 | jupyterhub.ingress.annotations."nginx.ingress.kubernetes.io/auth-response-headers" | string | `"X-Auth-Request-Token"` |  |
 | jupyterhub.ingress.annotations."nginx.ingress.kubernetes.io/auth-url" | string | `"http://gafaelfawr.gafaelfawr.svc.cluster.local:8080/auth?scope=exec:notebook&notebook=true"` |  |
 | jupyterhub.ingress.annotations."nginx.ingress.kubernetes.io/configuration-snippet" | string | `"error_page 403 = \"/auth/forbidden?scope=exec:notebook\";\n"` |  |
 | jupyterhub.ingress.enabled | bool | `true` |  |
+| jupyterhub.ingress.ingressClassName | string | `"nginx"` |  |
 | jupyterhub.ingress.pathSuffix | string | `"*"` |  |
 | jupyterhub.prePuller.continuous.enabled | bool | `false` |  |
 | jupyterhub.prePuller.hook.enabled | bool | `false` |  |

--- a/services/nublado2/values.yaml
+++ b/services/nublado2/values.yaml
@@ -160,12 +160,12 @@ jupyterhub:
   ingress:
     enabled: true
     annotations:
-      kubernetes.io/ingress.class: nginx
       nginx.ingress.kubernetes.io/auth-method: GET
       nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-Token"
       nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr.gafaelfawr.svc.cluster.local:8080/auth?scope=exec:notebook&notebook=true"
       nginx.ingress.kubernetes.io/configuration-snippet: |
         error_page 403 = "/auth/forbidden?scope=exec:notebook";
+    ingressClassName: "nginx"
     pathSuffix: "*"
 
   cull:

--- a/services/plot-navigator/templates/ingress.yaml
+++ b/services/plot-navigator/templates/ingress.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "plot-navigator.labels" . | nindent 4 }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     {{- if .Values.ingress.gafaelfawrAuthQuery }}
     nginx.ingress.kubernetes.io/auth-method: "GET"
     nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-User,X-Auth-Request-Email,X-Auth-Request-Token"
@@ -16,6 +15,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  ingressClassName: "nginx"
   rules:
   - host: {{ required "global.host must be set" .Values.global.host | quote }}
     http:

--- a/services/portal/templates/ingress-admin.yaml
+++ b/services/portal/templates/ingress-admin.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     {{- include "portal.labels" . | nindent 4 }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/session-cookie-change-on-failure: "true"
@@ -31,6 +30,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  ingressClassName: "nginx"
   rules:
     - host: {{ required "global.host must be set" .Values.global.host | quote }}
       http:

--- a/services/portal/templates/ingress.yaml
+++ b/services/portal/templates/ingress.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "portal.labels" . | nindent 4 }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/session-cookie-change-on-failure: "true"
@@ -32,6 +31,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  ingressClassName: "nginx"
   rules:
     - host: {{ required "global.host must be set" .Values.global.host | quote }}
       http:

--- a/services/production-tools/templates/ingress.yaml
+++ b/services/production-tools/templates/ingress.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     {{- include "production-tools.labels" . | nindent 4 }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     {{- if .Values.ingress.gafaelfawrAuthQuery }}
     nginx.ingress.kubernetes.io/auth-method: "GET"
     nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-User"
@@ -17,6 +16,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  ingressClassName: "nginx"
   rules:
     - host: {{ required ".Values.global.host must be set" .Values.global.host | quote }}
       http:

--- a/services/sasquatch/charts/kafdrop/templates/ingress.yaml
+++ b/services/sasquatch/charts/kafdrop/templates/ingress.yaml
@@ -8,11 +8,11 @@ metadata:
   labels:
     {{- include "kafdrop.labels" . | nindent 4 }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     {{- with .Values.ingress.annotations }}
     {{ toYaml . | indent 4 }}
     {{- end }}
 spec:
+  ingressClassName: "nginx"
   rules:
     - host: {{ .Values.ingress.hostname | quote }}
       http:

--- a/services/sasquatch/values-tucson-teststand.yaml
+++ b/services/sasquatch/values-tucson-teststand.yaml
@@ -15,7 +15,6 @@ influxdb:
     secretName: tls-certs
     hostname: influxdb-tucson-teststand-efd.lsst.codes
     annotations:
-      kubernetes.io/ingress.class: "nginx"
       nginx.ingress.kubernetes.io/ssl-redirect: "true"
       nginx.ingress.kubernetes.io/affinity: "cookie"
       nginx.ingress.kubernetes.io/proxy-body-size: "0m"

--- a/services/sasquatch/values.yaml
+++ b/services/sasquatch/values.yaml
@@ -32,8 +32,8 @@ influxdb:
     tls: false
     hostname: ""
     annotations:
-      kubernetes.io/ingress.class: "nginx"
       nginx.ingress.kubernetes.io/rewrite-target: /$2
+    className: "nginx"
     path: /influxdb(/|$)(.*)
   # -- Override InfluxDB configuration.
   # See https://docs.influxdata.com/influxdb/v1.8/administration/config
@@ -81,8 +81,7 @@ chronograf:
     enabled: false
     tls: false
     hostname: ""
-    annotations:
-      kubernetes.io/ingress.class: "nginx"
+    className: "nginx"
     path: /chronograf(/|$)
   # -- Chronograf environment variables.
   env:

--- a/services/semaphore/templates/ingress.yaml
+++ b/services/semaphore/templates/ingress.yaml
@@ -6,11 +6,11 @@ metadata:
   labels:
     {{- include "semaphore.labels" . | nindent 4 }}
   annotations:
-    kubernetes.io/ingress.class: nginx
     {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  ingressClassName: "nginx"
   rules:
     - host: {{ required "global.host must be set" .Values.global.host | quote }}
       http:

--- a/services/sherlock/templates/ingress.yaml
+++ b/services/sherlock/templates/ingress.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     {{- include "sherlock.labels" . | nindent 4 }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     {{- if .Values.ingress.gafaelfawrAuthQuery }}
     nginx.ingress.kubernetes.io/auth-method: GET
     nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-User,X-Auth-Request-Email,X-Auth-Request-Token
@@ -19,6 +18,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  ingressClassName: "nginx"
   rules:
     - host: {{ required "global.host must be set" .Values.global.host | quote }}
       http:

--- a/services/squareone/templates/ingress.yaml
+++ b/services/squareone/templates/ingress.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     {{- include "squareone.labels" . | nindent 4 }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     {{- if .Values.ingress.tls }}
     cert-manager.io/cluster-issuer: "letsencrypt-dns"
     {{- end }}
@@ -15,6 +14,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  ingressClassName: "nginx"
   {{- if .Values.ingress.tls }}
   tls:
     - hosts:

--- a/services/tap/templates/tap-ingress-anonymous.yaml
+++ b/services/tap/templates/tap-ingress-anonymous.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "cadc-tap.labels" . | nindent 4 }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "900"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "900"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "900"
@@ -18,6 +17,7 @@ metadata:
     {{- toYaml . | indent 4}}
     {{- end }}
 spec:
+  ingressClassName: "nginx"
   rules:
     - host: {{ required "global.host must be set" .Values.global.host | quote }}
       http:

--- a/services/tap/templates/tap-ingress-authenticated.yaml
+++ b/services/tap/templates/tap-ingress-authenticated.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "cadc-tap.labels" . | nindent 4 }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/auth-method: "GET"
     nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-Uid, X-Auth-Request-Token"
     nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.baseUrl }}/auth?{{ .Values.ingress.gafaelfawrAuthQuery }}"
@@ -24,6 +23,7 @@ metadata:
     {{- toYaml . | indent 4}}
     {{- end }}
 spec:
+  ingressClassName: "nginx"
   rules:
     - host: {{ required "global.host must be set" .Values.global.host | quote }}
       http:

--- a/services/times-square/README.md
+++ b/services/times-square/README.md
@@ -42,6 +42,7 @@ An API service for managing and rendering parameterized Jupyter notebooks.
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` | Secret names to use for all Docker pulls |
 | ingress.annotations | object | `{}` | Additional annotations for the ingress rule |
+| ingress.className | string | `"nginx"` | Class name that should serve this ingress |
 | ingress.enabled | bool | `true` | Create an ingress resource |
 | ingress.gafaelfawrAuthQuery | string | `"scope=exec:admin&auth_type=basic"` | Gafaelfawr auth query string |
 | ingress.path | string | `"/times-square/api"` | Root URL path prefix for times-square API |

--- a/services/times-square/templates/ingress-webhooks.yaml
+++ b/services/times-square/templates/ingress-webhooks.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     {{- include "times-square.labels" . | nindent 4 }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/services/times-square/templates/ingress.yaml
+++ b/services/times-square/templates/ingress.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     {{- include "times-square.labels" . | nindent 4 }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     {{- if .Values.ingress.gafaelfawrAuthQuery }}
     nginx.ingress.kubernetes.io/auth-method: GET
     nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-User,X-Auth-Request-Email,X-Auth-Request-Token

--- a/services/times-square/values.yaml
+++ b/services/times-square/values.yaml
@@ -62,6 +62,9 @@ ingress:
   # -- Additional annotations for the ingress rule
   annotations: {}
 
+  # -- Class name that should serve this ingress
+  className: "nginx"
+
   # -- Path type for the ingress rule
   pathType: ImplementationSpecific
 

--- a/services/vo-cutouts/templates/ingress.yaml
+++ b/services/vo-cutouts/templates/ingress.yaml
@@ -2,7 +2,6 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     {{- if .Values.ingress.gafaelfawrAuthQuery }}
     nginx.ingress.kubernetes.io/auth-method: "GET"
     nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-User
@@ -16,6 +15,7 @@ metadata:
   labels:
     {{- include "vo-cutouts.labels" . | nindent 4 }}
 spec:
+  ingressClassName: "nginx"
   rules:
     - host: {{ required "global.host must be set" .Values.global.host | quote }}
       http:

--- a/starters/web-service/templates/ingress.yaml
+++ b/starters/web-service/templates/ingress.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "<CHARTNAME>.labels" . | nindent 4 }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     {{- if .Values.ingress.gafaelfawrAuthQuery }}
     nginx.ingress.kubernetes.io/auth-method: "GET"
     nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-User"
@@ -16,6 +15,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  ingressClassName: "nginx"
   rules:
     - host: {{ required "global.host must be set" .Values.global.host | quote }}
       http:


### PR DESCRIPTION
The current Ingress API supports ingressClassName to configure the
name of the ingress controller that should serve this ingress.  Use
this instead of the older annotation to configure all ingresses to
use nginx.

Drop an old tls configuration for cachemachine. We only do tls via
squareone.

Hide another Gafaelfawr route only used for OpenID Connect if OpenID
Connect is not enabled.