### PR TITLE
DM-28493: Update Gafaelfawr documentation and starter

### DIFF
--- a/docs/developers/add-application.rst
+++ b/docs/developers/add-application.rst
@@ -13,10 +13,10 @@ Currently, all applications use Helm charts.
 
 .. note::
 
-   Kustomize is theoretically supported but has not been used to date in the `phalanx repository`_, and therefore isn't recommended.
+   Kustomize is theoretically supported but has not been used to date in the `Phalanx repository`_, and therefore isn't recommended.
 
 There does not yet exist a SQuaRE-produced a template for the Helm chart; rather, we use the built-in Helm starter template.
-Use ``helm create`` to create a new chart from that template.
+Use ``helm create -p starters/web-service`` to create a new chart from that template.
 **Be sure you are using Helm v3.**
 Helm v2 is not supported.
 
@@ -28,17 +28,10 @@ You will need to make at least the following changes to the default Helm chart t
   See :doc:`add-a-onepassword-secret` for more information about secrets.
 
 - Application providing a web API should be protected by Gafaelfawr and require an appropriate scope.
-  This normally means adding annotations to the ``Ingress`` resource via ``values.yaml`` similar to:
+  This is set up for you by the template using a ``GafaelfawrIngress`` resource in ``templates/ingress.yaml``, but you will need to customize the scope required for access, and may need to add additional configuration.
+  You will also need to customize the path under which your application should be served.
 
-  .. code-block:: yaml
-
-     ingress:
-       annotations:
-         nginx.ingress.kubernetes.io/auth-method: "GET"
-         nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr.gafaelfawr.svc.cluster.local:8080/auth?scope=exec:admin"
-
-  For user-facing applications you will want a scope other than ``exec:admin``.
-  See `the Gafaelfawr's documentation on Ingress configurations <https://gafaelfawr.lsst.io/user-guide/ingress.html>`__ for more information.
+  See `the Gafaelfawr's documentation on Ingress configurations <https://gafaelfawr.lsst.io/user-guide/gafaelfawringress.html>`__ for more information, and see :dmtn:`235` for a guide to what scopes to use to protect the application.
 
 - If your application exposes Prometheus endpoints, you will want to configure these in the `telegraf application's prometheus_config <https://github.com/lsst-sqre/phalanx/blob/master/services/telegraf/values.yaml#L36>`__.
 
@@ -58,7 +51,7 @@ Examples
 
 Existing Helm charts that are good examples to read or copy are:
 
-- `cachemachine <https://github.com/lsst-sqre/phalanx/tree/master/services/cachemachine>`__ (fairly simple)
+- `hips <https://github.com/lsst-sqre/phalanx/tree/master/services/hips>`__ (fairly simple)
 - `mobu <https://github.com/lsst-sqre/phalanx/tree/master/services/mobu>`__ (also simple)
 - `gafaelfawr <https://github.com/lsst-sqre/phalanx/tree/master/services/gafaelfawr>`__ (complex, including CRDs and multiple pods)
 

--- a/docs/developers/local-development.rst
+++ b/docs/developers/local-development.rst
@@ -52,7 +52,7 @@ Requirements
 
 #. Install `Helm 3 <https://helm.sh/docs/intro/install/>`__.
 
-#. Install `Vault <https://learn.hashicorp.com/tutorials/vault/getting-started-install>`__.
+#. Install `Vault <https://developer.hashicorp.com/vault/tutorials/getting-started/getting-started-install>`__.
 
 #. Clone the `Phalanx repository`_.
 

--- a/starters/web-service/README.md
+++ b/starters/web-service/README.md
@@ -20,8 +20,6 @@ Helm starter chart for a new RSP service.
 | image.repository | string | `"ghcr.io/lsst-sqre/<CHARTNAME>"` | Image to use in the <CHARTNAME> deployment |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | ingress.annotations | object | `{}` | Additional annotations for the ingress rule |
-| ingress.gafaelfawrAuthQuery | string | Unauthenticated | Gafaelfawr auth query string |
-| ingress.path | string | `"/<CHARTNAME>"` | Path at which to serve the service |
 | nodeSelector | object | `{}` | Node selection rules for the <CHARTNAME> deployment pod |
 | podAnnotations | object | `{}` | Annotations for the <CHARTNAME> deployment pod |
 | replicaCount | int | `1` | Number of web deployment pods to start |

--- a/starters/web-service/templates/ingress.yaml
+++ b/starters/web-service/templates/ingress.yaml
@@ -1,29 +1,32 @@
-apiVersion: networking.k8s.io/v1
-kind: Ingress
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
 metadata:
   name: "<CHARTNAME>"
   labels:
     {{- include "<CHARTNAME>.labels" . | nindent 4 }}
-  annotations:
-    {{- if .Values.ingress.gafaelfawrAuthQuery }}
-    nginx.ingress.kubernetes.io/auth-method: "GET"
-    nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-User"
-    nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.global.baseUrl }}/login"
-    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.baseUrl }}/auth?{{ .Values.ingress.gafaelfawrAuthQuery }}"
-    {{- end }}
+config:
+  baseUrl: {{ .Values.global.baseUrl | quote }}
+  scopes:
+    all:
+      - "read:image"
+  loginRedirect: true
+template:
+  metadata:
+    name: "<CHARTNAME>"
     {{- with .Values.ingress.annotations }}
-    {{- toYaml . | nindent 4 }}
+    annotations:
+      {{- toYaml . | nindent 6 }}
     {{- end }}
-spec:
-  ingressClassName: "nginx"
-  rules:
-    - host: {{ required "global.host must be set" .Values.global.host | quote }}
-      http:
-        paths:
-          - path: {{ .Values.ingress.path | quote }}
-            pathType: "Prefix"
-            backend:
-              service:
-                name: "<CHARTNAME>"
-                port:
-                  number: 8080
+  spec:
+    ingressClassName: "nginx"
+    rules:
+      - host: {{ required "global.host must be set" .Values.global.host | quote }}
+        http:
+          paths:
+            - path: "/<CHARTNAME>"
+              pathType: "Prefix"
+              backend:
+                service:
+                  name: "<CHARTNAME>"
+                  port:
+                    number: 8080

--- a/starters/web-service/values.yaml
+++ b/starters/web-service/values.yaml
@@ -16,15 +16,6 @@ image:
   tag: ""
 
 ingress:
-  # -- Gafaelfawr auth query string
-  # @default -- Unauthenticated
-  gafaelfawrAuthQuery: ""
-  # gafaelfawrAuthQuery: "scope=read:image"
-  # gafaelfawrAuthQuery: "scope=exec:portal&delegate_to=portal&delegate_scope=read:tap"
-
-  # -- Path at which to serve the service
-  path: "/<CHARTNAME>"
-
   # -- Additional annotations for the ingress rule
   annotations: {}
 


### PR DESCRIPTION
Update the developer documentation and web-service starter to use GafaelfawrIngress instead of a regular Ingress, and move more things into the template and out of values.yaml, following the pattern used with newer services where we try to avoid configuration for things that should never change.