### PR TITLE
[DM-36093] Update nublado2 templates for latest Gafaelfawr

### DIFF
--- a/services/nublado2/Chart.yaml
+++ b/services/nublado2/Chart.yaml
@@ -5,7 +5,7 @@ description: JupyterHub for the Rubin Science Platform
 home: https://github.com/lsst-sqre/nublado2
 sources:
   - https://github.com/lsst-sqre/nublado2
-appVersion: "2.4.1"
+appVersion: "2.5.0"
 # Match the jupyterhub Helm chart for kubeVersion
 kubeVersion: ">=1.20.0-0"
 dependencies:

--- a/services/nublado2/README.md
+++ b/services/nublado2/README.md
@@ -62,7 +62,7 @@ Kubernetes: `>=1.20.0-0`
 | jupyterhub.hub.extraVolumes[1].name | string | `"nublado-gafaelfawr"` |  |
 | jupyterhub.hub.extraVolumes[1].secret.secretName | string | `"gafaelfawr-token"` |  |
 | jupyterhub.hub.image.name | string | `"lsstsqre/nublado2"` |  |
-| jupyterhub.hub.image.tag | string | `"2.4.1"` |  |
+| jupyterhub.hub.image.tag | string | `"2.5.0"` |  |
 | jupyterhub.hub.loadRoles.self.scopes[0] | string | `"admin:servers!user"` |  |
 | jupyterhub.hub.loadRoles.self.scopes[1] | string | `"read:metrics"` |  |
 | jupyterhub.hub.loadRoles.server.scopes[0] | string | `"inherit"` |  |

--- a/services/nublado2/values.yaml
+++ b/services/nublado2/values.yaml
@@ -297,9 +297,8 @@ config:
           tss:x:59:
           cgred:x:997:
           screen:x:84:
-          jovyan:x:768:{{ user }}
-          provisionator:x:769:{% for group in groups %}
-          {{ group.name }}:x:{{ group.id }}:{{ user }}{% endfor %}
+          jovyan:x:768:{{ user }}{% for g in groups %}
+          {{ g.name }}:x:{{ g.id }}:{{ user if g.id != gid else "" }}{% endfor %}
     - apiVersion: v1
       kind: ConfigMap
       metadata:
@@ -342,9 +341,8 @@ config:
           tss:!::
           cgred:!::
           screen:!::
-          jovyan:!::{{ user }}
-          provisionator:!::{% for g in groups %}
-          {{ g.name }}:!::{{ user }}{% endfor %}
+          jovyan:!::{{ user }}{% for g in groups %}
+          {{ g.name }}:!::{{ user if g.id != gid else "" }}{% endfor %}
     - apiVersion: v1
       kind: ConfigMap
       metadata:
@@ -369,7 +367,6 @@ config:
           dbus:x:81:81:System message bus:/:/sbin/nologin
           lsst_lcl:x:1000:1000::/home/lsst_lcl:/bin/bash
           tss:x:59:59:Account used by the trousers package to sandbox the tcsd daemon:/dev/null:/sbin/nologin
-          provisionator:x:769:769:Lab provisioning user:/home/provisionator:/bin/bash
           {{ user }}:x:{{ uid }}:{{ gid if gid else uid }}::/home/{{ user }}:/bin/bash
     - apiVersion: v1
       kind: ConfigMap
@@ -395,7 +392,6 @@ config:
           dbus:*:18000:0:99999:7:::
           lsst_lcl:*:18000:0:99999:7:::
           tss:*:18000:0:99999:7:::
-          provisionator:*:18000:0:99999:7:::
           {{user}}:*:18000:0:99999:7:::
     - apiVersion: v1
       kind: ConfigMap

--- a/services/nublado2/values.yaml
+++ b/services/nublado2/values.yaml
@@ -234,6 +234,7 @@ config:
     WORKFLOW_ROUTE: /wf
     AUTO_REPO_URLS: https://github.com/lsst-sqre/notebook-demo
     NO_SUDO: "TRUE"
+    EXTERNAL_GID: "{{ gid if gid else uid }}"
     EXTERNAL_GROUPS: "{{ external_groups }}"
     EXTERNAL_UID: "{{ uid }}"
     ACCESS_TOKEN: "{{ token }}"

--- a/services/nublado2/values.yaml
+++ b/services/nublado2/values.yaml
@@ -7,7 +7,7 @@ jupyterhub:
     authenticatePrometheus: false
     image:
       name: lsstsqre/nublado2
-      tag: "2.4.1"
+      tag: "2.5.0"
     resources:
       limits:
         cpu: 900m
@@ -297,8 +297,7 @@ config:
           cgred:x:997:
           screen:x:84:
           jovyan:x:768:{{ user }}
-          provisionator:x:769:
-          {{user}}:x:{{uid}}:{% for group in groups %}
+          provisionator:x:769:{% for group in groups %}
           {{ group.name }}:x:{{ group.id }}:{{ user }}{% endfor %}
     - apiVersion: v1
       kind: ConfigMap
@@ -343,8 +342,7 @@ config:
           cgred:!::
           screen:!::
           jovyan:!::{{ user }}
-          provisionator:!::
-          {{ user }}:!::{% for g in groups %}
+          provisionator:!::{% for g in groups %}
           {{ g.name }}:!::{{ user }}{% endfor %}
     - apiVersion: v1
       kind: ConfigMap
@@ -371,7 +369,7 @@ config:
           lsst_lcl:x:1000:1000::/home/lsst_lcl:/bin/bash
           tss:x:59:59:Account used by the trousers package to sandbox the tcsd daemon:/dev/null:/sbin/nologin
           provisionator:x:769:769:Lab provisioning user:/home/provisionator:/bin/bash
-          {{ user }}:x:{{ uid }}:{{ uid }}::/home/{{ user }}:/bin/bash
+          {{ user }}:x:{{ uid }}:{{ gid if gid else uid }}::/home/{{ user }}:/bin/bash
     - apiVersion: v1
       kind: ConfigMap
       metadata:


### PR DESCRIPTION
- Update to latest nublado2 release
- Expose the user's primary GID in `EXTERNAL_GID` parallel to `EXTERNAL_UID`
- Drop the provisionator user and group, which I believe are no longer used
- Don't add the user as an additional member of the group matching their primary GID, following normal UNIX semantics
- Set the user's GID correctly if it differs from their UID