### PR TITLE
DM-37226: Fix noteburst and times-square ingress paths

### DIFF
--- a/services/noteburst/README.md
+++ b/services/noteburst/README.md
@@ -34,6 +34,7 @@ Noteburst is a notebook execution service for the Rubin Science Platform.
 | image.tag | string | The appVersion of the chart | Tag of the image |
 | imagePullSecrets | list | `[]` | Secret names to use for all Docker pulls |
 | ingress.annotations | object | `{}` | Additional annotations to add to the ingress |
+| ingress.path | string | `"/noteburst"` | Path prefix where noteburst is hosted |
 | nameOverride | string | `""` | Override the base name for resources |
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` | Annotations for API and worker pods |

--- a/services/noteburst/templates/ingress.yaml
+++ b/services/noteburst/templates/ingress.yaml
@@ -23,7 +23,7 @@ template:
       - host: {{ required "global.host must be set" .Values.global.host | quote }}
         http:
           paths:
-            - path: "/noteburst"
+            - path: {{ .Values.ingress.path | quote }}
               pathType: "Prefix"
               backend:
                 service:

--- a/services/noteburst/values.yaml
+++ b/services/noteburst/values.yaml
@@ -61,6 +61,9 @@ ingress:
   # -- Additional annotations to add to the ingress
   annotations: {}
 
+  # -- Path prefix where noteburst is hosted
+  path: "/noteburst"
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little

--- a/services/times-square/README.md
+++ b/services/times-square/README.md
@@ -38,6 +38,7 @@ An API service for managing and rendering parameterized Jupyter notebooks.
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` | Secret names to use for all Docker pulls |
 | ingress.annotations | object | `{}` | Additional annotations for the ingress rule |
+| ingress.path | string | `"/times-square/api"` | Root URL path prefix for times-square API |
 | nameOverride | string | `""` | Override the base name for resources |
 | nodeSelector | object | `{}` | Node selection rules for the times-square deployment pod |
 | podAnnotations | object | `{}` | Annotations for the times-square deployment pod |

--- a/services/times-square/templates/ingress-webhooks.yaml
+++ b/services/times-square/templates/ingress-webhooks.yaml
@@ -14,7 +14,7 @@ spec:
     - host: {{ required "global.host must be set" .Values.global.host | quote }}
       http:
         paths:
-          - path: "/times-square/api/github"
+          - path: "{{ .Values.ingress.path }}/github"
             pathType: "Prefix"
             backend:
               service:

--- a/services/times-square/templates/ingress.yaml
+++ b/services/times-square/templates/ingress.yaml
@@ -22,7 +22,7 @@ template:
       - host: {{ required "global.host must be set" .Values.global.host | quote }}
         http:
           paths:
-            - path: "/times-square/api"
+            - path: {{ .Values.ingress.path | quote }}
               pathType: "Prefix"
               backend:
                 service:

--- a/services/times-square/values.yaml
+++ b/services/times-square/values.yaml
@@ -56,6 +56,9 @@ ingress:
   # -- Additional annotations for the ingress rule
   annotations: {}
 
+  # -- Root URL path prefix for times-square API
+  path: "/times-square/api"
+
 # -- Resource limits and requests for the times-square deployment pod
 resources: {}
 


### PR DESCRIPTION
Noteburst and times-square were using the ingress path configuraiton in values.yaml. Restore it back to the way they were.