### PR TITLE
DM-36805: Add phalanx.lsst.io/docs annotation support in Chart.yaml

### DIFF
--- a/docs/applications/_summary.rst.jinja
+++ b/docs/applications/_summary.rst.jinja
@@ -20,6 +20,19 @@
    {% endfor %}
    {% endif %}
    {% endif %}
+   {% if app.doc_links %}
+   * - Related docs
+   {% if app.doc_links|length == 1 %}
+     - {{ app.doc_links[0] }}
+   {% else %}
+     - - {{ app.doc_links[0] }}
+   {% endif %}
+   {% if app.doc_links|length > 1 %}
+   {% for doc_link in app.doc_links[1:] %}
+       - {{ doc_link }}
+   {% endfor %}
+   {% endif %}
+   {% endif %}
    * - Type
      - Helm_
    * - Namespace

--- a/docs/developers/chart-overview.rst
+++ b/docs/developers/chart-overview.rst
@@ -49,3 +49,60 @@ This will cause the application resource in the ``science-platform`` app to show
 Additionally, many charts allow specification of a tag (usually some variable like ``image.tag`` in a values file), so that is a possibility as well.
 If your chart doesn't have a way to control what image tag you're deploying from, consider adding the capability.
 In any event, for RSP instances, we (as a matter of policy) disable automatic deployment in Argo CD so there is a human check on whether a given chart is safe to deploy in a given environment, and updates are deployed to production environments (barring extraordinary circumstances) during our specified maintenance windows.
+
+.. _chart-doc-links:
+
+Source and documentation links in Chart.yaml
+============================================
+
+You can add source and documentation links to an app's ``Chart.yaml`` and that information is included in the :doc:`app's homepage in the Phalanx docs </applications/index>`.
+
+home
+----
+
+Use the ``home`` field in ``Chart.yaml`` for the app's documentation site (if it has one).
+For example:
+
+.. code-block:: yaml
+   :caption: Chart.yaml
+
+   home: https://gafaelfawr.lsst.io/
+
+Don't use the ``home`` field for links to documents (technotes) or source repositories.
+
+sources
+-------
+
+Use ``sources`` to link to the Git repositories related to the application.
+Note that ``sources`` is an array of URLs:
+
+.. code-block:: yaml
+   :caption: Chart.yaml
+
+   sources:
+     - https://github.com/lsst-sqre/gafaelfawr
+
+phalanx.lsst.io/docs
+--------------------
+
+Use this custom annotation to link to documents (as opposed to the user guide, see ``home``).
+Documents are technotes and change-controlled documents:
+
+
+.. code-block:: yaml
+   :caption: Chart.yaml
+
+   annotations:
+     phalanx.lsst.io/docs: |
+       - id: "SQR-065"
+         title: "Design of Noteburst, a programatic JupyterLab notebook execution service for the Rubin Science Platform"
+         url: "https://sqr-065.lsst.io/"
+       - id: "SQR-062"
+         title: "The Times Square service for publishing parameterized Jupyter Notebooks in the Rubin Science platform"
+         url: "https://sqr-062.lsst.io/"
+
+.. note::
+
+   Note how the value of ``phalanx.lsst.io/docs`` is a YAML-formatted string (hence the ``|`` symbol).
+   The ``id`` field is optional, but can be set to the document's handle.
+   The ``title`` and ``url`` fields are required.

--- a/services/noteburst/Chart.yaml
+++ b/services/noteburst/Chart.yaml
@@ -16,3 +16,12 @@ dependencies:
   - name: redis
     version: 17.3.7
     repository: https://charts.bitnami.com/bitnami
+
+annotations:
+  phalanx.lsst.io/docs: |
+    - id: "SQR-065"
+      title: "Design of Noteburst, a programatic JupyterLab notebook execution service for the Rubin Science Platform"
+      url: "https://sqr-065.lsst.io/"
+    - id: "SQR-062"
+      title: "The Times Square service for publishing parameterized Jupyter Notebooks in the Rubin Science platform"
+      url: "https://sqr-062.lsst.io/"

--- a/services/semaphore/Chart.yaml
+++ b/services/semaphore/Chart.yaml
@@ -9,3 +9,8 @@ sources:
 maintainers:
   - name: jonathansick
     url: https://github.com/jonathansick
+annotations:
+  phalanx.lsst.io/docs: |
+    - id: "SQR-060"
+      title: "Design of the Semaphore user broadcast message system for the Rubin Science Platform"
+      url: "https://sqr-060.lsst.io/"

--- a/services/times-square/Chart.yaml
+++ b/services/times-square/Chart.yaml
@@ -13,3 +13,12 @@ dependencies:
   - name: redis
     version: 17.3.7
     repository: https://charts.bitnami.com/bitnami
+
+annotations:
+  phalanx.lsst.io/docs: |
+    - id: "SQR-062"
+      title: "The Times Square service for publishing parameterized Jupyter Notebooks in the Rubin Science platform"
+      url: "https://sqr-062.lsst.io/"
+    - id: "SQR-065"
+      title: "Design of Noteburst, a programatic JupyterLab notebook execution service for the Rubin Science Platform"
+      url: "https://sqr-065.lsst.io/"

--- a/services/times-square/Chart.yaml
+++ b/services/times-square/Chart.yaml
@@ -3,7 +3,8 @@ name: times-square
 version: 1.0.0
 description: |
   An API service for managing and rendering parameterized Jupyter notebooks.
-home: https://github.com/lsst-sqre/times-square
+sources:
+  - https://github.com/lsst-sqre/times-square
 type: application
 
 # The default version tag of the times-square docker image

--- a/services/times-square/README.md
+++ b/services/times-square/README.md
@@ -2,7 +2,9 @@
 
 An API service for managing and rendering parameterized Jupyter notebooks.
 
-**Homepage:** <https://github.com/lsst-sqre/times-square>
+## Source Code
+
+* <https://github.com/lsst-sqre/times-square>
 
 ## Requirements
 


### PR DESCRIPTION
This adds support for including links to technotes (and other Rubin documents) in a Phalanx app's Chart.yaml file, and including that information on the app's summary table in the Phalanx docs. This feature makes use of the ``annotations`` field in Helm. Annotations are key-value pairs. The key for this feature is `phalanx.lsst.io/docs` and the value is a YAML-formatted string:

```yaml
annotations:
  phalanx.lsst.io/docs: |
    - id: "SQR-065"
      title: "Design of Noteburst, a programatic JupyterLab notebook execution service for the Rubin Science Platform"
      url: "https://sqr-065.lsst.io/"
    - id: "SQR-062"
      title: "The Times Square service for publishing parameterized Jupyter Notebooks in the Rubin Science platform"
      url: "https://sqr-062.lsst.io/"
```

Example of the result in the docs: https://phalanx.lsst.io/v/DM-36805/applications/noteburst/index.html

This design is inspired by how Artifact Hub uses custom annotations: https://artifacthub.io/docs/topics/annotations/helm/

I've added a section to the Helm chart overview page with documentation on how `home`, `sources`, and `phalanx.lsst.io/docs` are used: https://phalanx.lsst.io/v/DM-36805/developers/chart-overview.html#source-and-documentation-links-in-chart-yaml