### PR TITLE
Stop pinning tap-schema on IDF dev

### DIFF
--- a/services/tap-schema/values-idfdev.yaml
+++ b/services/tap-schema/values-idfdev.yaml
@@ -1,3 +1,2 @@
 image:
   repository: "lsstsqre/tap-schema-idfdev"
-  tag: "1.2.1"


### PR DESCRIPTION
This has been rolled into the regular tap-schema release process, so it should float with the current appVersion like the other environments.