### PR TITLE
DM-36585: Add a Python package to Phalanx

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,10 +43,10 @@ jobs:
           python-version: 3.9
 
       - name: Install test dependencies
-        run: pip install -r tests/requirements.txt
+        run: pip install .
 
       - name: Expand modified charts
-        run: tests/expand-services
+        run: expand-charts
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.3.1

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -29,21 +29,22 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: "3.10"
 
       - name: Python install
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install -r docs/requirements.txt
+          python -m pip install --upgrade pip tox
+          python -m pip install -e ".[dev]"
           python -m pip install ltd-conveyor
 
       - name: Install graphviz
         run: sudo apt-get install graphviz
 
-      - name: Build
-        run: |
-          cd docs
-          make html
+      - name: Run tox
+        uses: lsst-sqre/run-tox@v1
+        with:
+          python-version: "3.10"
+          tox-envs: "docs,docs-linkcheck"
 
       # Only attempt documentation uploads for long-lived branches, tagged
       # releases, and pull requests from ticket branches.  This avoids version

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,135 @@
 /installer/docker-creds
 /services/*/charts/*.tgz
 /services-expanded/
-.DS_Store
 **/Chart.lock
+
+# Byte-compiled / optimized / DLL files
 __pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+docs/api/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -5,5 +5,12 @@ help:
 
 .PHONY:
 init:
-	pip install --upgrade pre-commit
+	pip install --upgrade pre-commit tox
 	pre-commit install
+	pip install -e ".[dev]"
+	rm -rf .tox
+
+.PHONY:
+clean:
+	rm -rf .tox
+	make -C docs clean

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,25 +1,11 @@
-# Makefile for Sphinx documentation
+# Makefile for Sphinx documentation.
+# Use tox -e docs,docs-linkcheck to build the docs.
 
 .PHONY: help
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
-	@echo "  init       install dependencies"
 	@echo "  clean      delete builds"
