### PR TITLE
DM-36302: Delete /etc/shadow and /etc/gshadow for labs

### DIFF
--- a/services/nublado2/README.md
+++ b/services/nublado2/README.md
@@ -108,14 +108,6 @@ Kubernetes: `>=1.20.0-0`
 | jupyterhub.singleuser.storage.extraVolumeMounts[6].name | string | `"group"` |  |
 | jupyterhub.singleuser.storage.extraVolumeMounts[6].readOnly | bool | `true` |  |
 | jupyterhub.singleuser.storage.extraVolumeMounts[6].subPath | string | `"group"` |  |
-| jupyterhub.singleuser.storage.extraVolumeMounts[7].mountPath | string | `"/etc/shadow"` |  |
-| jupyterhub.singleuser.storage.extraVolumeMounts[7].name | string | `"shadow"` |  |
-| jupyterhub.singleuser.storage.extraVolumeMounts[7].readOnly | bool | `true` |  |
-| jupyterhub.singleuser.storage.extraVolumeMounts[7].subPath | string | `"shadow"` |  |
-| jupyterhub.singleuser.storage.extraVolumeMounts[8].mountPath | string | `"/etc/gshadow"` |  |
-| jupyterhub.singleuser.storage.extraVolumeMounts[8].name | string | `"gshadow"` |  |
-| jupyterhub.singleuser.storage.extraVolumeMounts[8].readOnly | bool | `true` |  |
-| jupyterhub.singleuser.storage.extraVolumeMounts[8].subPath | string | `"gshadow"` |  |
 | jupyterhub.singleuser.storage.extraVolumes[0].configMap.name | string | `"dask"` |  |
 | jupyterhub.singleuser.storage.extraVolumes[0].name | string | `"dask"` |  |
 | jupyterhub.singleuser.storage.extraVolumes[1].configMap.name | string | `"idds-config"` |  |
@@ -133,12 +125,5 @@ Kubernetes: `>=1.20.0-0`
 | jupyterhub.singleuser.storage.extraVolumes[6].configMap.defaultMode | int | `420` |  |
 | jupyterhub.singleuser.storage.extraVolumes[6].configMap.name | string | `"group"` |  |
 | jupyterhub.singleuser.storage.extraVolumes[6].name | string | `"group"` |  |
-| jupyterhub.singleuser.storage.extraVolumes[7].configMap.defaultMode | int | `384` |  |
-| jupyterhub.singleuser.storage.extraVolumes[7].configMap.name | string | `"shadow"` |  |
-| jupyterhub.singleuser.storage.extraVolumes[7].name | string | `"shadow"` |  |
-| jupyterhub.singleuser.storage.extraVolumes[8].configMap.defaultMode | int | `384` |  |
-| jupyterhub.singleuser.storage.extraVolumes[8].configMap.name | string | `"gshadow"` |  |
-| jupyterhub.singleuser.storage.extraVolumes[8].name | string | `"gshadow"` |  |
 | jupyterhub.singleuser.storage.type | string | `"none"` |  |
 | network_policy.enabled | bool | `true` |  |
-| vault_secret_path | string | `""` |  |

--- a/services/nublado2/values-base.yaml
+++ b/services/nublado2/values-base.yaml
@@ -44,9 +44,3 @@ config:
       mountPath: /project
     - name: scratch
       mountPath: /scratch
-
-vault_secret_path: "secret/k8s_operator/base-lsp.lsst.codes/nublado2"
-
-pull-secret:
-  enabled: true
-  path: "secret/k8s_operator/base-lsp.lsst.codes/pull-secret"

--- a/services/nublado2/values-ccin2p3.yaml
+++ b/services/nublado2/values-ccin2p3.yaml
@@ -39,9 +39,3 @@ config:
       mountPath: /data
     - name: home
       mountPath: /home
-
-vault_secret_path: "secret/k8s_operator/rsp-cc/nublado2"
-
-pull-secret:
-  enabled: true
-  path: "secret/k8s_operator/rsp-cc/pull-secret"

--- a/services/nublado2/values-idfdev.yaml
+++ b/services/nublado2/values-idfdev.yaml
@@ -57,9 +57,3 @@ config:
       mountPath: /project
     - name: scratch
       mountPath: /scratch
-
-vault_secret_path: "secret/k8s_operator/data-dev.lsst.cloud/nublado2"
-
-pull-secret:
-  enabled: true
-  path: "secret/k8s_operator/data-dev.lsst.cloud/pull-secret"

