### PR TITLE
Enable DP0.2 TAP queries on IDF prod

### DIFF
--- a/services/mobu/values-idfprod.yaml
+++ b/services/mobu/values-idfprod.yaml
@@ -62,4 +62,7 @@ autostart:
         gidnumber: 74775
     scopes: ["read:tap"]
     business: "TAPQueryRunner"
+    options:
+      tap_sync: true
+      tap_query_set: "dp0.2"
     restart: true


### PR DESCRIPTION
DP0.2 is out so we should be checking this data set, even though we're currently getting errors.