-	@echo "  html       to make standalone HTML files"
-	@echo "  linkcheck  to check all external links for integrity"
-
-.PHONY: init
-init:
-	pip install -r requirements.txt
 
 .PHONY: clean
 clean:
 	rm -rf _build/*
-
-.PHONY: html
-html:
-	sphinx-build -b html -d _build/doctrees . _build/html
-
-.PHONY: linkcheck
-linkcheck:
-	sphinx-build -b linkcheck -d _build/doctrees . _build/linkcheck

--- a/docs/_rst_epilog.rst
+++ b/docs/_rst_epilog.rst
@@ -27,6 +27,7 @@
 .. _Services:
 .. _Service: https://kubernetes.io/docs/concepts/services-networking/service/
 .. _Sphinx: https://www.sphinx-doc.org/en/master/
+.. _tox: https://tox.wiki/en/latest/
 .. _pre-commit: https://pre-commit.com
 .. _Vault: https://www.vaultproject.io/
 .. _Vault Secrets Operator: https://github.com/ricoberger/vault-secrets-operator

--- a/docs/about/contributing-docs.rst
+++ b/docs/about/contributing-docs.rst
@@ -22,62 +22,27 @@ Set up pre-commit
 Phalanx uses Pre-commit_ to lint files and, in some cases, automatically reformat files.
 Follow the instructions in :doc:`precommit-and-helm-docs`.
 
-Install the Sphinx dependencies
--------------------------------
+Initialize the development environment
+--------------------------------------
 
-From the
-The Sphinx_ documentation project requires Python dependencies located in the ``docs/requirements.txt`` directory.
-For best results, install these dependencies in a dedicated Python virtual environment, such as with venv_ or other tools:
+From the ``phalanx`` directory, initialize your environment:
 
-.. tab-set::
+.. code-block:: bash
 
-   .. tab-item:: pip install
+    make init
 
-      .. code-block:: bash
-
-         cd docs
-         pip install -r requirements.txt
-
-   .. tab-item:: Workflow with venv
-
-      Create and activate the virtual environment:
-
-      .. code-block:: bash
-
-         cd docs
-         python -m venv .venv
-         source .venv/bin/activate
-
-      Install documentation dependencies:
-
-      .. code-block:: bash
-
-         pip install -r requirements.txt
-
-      .. note::
-
-         When you want to de-activate this virtual environment in your current shell you can run:
-
-         .. code-block:: bash
-
-            deactivate
-
-         And later set up the environment again by sourcing the ``activate`` script again with:
-
-         .. code-block:: bash
-
-            source .venv/bin/activate
+This steps installs tox_, the tooling for builds with isolated Python environments, and pre-commit_, a tool for linting and formatting files (see :doc:`precommit-and-helm-docs`).
 
 Compiling the documentation
 ===========================
 
-The Makefile includes a target for building the documentation:
+Use the tox_ ``docs`` environment for compiling the documentation:
 
 .. code-block:: bash
 
-   make html
+   tox -e docs
 
-The built documentation is located in the ``_build/html`` directory (relative to the ``/docs`` directory).
+The built documentation is located in the ``docs/_build/html`` directory.
 
 Sphinx caches build products and in some cases you may need to delete the build to get a consistent result:
 
@@ -92,7 +57,7 @@ Links in the documentation are validated in the GitHub Actions workflow, but you
 
 .. code-block:: bash
 
-   make linkcheck
+   tox -e docs-linkcheck
 
 Submitting a pull request and sharing documentation drafts
 ==========================================================

--- a/docs/about/repository.rst
+++ b/docs/about/repository.rst
@@ -74,7 +74,7 @@ See :doc:`contributing-docs`.
 starters directory
 ------------------
 
-:bdg-link-primary-line:`Browse /docs/ on GitHub <https://github.com/lsst-sqre/phalanx/tree/master/starers>`
+:bdg-link-primary-line:`Browse /docs/ on GitHub <https://github.com/lsst-sqre/phalanx/tree/master/starters>`
 
 This directory contains templates for contributing new applications to Phalanx.
 See :doc:`/developers/add-application`.

--- a/docs/admin/bootstrapping.rst
+++ b/docs/admin/bootstrapping.rst
@@ -110,7 +110,7 @@ If you are using GitHub, group membership will be synthesized from all of the te
 These must be team memberships, not just organization memberships.
 The corresponding group for Gafaelfawr purposes will be ``<organization>-<team>`` where ``<team>`` is the team **slug**, not the team name.
 That means the team name will be converted to lowercase and spaces will be replaced with dashes, and other transformations will be done for special characters.
-For more information about how Gafaelfawr constructs groups from GitHub teams, see `the Gafaelfawr documentation <https://gafaelfawr.lsst.io/arch/providers.html#github-groups>`__.
+For more information about how Gafaelfawr constructs groups from GitHub teams, see `the Gafaelfawr documentation <https://gafaelfawr.lsst.io/dev/providers.html#github-groups>`__.
 
 For an example of a ``group_mapping`` configuration for GitHub authentication, see `/applications/gafaelfawr/values-idfdev.yaml <https://github.com/lsst-sqre/phalanx/blob/master/services/gafaelfawr/values-idfdev.yaml>`__.
 

--- a/docs/admin/update-pull-secret.rst
+++ b/docs/admin/update-pull-secret.rst
@@ -6,7 +6,7 @@ The pull secret, present in each RSP instance, and shared by many
 applications there, is notoriously tricky to format correctly.
 
 The recommended way to update it is to edit the pull secret in 1Password
-and then deploy it with the `installer/update-secrets.sh` script;
+and then deploy it with the ``installer/update-secrets.sh`` script;
 however, this only works (at the time of writing, 20 May 2022) on Linux
 systems with the 1Password 1.x CLI installed.
 

--- a/docs/developers/add-application.rst
+++ b/docs/developers/add-application.rst
@@ -38,7 +38,7 @@ You will need to make at least the following changes to the default Helm chart t
          nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr.gafaelfawr.svc.cluster.local:8080/auth?scope=exec:admin"
 
   For user-facing applications you will want a scope other than ``exec:admin``.
-  See `the Gafaelfawr's documentation on protecting an application <https://gafaelfawr.lsst.io/applications.html#protecting-a-service>`__ for more information.
+  See `the Gafaelfawr's documentation on Ingress configurations <https://gafaelfawr.lsst.io/user-guide/ingress.html>`__ for more information.
 
 - If your application exposes Prometheus endpoints, you will want to configure these in the `telegraf application's prometheus_config <https://github.com/lsst-sqre/phalanx/blob/master/services/telegraf/values.yaml#L36>`__.
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,0 @@
-documenteer[guide]>=0.7.0b4
-sphinx-diagrams

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 name = "phalanx"
 version = "1.0.0"
 description = "Python support code for the Rubin Phalanx platform."
-# license = {file = "LICENSE"}
+license = {file = "LICENSE"}
 readme= "README.rst"
 keywords = [
     "rubin",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,74 @@
+[project]
+# https://packaging.python.org/en/latest/specifications/declaring-project-metadata/
+name = "phalanx"
+version = "1.0.0"
+description = "Python support code for the Rubin Phalanx platform."
+# license = {file = "LICENSE"}
+readme= "README.rst"
+keywords = [
+    "rubin",
+    "lsst",
+]
+# https://pypi.org/classifiers/
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Intended Audience :: Developers",
+    "Operating System :: POSIX",
+]
+requires-python = ">=3.8"
+dependencies = []
+
+[project.optional-dependencies]
+dev = [
+    # Testing
+    "coverage[toml]",
+    "pytest",
+    "pre-commit",
+    "mypy",
+    # Documentation
+    "documenteer[guide]>=0.7.0b4",
+    "sphinx-diagrams"
+]
+
+[project.urls]
+Homepage = "https://phalanx.lsst.io"
+Source = "https://github.com/lsst-sqre/phalanx"
+
+[build-system]
+requires = [
+    "setuptools>=61",
+    "wheel",
+    "setuptools_scm[toml]>=6.2"
+]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+
+[tool.coverage.run]
+parallel = true
+branch = true
+source = ["phalanx"]
+
+[tool.coverage.paths]
+source = ["src", ".tox/*/site-packages"]
+
+[tool.coverage.report]
+show_missing = true
+exclude_lines = [
+    "pragma: no cover",
+    "def __repr__",
+    "if self.debug:",
+    "if settings.DEBUG",
+    "raise AssertionError",
+    "raise NotImplementedError",
+    "if 0:",
+    "if __name__ == .__main__.:",
+    "if TYPE_CHECKING:"
+]
+
 [tool.black]
 line-length = 79
 target-version = ['py38']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,9 @@ classifiers = [
     "Operating System :: POSIX",
 ]
 requires-python = ">=3.8"