--- a/services/nublado2/values-idfint.yaml
+++ b/services/nublado2/values-idfint.yaml
@@ -129,50 +129,6 @@ config:
     - apiVersion: v1
       kind: ConfigMap
       metadata:
-        name: gshadow
-        namespace: "{{ user_namespace }}"
-      data:
-        gshadow: |
-          root:!::
-          bin:!::
-          daemon:!::
-          sys:!::
-          adm:!::
-          tty:!::
-          disk:!::
-          lp:!::
-          mem:!::
-          kmem:!::
-          wheel:!::
-          cdrom:!::
-          mail:!::
-          man:!::
-          dialout:!::
-          floppy:!::
-          games:!::
-          tape:!::
-          video:!::
-          ftp:!::
-          lock:!::
-          audio:!::
-          nobody:!::
-          users:!::
-          utmp:!::
-          utempter:!::
-          input:!::
-          systemd-journal:!::
-          systemd-network:!::
-          dbus:!::
-          ssh_keys:!::
-          lsst_lcl:!::{{ user }}
-          tss:!::
-          cgred:!::
-          screen:!::
-          jovyan:!::{{ user }}{% for g in groups %}
-          {{ g.name }}:!::{{ user if g.id != gid else "" }}{% endfor %}
-    - apiVersion: v1
-      kind: ConfigMap
-      metadata:
         name: passwd
         namespace: "{{ user_namespace }}"
       data:
@@ -195,31 +151,6 @@ config:
           lsst_lcl:x:1000:1000::/home/lsst_lcl:/bin/bash
           tss:x:59:59:Account used by the trousers package to sandbox the tcsd daemon:/dev/null:/sbin/nologin
           {{ user }}:x:{{ uid }}:{{ gid if gid else uid }}::/home/{{ user }}:/bin/bash
-    - apiVersion: v1
-      kind: ConfigMap
-      metadata:
-        name: shadow
-        namespace: "{{ user_namespace }}"
-      data:
-        shadow: |
-          root:*:18000:0:99999:7:::
-          bin:*:18000:0:99999:7:::
-          daemon:*:18000:0:99999:7:::
-          adm:*:18000:0:99999:7:::
-          lp:*:18000:0:99999:7:::
-          sync:*:18000:0:99999:7:::
-          shutdown:*:18000:0:99999:7:::
-          halt:*:18000:0:99999:7:::
-          mail:*:18000:0:99999:7:::
-          operator:*:18000:0:99999:7:::
-          games:*:18000:0:99999:7:::
-          ftp:*:18000:0:99999:7:::
-          nobody:*:18000:0:99999:7:::
-          systemd-network:*:18000:0:99999:7:::
-          dbus:*:18000:0:99999:7:::
-          lsst_lcl:*:18000:0:99999:7:::
-          tss:*:18000:0:99999:7:::
-          {{user}}:*:18000:0:99999:7:::
     - apiVersion: v1
       kind: ConfigMap
       metadata:
@@ -315,9 +246,3 @@ config:
         hard:
           limits.cpu: 9
           limits.memory: 27Gi
-
-vault_secret_path: "secret/k8s_operator/data-int.lsst.cloud/nublado2"
-
-pull-secret:
-  enabled: true
-  path: "secret/k8s_operator/data-int.lsst.cloud/pull-secret"

--- a/services/nublado2/values-idfprod.yaml
+++ b/services/nublado2/values-idfprod.yaml
@@ -109,50 +109,6 @@ config:
     - apiVersion: v1
       kind: ConfigMap
       metadata:
-        name: gshadow
-        namespace: "{{ user_namespace }}"
-      data:
-        gshadow: |
-          root:!::
-          bin:!::
-          daemon:!::
-          sys:!::
-          adm:!::
-          tty:!::
-          disk:!::
-          lp:!::
-          mem:!::
-          kmem:!::
-          wheel:!::
-          cdrom:!::
-          mail:!::
-          man:!::
-          dialout:!::
-          floppy:!::
-          games:!::
-          tape:!::
-          video:!::
-          ftp:!::
-          lock:!::
-          audio:!::
-          nobody:!::
-          users:!::
-          utmp:!::
-          utempter:!::
-          input:!::
-          systemd-journal:!::
-          systemd-network:!::
-          dbus:!::
-          ssh_keys:!::
-          lsst_lcl:!::{{ user }}
-          tss:!::
-          cgred:!::
-          screen:!::
-          jovyan:!::{{ user }}{% for g in groups %}
-          {{ g.name }}:!::{{ user if g.id != gid else "" }}{% endfor %}
-    - apiVersion: v1
-      kind: ConfigMap
-      metadata:
         name: passwd
         namespace: "{{ user_namespace }}"
       data:
