### PR TITLE
[DM-35977] Add read:image scopes to T&S deployments

### DIFF
--- a/services/gafaelfawr/values-base.yaml
+++ b/services/gafaelfawr/values-base.yaml
@@ -26,6 +26,11 @@ config:
       - "lsst-sqre-friends"
       - "lsst-ts-base-access"
       - "rubin-summit-rsp-access"
+    "read:image":
+      - "lsst-sqre-square"
+      - "lsst-sqre-friends"
+      - "lsst-ts-base-access"
+      - "rubin-summit-rsp-access"
     "read:tap":
       - "lsst-sqre-square"
       - "lsst-sqre-friends"

--- a/services/gafaelfawr/values-summit.yaml
+++ b/services/gafaelfawr/values-summit.yaml
@@ -31,6 +31,11 @@ config:
       - "lsst-sqre-friends"
       - "lsst-ts-summit-access"
       - "rubin-summit-rsp-access"
+    "read:image":
+      - "lsst-sqre-square"
+      - "lsst-sqre-friends"
+      - "lsst-ts-summit-access"
+      - "rubin-summit-rsp-access"
     "read:tap":
       - "lsst-sqre-square"
       - "lsst-sqre-friends"

--- a/services/gafaelfawr/values-tucson-teststand.yaml
+++ b/services/gafaelfawr/values-tucson-teststand.yaml
@@ -31,6 +31,11 @@ config:
       - "lsst-sqre-friends"
       - "lsst-ts-base-access"
       - "rubin-summit-rsp-access"
+    "read:image":
+      - "lsst-sqre-square"
+      - "lsst-sqre-friends"
+      - "lsst-ts-base-access"
+      - "rubin-summit-rsp-access"
     "read:tap":
       - "lsst-sqre-square"
       - "lsst-sqre-friends"


### PR DESCRIPTION
I didn't add these when the scope was added for the cutout service,
since it wasn't clear we would have images in the same sense on T&S
deployments, but now the Portal requests this scope, which means users
have to have it when using the Portal to do image display.  It's
simpler to just grant the scope to the same groups as have exec:portal
access than try to change the scope requirements in those environments.
This matches what we did with read:tap, which also isn't directly in
use there.