### PR TITLE
[DM-35698] Update Gafaelfawr configuration for IDF dev

### DIFF
--- a/services/gafaelfawr/values-idfdev.yaml
+++ b/services/gafaelfawr/values-idfdev.yaml
@@ -9,7 +9,7 @@ config:
 
   cilogon:
     clientId: "cilogon:/client_id/46f9ae932fd30e9fb1b246972a3c0720"
-    enrollmentUrl: "https://registry-test.lsst.codes/registry/co_petitions/start/coef:6"
+    enrollmentUrl: "https://id-dev.lsst.cloud/registry/co_petitions/start/coef:6"
     test: true
     usernameClaim: "username"
 
@@ -18,11 +18,11 @@ config:
 
   ldap:
     url: "ldaps://ldap-test.cilogon.org"
-    userDn: "uid=readonly_user,ou=system,o=LSST,o=CO,dc=lsst,dc=org"
-    groupBaseDn: "ou=groups,o=LSST,o=CO,dc=lsst,dc=org"
+    userDn: "uid=readonly_user,ou=system,o=LSST,o=CO,dc=lsst_dev,dc=org"
+    groupBaseDn: "ou=groups,o=LSST,o=CO,dc=lsst_dev,dc=org"
     groupObjectClass: "eduMember"
     groupMemberAttr: "hasMember"
-    userBaseDn: "ou=people,o=LSST,o=CO,dc=lsst,dc=org"
+    userBaseDn: "ou=people,o=LSST,o=CO,dc=lsst_dev,dc=org"
     userSearchAttr: "voPersonApplicationUID"
     addUserGroup: true
 


### PR DESCRIPTION
The LDAP DNs and enrollment URL have changed for the renaming of the environment to id-dev.lsst.cloud.