### PR TITLE
Fix typo in generate_secrets script

### DIFF
--- a/installer/generate_secrets.py
+++ b/installer/generate_secrets.py
@@ -223,7 +223,7 @@ class SecretGenerator:
             )
 
         self.input_field("gafaelfawr", "ldap", "Use LDAP? (y/n):")
-        use_ldap = self.secrets["gaelfawr"]["ldap"]
+        use_ldap = self.secrets["gafaelfawr"]["ldap"]
         if use_ldap == "y":
             self.input_field("gafaelfawr", "ldap-password", "LDAP password")
 


### PR DESCRIPTION
**Description:**

Small typo in generate_secrets script, causes script to fail when trying to regenerate secrets for (roe) environment.

**Fix:**
Change gaelfawr -> gafaelfawr