### PR TITLE
DM-37226: Remove stray ingressClassName from plot-navigator

### DIFF
--- a/services/plot-navigator/templates/ingress.yaml
+++ b/services/plot-navigator/templates/ingress.yaml
@@ -22,7 +22,6 @@ template:
       {{- toYaml . | nindent 6 }}
     {{- end }}
   spec:
-    ingressClassName: "nginx"
     rules:
     - host: {{ required "global.host must be set" .Values.global.host | quote }}
       http:

--- a/services/production-tools/templates/ingress.yaml
+++ b/services/production-tools/templates/ingress.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "production-tools.labels" . | nindent 4 }}
 config:
+  baseUrl: {{ .Values.global.baseUrl | quote }}
   scopes:
     all:
       - "exec:portal"

--- a/services/vo-cutouts/templates/ingress.yaml
+++ b/services/vo-cutouts/templates/ingress.yaml
@@ -9,7 +9,7 @@ config:
   scopes:
     all:
       - "read:image"
-templates:
+template:
   metadata:
     name: {{ template "vo-cutouts.fullname" . }}
     {{- with .Values.ingress.annotations }}


### PR DESCRIPTION
This setting isn't used with GafaelfawrIngress.