### PR TITLE
[DM-36233] Evaluate Telegraf as replacement for the InlfuxDB Sink connector in Sasquatch

### DIFF
--- a/services/sasquatch/Chart.yaml
+++ b/services/sasquatch/Chart.yaml
@@ -22,3 +22,6 @@ dependencies:
     repository: https://helm.influxdata.com/
   - name: kafdrop
     version: 1.0.0
+  - name: telegraf
+    version: 1.8.20
+    repository: https://helm.influxdata.com/

--- a/services/sasquatch/Chart.yaml
+++ b/services/sasquatch/Chart.yaml
@@ -22,6 +22,5 @@ dependencies:
     repository: https://helm.influxdata.com/
   - name: kafdrop
     version: 1.0.0
-  - name: telegraf
-    version: 1.8.20
-    repository: https://helm.influxdata.com/
+  - name: telegraf-kafka-consumer
+    version: 1.0.0

--- a/services/sasquatch/README.md
+++ b/services/sasquatch/README.md
@@ -45,3 +45,13 @@ Rubin Observatory's telemetry service.
 | strimzi-kafka | object | `{}` | Override strimzi-kafka configuration. |
 | strimzi-registry-operator | object | `{"clusterName":"sasquatch","clusterNamespace":"sasquatch","operatorNamespace":"sasquatch"}` | strimzi-registry-operator configuration. |
 | telegraf-kafka-consumer | object | `{}` | Override telegraf-kafka-consumer |
+| telegraf.config.inputs | list | `[{"kafka_consumer":{"avro_fields":["heartbeat","private_efdStamp","salIndex"],"avro_measurement":"test","avro_schema_registry":"http://sasquatch-schema-registry.sasquatch:8081","avro_timestamp":"private_efdStamp","avro_timestamp_format":"unix_us","brokers":["sasquatch-kafka-brokers.sasquatch:9092"],"consumer_group":"telegraf-test","data_format":"avro","max_message_len":32768,"sasl_mechanism":"SCRAM-SHA-512","sasl_password":"$TELEGRAF_PASSWORD","sasl_username":"telegraf","topics":["lsst.sal.Test.logevent_heartbeat"]}}]` | Telegraf input plugins. |
+| telegraf.config.inputs[0] | object | `{"kafka_consumer":{"avro_fields":["heartbeat","private_efdStamp","salIndex"],"avro_measurement":"test","avro_schema_registry":"http://sasquatch-schema-registry.sasquatch:8081","avro_timestamp":"private_efdStamp","avro_timestamp_format":"unix_us","brokers":["sasquatch-kafka-brokers.sasquatch:9092"],"consumer_group":"telegraf-test","data_format":"avro","max_message_len":32768,"sasl_mechanism":"SCRAM-SHA-512","sasl_password":"$TELEGRAF_PASSWORD","sasl_username":"telegraf","topics":["lsst.sal.Test.logevent_heartbeat"]}}` | See https://github.com/influxdata/telegraf/blob/master/plugins/inputs/kafka_consumer/README.md |
+| telegraf.config.outputs | list | `[{"influxdb":{"database":"kafkaconsumer","password":"$INFLUXDB_ADMIN_PASSWORD","urls":["http://sasquatch-influxdb.sasquatch:8086"],"username":"admin"}}]` | Telegraf output destination. |
+| telegraf.config.processors | object | `{}` | Telegraf processor plugins. |
+| telegraf.env[0] | object | `{"name":"TELEGRAF_PASSWORD","valueFrom":{"secretKeyRef":{"key":"telegraf-password","name":"sasquatch"}}}` | Telegraf KafkaUser password. |
+| telegraf.env[1] | object | `{"name":"INFLUXDB_ADMIN_PASSWORD","valueFrom":{"secretKeyRef":{"key":"influxdb-password","name":"sasquatch"}}}` | InfluxDB admin password. |
+| telegraf.image.pullPolicy | string | `"Always"` |  |
+| telegraf.image.repo | string | `"lsstsqre/telegraf"` | Telegraf image repository |
+| telegraf.image.tag | string | `"avro"` | Telegraf image tag |
+| telegraf.service.enabled | bool | `false` | Telegraf service. |

--- a/services/sasquatch/README.md
+++ b/services/sasquatch/README.md
@@ -9,6 +9,7 @@ Rubin Observatory's telemetry service.
 |  | kafdrop | 1.0.0 |
 |  | kafka-connect-manager | 1.0.0 |
 |  | strimzi-kafka | 1.0.0 |
