### PR TITLE
DM-36624: Bump version of nublado2 to 2.6.1

### DIFF
--- a/services/nublado2/Chart.yaml
+++ b/services/nublado2/Chart.yaml
@@ -5,7 +5,7 @@ description: JupyterHub for the Rubin Science Platform
 home: https://github.com/lsst-sqre/nublado2
 sources:
   - https://github.com/lsst-sqre/nublado2
-appVersion: "2.5.0"
+appVersion: "2.6.1"
 # Match the jupyterhub Helm chart for kubeVersion
 kubeVersion: ">=1.20.0-0"
 dependencies:

--- a/services/nublado2/README.md
+++ b/services/nublado2/README.md
@@ -62,7 +62,7 @@ Kubernetes: `>=1.20.0-0`
 | jupyterhub.hub.extraVolumes[1].name | string | `"nublado-gafaelfawr"` |  |
 | jupyterhub.hub.extraVolumes[1].secret.secretName | string | `"gafaelfawr-token"` |  |
 | jupyterhub.hub.image.name | string | `"lsstsqre/nublado2"` |  |
-| jupyterhub.hub.image.tag | string | `"2.6.0"` |  |
+| jupyterhub.hub.image.tag | string | `"2.6.1"` |  |
 | jupyterhub.hub.loadRoles.self.scopes[0] | string | `"admin:servers!user"` |  |
 | jupyterhub.hub.loadRoles.self.scopes[1] | string | `"read:metrics"` |  |
 | jupyterhub.hub.loadRoles.server.scopes[0] | string | `"inherit"` |  |

--- a/services/nublado2/values.yaml
+++ b/services/nublado2/values.yaml
@@ -7,7 +7,7 @@ jupyterhub:
     authenticatePrometheus: false
     image:
       name: lsstsqre/nublado2
-      tag: "2.6.0"
+      tag: "2.6.1"
     resources:
       limits:
         cpu: 900m


### PR DESCRIPTION
Pick up fix for the communication to moneypenny when some groups do not have GIDs.