### PR TITLE
Deploy bucketmapper and telegraf-kafka-consumer only if influxdb2 is enabled

### DIFF
--- a/services/sasquatch/Chart.yaml
+++ b/services/sasquatch/Chart.yaml
@@ -28,6 +28,7 @@ dependencies:
   - name: kafdrop
     version: 1.0.0
   - name: telegraf-kafka-consumer
+    condition: influxdb2.enabled
     version: 1.0.0
 
 annotations:

--- a/services/sasquatch/templates/bucketmapper.yaml
+++ b/services/sasquatch/templates/bucketmapper.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.influxdb2.enabled }}
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -37,3 +38,4 @@ spec:
               - name: "DEBUG"
                 value: "true"
             command: [ "bucketmapper" ]
+{{- end }}


### PR DESCRIPTION
These components only make sense in environments where influxdb2 is deployed, so make the environments cleaner while transitioning from influxdb to influxdb2.