### PR TITLE
Upgrades to ROE environment

### DIFF
--- a/services/ingress-nginx/values-roe.yaml
+++ b/services/ingress-nginx/values-roe.yaml
@@ -1,18 +1,30 @@
 ingress-nginx:
   controller:
+    config:
+      compute-full-forwarded-for: "true"
+      large-client-header-buffers: "4 64k"
+      proxy-body-size: "100m"
+      proxy-buffer-size: "64k"
+      ssl-redirect: "true"
+      use-forwarded-headers: "true"
     service:
+      externalTrafficPolicy: null
       type: ClusterIP
-    dnsPolicy: ClusterFirstWithHostNet
-    hostNetwork: true
     affinity:
       nodeAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-          nodeSelectorTerms:
-            - matchExpressions:
-                - key: node-role.kubernetes.io/etcd
-                  operator: Exists
+        preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 1
+          preference:
+            matchExpressions:
+            - key: nodetype
+              operator: In
+              values:
+              - public
+    dnsPolicy: ClusterFirstWithHostNet
+    hostNetwork: true
     extraArgs:
       default-ssl-certificate: ingress-nginx/ingress-certificate
-
+    podLabels:
+      hub.jupyter.org/network-access-proxy-http: "true"
 vaultCertificate:
   enabled: true

--- a/services/moneypenny/values-roe.yaml
+++ b/services/moneypenny/values-roe.yaml
@@ -8,3 +8,8 @@ orders:
       volumeMounts:
         - mountPath: /homedirs
           name: homedirs
+  volumes:
+    - name: homedirs
+      nfs:
+        server: 192.41.122.33
+        path: /jhome

--- a/services/moneypenny/values-roe.yaml
+++ b/services/moneypenny/values-roe.yaml
@@ -11,5 +11,5 @@ orders:
   volumes:
     - name: homedirs
       nfs:
-        server: 192.41.122.33
+        server: 10.72.0.23
         path: /jhome

--- a/services/nublado2/values-roe.yaml
+++ b/services/nublado2/values-roe.yaml
@@ -17,24 +17,28 @@ config:
     - image_url: registry.hub.docker.com/lsstsqre/sciplat-lab:recommended
       name: Recommended
   volumes:
-    - name: datasets
-      hostPath:
-        path: /lsstdata/user/precursor_data/datasets
+    - name: data
+      nfs:
+        path: /data
+        server: 192.41.122.33
     - name: home
-      hostPath:
-        path: /lsstdata/user/staff/jhome
-    - name: project
-      hostPath:
-        path: /lsstdata/user/staff/project
-    - name: scratch
-      hostPath:
-        path: /lsstdata/user/staff/scratch
-  volume_mounts:
+      nfs:
+        path: /jhome
+        server: 192.41.122.33
     - name: datasets
-      mountPath: /datasets
+      nfs:
+        path: /datasets
+        server: 192.41.122.33
+  volume_mounts:
+    - name: data
+      mountPath: /data
     - name: home
       mountPath: /home
-    - name: project
-      mountPath: /project
-    - name: scratch
-      mountPath: /scratch
+    - name: datasets
+      mountPath: /datasets
+
+vault_secret_path: "secret/k8s_operator/roe/nublado2"
+
+pull-secret:
+  enabled: true
+  path: "secret/k8s_operator/roe/pull-secret"

--- a/services/nublado2/values-roe.yaml
+++ b/services/nublado2/values-roe.yaml
@@ -20,15 +20,15 @@ config:
     - name: data
       nfs:
         path: /data
-        server: 192.41.122.33
+        server: 10.72.0.23
     - name: home
       nfs:
         path: /jhome
-        server: 192.41.122.33
+        server: 10.72.0.23
     - name: datasets
       nfs:
         path: /datasets
-        server: 192.41.122.33
+        server: 10.72.0.23
   volume_mounts:
     - name: data
       mountPath: /data

--- a/services/tap-schema/values-roe.yaml
+++ b/services/tap-schema/values-roe.yaml
@@ -1,0 +1,2 @@
+image:
+   repository: "stvoutsin/tap-schema-roe"

--- a/services/tap/values-roe.yaml
+++ b/services/tap/values-roe.yaml
@@ -1,0 +1,4 @@
+qserv:
+  host: "192.41.122.228:30040"
+  mock:
+    enabled: false


### PR DESCRIPTION
Upgrades include:

- Change Ingress to add an affinity rule & fix a few other params (externalTrafficPolicy, hostNetwork etc..)
- Add Mounts for NFS shares
- Enable Qserv in TAP
- Change TAP_SCHEMA to use a custom image that includes additional databases