### PR TITLE
DM-37226: Make times-square NetworkPolicy unconditional

### DIFF
--- a/services/noteburst/templates/ingress.yaml
+++ b/services/noteburst/templates/ingress.yaml
@@ -18,7 +18,6 @@ template:
       {{- toYaml . | nindent 6 }}
     {{- end }}
   spec:
-    ingressClassName: "nginx"
     rules:
       - host: {{ required "global.host must be set" .Values.global.host | quote }}
         http:

--- a/services/times-square/templates/networkpolicy.yaml
+++ b/services/times-square/templates/networkpolicy.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.ingress.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -20,4 +19,3 @@ spec:
       ports:
         - protocol: "TCP"
           port: 8080
-{{- end }}


### PR DESCRIPTION
There's no longer an option to not install the ingress, so the conditional has to be removed for the NetworkPolicy.