-dependencies = []
+dependencies = [
+    "GitPython",
+]
 
 [project.optional-dependencies]
 dev = [
@@ -32,6 +34,9 @@ dev = [
     "documenteer[guide]>=0.7.0b4",
     "sphinx-diagrams"
 ]
+
+[project.scripts]
+expand-charts = "phalanx.testing.expandcharts:main"
 
 [project.urls]
 Homepage = "https://phalanx.lsst.io"

--- a/src/phalanx/__init__.py
+++ b/src/phalanx/__init__.py
@@ -1,0 +1,18 @@
+"""The phalanx package provides support tooling for Phalanx, SQuaRE's
+application deployment platform.
+"""
+
+__all__ = ["__version__"]
+
+from importlib.metadata import PackageNotFoundError, version
+
+__version__: str
+"""The version string, although ``phalanx`` isn't technically released
+like a typical Python package.
+"""
+
+try:
+    __version__ = version(__name__)
+except PackageNotFoundError:
+    # package is not installed
+    __version__ = "0.0.0"

--- a/src/phalanx/testing/expandcharts.py
+++ b/src/phalanx/testing/expandcharts.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 """Expand Helm charts for testing.
 
 Discover the list of supported environments, find all charts that have changed
@@ -85,7 +83,3 @@ def main() -> None:
     environments = get_environments()
     for chart in charts:
         expand_chart(chart, environments)
-
-
-if __name__ == "__main__":
-    main()

--- a/tests/packaging_test.py
+++ b/tests/packaging_test.py
@@ -1,0 +1,11 @@
+"""Test that the Python packaging metadata."""
+
+from __future__ import annotations
+
+from phalanx import __version__
+
+
+def test_vesrion() -> None:
+    """Test that the package has a version (and is installed)."""
+    assert len(__version__) > 0
+    assert __version__ != "0.0.0"  # would be if not installed

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,1 +1,0 @@
-GitPython

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,45 @@
+[tox]
+envlist = py,coverage-report,typing,lint,docs,docs-linkcheck
+isolated_build = True
+
+[testenv]
+description = Run pytest against {envname}.
+extras =
+    dev
+
+[testenv:py]
+description = Run pytest
+commands =
+    coverage run -m pytest {posargs}
+
+[testenv:coverage-report]
+description = Compile coverage from each test run.
+skip_install = true
+deps = coverage[toml]>=5.0.2
+depends =
+    py
+commands =
+    coverage combine
+    coverage report
+
+[testenv:typing]
+description = Run mypy.
+commands =
+    mypy src/phalanx tests
+
+[testenv:lint]
+description = Lint codebase by running pre-commit (Black, isort, Flake8).
+skip_install = true
+deps =
+    pre-commit
+commands = pre-commit run --all-files
+
+[testenv:docs]
+description = Build documentation (HTML) with Sphinx.
+commands =
+    sphinx-build --keep-going -n -W -T -b html -d {envtmpdir}/doctrees docs docs/_build/html
+
+[testenv:docs-linkcheck]
+description = Check links in the documentation.
+commands =
+    sphinx-build --keep-going -n -W -T -b linkcheck -d {envtmpdir}/doctrees docs docs/_build/linkcheck


### PR DESCRIPTION
This PR adds a standard Python package to phalanx for the purpose of hosting Python infrastructure for testing, developing, and generating documentation.

Since there is now Python package infrastructure, the docs are now built with tox. The `expand-services` script is also moved into the Python package and installed as an entrypoint along with its GitPython dependency.