### PR TITLE
DM-36247: Update Gafaelfawr configuration for 6.0.0

### DIFF
--- a/services/gafaelfawr/Chart.yaml
+++ b/services/gafaelfawr/Chart.yaml
@@ -5,4 +5,4 @@ description: Science Platform authentication and authorization system
 home: https://gafaelfawr.lsst.io/
 sources:
   - https://github.com/lsst-sqre/gafaelfawr
-appVersion: 5.2.0
+appVersion: 6.0.0

--- a/services/gafaelfawr/README.md
+++ b/services/gafaelfawr/README.md
@@ -29,7 +29,6 @@ Science Platform authentication and authorization system
 | config.cilogon.gidClaim | string | Do not set a primary GID | Claim from which to get the primary GID (only used if not retrieved from LDAP or Firestore) |
 | config.cilogon.groupsClaim | string | `"isMemberOf"` | Claim from which to get the group membership (only used if not retrieved from LDAP) |
 | config.cilogon.loginParams | object | `{"skin":"LSST"}` | Additional parameters to add |
-| config.cilogon.redirectUrl | string | `/login` at the value of config.host | Return URL given to CILogon (must match the CILogon configuration) |
 | config.cilogon.test | bool | `false` | Whether to use the test instance of CILogon |
 | config.cilogon.uidClaim | string | `"uidNumber"` | Claim from which to get the numeric UID (only used if not retrieved from LDAP or Firestore) |
 | config.cilogon.usernameClaim | string | `"uid"` | Claim from which to get the username |

