### PR TITLE
DM-36321: Fix authorization for datalinker

### DIFF
--- a/services/datalinker/README.md
+++ b/services/datalinker/README.md
@@ -24,8 +24,7 @@ Service and data discovery for Rubin Science Platform
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the datalinker image |
 | image.repository | string | `"ghcr.io/lsst-sqre/datalinker"` | Image to use in the datalinker deployment |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
-| ingress.annotations | object | `{}` | Additional annotations for the ingress rule |
-| ingress.gafaelfawrAuthQuery | string | `"scope=read:image"` | Gafaelfawr auth query string |
+| ingress.annotations | object | `{}` | Additional annotations for the ingresses |
 | nameOverride | string | `""` | Override the base name for resources |
 | nodeSelector | object | `{}` | Node selection rules for the datalinker deployment pod |
 | podAnnotations | object | `{}` | Annotations for the datalinker deployment pod |

--- a/services/datalinker/templates/ingress-image.yaml
+++ b/services/datalinker/templates/ingress-image.yaml
@@ -5,12 +5,9 @@ metadata:
   labels:
     {{- include "datalinker.labels" . | nindent 4 }}
   annotations:
-    {{- if .Values.ingress.gafaelfawrAuthQuery }}
     nginx.ingress.kubernetes.io/auth-method: "GET"
     nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-User"
-    nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.global.baseUrl }}/login"
-    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.baseUrl }}/auth?{{ .Values.ingress.gafaelfawrAuthQuery }}"
-    {{- end }}
+    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.baseUrl }}/auth?scope=read:image"
     {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -20,8 +17,8 @@ spec:
     - host: {{ required "global.host must be set" .Values.global.host | quote }}
       http:
         paths:
-          - path: "/api/datalink"
-            pathType: "Prefix"
+          - path: "/api/datalink/links"
+            pathType: "Exact"
             backend:
               service:
                 name: {{ include "datalinker.fullname" . }}

--- a/services/datalinker/templates/ingress-tap.yaml
+++ b/services/datalinker/templates/ingress-tap.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "datalinker.fullname" . }}
+  labels:
+    {{- include "datalinker.labels" . | nindent 4 }}
+  annotations:
+    nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-User"
+    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.baseUrl }}/auth?scope=read:tap"
+    {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  ingressClassName: "nginx"
+  rules:
+    - host: {{ required "global.host must be set" .Values.global.host | quote }}
+      http:
+        paths:
+          - path: "/api/datalink"
+            pathType: "Prefix"
+            backend:
+              service:
+                name: {{ include "datalinker.fullname" . }}
+                port:
+                  number: 8080

--- a/services/datalinker/values.yaml
+++ b/services/datalinker/values.yaml
@@ -22,10 +22,7 @@ nameOverride: ""
 fullnameOverride: ""
 
 ingress:
-  # -- Gafaelfawr auth query string
-  gafaelfawrAuthQuery: "scope=read:image"
-
-  # -- Additional annotations for the ingress rule
+  # -- Additional annotations for the ingresses
   annotations: {}
 
 autoscaling:


### PR DESCRIPTION
datalinker was using read:image for access control to all of its non-public routes, but all the routes except /api/datalink/links are TAP query helpers.  Require read:tap for those and read:image only for /api/datalink/links.  Remove the conditionals and values.yaml configuration for scopes and hard-code them, as we do for other complex configurations.

Also remove the auth-url setting, since we expect datalinker links to mostly be followed by scripts and the Portal Aspect, for which redirects to a login page are not useful.