### PR TITLE
DM-29094: Set minimum lifetime for notebook tokens

### DIFF
--- a/services/nublado2/README.md
+++ b/services/nublado2/README.md
@@ -72,7 +72,7 @@ Kubernetes: `>=1.20.0-0`
 | jupyterhub.imagePullSecrets[0].name | string | `"pull-secret"` |  |
 | jupyterhub.ingress.annotations."nginx.ingress.kubernetes.io/auth-method" | string | `"GET"` |  |
 | jupyterhub.ingress.annotations."nginx.ingress.kubernetes.io/auth-response-headers" | string | `"X-Auth-Request-Token"` |  |
-| jupyterhub.ingress.annotations."nginx.ingress.kubernetes.io/auth-url" | string | `"http://gafaelfawr.gafaelfawr.svc.cluster.local:8080/auth?scope=exec:notebook&notebook=true"` |  |
+| jupyterhub.ingress.annotations."nginx.ingress.kubernetes.io/auth-url" | string | `"http://gafaelfawr.gafaelfawr.svc.cluster.local:8080/auth?scope=exec:notebook&notebook=true&minimum_lifetime=2160000"` |  |
 | jupyterhub.ingress.annotations."nginx.ingress.kubernetes.io/configuration-snippet" | string | `"error_page 403 = \"/auth/forbidden?scope=exec:notebook\";\n"` |  |
 | jupyterhub.ingress.enabled | bool | `true` |  |
 | jupyterhub.ingress.ingressClassName | string | `"nginx"` |  |

--- a/services/nublado2/values.yaml
+++ b/services/nublado2/values.yaml
@@ -146,7 +146,7 @@ jupyterhub:
     annotations:
       nginx.ingress.kubernetes.io/auth-method: GET
       nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-Token"
-      nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr.gafaelfawr.svc.cluster.local:8080/auth?scope=exec:notebook&notebook=true"
+      nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr.gafaelfawr.svc.cluster.local:8080/auth?scope=exec:notebook&notebook=true&minimum_lifetime=2160000"
       nginx.ingress.kubernetes.io/configuration-snippet: |
         error_page 403 = "/auth/forbidden?scope=exec:notebook";
     ingressClassName: "nginx"


### PR DESCRIPTION
Require that notebook tokens will last at least 25 days, matching the maximum lifetime configuration in the culler.  This will hopefully ensure that the notebook token of a user will last at least as long as their notebook does.

This will force Notebook Aspect users to reauthenticate every five days, since the maximum ticket lifetime is 30 days.