@@ -175,31 +131,6 @@ config:
           lsst_lcl:x:1000:1000::/home/lsst_lcl:/bin/bash
           tss:x:59:59:Account used by the trousers package to sandbox the tcsd daemon:/dev/null:/sbin/nologin
           {{ user }}:x:{{ uid }}:{{ gid if gid else uid }}::/home/{{ user }}:/bin/bash
-    - apiVersion: v1
-      kind: ConfigMap
-      metadata:
-        name: shadow
-        namespace: "{{ user_namespace }}"
-      data:
-        shadow: |
-          root:*:18000:0:99999:7:::
-          bin:*:18000:0:99999:7:::
-          daemon:*:18000:0:99999:7:::
-          adm:*:18000:0:99999:7:::
-          lp:*:18000:0:99999:7:::
-          sync:*:18000:0:99999:7:::
-          shutdown:*:18000:0:99999:7:::
-          halt:*:18000:0:99999:7:::
-          mail:*:18000:0:99999:7:::
-          operator:*:18000:0:99999:7:::
-          games:*:18000:0:99999:7:::
-          ftp:*:18000:0:99999:7:::
-          nobody:*:18000:0:99999:7:::
-          systemd-network:*:18000:0:99999:7:::
-          dbus:*:18000:0:99999:7:::
-          lsst_lcl:*:18000:0:99999:7:::
-          tss:*:18000:0:99999:7:::
-          {{user}}:*:18000:0:99999:7:::
     - apiVersion: v1
       kind: ConfigMap
       metadata:
@@ -295,9 +226,3 @@ config:
         hard:
           limits.cpu: 9
           limits.memory: 27Gi
-
-vault_secret_path: "secret/k8s_operator/data.lsst.cloud/nublado2"
-
-pull-secret:
-  enabled: true
-  path: "secret/k8s_operator/data.lsst.cloud/pull-secret"

--- a/services/nublado2/values-minikube.yaml
+++ b/services/nublado2/values-minikube.yaml
@@ -19,9 +19,3 @@ config:
   volume_mounts:
     - name: home
       mountPath: /home
-
-vault_secret_path: "secret/k8s_operator/minikube.lsst.codes/nublado2"
-
-pull-secret:
-  enabled: true
-  path: "secret/k8s_operator/minikube.lsst.codes/pull-secret"

--- a/services/nublado2/values-roe.yaml
+++ b/services/nublado2/values-roe.yaml
@@ -38,9 +38,3 @@ config:
       mountPath: /project
     - name: scratch
       mountPath: /scratch
-
-vault_secret_path: "secret/k8s_operator/roe/nublado2"
-
-pull-secret:
-  enabled: true
-  path: "secret/k8s_operator/roe/pull-secret"

--- a/services/nublado2/values-summit.yaml
+++ b/services/nublado2/values-summit.yaml
@@ -97,9 +97,3 @@ config:
     - name: base-comcam
       mountPath: /data/lsstdata/base/comcam
       readOnly: true
-
-vault_secret_path: "secret/k8s_operator/summit-lsp.lsst.codes/nublado2"
-
-pull-secret:
-  enabled: true
-  path: "secret/k8s_operator/summit-lsp.lsst.codes/pull-secret"

--- a/services/nublado2/values-tucson-teststand.yaml
+++ b/services/nublado2/values-tucson-teststand.yaml
@@ -79,9 +79,3 @@ config:
     - name: comcam-oods
       mountPath: /data/lsstdata/TTS/comcam
       readOnly: true
-
-vault_secret_path: "secret/k8s_operator/tucson-teststand.lsst.codes/nublado2"
-
-pull-secret:
-  enabled: true
-  path: "secret/k8s_operator/tucson-teststand.lsst.codes/pull-secret"

--- a/services/nublado2/values.yaml
+++ b/services/nublado2/values.yaml
@@ -104,14 +104,6 @@ jupyterhub:
           configMap:
             defaultMode: 420
             name: group
