### PR TITLE
Update nublado summit deployment to cycle 27.

### DIFF
--- a/services/cachemachine/values-summit.yaml
+++ b/services/cachemachine/values-summit.yaml
@@ -8,11 +8,11 @@ autostart:
           "type": "RubinRepoMan",
           "registry_url": "ts-dockerhub.lsst.org",
           "repo": "sal-sciplat-lab",
-          "recommended_tag": "recommended_c0026",
+          "recommended_tag": "recommended_c0027",
           "num_releases": 0,
           "num_weeklies": 3,
           "num_dailies": 2,
-          "cycle": 26,
+          "cycle": 27,
           "alias_tags": [
               "latest",
               "latest_daily",


### PR DESCRIPTION
FYI, this cannot be pushed to the summit until Thursday after the deployment is completed. 

⚠️  This PR needs to remain unmerged until the appropriate time. I will do the merge when it is time to sync.