+|  | telegraf-kafka-consumer | 1.0.0 |
 | https://helm.influxdata.com/ | chronograf | 1.2.5 |
 | https://helm.influxdata.com/ | influxdb | 4.12.0 |
 | https://helm.influxdata.com/ | kapacitor | 1.4.6 |
@@ -43,3 +44,4 @@ Rubin Observatory's telemetry service.
 | kapacitor.resources.requests.memory | string | `"1Gi"` |  |
 | strimzi-kafka | object | `{}` | Override strimzi-kafka configuration. |
 | strimzi-registry-operator | object | `{"clusterName":"sasquatch","clusterNamespace":"sasquatch","operatorNamespace":"sasquatch"}` | strimzi-registry-operator configuration. |
+| telegraf-kafka-consumer | object | `{}` | Override telegraf-kafka-consumer |

--- a/services/sasquatch/charts/strimzi-kafka/templates/users.yaml
+++ b/services/sasquatch/charts/strimzi-kafka/templates/users.yaml
@@ -122,3 +122,33 @@ spec:
         type: allow
         host: "*"
         operation: All
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaUser
+metadata:
+  name: telegraf
+  labels:
+    strimzi.io/cluster: {{ .Values.cluster.name }}
+spec:
+  authentication:
+    type: scram-sha-512
+    password:
+      valueFrom:
+        secretKeyRef:
+          name: sasquatch
+          key: telegraf-password
+  authorization:
+    type: simple
+    acls:
+      - resource:
+          type: group
+          name: "*"
+          patternType: literal
+        operation: All
+      - resource:
+          type: topic
+          name: "*"
+          patternType: literal
+        type: allow
+        host: "*"
+        operation: Read

--- a/services/sasquatch/charts/telegraf-kafka-consumer/Chart.yaml
+++ b/services/sasquatch/charts/telegraf-kafka-consumer/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: telegraf-kafka-consumer
+version: 1.0.0
+description: >
+  Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.
+  This chart deploys multiple instances of the telegraf agent to connect Kafka and InfluxDB in Sasquatch.
+appVersion: 1.23.3

--- a/services/sasquatch/charts/telegraf-kafka-consumer/README.md
+++ b/services/sasquatch/charts/telegraf-kafka-consumer/README.md
@@ -1,0 +1,31 @@
+# telegraf-kafka-consumer
+
+Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics. This chart deploys multiple instances of the telegraf agent to connect Kafka and InfluxDB in Sasquatch.
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Affinity for pod assignment. |
+| args | list | `[]` | Arguments passed to the Telegraf agent containers. |
+| envFromSecret | string | `""` | Name of the secret with values to be added to the environment. |
+| env[0].name | string | `"TELEGRAF_PASSWORD"` |  |
+| env[0].valueFrom.secretKeyRef.key | string | `"telegraf-password"` | Telegraf KafkaUser password. |
+| env[0].valueFrom.secretKeyRef.name | string | `"sasquatch"` |  |
+| env[1].name | string | `"INFLUXDB_ADMIN_PASSWORD"` |  |
+| env[1].valueFrom.secretKeyRef.key | string | `"influxdb-password"` | InfluxDB admin password. |
+| env[1].valueFrom.secretKeyRef.name | string | `"sasquatch"` |  |
+| image.pullPolicy | string | IfNotPresent | Image pull policy. |
+| image.repo | string | `"lsstsqre/telegraf"` | Telegraf image repository. |
+| image.tag | string | `"kafka-regexp"` | Telegraf image tag. |
+| imagePullSecrets | list | `[]` | Secret names to use for Docker pulls. |
+| influxdb.database | string | `"telegraf-kafka-consumer"` | Name of the InfluxDB database to write to. |
+| kafkaConsumers.test.enabled | bool | `false` | Enable the Telegraf Kafka consumer. |
+| kafkaConsumers.test.flush_interval | string | `"1s"` | Default data flushing interval to InfluxDB. |
+| kafkaConsumers.test.interval | string | `"1s"` | Data collection interval for the Kafka consumer. |
+| kafkaConsumers.test.topicRegexps | string | `"[ \".*Test\" ]\n"` | List of regular expressions to specify the Kafka topics consumed by this agent. |
+| nodeSelector | object | `{}` | Node labels for pod assignment. |
+| podAnnotations | object | `{}` | Annotations for telegraf-kafka-consumers pods. |
+| podLabels | object | `{}` | Labels for telegraf-kafka-consumer pods. |
+| resources | object | `{}` | Kubernetes resources requests and limits. |
+| tolerations | list | `[]` | Tolerations for pod assignment. |

