### PR TITLE
[DM-35982] Delete references to pull-secret in TAP

### DIFF
--- a/services/tap/templates/mock-qserv-deployment.yaml
+++ b/services/tap/templates/mock-qserv-deployment.yaml
@@ -21,8 +21,6 @@ spec:
         {{- include "cadc-tap.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: "mock-qserv"
     spec:
-      imagePullSecrets:
-        - name: "pull-secret"
       automountServiceAccountToken: false
       containers:
         - name: "mock-qserv"

--- a/services/tap/templates/tap-deployment.yaml
+++ b/services/tap/templates/tap-deployment.yaml
@@ -20,8 +20,6 @@ spec:
         {{- include "cadc-tap.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: "server"
     spec:
-      imagePullSecrets:
-        - name: "pull-secret"
       automountServiceAccountToken: false
       containers:
         - name: "tap-server"

--- a/services/tap/templates/uws-db-deployment.yaml
+++ b/services/tap/templates/uws-db-deployment.yaml
@@ -20,8 +20,6 @@ spec:
         {{- include "cadc-tap.labels" . | nindent 8 }}
         app.kubernetes.io/component: "uws-db"
     spec:
-      imagePullSecrets:
-        - name: "pull-secret"
       automountServiceAccountToken: false
       containers:
         - name: "postgresql"


### PR DESCRIPTION
I stopped installing it but forgot to clean up the references in
the deployments.