--- a/services/gafaelfawr/README.md
+++ b/services/gafaelfawr/README.md
@@ -37,8 +37,6 @@ Science Platform authentication and authorization system
 | config.firestore.project | string | Firestore support is disabled | If set, assign UIDs and GIDs using Google Firestore in the given project.  Cloud SQL must be enabled and the Cloud SQL service account must have read/write access to that Firestore instance. |
 | config.github.clientId | string | `""` | GitHub client ID. One and only one of this, `config.cilogon.clientId`, or `config.oidc.clientId` must be set. |
 | config.groupMapping | object | `{}` | Defines a mapping of scopes to groups that provide that scope. See [DMTN-235](https://dmtn-235.lsst.io/) for more details on scopes. |
-| config.influxdb.enabled | bool | `false` | Whether to issue tokens for InfluxDB. If set to true, `influxdb-secret` must be set in the Gafaelfawr secret. |
-| config.influxdb.username | string | `""` | If set, force all InfluxDB tokens to have that username instead of the authenticated identity of the user requesting a token |
 | config.initialAdmins | list | `[]` | Usernames to add as administrators when initializing a new database. Used only if there are no administrators. |
 | config.knownScopes | object | See the `values.yaml` file | Names and descriptions of all scopes in use. This is used to populate the new token creation page. Only scopes listed here will be options when creating a new token. See [DMTN-235](https://dmtn-235.lsst.io/). |
 | config.ldap.addUserGroup | bool | `false` | Whether to synthesize a user private group for each user with a GID equal to their UID |

--- a/services/gafaelfawr/templates/configmap.yaml
+++ b/services/gafaelfawr/templates/configmap.yaml
@@ -63,11 +63,7 @@
         {{ $key }}: {{ $value | quote }}
         {{- end }}
       {{- end }}
-      {{- if .Values.config.cilogon.redirectUrl }}
-      redirect_url: {{ .Values.config.cilogon.redirectUrl | quote }}
-      {{- else }}
       redirect_url: "{{ .Values.global.baseUrl }}/login"
-      {{- end }}
       scopes:
         - "email"
         - "org.cilogon.userinfo"
@@ -101,11 +97,7 @@
       enrollment_url: {{ .Values.config.oidc.enrollmentUrl | quote }}
       {{- end }}
       issuer: {{ required "config.oidc.issuer must be set" .Values.config.oidc.issuer | quote }}
-      {{- if .Values.config.oidc.redirectUrl }}
-      redirect_url: {{ .Values.config.oidc.redirectUrl | quote }}
-      {{- else }}
       redirect_url: "{{ .Values.global.baseUrl }}/login"
-      {{- end }}
       scopes:
         {{- with .Values.config.oidc.scopes }}
         {{- toYaml . | nindent 8 }}

--- a/services/gafaelfawr/templates/configmap.yaml
+++ b/services/gafaelfawr/templates/configmap.yaml
@@ -26,14 +26,6 @@
     error_footer: {{ .Values.config.errorFooter | quote }}
     {{- end }}
 
-    {{- if .Values.config.influxdb.enabled }}
-    influxdb:
-      secret_file: "/etc/gafaelfawr/secrets/influxdb-secret"
-      {{- if .Values.config.issuer.influxdb.username }}
-      username: {{ .Values.config.issuer.influxdb.username | quote }}
-      {{- end }}
-    {{- end }}
-
     {{- if .Values.config.github.clientId }}
 
     github:

--- a/services/gafaelfawr/templates/ingress.yaml
+++ b/services/gafaelfawr/templates/ingress.yaml
@@ -31,13 +31,6 @@ spec:
                 name: {{ template "gafaelfawr.fullname" . }}
                 port:
                   number: 8080
-          - path: "/oauth2/callback"
-            pathType: Exact
-            backend:
-              service:
-                name: {{ template "gafaelfawr.fullname" . }}
-                port:
-                  number: 8080
           {{- if .Values.config.oidcServer.enabled }}
           - path: "/.well-known/jwks.json"
             pathType: Exact

--- a/services/gafaelfawr/values.yaml
+++ b/services/gafaelfawr/values.yaml
@@ -64,10 +64,6 @@ config:
     # `config.github.clientId`, or `config.oidc.clientId` must be set.
     clientId: ""
 
-    # -- Return URL given to CILogon (must match the CILogon configuration)
-    # @default -- `/login` at the value of config.host
-    redirectUrl: ""
-
     # -- Where to send the user if their username cannot be found in LDAP
     # @default -- Login fails with an error
     enrollmentUrl: ""

--- a/services/gafaelfawr/values.yaml
+++ b/services/gafaelfawr/values.yaml
@@ -205,15 +205,6 @@ config:
     # equal to their UID
     addUserGroup: false
 
-  influxdb:
-    # -- Whether to issue tokens for InfluxDB. If set to true,
-    # `influxdb-secret` must be set in the Gafaelfawr secret.
-    enabled: false
-
-    # -- If set, force all InfluxDB tokens to have that username instead of
-    # the authenticated identity of the user requesting a token
-    username: ""
-
   oidcServer:
     # -- Whether to support OpenID Connect clients. If set to true,
     # `oidc-server-secrets` must be set in the Gafaelfawr secret.

--- a/services/sasquatch/values-idfdev.yaml
+++ b/services/sasquatch/values-idfdev.yaml
@@ -43,7 +43,7 @@ chronograf:
     GENERIC_TOKEN_URL: https://data-dev.lsst.cloud/auth/openid/token
     USE_ID_TOKEN: 1
     JWKS_URL: https://data-dev.lsst.cloud/.well-known/jwks.json
-    GENERIC_API_URL: https://data-dev.lsst.cloud/auth/userinfo
+    GENERIC_API_URL: https://data-dev.lsst.cloud/auth/openid/userinfo
     GENERIC_SCOPES: openid
     GENERIC_API_KEY: sub
     PUBLIC_URL: https://data-dev.lsst.cloud/

--- a/services/sasquatch/values-idfint.yaml
+++ b/services/sasquatch/values-idfint.yaml
@@ -48,7 +48,7 @@ chronograf:
     GENERIC_TOKEN_URL: https://data-int.lsst.cloud/auth/openid/token
     USE_ID_TOKEN: 1
     JWKS_URL: https://data-int.lsst.cloud/.well-known/jwks.json
-    GENERIC_API_URL: https://data-int.lsst.cloud/auth/userinfo
+    GENERIC_API_URL: https://data-int.lsst.cloud/auth/openid/userinfo
     GENERIC_SCOPES: openid
     GENERIC_API_KEY: sub
     PUBLIC_URL: https://data-int.lsst.cloud/

--- a/services/sasquatch/values-summit.yaml
+++ b/services/sasquatch/values-summit.yaml
@@ -92,7 +92,7 @@ chronograf:
     GENERIC_TOKEN_URL: https://summit-lsp.lsst.codes/auth/openid/token
     USE_ID_TOKEN: 1
     JWKS_URL: https://summit-lsp.lsst.codes/.well-known/jwks.json
-    GENERIC_API_URL: https://summit-lsp.lsst.codes/auth/userinfo
+    GENERIC_API_URL: https://summit-lsp.lsst.codes/auth/openid/userinfo
     GENERIC_SCOPES: openid
     GENERIC_API_KEY: sub
     PUBLIC_URL: https://summit-lsp.lsst.codes

--- a/services/sasquatch/values-tucson-teststand.yaml
+++ b/services/sasquatch/values-tucson-teststand.yaml
@@ -113,7 +113,7 @@ chronograf:
     GENERIC_TOKEN_URL: https://tucson-teststand.lsst.codes/auth/openid/token
     USE_ID_TOKEN: 1
     JWKS_URL: https://tucson-teststand.lsst.codes/.well-known/jwks.json
-    GENERIC_API_URL: https://tucson-teststand.lsst.codes/auth/userinfo
+    GENERIC_API_URL: https://tucson-teststand.lsst.codes/auth/openid/userinfo
     GENERIC_SCOPES: openid
     GENERIC_API_KEY: sub
     PUBLIC_URL: https://tucson-teststand.lsst.codes

--- a/services/tap/templates/tap-ingress-authenticated.yaml
+++ b/services/tap/templates/tap-ingress-authenticated.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "cadc-tap.labels" . | nindent 4 }}
   annotations:
     nginx.ingress.kubernetes.io/auth-method: "GET"
-    nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-Uid, X-Auth-Request-Token"
+    nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-Token"
     nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.baseUrl }}/auth?{{ .Values.ingress.gafaelfawrAuthQuery }}"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       auth_request_set $auth_token $upstream_http_x_auth_request_token;


### PR DESCRIPTION
- Update version of Gafaelfawr
- Drop support for changing the redirect URL with CILogon or OIDC
- Fix userinfo URL for OpenID Connect integration with Sasquatch
- Drop support for InfluxDB 1.x token generation
- Stop requesting the UID in headers for TAP (which didn't use it)