### PR TITLE
[DM-35977] Clean up unused injected variables

### DIFF
--- a/science-platform/templates/noteburst-application.yaml
+++ b/science-platform/templates/noteburst-application.yaml
@@ -29,8 +29,6 @@ spec:
           value: {{ .Values.fqdn | quote }}
         - name: "global.baseUrl"
           value: "https://{{ .Values.fqdn }}"
-        - name: "global.vaultSecretsPathPrefix"
-          value: {{ .Values.vault_path_prefix | quote }}
       valueFiles:
         - "values.yaml"
         - "values-{{ .Values.environment }}.yaml"

--- a/science-platform/templates/tap-schema-application.yaml
+++ b/science-platform/templates/tap-schema-application.yaml
@@ -25,10 +25,6 @@ spec:
     targetRevision: {{ .Values.revision | quote }}
     helm:
       parameters:
-        - name: "global.host"
-          value: {{ .Values.fqdn | quote }}
-        - name: "global.baseUrl"
-          value: "https://{{ .Values.fqdn }}"
         - name: "global.vaultSecretsPath"
           value: {{ .Values.vault_path_prefix | quote }}
       valueFiles:

--- a/services/ingress-nginx/README.md
+++ b/services/ingress-nginx/README.md
@@ -10,6 +10,7 @@
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | ingress-nginx.controller.config.compute-full-forwarded-for | string | `"true"` |  |
 | ingress-nginx.controller.config.large-client-header-buffers | string | `"4 64k"` |  |
 | ingress-nginx.controller.config.proxy-body-size | string | `"100m"` |  |
@@ -20,4 +21,4 @@
 | ingress-nginx.controller.podLabels."gafaelfawr.lsst.io/ingress" | string | `"true"` |  |
 | ingress-nginx.controller.podLabels."hub.jupyter.org/network-access-proxy-http" | string | `"true"` |  |
 | ingress-nginx.controller.service.externalTrafficPolicy | string | `"Local"` |  |
-| vault_certificate.enabled | bool | `false` | Whether to store ingress TLS certificate via vault-secrets-operator.  Typically "squareone" owns it instead in an RSP. |
+| vaultCertificate.enabled | bool | `false` | Whether to store ingress TLS certificate via vault-secrets-operator.  Typically "squareone" owns it instead in an RSP. |

--- a/services/ingress-nginx/templates/vault-secrets.yaml
+++ b/services/ingress-nginx/templates/vault-secrets.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.vault_certificate.enabled }}
+{{ if .Values.vaultCertificate.enabled }}
 apiVersion: ricoberger.de/v1alpha1
 kind: VaultSecret
 metadata:

--- a/services/ingress-nginx/values-minikube.yaml
+++ b/services/ingress-nginx/values-minikube.yaml
@@ -10,5 +10,5 @@ ingress-nginx:
     extraArgs:
       default-ssl-certificate: ingress-nginx/ingress-certificate
 
-vault_certificate:
+vaultCertificate:
   enabled: true

--- a/services/ingress-nginx/values-roe.yaml
+++ b/services/ingress-nginx/values-roe.yaml
@@ -14,5 +14,5 @@ ingress-nginx:
     extraArgs:
       default-ssl-certificate: ingress-nginx/ingress-certificate
 
-vault_certificate:
+vaultCertificate:
   enabled: true

--- a/services/ingress-nginx/values.yaml
+++ b/services/ingress-nginx/values.yaml
@@ -17,8 +17,15 @@ ingress-nginx:
     metrics:
       enabled: true
 
-vault_certificate:
+vaultCertificate:
   # -- Whether to store ingress TLS certificate via
   # vault-secrets-operator.  Typically "squareone" owns it instead in an
   # RSP.
   enabled: false
+
+# The following will be set by parameters injected by Argo CD and should not
+# be set in the individual environment values files.
+global:
+  # -- Base path for Vault secrets
+  # @default -- Set by Argo CD
+  vaultSecretsPath: ""

--- a/services/noteburst/README.md
+++ b/services/noteburst/README.md
@@ -35,7 +35,6 @@ Noteburst is a notebook execution service for the Rubin Science Platform.
 | fullnameOverride | string | `""` | Override the full name for resources (includes the release name) |
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
-| global.vaultSecretsPathPrefix | string | Set by Argo CD | Base path for Vault secrets |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | image.repository | string | `"ghcr.io/lsst-sqre/noteburst"` | Noteburst image repository |
 | image.tag | string | The appVersion of the chart | Tag of the image |

--- a/services/noteburst/values.yaml
+++ b/services/noteburst/values.yaml
@@ -13,10 +13,6 @@ global:
   # @default -- Set by Argo CD
   host: ""
 
-  # -- Base path for Vault secrets
-  # @default -- Set by Argo CD
-  vaultSecretsPathPrefix: ""
-
 # -- Number of API pods to run
 replicaCount: 1
 

--- a/services/postgres/README.md
+++ b/services/postgres/README.md
@@ -11,8 +11,6 @@ Postgres RDBMS for LSP
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | debug | string | `""` | Set to non-empty to enable debugging output |
-| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
-| global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the postgres image |
 | image.repository | string | `"lsstsqre/lsp-postgres"` | postgres image to use |

--- a/services/postgres/values.yaml
+++ b/services/postgres/values.yaml
@@ -32,14 +32,6 @@ volumeName: ""
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:
-  # -- Base URL for the environment
-  # @default -- Set by Argo CD
-  baseUrl: ""
-
-  # -- Host name for ingress
-  # @default -- Set by Argo CD
-  host: ""
-
   # -- Base path for Vault secrets
   # @default -- Set by Argo CD
   vaultSecretsPath: ""

--- a/services/tap-schema/README.md
+++ b/services/tap-schema/README.md
@@ -10,8 +10,6 @@ The TAP_SCHEMA database
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules for the MySQL pod |
 | fullnameOverride | string | `""` | Override the full name for resources (includes the release name) |
-| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
-| global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the tap-schema image |
 | image.repository | string | `"lsstsqre/tap-schema-mock"` | tap-schema image to use |

--- a/services/tap-schema/values.yaml
+++ b/services/tap-schema/values.yaml
@@ -35,14 +35,6 @@ affinity: {}
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:
-  # -- Base URL for the environment
-  # @default -- Set by Argo CD
-  baseUrl: ""
-
-  # -- Host name for ingress
-  # @default -- Set by Argo CD
-  host: ""
-
   # -- Base path for Vault secrets
   # @default -- Set by Argo CD
   vaultSecretsPath: ""


### PR DESCRIPTION
Remove Argo CD injected Helm variables that aren't used, and
document the ones that are used.  Rename the vault_certificate
setting for ingress-nginx to vaultCertificate, following the naming
rules for Helm chart parameters.

This leaves some unused injected variables for semaphore on the
grounds that they may be used in the future.