### PR TITLE
sqlproxy butler int

### DIFF
--- a/science-platform/templates/sqlproxy-butler-int-application.yaml
+++ b/science-platform/templates/sqlproxy-butler-int-application.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.sqlproxy_butler_int.enabled -}}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sqlproxy-butler-int
+spec:
+  finalizers:
+    - kubernetes
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: sqlproxy-butler-int
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: sqlproxy-butler-int
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: services/sqlproxy-gcp
+    repoURL: {{ .Values.repoURL }}
+    targetRevision: {{ .Values.revision }}
+    helm:
+      parameters:
+        - name: "global.vaultSecretsPath"
+          value: {{ .Values.vault_path_prefix | quote }}
+      valueFiles:
+        - "values.yaml"
+        - "values-{{ .Values.environment }}.yaml"
+{{- end -}}

--- a/science-platform/values-idfdev.yaml
+++ b/science-platform/values-idfdev.yaml
@@ -46,6 +46,8 @@ squareone:
   enabled: true
 squash_api:
   enabled: false
+sqlproxy_butler_int:
+  enabled: true
 strimzi:
   enabled: true
 strimzi_registry_operator:

--- a/services/sqlproxy-gcp/.helmignore
+++ b/services/sqlproxy-gcp/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/services/sqlproxy-gcp/Chart.yaml
+++ b/services/sqlproxy-gcp/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: sqlproxy
+description: gcp sql proxy as a service deployment
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/services/sqlproxy-gcp/templates/_helpers.tpl
+++ b/services/sqlproxy-gcp/templates/_helpers.tpl
@@ -1,0 +1,52 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "sqlproxy.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "sqlproxy.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "sqlproxy.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "sqlproxy.labels" -}}
+helm.sh/chart: {{ include "sqlproxy.chart" . }}
+{{ include "sqlproxy.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "sqlproxy.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "sqlproxy.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/services/sqlproxy-gcp/templates/deployment.yaml
+++ b/services/sqlproxy-gcp/templates/deployment.yaml
@@ -1,0 +1,64 @@
+{{- if .Values.cloudsql.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "sqlproxy.fullname" . }}
+  labels:
+    {{- include "sqlproxy.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "sqlproxy.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "sqlproxy.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ .Values.serviceAccountName }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+      containers:
+        - name: cloud-sql-proxy
+          command:
+            - "/cloud_sql_proxy"
+            - "-log_debug_stdout"
+            - "-structured_logs"
+            - "-ip_address_types={{ required "cloudsql.ipAddressType must be specified" .Values.cloudsql.ipAddressType}}"
+            - "-instances={{ required "cloudsql.instanceConnectionName must be specified" .Values.cloudsql.instanceConnectionName }}=tcp:0.0.0.0:5432"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+            readOnlyRootFilesystem: true
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: 5432
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/services/sqlproxy-gcp/templates/service.yaml
+++ b/services/sqlproxy-gcp/templates/service.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.cloudsql.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "sqlproxy.fullname" . }}
+  labels:
+    {{- include "sqlproxy.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 5432
+      targetPort: 5432
+      protocol: TCP
+  selector:
+    {{- include "sqlproxy.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/services/sqlproxy-gcp/templates/serviceaccount.yaml
+++ b/services/sqlproxy-gcp/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.cloudsql.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "sqlproxy.fullname" . }}
+  labels:
+    {{- include "sqlproxy.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/services/sqlproxy-gcp/values-idfdev.yaml
+++ b/services/sqlproxy-gcp/values-idfdev.yaml
@@ -1,0 +1,25 @@
+serviceAccountName: sqlproxy-butler-int
+
+nameOverride: sqlproxy-butler-int
+
+serviceAccount:
+  annotations: {
+    iam.gke.io/gcp-service-account:  sqlproxy-butler-int@science-platform-dev-7696.iam.gserviceaccount.com
+  }
+
+cloudsql:
+  enabled: true
+  nameSuffix: "butler-int" 
+  ipAddressType: "PUBLIC"
+  instanceConnectionName: "science-platform-int-dc5d:us-central1:butler-registry-int-72f9812d"
+
+replicaCount: 1
+
+image:
+  repository: gcr.io/cloudsql-docker/gce-proxy
+  tag: 1.28.0
+
+resources: 
+  requests:
+     cpu: "1"
+     memory: "2Gi"

--- a/services/sqlproxy-gcp/values.yaml
+++ b/services/sqlproxy-gcp/values.yaml
@@ -1,0 +1,62 @@
+# Default values for sqlproxy-gcp
+
+# -- Override the base name for resources
+nameOverride: ""
+
+# -- Override the full name for resources (includes the release name)
+fullnameOverride: ""
+
+image:
+  # -- cachemachine image to use
+  repository: gcr.io/cloudsql-docker/gce-proxy
+
+  # -- Pull policy for the cachemachine image
+  pullPolicy: IfNotPresent
+
+  # -- Tag of cachemachine image to use
+  # @default -- The appVersion of the chart
+  tag: ""
+
+# -- Secret names to use for all Docker pulls
+serviceAccount:
+  # -- Name of the service account to use
+  # @default -- Name based on the fullname template
+  name: ""
+
+  # -- Annotations to add to the service account
+  annotations: {}
+
+# -- Resource limits and requests for the cachemachine frontend pod
+resources: {}
+
+# -- Annotations for the cachemachine frontend pod
+podAnnotations: {}
+
+# -- Node selector rules for the cachemachine frontend pod
+nodeSelector: {}
+
+# -- Tolerations for the cachemachine frontend pod
+tolerations: []
+
+# -- Affinity rules for the cachemachine frontend pod
+affinity: {}
+
+# -- Autostart configuration. Each key is the name of a class of images to
+# pull, and the value is the JSON specification for which and how many images
+# to pull.
+autostart: {}
+
+# The following will be set by parameters injected by Argo CD and should not
+# be set in the individual environment values files.
+global:
+  # -- Base URL for the environment
+  # @default -- Set by Argo CD
+  baseUrl: ""
+
+  # -- Host name for ingress
+  # @default -- Set by Argo CD
+  host: ""
+
+  # -- Base path for Vault secrets
+  # @default -- Set by Argo CD
+  vaultSecretsPath: ""

--- a/services/tap/values-idfdev.yaml
+++ b/services/tap/values-idfdev.yaml
@@ -1,3 +1,8 @@
 config:
   gcsBucket: "async-results.lsst.codes"
   gcsBucketUrl: "http://async-results.lsst.codes"
+
+qserv:
+  host: "10.136.1.211:4040"
+  mock:
+    enabled: false


### PR DESCRIPTION
Add sqlproxy as a standalone service.  Included in this PR is helm chart for the service and the argo CD configuration to deploy as an app.  Tried to make the sqlproxy service as generic so it can be used again.  The argo CD app is specific for the butler-int integration.  