### PR TITLE
[DM-36152] Fix optionality of slack-webhook secret

### DIFF
--- a/installer/generate_secrets.py
+++ b/installer/generate_secrets.py
@@ -255,7 +255,7 @@ class SecretGenerator:
         else:
             raise Exception(f"Invalid auth provider {auth_type}")
 
-        slack_webhook = self.secrets["rsp-alerts"]["slack-webhook"]
+        slack_webhook = self._get_current("rsp-alerts", "slack-webhook")
         if slack_webhook:
             self._set("gafaelfawr", "slack-webhook", slack_webhook)
 


### PR DESCRIPTION
The way that this was checked for would fail if it wasn't set due to missing dicts.  Use the _get_current method instead, since that's what it was intended for.