### PR TITLE
DM-36809: Add tech note references to services

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -4,6 +4,8 @@ name: Docs
   pull_request:
     paths:
       - "docs/**"
+      - "services/*/Chart.yaml"
+      - "services/*/values.yaml"
   push:
     branches-ignore:
       # These should always correspond to pull requests, so ignore them for
@@ -18,6 +20,8 @@ name: Docs
       - "*"
     paths:
       - "docs/**"
+      - "services/*/Chart.yaml"
+      - "services/*/values.yaml"
 
 jobs:
   docs:

--- a/services/datalinker/Chart.yaml
+++ b/services/datalinker/Chart.yaml
@@ -5,3 +5,8 @@ description: Service and data discovery for Rubin Science Platform
 sources:
   - https://github.com/lsst-sqre/datalinker
 appVersion: 1.5.0
+annotations:
+  phalanx.lsst.io/docs: |
+    - id: "DMTN-238"
+      title: "RSP DataLink service implementation strategy"
+      url: "https://dmtn-238.lsst.io/"

--- a/services/gafaelfawr/Chart.yaml
+++ b/services/gafaelfawr/Chart.yaml
@@ -6,3 +6,14 @@ home: https://gafaelfawr.lsst.io/
 sources:
   - https://github.com/lsst-sqre/gafaelfawr
 appVersion: 7.0.0
+annotations:
+  phalanx.lsst.io/docs: |
+    - id: "DMTN-234"
+      title: "RSP identity management design"
+      url: "https://dmtn-234.lsst.io/"
+    - id: "DMTN-224"
+      title: "RSP identity management implementation strategy"
+      url: "https://dmtn-224.lsst.io/"
+    - id: "SQR-069"
+      title: "Implementation decisions for RSP identity management"
+      url: "https://sqr-069.lsst.io/"

--- a/services/hips/Chart.yaml
+++ b/services/hips/Chart.yaml
@@ -5,3 +5,8 @@ description: HiPS web server backed by Google Cloud Storage
 sources:
   - https://github.com/lsst-sqre/crawlspace
 appVersion: 0.2.1
+annotations:
+  phalanx.lsst.io/docs: |
+    - id: "DMTN-230"
+      title: "RSP HiPS service implementation strategy"
+      url: "https://dmtn-230.lsst.io/"

--- a/services/moneypenny/Chart.yaml
+++ b/services/moneypenny/Chart.yaml
@@ -3,3 +3,9 @@ appVersion: "1.0.0"
 description: User provisioning actions for the Science Platform
 name: moneypenny
 version: 1.0.2
+annotations:
+  phalanx.lsst.io/docs: |
+    - id: "SQR-052"
+      title: >-
+        Proposal for privilege separation in RSP Notebook Aspect containers
+      url: "https://sqr-052.lsst.io/"

--- a/services/nublado2/Chart.yaml
+++ b/services/nublado2/Chart.yaml
@@ -5,7 +5,9 @@ description: JupyterHub for the Rubin Science Platform
 home: https://github.com/lsst-sqre/nublado2
 sources:
   - https://github.com/lsst-sqre/nublado2
+# This version is not used directly.  Also update the tag in values.yaml.
 appVersion: "2.6.1"
+
 # Match the jupyterhub Helm chart for kubeVersion
 kubeVersion: ">=1.20.0-0"
 dependencies:
@@ -14,3 +16,9 @@ dependencies:
     # Jupyterhub package itself.
     version: "2.0.0"
     repository: https://jupyterhub.github.io/helm-chart/
+
+annotations:
+  phalanx.lsst.io/docs: |
+    - id: "DMTN-164"
+      title: "Nublado v2 Architecture"
+      url: "https://dmtn-164.lsst.io/"

--- a/services/sasquatch/Chart.yaml
+++ b/services/sasquatch/Chart.yaml
@@ -3,6 +3,7 @@ name: sasquatch
 version: 1.0.0
 description: Rubin Observatory's telemetry service.
 appVersion: 0.1.0
+
 dependencies:
   - name: strimzi-kafka
     version: 1.0.0
@@ -27,3 +28,9 @@ dependencies:
     version: 1.0.0
   - name: telegraf-kafka-consumer
     version: 1.0.0
+
+annotations:
+  phalanx.lsst.io/docs: |
+    - id: "SQR-068"
+      title: "Sasquatch: beyond the EFD"
+      url: "https://sqr-068.lsst.io/"

--- a/services/telegraf-ds/Chart.yaml
+++ b/services/telegraf-ds/Chart.yaml
@@ -6,3 +6,8 @@ dependencies:
   - name: telegraf-ds
     version: 1.1.4
     repository: https://helm.influxdata.com/
+annotations:
+  phalanx.lsst.io/docs: |
+    - id: "SQR-061"
+      title: "Monitoring architecture for the RSP"
+      url: "https://sqr-061.lsst.io/"

--- a/services/telegraf/Chart.yaml
+++ b/services/telegraf/Chart.yaml
@@ -6,3 +6,8 @@ dependencies:
   - name: telegraf
     version: 1.8.22
     repository: https://helm.influxdata.com/
+annotations:
+  phalanx.lsst.io/docs: |
+    - id: "SQR-061"
+      title: "Monitoring architecture for the RSP"
+      url: "https://sqr-061.lsst.io/"

--- a/services/vo-cutouts/Chart.yaml
+++ b/services/vo-cutouts/Chart.yaml
@@ -5,3 +5,8 @@ description: "Image cutout service complying with IVOA SODA"
 sources:
   - "https://github.com/lsst-sqre/vo-cutouts"
 appVersion: 0.4.2
+annotations:
+  phalanx.lsst.io/docs: |
+    - id: "DMTN-208"
+      title: "RSP image cutout service implementation strategy"
+      url: "https://dmtn-208.lsst.io/"


### PR DESCRIPTION
For services that have associated tech notes, add the references using the new annotation syntax.

Rebuild the documentation if `Chart.yaml` or `values.yaml` for any of the services change, since we pull from those files to generate the application documentation.