--- a/services/sasquatch/charts/telegraf-kafka-consumer/templates/configmap.yaml
+++ b/services/sasquatch/charts/telegraf-kafka-consumer/templates/configmap.yaml
@@ -1,0 +1,55 @@
+{{- range $key, $value := .Values.kafkaConsumers }}
+{{- if $value.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sasquatch-telegraf-kafka-consumer-{{ $key }}
+  labels:
+    app: sasquatch-telegraf-kafka-consumer
+data:
+  telegraf.conf: |+
+    [agent]
+      collection_jitter = "0s"
+      debug = true
+      flush_interval = {{ default "1s" $value.flush_interval | quote }}
+      flush_jitter = "0s"
+      interval = {{ default "1s" $value.interval | quote }}
+      logfile = ""
+      metric_batch_size = 1000
+      metric_buffer_limit = 10000
+      omit_hostname = true
+      precision = ""
+      quiet = false
+      round_interval = true
+
+    [[outputs.influxdb]]
+      database = {{ $.Values.influxdb.database | quote }}
+      password = "$INFLUXDB_ADMIN_PASSWORD"
+      urls = [
+        "http://sasquatch-influxdb.sasquatch:8086"
+      ]
+      username = "admin"
+
+    [[inputs.kafka_consumer]]
+      avro_schema_registry = "http://sasquatch-schema-registry.sasquatch:8081"
+      avro_timestamp = "private_efdStamp"
+      avro_timestamp_format = "unix_us"
+      brokers = [
+        "sasquatch-kafka-brokers.sasquatch:9092"
+      ]
+      consumer_group = "telegraf-kafka-consumer-{{ $key }}"
+      data_format = "avro"
+      max_message_len = 1000000
+      sasl_mechanism = "SCRAM-SHA-512"
+      sasl_password = "$TELEGRAF_PASSWORD"
+      sasl_username = "telegraf"
+      topic_refresh_interval = "60s"
+      topic_regexps = {{ $value.topicRegexps }}
+      offset = "newest"
+      consumer_fetch_default = "20MB"
+
+    [[inputs.internal]]
+      collect_memstats = false
+{{- end }}
+{{- end }}

--- a/services/sasquatch/charts/telegraf-kafka-consumer/templates/deployment.yaml
+++ b/services/sasquatch/charts/telegraf-kafka-consumer/templates/deployment.yaml
@@ -1,0 +1,79 @@
+{{- range $key, $value := .Values.kafkaConsumers }}
+{{- if $value.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sasquatch-telegraf-kafka-consumer-{{ $key }}
+  labels:
+    app: sasquatch-telegraf-kafka-consumer
+spec:
+  replicas: {{ default 1 $value.replicaCount }}
+  selector:
+    matchLabels:
+      app: sasquatch-telegraf-kafka-consumer
+  template:
+    metadata:
+      labels:
+        app: sasquatch-telegraf-kafka-consumer
+      {{- if $.Values.podAnnotations }}
+      annotations:
+        {{- toYaml $.Values.podAnnotations | nindent 8 }}
+      {{- end }}
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+      containers:
+      - name: telegraf
+        securityContext:
+          capabilities:
+            drop:
+              - all
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+        image: "{{ $.Values.image.repo }}:{{ $.Values.image.tag }}"
+        imagePullPolicy: {{ default "IfNotPresent" $.Values.image.pullPolicy | quote }}
+        {{- if $.Values.resources }}
+        resources:
+          {{- toYaml $.Values.resources | nindent 10 }}
+        {{- end }}
+        {{- if $.Values.args }}
+        args:
+          {{- toYaml $.Values.args | nindent 8 }}
+        {{- end }}
+        {{- if $.Values.env }}
+        env:
+          {{- toYaml $.Values.env | nindent 8 }}
+        {{- end }}
+        {{- if $.Values.envFromSecret }}
+        envFrom:
+          - secretRef:
+              name: {{ $.Values.envFromSecret }}
+        {{- end }}
+        volumeMounts:
+        - name: config
+          mountPath: /etc/telegraf
+      {{- if $.Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml $.Values.imagePullSecrets | nindent 8 }}
+      {{- end }}
+      {{- if $.Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml $.Values.nodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if $.Values.affinity }}
+      affinity:
+        {{- toYaml $.Values.affinity | nindent 8 }}
+      {{- end }}
+      {{- if $.Values.tolerations }}
+      tolerations:
+        {{- toYaml $.Values.tolerations | nindent 8 }}
+      {{- end }}
+      volumes:
+      - name: config
+        configMap:
+          name: sasquatch-telegraf-kafka-consumer-{{ $key }}
+{{- end }}
+{{- end }}

--- a/services/sasquatch/charts/telegraf-kafka-consumer/values.yaml
+++ b/services/sasquatch/charts/telegraf-kafka-consumer/values.yaml
@@ -1,0 +1,68 @@
+## Default values.yaml for Telegraf Kafka Consumer
+image:
+  # -- Telegraf image repository.
+  repo: "lsstsqre/telegraf"
+  # -- Telegraf image tag.
+  tag: "kafka-regexp"
+  # -- Image pull policy.
+  # @default -- IfNotPresent
+  pullPolicy: "Always"
+
+# -- Annotations for telegraf-kafka-consumers pods.
+podAnnotations: {}
+
+# -- Labels for telegraf-kafka-consumer pods.
+podLabels: {}
+
+# -- Secret names to use for Docker pulls.
+imagePullSecrets: []
+
+# -- Arguments passed to the Telegraf agent containers.
+args: []
+
+# Telegraf agent enviroment variables
+env:
+  - name: TELEGRAF_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: sasquatch
+        # -- Telegraf KafkaUser password.
+        key: telegraf-password
+  - name: INFLUXDB_ADMIN_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: sasquatch
+        # -- InfluxDB admin password.
+        key: influxdb-password
+
+# -- Name of the secret with values to be added to the environment.
+envFromSecret: ""
+
+# List of Telegraf Kafka consumers to deploy.
+kafkaConsumers:
+  test:
+    # -- Enable the Telegraf Kafka consumer.
+    enabled: false
+    # -- Data collection interval for the Kafka consumer.
+    interval: "1s"
+    # -- Default data flushing interval to InfluxDB.
+    flush_interval: "1s"
+    # -- List of regular expressions to specify the Kafka topics consumed by this agent.
+    topicRegexps: |
+      [ ".*Test" ]
+
+influxdb:
+  # -- Name of the InfluxDB database to write to.
+  database: "telegraf-kafka-consumer"
+
+# -- Kubernetes resources requests and limits.
+resources: {}
+
+# -- Node labels for pod assignment.
+nodeSelector: {}
+
+# -- Affinity for pod assignment.
+affinity: {}
+
+# -- Tolerations for pod assignment.
+tolerations: []

--- a/services/sasquatch/values-idfdev.yaml
+++ b/services/sasquatch/values-idfdev.yaml
@@ -20,12 +20,19 @@ influxdb:
     enabled: true
     hostname: data-dev.lsst.cloud
 
-kafka-connect-manager:
-  influxdbSink:
-    connectors:
-      test:
-        enabled: true
-        topicsRegex: ".*Test"
+telegraf-kafka-consumer:
+  kafkaConsumers:
+    test:
+      enabled: true
+      replicaCount: 1
+      topicRegexps: |
+        [ ".*Test" ]
+    atmcs:
+      enabled: true
+      replicaCount: 1
+      topicRegexps: |
+        [ ".*ATMCS" ]
+
 
 kafdrop:
   ingress:

--- a/services/sasquatch/values-tucson-teststand.yaml
+++ b/services/sasquatch/values-tucson-teststand.yaml
@@ -42,6 +42,75 @@ influxdb:
         proxy_set_header X-Forwarded-Path /;
     path: /
 
+telegraf-kafka-consumer:
+  kafkaConsumers:
+    auxtel:
+      enabled: true
+      topicRegexps: |
+        [ ".*ATAOS", ".*ATDome", ".*ATDomeTrajectory", ".*ATHexapod", ".*ATPneumatics", ".*ATPtg", ".*ATMCS" ]
+    maintel:
+      enabled: true
+      topicRegexps: |
+        [ ".*MTAOS", ".*MTDome", ".*MTDomeTrajectory", ".*MTPtg" ]
+    mtmount:
+      enabled: true
+      topicRegexps: |
+        [ ".*MTMount" ]
+    comcam:
+      enabled: true
+      topicRegexps: |
+        [ ".*CCArchiver", ".*CCCamera", ".*CCHeaderService", ".*CCOODS" ]
+    eas:
+      enabled: true
+      topicRegexps: |
+        [ ".*DIMM", ".*DSM", ".*WeatherStation" ]
+    latiss:
+      enabled: true
+      topicRegexps: |
+        [ ".*ATArchiver", ".*ATCamera", ".*ATHeaderService", ".*ATOODS", ".*ATSpectrograph" ]
+    m1m3:
+      enabled: true
+      flush_interval: "0.1s"
+      interval: "0.1s"
+      topicRegexps: |
+        [ ".*MTM1M3" ]
+    m2:
+      enabled: true
+      topicRegexps: |
+        [ ".*MTHexapod", ".*MTM2", ".*MTRotator" ]
+    obssys:
+      enabled: true
+      topicRegexps: |
+        [ ".*GenericCamera", ".*Scheduler", ".*Script", ".*ScriptQueue", ".*Watcher" ]
+    ocps:
+      enabled: true
+      topicRegexps: |
+        [ ".*OCPS" ]
+    pmd:
+      enabled: true
+      topicRegexps: |
+        [ ".*PMD" ]
+    calsys:
+      enabled: true
+      topicRegexps: |
+        [ ".*ATMonochromator", ".*ATWhiteLight", ".*CBP", ".*Electrometer", ".*FiberSpectrograph", ".*LinearStage", ".*TunableLaser" ]
+    mtaircompressor:
+      enabled: true
+      topicRegexps: |
+        [ ".*MTAirCompressor" ]
+    authorize:
+      enabled: true
+      topicRegexps: |
+        [ ".*Authorize" ]
+    mtalignment:
+      enabled: true
+      topicRegexps: |
+        [ ".*MTAlignment" ]
+    test:
+      enabled: true
+      topicRegexps: |
+        [ "lsst.sal.Test" ]
+
 kafka-connect-manager:
   influxdbSink:
     # Based on the kafka producers configuration for the TTS

--- a/services/sasquatch/values.yaml
+++ b/services/sasquatch/values.yaml
@@ -66,6 +66,10 @@ influxdb:
 # -- Override kafka-connect-manager configuration.
 kafka-connect-manager: {}
 
+# -- Override telegraf-kafka-consumer
+telegraf-kafka-consumer: {}
+
+
 chronograf:
   # -- Chronograf image tag.
   image:
@@ -114,6 +118,63 @@ kapacitor:
     limits:
       memory: 16Gi
       cpu: 4
+
+telegraf:
+  image:
+    # -- Telegraf image repository
+    repo: "lsstsqre/telegraf"
+    # -- Telegraf image tag
+    tag: "avro"
+    pullPolicy: Always
+  env:
+    # -- Telegraf KafkaUser password.
+    - name: TELEGRAF_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: sasquatch
+          key: telegraf-password
+    # -- InfluxDB admin password.
+    - name: INFLUXDB_ADMIN_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: sasquatch
+          key: influxdb-password
+  service:
+    # -- Telegraf service.
+    enabled: false
+  config:
+    # -- Telegraf processor plugins.
+    processors: {}
+    # -- Telegraf input plugins.
+    inputs:
+      # -- See https://github.com/influxdata/telegraf/blob/master/plugins/inputs/kafka_consumer/README.md
+      - kafka_consumer:
+          brokers:
+            - sasquatch-kafka-brokers.sasquatch:9092
+          topics:
+            - lsst.sal.Test.logevent_heartbeat
+          sasl_username: telegraf
+          sasl_password: $TELEGRAF_PASSWORD
+          sasl_mechanism: SCRAM-SHA-512
+          consumer_group: telegraf-test
+          max_message_len: 32768
+          data_format: avro
+          avro_schema_registry: "http://sasquatch-schema-registry.sasquatch:8081"
+          avro_measurement: "test"
+          avro_fields:
+            - heartbeat
+            - private_efdStamp
+            - salIndex
+          avro_timestamp: private_efdStamp
+          avro_timestamp_format: unix_us
+    # -- Telegraf output destination.
+    outputs:
+      - influxdb:
+          urls:
+            - "http://sasquatch-influxdb.sasquatch:8086"
+          database: "kafkaconsumer"
+          username: admin
+          password: $INFLUXDB_ADMIN_PASSWORD
 
 global:
   # -- Base path for Vault secrets


### PR DESCRIPTION
- Add a subchart to deploy a list of Telegraf Kafka consumer agents to consumer Kafka topics and write them to InfluxDB
- Enable the Telegraf Kafka consumers and deploy on TTS to compare performance with the Lenses InfluxDB Sink Kafka connector.