### PR TITLE
[DM-36684] Add Kafka bridge to Sasquatch

### DIFF
--- a/science-platform/templates/sasquatch-application.yaml
+++ b/science-platform/templates/sasquatch-application.yaml
@@ -25,6 +25,10 @@ spec:
     targetRevision: {{ .Values.revision }}
     helm:
       parameters:
+        - name: "global.host"
+          value: {{ .Values.fqdn | quote }}
+        - name: "global.baseUrl"
+          value: "https://{{ .Values.fqdn }}"
         - name: "global.vaultSecretsPath"
           value: {{ .Values.vault_path_prefix | quote }}
       valueFiles:

--- a/services/sasquatch/README.md
+++ b/services/sasquatch/README.md
@@ -32,6 +32,8 @@ Rubin Observatory's telemetry service.
 | chronograf.resources.limits.memory | string | `"16Gi"` |  |
 | chronograf.resources.requests.cpu | int | `1` |  |
 | chronograf.resources.requests.memory | string | `"1Gi"` |  |
+| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
+| global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | influxdb.config | object | `{"continuous_queries":{"enabled":false},"coordinator":{"log-queries-after":"15s","max-concurrent-queries":0,"query-timeout":"0s","write-timeout":"1h"},"data":{"cache-max-memory-size":0,"trace-logging-enabled":true,"wal-fsync-delay":"100ms"},"http":{"auth-enabled":true,"enabled":true,"flux-enabled":true,"max-row-limit":0},"logging":{"level":"debug"}}` | Override InfluxDB configuration. See https://docs.influxdata.com/influxdb/v1.8/administration/config |
 | influxdb.image | object | `{"tag":"1.8.10"}` | InfluxDB image tag. |

--- a/services/sasquatch/charts/strimzi-kafka/templates/bridge.yaml
+++ b/services/sasquatch/charts/strimzi-kafka/templates/bridge.yaml
@@ -27,7 +27,7 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-    - host: data-dev.lsst.cloud
+    - host: {{ required "global.host must be set" .Values.global.host | quote }}
       http:
         paths:
           - backend:

--- a/services/sasquatch/charts/strimzi-kafka/templates/bridge.yaml
+++ b/services/sasquatch/charts/strimzi-kafka/templates/bridge.yaml
@@ -1,0 +1,49 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaBridge
+metadata:
+  name: {{ .Values.cluster.name }}
+spec:
+  replicas: 1
+  bootstrapServers: {{ .Values.cluster.name }}-kafka-bootstrap:9093
+  http:
+    port: 8080
+  tls:
+    trustedCertificates:
+      - secretName: {{ .Values.cluster.name }}-cluster-ca-cert
+        certificate: ca.crt
+  authentication:
+    type: tls
+    certificateAndKey:
+      secretName: {{ .Values.cluster.name }}-bridge
+      certificate: user.crt
+      key: user.key
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+  name: {{ .Values.cluster.name }}-bridge
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: data-dev.lsst.cloud
+      http:
+        paths:
+          - backend:
+              service:
+                name: {{ .Values.cluster.name }}-bridge-service
+                port:
+                  number: 8080
+            path: /{{ .Values.cluster.name }}-bridge(/|$)(.*)
+            pathType: Prefix
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaUser
+metadata:
+  name: {{ .Values.cluster.name }}-bridge
+  labels:
+    strimzi.io/cluster: {{ .Values.cluster.name }}
+spec:
+  authentication:
+    type: tls

--- a/services/sasquatch/charts/strimzi-kafka/templates/bridge.yaml
+++ b/services/sasquatch/charts/strimzi-kafka/templates/bridge.yaml
@@ -47,3 +47,28 @@ metadata:
 spec:
   authentication:
     type: tls
+  authorization:
+    type: simple
+    acls:
+      - resource:
+          type: group
+          name: "*"
+          patternType: literal
+        operation: All
+      - resource:
+          type: topic
+          name: "object-table-core-metrics"
+          patternType: literal
+        type: allow
+        host: "*"
+        operation: All
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: object-table-core-metrics
+  labels:
+    strimzi.io/cluster: {{ .Values.cluster.name }}
+spec:
+  partitions: 1
+  replicas: 3

--- a/services/sasquatch/values.yaml
+++ b/services/sasquatch/values.yaml
@@ -189,6 +189,14 @@ bucketmapper:
     tag: 0.1.23
 
 global:
+   # -- Base URL for the environment
+  # @default -- Set by Argo CD
+  baseUrl: ""
+
+  # -- Host name for ingress
+  # @default -- Set by Argo CD
+  host: ""
+
   # -- Base path for Vault secrets
   # @default -- Set by Argo CD
   vaultSecretsPath: ""


### PR DESCRIPTION
- Add Kafka bridge, a REST interface that allows clients to interact with Kafka.
- Enable TLS authentication
- Reach the kafka bridge at <host>/sasquatch-bridge