### PR TITLE
Missing slack-webhook value causes generate_secrets script to fail

### DIFF
--- a/installer/generate_secrets.py
+++ b/installer/generate_secrets.py
@@ -255,7 +255,10 @@ class SecretGenerator:
         else:
             raise Exception(f"Invalid auth provider {auth_type}")
             
-        if  self.secrets.get("rsp-alerts", {}).get("slack-webhook", None) != None:
+        if (
+            self.secrets.get("rsp-alerts", {}).get("slack-webhook", None) 
+            != None
+        ):
             slack_webhook = self.secrets["rsp-alerts"]["slack-webhook"]
             if slack_webhook:
                 self._set("gafaelfawr", "slack-webhook", slack_webhook)

--- a/installer/generate_secrets.py
+++ b/installer/generate_secrets.py
@@ -254,9 +254,9 @@ class SecretGenerator:
                 )
         else:
             raise Exception(f"Invalid auth provider {auth_type}")
-            
+
         if (
-            self.secrets.get("rsp-alerts", {}).get("slack-webhook", None) 
+            self.secrets.get("rsp-alerts", {}).get("slack-webhook", None)
             != None
         ):
             slack_webhook = self.secrets["rsp-alerts"]["slack-webhook"]

--- a/installer/generate_secrets.py
+++ b/installer/generate_secrets.py
@@ -254,10 +254,11 @@ class SecretGenerator:
                 )
         else:
             raise Exception(f"Invalid auth provider {auth_type}")
-
-        slack_webhook = self.secrets["rsp-alerts"]["slack-webhook"]
-        if slack_webhook:
-            self._set("gafaelfawr", "slack-webhook", slack_webhook)
+            
+        if  self.secrets.get("rsp-alerts", {}).get("slack-webhook", None) != None:
+            slack_webhook = self.secrets["rsp-alerts"]["slack-webhook"]
+            if slack_webhook:
+                self._set("gafaelfawr", "slack-webhook", slack_webhook)
 
     def _pull_secret(self):
         self.input_file(

--- a/installer/generate_secrets.py
+++ b/installer/generate_secrets.py
@@ -257,7 +257,7 @@ class SecretGenerator:
 
         if (
             self.secrets.get("rsp-alerts", {}).get("slack-webhook", None)
-            != None
+            is not None
         ):
             slack_webhook = self.secrets["rsp-alerts"]["slack-webhook"]
             if slack_webhook:


### PR DESCRIPTION
**Description**:
When the `slack-webhook` key is missing from the `secrets[rsp-alerts]` dictionary, the generate_secrets scripts fails at the following line, where it can not find that key in the dict:
https://github.com/lsst-sqre/phalanx/blob/master/installer/generate_secrets.py#L258

**Fix**:
Add a check to see that the key exists, and only then set the `secrets[gafaelfawr][slack_webhook] `value

If there are other better ways to fix this, or if this works as intended please ignore/close 