### PR TITLE
Upgrade JupyterHub database at summit

### DIFF
--- a/services/nublado2/values-summit.yaml
+++ b/services/nublado2/values-summit.yaml
@@ -1,4 +1,7 @@
 jupyterhub:
+  hub:
+    db:
+      upgrade: true
   ingress:
     hosts: ["summit-lsp.lsst.codes"]
     annotations:


### PR DESCRIPTION
Enable automatic upgrade of the JupyterHub database at the summit for the JupyterHub 3.0 migration.