### PR TITLE
[DM-36152] Fix several issues with Gafaelfawr audits

### DIFF
--- a/services/gafaelfawr/templates/cloudsql-networkpolicy.yaml
+++ b/services/gafaelfawr/templates/cloudsql-networkpolicy.yaml
@@ -21,6 +21,10 @@ spec:
         - podSelector:
             matchLabels:
               {{- include "gafaelfawr.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: "audit"
+        - podSelector:
+            matchLabels:
+              {{- include "gafaelfawr.selectorLabels" . | nindent 14 }}
               app.kubernetes.io/component: "maintenance"
         - podSelector:
             matchLabels:

--- a/services/gafaelfawr/templates/cronjob-audit.yaml
+++ b/services/gafaelfawr/templates/cronjob-audit.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.config.slackAlerts -}}
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -68,3 +69,4 @@ spec:
           tolerations:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+{{- end }}

--- a/services/gafaelfawr/templates/redis-networkpolicy.yaml
+++ b/services/gafaelfawr/templates/redis-networkpolicy.yaml
@@ -20,6 +20,10 @@ spec:
         - podSelector:
             matchLabels:
               {{- include "gafaelfawr.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: "audit"
+        - podSelector:
+            matchLabels:
+              {{- include "gafaelfawr.selectorLabels" . | nindent 14 }}
               app.kubernetes.io/component: "frontend"
         - podSelector:
             matchLabels:

--- a/services/gafaelfawr/values-base.yaml
+++ b/services/gafaelfawr/values-base.yaml
@@ -1,10 +1,9 @@
-# Reset token storage on every Redis restart for now.  This should change to
-# use persistent volumes once we can coordinate that.
 redis:
   persistence:
     storageClass: "rook-ceph-block"
 
 config:
+  slackAlerts: true
   databaseUrl: "postgresql://gafaelfawr@postgres.postgres/gafaelfawr"
 
   github:

--- a/services/gafaelfawr/values-idfint.yaml
+++ b/services/gafaelfawr/values-idfint.yaml
@@ -4,6 +4,8 @@ redis:
     storageClass: "standard-rwo"
 
 config:
+  slackAlerts: true
+
   github:
     clientId: "0c4cc7eaffc0f89b9ace"
 

--- a/services/gafaelfawr/values-idfprod.yaml
+++ b/services/gafaelfawr/values-idfprod.yaml
@@ -6,6 +6,8 @@ redis:
     storageClass: "standard-rwo"
 
 config:
+  slackAlerts: true
+
   github:
     clientId: "65b6333a066375091548"
 

--- a/services/gafaelfawr/values-summit.yaml
+++ b/services/gafaelfawr/values-summit.yaml
@@ -1,10 +1,9 @@
-# Reset token storage on every Redis restart for now.  This should change to
-# use persistent volumes once we can coordinate that.
 redis:
   persistence:
     storageClass: "rook-ceph-block"
 
 config:
+  slackAlerts: true
   databaseUrl: "postgresql://gafaelfawr@postgres.postgres/gafaelfawr"
 
   github:

--- a/services/gafaelfawr/values-tucson-teststand.yaml
+++ b/services/gafaelfawr/values-tucson-teststand.yaml
@@ -1,10 +1,9 @@
-# Reset token storage on every Redis restart for now.  This should change to
-# use persistent volumes once we can coordinate that.
 redis:
   persistence:
     storageClass: "rook-ceph-block"
 
 config:
+  slackAlerts: true
   databaseUrl: "postgresql://gafaelfawr@postgres.postgres/gafaelfawr"
 
   github:


### PR DESCRIPTION
Suppress the audit CronJob if Slack alerts are not enabled, since it will just fail anyway.  Enable Slack alerts for most environments now that Slack webhook secrets are in place.  Add the audit CronJob to the NetworkPolicy for CloudSQL and Redis.