### PR TITLE
DM-37226: Switch remaining ingresses to GafaelfawrIngress

### DIFF
--- a/services/datalinker/templates/ingress-anonymous.yaml
+++ b/services/datalinker/templates/ingress-anonymous.yaml
@@ -4,10 +4,10 @@ metadata:
   name: {{ include "datalinker.fullname" . }}-anonymous
   labels:
     {{- include "datalinker.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
   annotations:
-    {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
-    {{- end }}
+  {{- end }}
 spec:
   ingressClassName: "nginx"
   rules:

--- a/services/datalinker/templates/ingress-image.yaml
+++ b/services/datalinker/templates/ingress-image.yaml
@@ -1,26 +1,30 @@
-apiVersion: networking.k8s.io/v1
-kind: Ingress
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
 metadata:
   name: {{ include "datalinker.fullname" . }}-image
   labels:
     {{- include "datalinker.labels" . | nindent 4 }}
-  annotations:
-    nginx.ingress.kubernetes.io/auth-method: "GET"
-    nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-User"
-    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.baseUrl }}/auth?scope=read:image"
+config:
+  baseUrl: {{ .Values.global.baseUrl | quote }}
+  scopes:
+    all:
+      - "read:image"
+template:
+  metadata:
+    name: {{ include "datalinker.fullname" . }}-image
     {{- with .Values.ingress.annotations }}
-    {{- toYaml . | nindent 4 }}
+    annotations:
+      {{- toYaml . | nindent 6 }}
     {{- end }}
-spec:
-  ingressClassName: "nginx"
-  rules:
-    - host: {{ required "global.host must be set" .Values.global.host | quote }}
-      http:
-        paths:
-          - path: "/api/datalink/links"
-            pathType: "Exact"
-            backend:
-              service:
-                name: {{ include "datalinker.fullname" . }}
-                port:
-                  number: 8080
+  spec:
+    rules:
+      - host: {{ required "global.host must be set" .Values.global.host | quote }}
+        http:
+          paths:
+            - path: "/api/datalink/links"
+              pathType: "Exact"
+              backend:
+                service:
+                  name: {{ include "datalinker.fullname" . }}
+                  port:
+                    number: 8080

--- a/services/datalinker/templates/ingress-tap.yaml
+++ b/services/datalinker/templates/ingress-tap.yaml
@@ -1,26 +1,30 @@
-apiVersion: networking.k8s.io/v1
-kind: Ingress
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
 metadata:
   name: {{ include "datalinker.fullname" . }}-tap
   labels:
     {{- include "datalinker.labels" . | nindent 4 }}
-  annotations:
-    nginx.ingress.kubernetes.io/auth-method: "GET"
-    nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-User"
-    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.baseUrl }}/auth?scope=read:tap"
+config:
+  baseUrl: {{ .Values.global.baseUrl | quote }}
+  scopes:
+    all:
+      - "read:tap"
+template:
+  metadata:
+    name: {{ include "datalinker.fullname" . }}-tap
     {{- with .Values.ingress.annotations }}
-    {{- toYaml . | nindent 4 }}
+    annotations:
+      {{- toYaml . | nindent 6 }}
     {{- end }}
-spec:
-  ingressClassName: "nginx"
-  rules:
-    - host: {{ required "global.host must be set" .Values.global.host | quote }}
-      http:
-        paths:
-          - path: "/api/datalink"
-            pathType: "Prefix"
-            backend:
-              service:
-                name: {{ include "datalinker.fullname" . }}
-                port:
-                  number: 8080
+  spec:
+    rules:
+      - host: {{ required "global.host must be set" .Values.global.host | quote }}
+        http:
+          paths:
+            - path: "/api/datalink"
+              pathType: "Prefix"
+              backend:
+                service:
+                  name: {{ include "datalinker.fullname" . }}
+                  port:
+                    number: 8080

--- a/services/hips/README.md
+++ b/services/hips/README.md
@@ -24,9 +24,7 @@ HiPS tile server backed by Google Cloud Storage
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the hips image |
 | image.repository | string | `"ghcr.io/lsst-sqre/crawlspace"` | Image to use in the hips deployment |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
-| ingress.annotations | object | `{}` | Additional annotations for the ingress rule |
-| ingress.gafaelfawrAuthQuery | string | `"scope=read:image"` | Gafaelfawr auth query string |
-| ingress.path | string | `"/api/hips"` | Path at which to serve the service |
+| ingress.annotations | object | `{}` | Additional annotations for the ingress |
 | nodeSelector | object | `{}` | Node selection rules for the hips deployment pod |
 | podAnnotations | object | `{}` | Annotations for the hips deployment pod |
 | replicaCount | int | `1` | Number of web deployment pods to start |

--- a/services/hips/templates/ingress.yaml
+++ b/services/hips/templates/ingress.yaml
@@ -1,28 +1,30 @@
-apiVersion: networking.k8s.io/v1
-kind: Ingress
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
 metadata:
   name: "hips"
   labels:
     {{- include "hips.labels" . | nindent 4 }}