-        - name: shadow
-          configMap:
-            defaultMode: 384
-            name: shadow
-        - name: gshadow
-          configMap:
-            defaultMode: 384
-            name: gshadow
       extraVolumeMounts:
         - name: dask
           mountPath: /etc/dask
@@ -131,14 +123,6 @@ jupyterhub:
           mountPath: /etc/group
           readOnly: true
           subPath: group
-        - name: shadow
-          mountPath: /etc/shadow
-          readOnly: true
-          subPath: shadow
-        - name: gshadow
-          mountPath: /etc/gshadow
-          readOnly: true
-          subPath: gshadow
       type: none
 
   proxy:
@@ -302,50 +286,6 @@ config:
     - apiVersion: v1
       kind: ConfigMap
       metadata:
-        name: gshadow
-        namespace: "{{ user_namespace }}"
-      data:
-        gshadow: |
-          root:!::
-          bin:!::
-          daemon:!::
-          sys:!::
-          adm:!::
-          tty:!::
-          disk:!::
-          lp:!::
-          mem:!::
-          kmem:!::
-          wheel:!::
-          cdrom:!::
-          mail:!::
-          man:!::
-          dialout:!::
-          floppy:!::
-          games:!::
-          tape:!::
-          video:!::
-          ftp:!::
-          lock:!::
-          audio:!::
-          nobody:!::
-          users:!::
-          utmp:!::
-          utempter:!::
-          input:!::
-          systemd-journal:!::
-          systemd-network:!::
-          dbus:!::
-          ssh_keys:!::
-          lsst_lcl:!::{{ user }}
-          tss:!::
-          cgred:!::
-          screen:!::
-          jovyan:!::{{ user }}{% for g in groups %}
-          {{ g.name }}:!::{{ user if g.id != gid else "" }}{% endfor %}
-    - apiVersion: v1
-      kind: ConfigMap
-      metadata:
         name: passwd
         namespace: "{{ user_namespace }}"
       data:
@@ -368,31 +308,6 @@ config:
           lsst_lcl:x:1000:1000::/home/lsst_lcl:/bin/bash
           tss:x:59:59:Account used by the trousers package to sandbox the tcsd daemon:/dev/null:/sbin/nologin
           {{ user }}:x:{{ uid }}:{{ gid if gid else uid }}::/home/{{ user }}:/bin/bash
-    - apiVersion: v1
-      kind: ConfigMap
-      metadata:
-        name: shadow
-        namespace: "{{ user_namespace }}"
-      data:
-        shadow: |
-          root:*:18000:0:99999:7:::
-          bin:*:18000:0:99999:7:::
-          daemon:*:18000:0:99999:7:::
-          adm:*:18000:0:99999:7:::
-          lp:*:18000:0:99999:7:::
-          sync:*:18000:0:99999:7:::
-          shutdown:*:18000:0:99999:7:::
-          halt:*:18000:0:99999:7:::
-          mail:*:18000:0:99999:7:::
-          operator:*:18000:0:99999:7:::
-          games:*:18000:0:99999:7:::
-          ftp:*:18000:0:99999:7:::
-          nobody:*:18000:0:99999:7:::
-          systemd-network:*:18000:0:99999:7:::
-          dbus:*:18000:0:99999:7:::
-          lsst_lcl:*:18000:0:99999:7:::
-          tss:*:18000:0:99999:7:::
-          {{user}}:*:18000:0:99999:7:::
     - apiVersion: v1
       kind: ConfigMap
       metadata:
@@ -480,14 +395,10 @@ config:
         path: "{{ pull_secret_path }}"
         type: kubernetes.io/dockerconfigjson
 
-# Note: See note above about existingSecret.
-vault_secret_path: ""
-
 # Built-in network policy doesn't quite work (Labs can't talk to Hub,
 # even with port 8081 explicitly enabled), so let's use our own for now.
 network_policy:
   enabled: true
-
 
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.


### PR DESCRIPTION
We no longer support PAM, sudo, or privilege escalation in labs, so nothing should be reading these files.  Simplify the config by removing the generated ConfigMaps and mounts.

Also delete obsolete settings for vault_secrets_path and pull-secret, which were migrated to use the injected global path.

The sciplat-lab build already deletes /etc/shadow and /etc/gshadow, so with this change those files simply won't exist.