### PR TITLE
[DM-36074] Fix TAP for S3, moneypenny for CC-IN2P3

### DIFF
--- a/services/moneypenny/values-ccin2p3.yaml
+++ b/services/moneypenny/values-ccin2p3.yaml
@@ -7,7 +7,7 @@ orders:
         runAsNonRootUser: false
       volumeMounts:
         - mountPath: /data/rsp/home
-          name: home
+          name: homedirs
   volumes:
     - name: home
       hostPath:

--- a/services/moneypenny/values-ccin2p3.yaml
+++ b/services/moneypenny/values-ccin2p3.yaml
@@ -6,7 +6,7 @@ orders:
         runAsUser: 0
         runAsNonRootUser: false
       volumeMounts:
-        - mountPath: /data/rsp/home
+        - mountPath: /home
           name: home
   volumes:
     - name: home

--- a/services/moneypenny/values-ccin2p3.yaml
+++ b/services/moneypenny/values-ccin2p3.yaml
@@ -1,4 +1,4 @@
-orders: |
+orders:
   commission:
     - name: initcommission
       image: lsstsqre/inituserhome

--- a/services/moneypenny/values-ccin2p3.yaml
+++ b/services/moneypenny/values-ccin2p3.yaml
@@ -6,10 +6,10 @@ orders:
         runAsUser: 0
         runAsNonRootUser: false
       volumeMounts:
-        - mountPath: /home
-          name: home
+        - mountPath: /homedirs
+          name: homedirs
   volumes:
-    - name: home
+    - name: homedirs
       hostPath:
         path: /data/rsp/home
         type: Directory

--- a/services/moneypenny/values-ccin2p3.yaml
+++ b/services/moneypenny/values-ccin2p3.yaml
@@ -6,7 +6,7 @@ orders:
         runAsUser: 0
         runAsNonRootUser: false
       volumeMounts:
-        - mountPath: /home
+        - mountPath: /data/rsp/home
           name: home
   volumes:
     - name: home

--- a/services/moneypenny/values-ccin2p3.yaml
+++ b/services/moneypenny/values-ccin2p3.yaml
@@ -7,7 +7,7 @@ orders:
         runAsNonRootUser: false
       volumeMounts:
         - mountPath: /data/rsp/home
-          name: homedirs
+          name: home
   volumes:
     - name: home
       hostPath:

--- a/services/tap/templates/tap-deployment.yaml
+++ b/services/tap/templates/tap-deployment.yaml
@@ -52,7 +52,7 @@ spec:
                 -Xmx{{ .Values.config.jvmMaxHeapSize }}
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: "/etc/creds/google_creds.json"
-            {{- if eq .Values.config.gcsBucketType "AWS" }}
+            {{- if eq .Values.config.gcsBucketType "S3" }}
             - name: AWS_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
- Fix the TAP deployment template to expect `S3`, not `AWS`, consistent with `values.yaml`
- Fix the moneypenny configuration for CC-IN2P3

This is a copy of https://github.com/lsst-sqre/phalanx/pull/1694 to allow tests to run.