-  annotations:
-    {{- if .Values.ingress.gafaelfawrAuthQuery }}
-    nginx.ingress.kubernetes.io/auth-method: "GET"
-    nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-User"
-    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.baseUrl }}/auth?{{ .Values.ingress.gafaelfawrAuthQuery }}"
-    {{- end }}
+config:
+  baseUrl: {{ .Values.global.baseUrl | quote }}
+  scopes:
+    all:
+      - "read:image"
+template:
+  metadata:
+    name: "hips"
     {{- with .Values.ingress.annotations }}
-    {{- toYaml . | nindent 4 }}
+    annotations:
+      {{- toYaml . | nindent 6 }}
     {{- end }}
-spec:
-  ingressClassName: "nginx"
-  rules:
-    - host: {{ required "global.host must be set" .Values.global.host | quote }}
-      http:
-        paths:
-          - path: {{ .Values.ingress.path | quote }}
-            pathType: "Prefix"
-            backend:
-              service:
-                name: "hips"
-                port:
-                  number: 8080
+  spec:
+    rules:
+      - host: {{ required "global.host must be set" .Values.global.host | quote }}
+        http:
+          paths:
+            - path: "/api/hips"
+              pathType: "Prefix"
+              backend:
+                service:
+                  name: "hips"
+                  port:
+                    number: 8080

--- a/services/hips/values.yaml
+++ b/services/hips/values.yaml
@@ -33,13 +33,7 @@ image:
   tag: ""
 
 ingress:
-  # -- Gafaelfawr auth query string
-  gafaelfawrAuthQuery: "scope=read:image"
-
-  # -- Path at which to serve the service
-  path: "/api/hips"
-
-  # -- Additional annotations for the ingress rule
+  # -- Additional annotations for the ingress
   annotations: {}
 
 autoscaling:

--- a/services/mobu/README.md
+++ b/services/mobu/README.md
@@ -21,7 +21,6 @@ Continuous integration testing
 | image.repository | string | `"ghcr.io/lsst-sqre/mobu"` | mobu image to use |
 | image.tag | string | The appVersion of the chart | Tag of mobu image to use |
 | ingress.annotations | object | `{}` | Additional annotations to add to the ingress |
-| ingress.gafaelfawrAuthQuery | string | `"scope=exec:admin"` | Gafaelfawr auth query string |
 | nameOverride | string | `""` | Override the base name for resources |
 | nodeSelector | object | `{}` | Node selector rules for the mobu frontend pod |
 | podAnnotations | object | `{}` | Annotations for the mobu frontend pod |

--- a/services/mobu/templates/ingress.yaml
+++ b/services/mobu/templates/ingress.yaml
@@ -1,29 +1,31 @@
-apiVersion: networking.k8s.io/v1
-kind: Ingress
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
 metadata:
