### PR TITLE
Revert "Update Helm release argo-cd to v5.5.16"

### DIFF
--- a/services/argocd/Chart.yaml
+++ b/services/argocd/Chart.yaml
@@ -3,5 +3,5 @@ name: argo-cd
 version: 1.0.0
 dependencies:
 - name: argo-cd
-  version: 5.5.16
+  version: 5.5.7
   repository: https://argoproj.github.io/argo-helm

--- a/services/argocd/README.md
+++ b/services/argocd/README.md
@@ -4,7 +4,7 @@
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://argoproj.github.io/argo-helm | argo-cd | 5.5.16 |
+| https://argoproj.github.io/argo-helm | argo-cd | 5.5.7 |
 
 ## Values
 


### PR DESCRIPTION
This reverts commit 1c9af4c6780469cee33ac7e87aa905b8dbf57bf8. This release of Argo CD has a buggy version of Dax that breaks Google authentication.  Hopefully the next release will import the version of Dax with a fix.