-  annotations:
-    {{- if .Values.ingress.gafaelfawrAuthQuery }}
-    nginx.ingress.kubernetes.io/auth-method: "GET"
-    nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-User"
-    nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.global.baseUrl }}/login"
-    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.baseUrl }}/auth?{{ .Values.ingress.gafaelfawrAuthQuery }}"
-    {{- end }}
-    {{- with .Values.ingress.annotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
   name: {{ template "mobu.fullname" . }}
   labels:
     {{- include "mobu.labels" . | nindent 4 }}
-spec:
-  ingressClassName: "nginx"
-  rules:
-    - host: {{ required "global.host must be set" .Values.global.host | quote }}
-      http:
-        paths:
-          - path: "/mobu"
-            pathType: "Prefix"
-            backend:
-              service:
-                name: {{ template "mobu.fullname" . }}
-                port:
-                  number: 8080
+config:
+  baseUrl: {{ .Values.global.baseUrl | quote }}
+  scopes:
+    all:
+      - "exec:admin"
+  loginRedirect: true
+template:
+  metadata:
+    name: {{ template "mobu.fullname" . }}
+    {{- with .Values.ingress.annotations }}
+    annotations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  spec:
+    rules:
+      - host: {{ required "global.host must be set" .Values.global.host | quote }}
+        http:
+          paths:
+            - path: "/mobu"
+              pathType: "Prefix"
+              backend:
+                service:
+                  name: {{ template "mobu.fullname" . }}
+                  port:
+                    number: 8080

--- a/services/mobu/values.yaml
+++ b/services/mobu/values.yaml
@@ -28,9 +28,6 @@ image:
   tag: ""
 
 ingress:
-  # -- Gafaelfawr auth query string
-  gafaelfawrAuthQuery: "scope=exec:admin"
-
   # -- Additional annotations to add to the ingress
   annotations: {}
 

--- a/services/moneypenny/README.md
+++ b/services/moneypenny/README.md
@@ -20,8 +20,7 @@ User provisioning actions
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the moneypenny image |
 | image.repository | string | `"lsstsqre/moneypenny"` | moneypenny image to use |
 | image.tag | string | The appVersion of the chart | Tag of moneypenny image to use |
-| ingress.gafaelfawrAuthQuery | string | `"scope=admin:provision"` | Gafaelfawr auth query string |
-| ingress.tls | list | `[]` | Configure TLS for the ingress if needed. If multiple ingresses share the same hostname, only one of them needs a TLS configuration. |
+| ingress.annotations | object | `{}` | Additional annotations to add to the ingress |
 | nameOverride | string | `""` | Override the base name for resources |
 | nodeSelector | object | `{}` | Node selector rules for the vo-cutouts frontend pod |
 | orders.commission | list | `[{"image":"lsstsqre/farthing","name":"farthing","securityContext":{"allowPrivilegeEscalation":false,"runAsNonRootUser":true,"runAsUser":1000}}]` | List of specifications for containers to run to commission a new user. Each member of the list should set a container `name`, `image`, and `securityContext` and may contain `volumeMounts`. |

--- a/services/moneypenny/templates/ingress.yaml
+++ b/services/moneypenny/templates/ingress.yaml
@@ -1,26 +1,31 @@
-apiVersion: networking.k8s.io/v1
-kind: Ingress
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
 metadata:
-  annotations:
-    nginx.ingress.kubernetes.io/auth-method: "GET"
-    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.baseUrl }}/auth?{{ required "ingress.gafaelfawrAuthQuery must be set" .Values.ingress.gafaelfawrAuthQuery }}"
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "310"
-    {{- with .Values.ingress.annotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
   name: {{ template "moneypenny.fullname" . }}
   labels:
     {{- include "moneypenny.labels" . | nindent 4 }}
-spec:
-  ingressClassName: "nginx"
-  rules:
-    - host: {{ required "global.host must be set" .Values.global.host | quote }}
-      http:
-        paths:
-          - path: "/moneypenny"
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ include "moneypenny.fullname" . }}
-                port:
-                  number: 8080
+config:
+  baseUrl: {{ .Values.global.baseUrl | quote }}
+  scopes:
+    all:
+      - "admin:provision"
+template:
+  metadata:
+    name: {{ template "moneypenny.fullname" . }}
+    annotations:
+      nginx.ingress.kubernetes.io/proxy-read-timeout: "310"
+      {{- with .Values.ingress.annotations }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+  spec:
+    rules:
+      - host: {{ required "global.host must be set" .Values.global.host | quote }}
+        http:
+          paths:
+            - path: "/moneypenny"
+              pathType: Prefix
+              backend:
+                service:
+                  name: {{ include "moneypenny.fullname" . }}
+                  port:
+                    number: 8080

--- a/services/moneypenny/values.yaml
+++ b/services/moneypenny/values.yaml
@@ -28,12 +28,8 @@ serviceAccount:
   name: ""
 
 ingress:
-  # -- Gafaelfawr auth query string
-  gafaelfawrAuthQuery: "scope=admin:provision"
-
-  # -- Configure TLS for the ingress if needed. If multiple ingresses share
-  # the same hostname, only one of them needs a TLS configuration.
-  tls: []
+  # -- Additional annotations to add to the ingress
+  annotations: {}
 
 orders:
   # -- List of specifications for containers to run to commission a new user.

--- a/services/noteburst/README.md
+++ b/services/noteburst/README.md
@@ -34,9 +34,6 @@ Noteburst is a notebook execution service for the Rubin Science Platform.
 | image.tag | string | The appVersion of the chart | Tag of the image |
 | imagePullSecrets | list | `[]` | Secret names to use for all Docker pulls |
 | ingress.annotations | object | `{}` | Additional annotations to add to the ingress |
-| ingress.enabled | bool | `true` | Enable ingress |
-| ingress.gafaelfawrAuthQuery | string | `"scope=exec:admin&auth_type=basic"` | Gafaelfawr auth query string |
-| ingress.path | string | `"/noteburst"` | Path prefix where noteburst is hosted |
 | nameOverride | string | `""` | Override the base name for resources |
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` | Annotations for API and worker pods |

--- a/services/noteburst/templates/ingress.yaml
+++ b/services/noteburst/templates/ingress.yaml
@@ -1,31 +1,32 @@
-{{- if .Values.ingress.enabled -}}
-apiVersion: networking.k8s.io/v1
-kind: Ingress
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
 metadata:
   name: {{ template "noteburst.fullname" . }}
   labels:
     {{- include "noteburst.labels" . | nindent 4 }}
-  annotations:
-    {{- if .Values.ingress.gafaelfawrAuthQuery }}
-    nginx.ingress.kubernetes.io/auth-method: "GET"
-    nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-User,X-Auth-Request-Email,X-Auth-Request-Token
-    nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.global.baseUrl }}/login"
-    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.baseUrl }}/auth?{{ .Values.ingress.gafaelfawrAuthQuery }}"
-    {{- end }}
+config:
+  baseUrl: {{ .Values.global.baseUrl | quote }}
+  scopes:
+    all:
+      - "exec:admin"
+  loginRedirect: true
+template:
+  metadata:
+    name: {{ template "noteburst.fullname" . }}
     {{- with .Values.ingress.annotations }}
-    {{- toYaml . | nindent 4 }}
+    annotations:
+      {{- toYaml . | nindent 6 }}
     {{- end }}
-spec:
-  ingressClassName: "nginx"
-  rules:
-    - host: {{ required "global.host must be set" .Values.global.host | quote }}
-      http:
-        paths:
-          - path: {{ .Values.ingress.path }}
-            pathType: "Prefix"
-            backend:
-              service:
-                name: {{ template "noteburst.fullname" . }}
-                port:
-                  number: {{ .Values.service.port }}
-{{- end }}
+  spec:
+    ingressClassName: "nginx"
+    rules:
+      - host: {{ required "global.host must be set" .Values.global.host | quote }}
+        http:
+          paths:
+            - path: "/noteburst"
+              pathType: "Prefix"
+              backend:
+                service:
+                  name: {{ template "noteburst.fullname" . }}
+                  port:
+                    number: {{ .Values.service.port }}

--- a/services/noteburst/values.yaml
+++ b/services/noteburst/values.yaml
@@ -58,17 +58,8 @@ service:
   port: 80
 
 ingress:
-  # -- Enable ingress
-  enabled: true
-
-  # -- Gafaelfawr auth query string
-  gafaelfawrAuthQuery: "scope=exec:admin&auth_type=basic"
-
   # -- Additional annotations to add to the ingress
   annotations: {}
-
-  # -- Path prefix where noteburst is hosted
-  path: "/noteburst"
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/services/plot-navigator/README.md
+++ b/services/plot-navigator/README.md
@@ -17,4 +17,3 @@ Panel-based plot viewer
 | image.repository | string | `"lsstdm/pipetask-plot-navigator"` | plot-navigator image to use |
 | image.tag | string | `""` |  |
 | ingress.annotations | object | `{}` | Additional annotations to add to the ingress |
-| ingress.gafaelfawrAuthQuery | string | `"scope=exec:portal&delegate_to=plotnavigator"` | Gafaelfawr auth query string |

--- a/services/plot-navigator/templates/ingress.yaml
+++ b/services/plot-navigator/templates/ingress.yaml
@@ -1,29 +1,36 @@
-apiVersion: networking.k8s.io/v1
-kind: Ingress
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
 metadata:
-  name: plot-navigator
+  name: "plot-navigator"
   labels:
     {{- include "plot-navigator.labels" . | nindent 4 }}
-  annotations:
-    {{- if .Values.ingress.gafaelfawrAuthQuery }}
-    nginx.ingress.kubernetes.io/auth-method: "GET"
-    nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-User,X-Auth-Request-Email,X-Auth-Request-Token"
-    nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.global.baseUrl }}/login"
-    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.baseUrl }}/auth?{{ .Values.ingress.gafaelfawrAuthQuery }}"
-    {{- end }}
+config:
+  baseUrl: {{ .Values.global.baseUrl | quote }}
+  scopes:
+    all:
+      - "exec:portal"
+  loginRedirect: true
+  delegate:
+    internal:
+      scopes: []
+      service: "plot-navigator"
+template:
+  metadata:
+    name: "plot-navigator"
     {{- with .Values.ingress.annotations }}
-    {{- toYaml . | nindent 4 }}
+    annotations:
+      {{- toYaml . | nindent 6 }}
     {{- end }}
-spec:
-  ingressClassName: "nginx"
-  rules:
-  - host: {{ required "global.host must be set" .Values.global.host | quote }}
-    http:
-      paths:
-      - path: "/plot-navigator"
-        pathType: ImplementationSpecific
-        backend:
-          service:
-            name: plot-navigator
-            port:
-              number: 80
+  spec:
+    ingressClassName: "nginx"
+    rules:
+    - host: {{ required "global.host must be set" .Values.global.host | quote }}
+      http:
+        paths:
+        - path: "/plot-navigator"
+          pathType: "Prefix"
+          backend:
+            service:
+              name: "plot-navigator"
+              port:
+                number: 80

--- a/services/plot-navigator/values.yaml
+++ b/services/plot-navigator/values.yaml
@@ -7,8 +7,6 @@ image:
 environment: {}
 
 ingress:
-  # -- Gafaelfawr auth query string
-  gafaelfawrAuthQuery: "scope=exec:portal&delegate_to=plotnavigator"
   # -- Additional annotations to add to the ingress
   annotations: {}
 

--- a/services/production-tools/README.md
+++ b/services/production-tools/README.md
@@ -20,8 +20,6 @@ A collection of utility pages for monitoring data processing.
 | image.repository | string | `"lsstdm/production_tools"` | Image to use in the production-tools deployment |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | ingress.annotations | object | `{}` | Additional annotations for the ingress rule |
-| ingress.gafaelfawrAuthQuery | string | `"scope=exec:portal"` | Gafaelfawr Auth Query string (default, unauthenticated) |
-| ingress.pathType | string | `"Prefix"` | Path type for the ingress rule |
 | nameOverride | string | `""` | Override the base name for resources |
 | nodeSelector | object | `{}` | Node selection rules for the production-tools deployment pod |
 | podAnnotations | object | `{}` | Annotations for the production-tools deployment pod |

--- a/services/production-tools/templates/ingress.yaml
+++ b/services/production-tools/templates/ingress.yaml
@@ -1,30 +1,30 @@
-{{- $fullName := include "production-tools.fullname" . -}}
-apiVersion: networking.k8s.io/v1
-kind: Ingress
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
 metadata:
-  name: {{ $fullName }}
+  name: {{ template "production-tools.fullname" . }}
   labels:
     {{- include "production-tools.labels" . | nindent 4 }}
-  annotations:
-    {{- if .Values.ingress.gafaelfawrAuthQuery }}
-    nginx.ingress.kubernetes.io/auth-method: "GET"
-    nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-User"
-    nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.global.baseUrl }}/login"
-    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.baseUrl }}/auth?{{ .Values.ingress.gafaelfawrAuthQuery }}"
-    {{- end }}
+config:
+  scopes:
+    all:
+      - "exec:portal"
+  loginRedirect: true
+template:
+  metadata:
+    name: {{ template "production-tools.fullname" . }}
     {{- with .Values.ingress.annotations }}
-    {{- toYaml . | nindent 4 }}
+    annotations:
+      {{- toYaml . | nindent 6 }}
     {{- end }}
-spec:
-  ingressClassName: "nginx"
-  rules:
-    - host: {{ required ".Values.global.host must be set" .Values.global.host | quote }}
-      http:
-        paths:
-          - path: "/production-tools"
-            pathType: "Prefix"
-            backend:
-              service:
-                name: {{ template "production-tools.fullname" . }}
-                port:
-                  number: 8080
+  spec:
+    rules:
+      - host: {{ required ".Values.global.host must be set" .Values.global.host | quote }}
+        http:
+          paths:
+            - path: "/production-tools"
+              pathType: "Prefix"
+              backend:
+                service:
+                  name: {{ template "production-tools.fullname" . }}
+                  port:
+                    number: 8080

--- a/services/production-tools/values.yaml
+++ b/services/production-tools/values.yaml
@@ -28,14 +28,8 @@ podAnnotations: {}
 environment: {}
 
 ingress:
-  # -- Gafaelfawr Auth Query string (default, unauthenticated)
-  gafaelfawrAuthQuery: "scope=exec:portal"
-
   # -- Additional annotations for the ingress rule
   annotations: {}
-
-  # -- Path type for the ingress rule
-  pathType: Prefix
 
 # -- Resource limits and requests for the production-tools deployment pod
 resources: {}

--- a/services/sherlock/README.md
+++ b/services/sherlock/README.md
@@ -24,7 +24,6 @@ Application ingress status and metrics
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` | Secret names to use for all Docker pulls |
 | ingress.annotations | object | `{}` | Additional annotations for the ingress rule |
-| ingress.gafaelfawrAuthQuery | string | `"scope=exec:admin"` | Gafaelfawr auth query string (default, unauthenticated) |
 | nameOverride | string | `""` | Override the base name for resources |
 | nodeSelector | object | `{}` | Node selection rules for the sherlock deployment pod |
 | podAnnotations | object | `{}` | Annotations for the sherlock deployment pod |

--- a/services/sherlock/templates/ingress.yaml
+++ b/services/sherlock/templates/ingress.yaml
@@ -1,32 +1,33 @@
-{{- $fullName := include "sherlock.fullname" . -}}
-apiVersion: networking.k8s.io/v1
-kind: Ingress
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
 metadata:
-  name: {{ $fullName }}
+  name: {{ template "sherlock.fullname" . }}
   labels:
     {{- include "sherlock.labels" . | nindent 4 }}
-  annotations:
-    {{- if .Values.ingress.gafaelfawrAuthQuery }}
-    nginx.ingress.kubernetes.io/auth-method: GET
-    nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-User,X-Auth-Request-Email,X-Auth-Request-Token
-    nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.global.baseUrl }}/login"
-    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.baseUrl }}/auth?{{ .Values.ingress.gafaelfawrAuthQuery }}"
-    nginx.ingress.kubernetes.io/cors-allow-methods: "GET"
-    nginx.ingress.kubernetes.io/enable-cors: "true"
-    {{- end }}
-    {{- with .Values.ingress.annotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-spec:
-  ingressClassName: "nginx"
-  rules:
-    - host: {{ required "global.host must be set" .Values.global.host | quote }}
-      http:
-        paths:
-          - path: "/sherlock"
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: {{ $fullName }}
-                port:
-                  number: 8080
+config:
+  baseUrl: {{ .Values.global.baseUrl | quote }}
+  scopes:
+    all:
+      - "exec:admin"
+  loginRedirect: true
+template:
+  metadata:
+    name: {{ template "sherlock.fullname" . }}
+    annotations:
+      nginx.ingress.kubernetes.io/cors-allow-methods: "GET"
+      nginx.ingress.kubernetes.io/enable-cors: "true"
+      {{- with .Values.ingress.annotations }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+  spec:
+    rules:
+      - host: {{ required "global.host must be set" .Values.global.host | quote }}
+        http:
+          paths:
+            - path: "/sherlock"
+              pathType: "Prefix"
+              backend:
+                service:
+                  name: {{ template "sherlock.fullname" . }}
+                  port:
+                    number: 8080

--- a/services/sherlock/values.yaml
+++ b/services/sherlock/values.yaml
@@ -28,9 +28,6 @@ fullnameOverride: ""
 podAnnotations: {}
 
 ingress:
-  # -- Gafaelfawr auth query string (default, unauthenticated)
-  gafaelfawrAuthQuery: "scope=exec:admin"
-
   # -- Additional annotations for the ingress rule
   annotations: {}
 

--- a/services/tap/README.md
+++ b/services/tap/README.md
@@ -28,7 +28,6 @@ IVOA TAP service
 | image.tag | string | The appVersion of the chart | Tag of tap image to use |
 | ingress.anonymousAnnotations | object | `{}` | Additional annotations to use for endpoints that allow anonymous access, such as `/capabilities` and `/availability` |
 | ingress.authenticatedAnnotations | object | `{}` | Additional annotations to use for endpoints that are authenticated, such as `/sync`, `/async`, and `/tables` |
-| ingress.gafaelfawrAuthQuery | string | `"scope=read:tap&auth_type=basic&delegate_to=tap"` | Gafaelfawr auth query string |
 | nameOverride | string | `""` | Override the base name for resources |
 | nodeSelector | object | `{}` | Node selector rules for the Gafaelfawr frontend pod |
 | podAnnotations | object | `{}` | Annotations for the Gafaelfawr frontend pod |

--- a/services/tap/templates/tap-ingress-authenticated.yaml
+++ b/services/tap/templates/tap-ingress-authenticated.yaml
@@ -1,37 +1,46 @@
-apiVersion: networking.k8s.io/v1
-kind: Ingress
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
 metadata:
   name: {{ template "cadc-tap.fullname" . }}-authenticated
   labels:
     {{- include "cadc-tap.labels" . | nindent 4 }}
-  annotations:
-    nginx.ingress.kubernetes.io/auth-method: "GET"
-    nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-Token"
-    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.baseUrl }}/auth?{{ .Values.ingress.gafaelfawrAuthQuery }}"
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      auth_request_set $auth_token $upstream_http_x_auth_request_token;
-      proxy_set_header Authorization "Bearer $auth_token";
-    nginx.ingress.kubernetes.io/proxy-connect-timeout: "1800"
-    nginx.ingress.kubernetes.io/proxy-send-timeout: "1800"
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "1800"
-    nginx.ingress.kubernetes.io/rewrite-target: "/tap/$2"
-    nginx.ingress.kubernetes.io/proxy-redirect-from: "http://$host/tap/"
-    nginx.ingress.kubernetes.io/proxy-redirect-to: "https://$host/api/tap/"
-    nginx.ingress.kubernetes.io/ssl-redirect: "true"
-    nginx.ingress.kubernetes.io/use-regex: "true"
-    {{- with .Values.ingress.authenticatedAnnotations }}
-    {{- toYaml . | indent 4}}
-    {{- end }}
-spec:
-  ingressClassName: "nginx"
-  rules:
-    - host: {{ required "global.host must be set" .Values.global.host | quote }}
-      http:
-        paths:
-          - path: "/api/tap(/|$)(.*)"
-            pathType: "ImplementationSpecific"
-            backend:
-              service:
-                name: {{ template "cadc-tap.fullname" . }}
-                port:
-                  number: 80
+config:
+  baseUrl: {{ .Values.global.baseUrl | quote }}
+  scopes:
+    all:
+      - "read:tap"
+  authType: "basic"
+  delegate:
+    internal:
+      scopes: []
+      service: "tap"
+template:
+  metadata:
+    name: {{ template "cadc-tap.fullname" . }}-authenticated
+    annotations:
+      nginx.ingress.kubernetes.io/configuration-snippet: |
+        auth_request_set $auth_token $upstream_http_x_auth_request_token;
+        proxy_set_header Authorization "Bearer $auth_token";
+      nginx.ingress.kubernetes.io/proxy-connect-timeout: "1800"
+      nginx.ingress.kubernetes.io/proxy-send-timeout: "1800"
+      nginx.ingress.kubernetes.io/proxy-read-timeout: "1800"
+      nginx.ingress.kubernetes.io/rewrite-target: "/tap/$2"
+      nginx.ingress.kubernetes.io/proxy-redirect-from: "http://$host/tap/"
+      nginx.ingress.kubernetes.io/proxy-redirect-to: "https://$host/api/tap/"
+      nginx.ingress.kubernetes.io/ssl-redirect: "true"
+      nginx.ingress.kubernetes.io/use-regex: "true"
+      {{- with .Values.ingress.authenticatedAnnotations }}
+      {{- toYaml . | indent 6 }}
+      {{- end }}
+  spec:
+    rules:
+      - host: {{ required "global.host must be set" .Values.global.host | quote }}
+        http:
+          paths:
+            - path: "/api/tap(/|$)(.*)"
+              pathType: "ImplementationSpecific"
+              backend:
+                service:
+                  name: {{ template "cadc-tap.fullname" . }}
+                  port:
+                    number: 80

--- a/services/tap/values.yaml
+++ b/services/tap/values.yaml
@@ -24,9 +24,6 @@ image:
 
 # Settings for the ingress rules.
 ingress:
-  # -- Gafaelfawr auth query string
-  gafaelfawrAuthQuery: "scope=read:tap&auth_type=basic&delegate_to=tap"
-
   # -- Additional annotations to use for endpoints that allow anonymous
   # access, such as `/capabilities` and `/availability`
   anonymousAnnotations: {}

--- a/services/times-square/README.md
+++ b/services/times-square/README.md
@@ -38,11 +38,6 @@ An API service for managing and rendering parameterized Jupyter notebooks.
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` | Secret names to use for all Docker pulls |
 | ingress.annotations | object | `{}` | Additional annotations for the ingress rule |
-| ingress.className | string | `"nginx"` | Class name that should serve this ingress |
-| ingress.enabled | bool | `true` | Create an ingress resource |
-| ingress.gafaelfawrAuthQuery | string | `"scope=exec:admin&auth_type=basic"` | Gafaelfawr auth query string |
-| ingress.path | string | `"/times-square/api"` | Root URL path prefix for times-square API |
-| ingress.pathType | string | `"ImplementationSpecific"` | Path type for the ingress rule |
 | nameOverride | string | `""` | Override the base name for resources |
 | nodeSelector | object | `{}` | Node selection rules for the times-square deployment pod |
 | podAnnotations | object | `{}` | Annotations for the times-square deployment pod |

--- a/services/times-square/templates/ingress-webhooks.yaml
+++ b/services/times-square/templates/ingress-webhooks.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.ingress.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -10,18 +9,15 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  {{- if .Values.ingress.className }}
-  ingressClassName: {{ .Values.ingress.className }}
-  {{- end }}
+  ingressClassName: "nginx"
   rules:
     - host: {{ required "global.host must be set" .Values.global.host | quote }}
       http:
         paths:
-          - path: {{ .Values.ingress.path }}/github
-            pathType: {{ default "Prefix" .Values.ingress.pathType }}
+          - path: "/times-square/api/github"
+            pathType: "Prefix"
             backend:
               service:
                 name: {{ include "times-square.fullname" . }}
                 port:
                   number: {{ .Values.service.port }}
-{{- end }}

--- a/services/times-square/templates/ingress.yaml
+++ b/services/times-square/templates/ingress.yaml
@@ -1,34 +1,31 @@
-{{- if .Values.ingress.enabled -}}
-{{- $fullName := include "times-square.fullname" . -}}
-apiVersion: networking.k8s.io/v1
-kind: Ingress
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
 metadata:
-  name: {{ $fullName }}
+  name: {{ template "times-square.fullname" . }}
   labels:
     {{- include "times-square.labels" . | nindent 4 }}
-  annotations:
-    {{- if .Values.ingress.gafaelfawrAuthQuery }}
-    nginx.ingress.kubernetes.io/auth-method: GET
-    nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-User,X-Auth-Request-Email,X-Auth-Request-Token
-    nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.global.baseUrl }}/login"
-    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.baseUrl }}/auth?{{ .Values.ingress.gafaelfawrAuthQuery }}"
-    {{- end }}
+config:
+  baseUrl: {{ .Values.global.baseUrl | quote }}
+  scopes:
+    all:
+      - "exec:admin"
+  loginRedirect: true
+template:
+  metadata:
+    name: {{ template "times-square.fullname" . }}
     {{- with .Values.ingress.annotations }}
-    {{- toYaml . | nindent 4 }}
+    annotations:
+      {{- toYaml . | nindent 6 }}
     {{- end }}
-spec:
-  {{- if .Values.ingress.className }}
-  ingressClassName: {{ .Values.ingress.className }}
-  {{- end }}
-  rules:
-    - host: {{ required "global.host must be set" .Values.global.host | quote }}
-      http:
-        paths:
-          - path: {{ .Values.ingress.path }}
-            pathType: {{ default "Prefix" .Values.ingress.pathType }}
-            backend:
-              service:
-                name: {{ $fullName }}
-                port:
-                  number: {{ .Values.service.port }}
-{{- end }}
+  spec:
+    rules:
+      - host: {{ required "global.host must be set" .Values.global.host | quote }}
+        http:
+          paths:
+            - path: "/times-square/api"
+              pathType: "Prefix"
+              backend:
+                service:
+                  name: {{ template "times-square.fullname" . }}
+                  port:
+                    number: {{ .Values.service.port }}

--- a/services/times-square/values.yaml
+++ b/services/times-square/values.yaml
@@ -53,23 +53,8 @@ service:
   port: 8080
 
 ingress:
-  # -- Create an ingress resource
-  enabled: true
-
-  # -- Gafaelfawr auth query string
-  gafaelfawrAuthQuery: "scope=exec:admin&auth_type=basic"
-
   # -- Additional annotations for the ingress rule
   annotations: {}
-
-  # -- Class name that should serve this ingress
-  className: "nginx"
-
-  # -- Path type for the ingress rule
-  pathType: ImplementationSpecific
-
-  # -- Root URL path prefix for times-square API
-  path: "/times-square/api"
 
 # -- Resource limits and requests for the times-square deployment pod
 resources: {}

--- a/services/vo-cutouts/README.md
+++ b/services/vo-cutouts/README.md
@@ -47,7 +47,6 @@ Image cutout service complying with IVOA SODA
 | image.repository | string | `"ghcr.io/lsst-sqre/vo-cutouts"` | vo-cutouts image to use |
 | image.tag | string | The appVersion of the chart | Tag of vo-cutouts image to use |
 | ingress.annotations | object | `{}` | Additional annotations to add to the ingress |
-| ingress.gafaelfawrAuthQuery | string | `"scope=read:image"` | Gafaelfawr auth query string |
 | nameOverride | string | `""` | Override the base name for resources |
 | nodeSelector | object | `{}` | Node selector rules for the vo-cutouts frontend pod |
 | podAnnotations | object | `{}` | Annotations for the vo-cutouts frontend pod |

--- a/services/vo-cutouts/templates/ingress.yaml
+++ b/services/vo-cutouts/templates/ingress.yaml
@@ -1,29 +1,30 @@
-apiVersion: networking.k8s.io/v1
-kind: Ingress
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
 metadata:
-  annotations:
-    {{- if .Values.ingress.gafaelfawrAuthQuery }}
-    nginx.ingress.kubernetes.io/auth-method: "GET"
-    nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-User
-    nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.global.baseUrl }}/login"
-    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.baseUrl }}/auth?{{ .Values.ingress.gafaelfawrAuthQuery }}"
-    {{- end }}
-    {{- with .Values.ingress.annotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
   name: {{ template "vo-cutouts.fullname" . }}
   labels:
     {{- include "vo-cutouts.labels" . | nindent 4 }}
-spec:
-  ingressClassName: "nginx"
-  rules:
-    - host: {{ required "global.host must be set" .Values.global.host | quote }}
-      http:
-        paths:
-          - path: "/api/cutout"
-            pathType: "Prefix"
-            backend:
-              service:
-                name: {{ template "vo-cutouts.fullname" . }}
-                port:
-                  number: 8080
+config:
+  baseUrl: {{ .Values.global.baseUrl | quote }}
+  scopes:
+    all:
+      - "read:image"
+templates:
+  metadata:
+    name: {{ template "vo-cutouts.fullname" . }}
+    {{- with .Values.ingress.annotations }}
+    annotations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  spec:
+    rules:
+      - host: {{ required "global.host must be set" .Values.global.host | quote }}
+        http:
+          paths:
+            - path: "/api/cutout"
+              pathType: "Prefix"
+              backend:
+                service:
+                  name: {{ template "vo-cutouts.fullname" . }}
+                  port:
+                    number: 8080

--- a/services/vo-cutouts/values.yaml
+++ b/services/vo-cutouts/values.yaml
@@ -21,9 +21,6 @@ image:
   tag: ""
 
 ingress:
-  # -- Gafaelfawr auth query string
-  gafaelfawrAuthQuery: "scope=read:image"
-
   # -- Additional annotations to add to the ingress
   annotations: {}
 


### PR DESCRIPTION
Switch all the remaining authenticated ingresses except for the nublado2 configuration, which will continue to have to be hand-configured to work with Zero-to-JupyterHub, over to using GafaelfawrIngress to generate the ingress.

In the process, hard-code more things in the GafaelfawrIngress templates and remove them from values.yaml, since we're standardizing on not customizing paths, scopes, and similar bits of the ingress.