### PR TITLE
Update IP and add tls in values-idfint.yaml + add clusterNamespace

### DIFF
--- a/services/alert-stream-broker/README.md
+++ b/services/alert-stream-broker/README.md
@@ -12,5 +12,6 @@ Alert transmission to community brokers
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | strimzi-registry-operator.clusterName | string | `"alert-broker"` |  |
+| strimzi-registry-operator.clusterNamespace | string | `"alert-stream-broker"` |  |
 | strimzi-registry-operator.operatorNamespace | string | `"alert-stream-broker"` |  |
 | strimzi-registry-operator.watchNamespace | string | `"alert-stream-broker"` |  |

--- a/services/alert-stream-broker/charts/alert-database/Chart.yaml
+++ b/services/alert-stream-broker/charts/alert-database/Chart.yaml
@@ -3,7 +3,7 @@ name: alert-database
 version: 2.1.0
 description: Archival database of alerts sent through the alert stream.
 maintainers:
-  - name: swnelson
-    email: swnelson@uw.edu
+  - name: bsmart
+    email: drbsmart@uw.edu
 appVersion: 1.0.0
 type: application

--- a/services/alert-stream-broker/charts/alert-stream-broker/Chart.yaml
+++ b/services/alert-stream-broker/charts/alert-stream-broker/Chart.yaml
@@ -3,7 +3,7 @@ name: alert-stream-broker
 version: 2.5.1
 description: Kafka broker cluster for distributing alerts
 maintainers:
-  - name: swnelson
-    email: swnelson@uw.edu
+  - name: bsmart
+    email: drbsmart@uw.edu
 appVersion: 1.0.0
 type: application

--- a/services/alert-stream-broker/charts/alert-stream-broker/README.md
+++ b/services/alert-stream-broker/charts/alert-stream-broker/README.md
@@ -8,15 +8,15 @@ Kafka broker cluster for distributing alerts
 |-----|------|---------|-------------|
 | cluster.name | string | `"alert-broker"` | Name used for the Kafka broker, and used by Strimzi for many annotations. |
 | fullnameOverride | string | `""` | Override for the full name used for Kubernetes resources; by default one will be created based on the chart name and helm release name. |
-| kafka.config | object | `{"log.retention.bytes":"644245094400","log.retention.hours":168,"offsets.retention.minutes":10080}` | Configuration overrides for the Kafka server. |
-| kafka.config."log.retention.bytes" | string | `"644245094400"` | to avoid YAML type conversion issues for large numbers. |
-| kafka.config."log.retention.hours" | int | `168` | Number of days for a topic's data to be retained. |
-| kafka.config."offsets.retention.minutes" | int | `10080` | Number of minutes for a consumer group's offsets to be retained. |
+| kafka.config | object | `{"log.retention.bytes":"42949672960","log.retention.hours":168,"offsets.retention.minutes":1440}` | Configuration overrides for the Kafka server. |
+| kafka.config."log.retention.bytes" | string | `"42949672960"` | to avoid YAML type conversion issues for large numbers. |
+| kafka.config."log.retention.hours" | int | `168` | Number of hours for a brokers data to be retained. |
+| kafka.config."offsets.retention.minutes" | int | `1440` | Number of minutes for a consumer group's offsets to be retained. |
 | kafka.externalListener.bootstrap.annotations | object | `{}` |  |
 | kafka.externalListener.bootstrap.host | string | `""` | Hostname that should be used by clients who want to connect to the broker through the bootstrap address. |
 | kafka.externalListener.bootstrap.ip | string | `""` | IP address that should be used by the broker's external bootstrap load balancer for access from the internet. The format of this is a string like "192.168.1.1". |
 | kafka.externalListener.brokers | list | `[]` | List of hostname and IP for each broker. The format of this is a list of maps with 'ip' and 'host' keys. For example:     - ip: "192.168.1.1"      host: broker-0.example    - ip: "192.168.1.2"      host: broker-1.example  Each replica should get a host and IP. If these are unset, then IP addresses will be chosen automatically by the Kubernetes cluster's LoadBalancer controller, and hostnames will be unset, which will break TLS connections. |
-| kafka.externalListener.tls.certIssuerName | string | `"letsencrypt-dns"` |  |
+| kafka.externalListener.tls.certIssuerName | string | `"letsencrypt-dns"` | Name of the certificate issuer. |
 | kafka.externalListener.tls.enabled | bool | `false` | Whether TLS encryption is enabled. |
 | kafka.interBrokerProtocolVersion | float | `3.2` | Version of the protocol for inter-broker communication, see https://strimzi.io/docs/operators/latest/deploying.html#ref-kafka-versions-str. |
 | kafka.logMessageFormatVersion | float | `3.2` | Encoding version for messages, see https://strimzi.io/docs/operators/latest/deploying.html#ref-kafka-versions-str. |

--- a/services/alert-stream-broker/charts/alert-stream-broker/README.md
+++ b/services/alert-stream-broker/charts/alert-stream-broker/README.md
@@ -9,7 +9,7 @@ Kafka broker cluster for distributing alerts
 | cluster.name | string | `"alert-broker"` | Name used for the Kafka broker, and used by Strimzi for many annotations. |
 | fullnameOverride | string | `""` | Override for the full name used for Kubernetes resources; by default one will be created based on the chart name and helm release name. |
 | kafka.config | object | `{"log.retention.bytes":"42949672960","log.retention.hours":168,"offsets.retention.minutes":1440}` | Configuration overrides for the Kafka server. |
-| kafka.config."log.retention.bytes" | string | `"42949672960"` | to avoid YAML type conversion issues for large numbers. |
+| kafka.config."log.retention.bytes" | string | `"42949672960"` | Maximum retained number of bytes for a broker's data. This is a string to avoid YAML type conversion issues for large numbers. |
 | kafka.config."log.retention.hours" | int | `168` | Number of hours for a brokers data to be retained. |
 | kafka.config."offsets.retention.minutes" | int | `1440` | Number of minutes for a consumer group's offsets to be retained. |
 | kafka.externalListener.bootstrap.annotations | object | `{}` |  |

--- a/services/alert-stream-broker/charts/alert-stream-broker/values.yaml
+++ b/services/alert-stream-broker/charts/alert-stream-broker/values.yaml
@@ -32,8 +32,8 @@ kafka:
     offsets.retention.minutes: 1440
     # -- Number of hours for a brokers data to be retained.
     log.retention.hours: 168
-    # -- Maximum retained number of bytes for a brokers's data. This is a string
-    # -- to avoid YAML type conversion issues for large numbers.
+    # -- Maximum retained number of bytes for a broker's data. This is a string
+    # to avoid YAML type conversion issues for large numbers.
     log.retention.bytes: "42949672960"
 
   externalListener:

--- a/services/alert-stream-broker/charts/alert-stream-broker/values.yaml
+++ b/services/alert-stream-broker/charts/alert-stream-broker/values.yaml
@@ -29,17 +29,18 @@ kafka:
   # -- Configuration overrides for the Kafka server.
   config:
     # -- Number of minutes for a consumer group's offsets to be retained.
-    offsets.retention.minutes: 10080
-    # -- Number of days for a topic's data to be retained.
+    offsets.retention.minutes: 1440
+    # -- Number of hours for a brokers data to be retained.
     log.retention.hours: 168
-    # -- Maximum retained number of bytes for a topic's data. This is a string
+    # -- Maximum retained number of bytes for a brokers's data. This is a string
     # -- to avoid YAML type conversion issues for large numbers.
-    log.retention.bytes: "644245094400"
+    log.retention.bytes: "42949672960"
 
   externalListener:
     tls:
       # -- Whether TLS encryption is enabled.
       enabled: false
+      # -- Name of the certificate issuer.
       certIssuerName: "letsencrypt-dns"
     bootstrap:
       # -- IP address that should be used by the broker's external bootstrap load

--- a/services/alert-stream-broker/charts/alert-stream-schema-registry/Chart.yaml
+++ b/services/alert-stream-broker/charts/alert-stream-schema-registry/Chart.yaml
@@ -3,7 +3,7 @@ name: alert-stream-schema-registry
 version: 2.1.0
 description: Confluent Schema Registry for managing schema versions for the Alert Stream
 maintainers:
-  - name: swnelson
-    email: swnelson@uw.edu
+  - name: bsmart
+    email: drbsmart@uw.edu
 appVersion: 1.0.0
 type: application

--- a/services/alert-stream-broker/charts/alert-stream-simulator/Chart.yaml
+++ b/services/alert-stream-broker/charts/alert-stream-simulator/Chart.yaml
@@ -3,7 +3,7 @@ name: alert-stream-simulator
 version: 1.6.2
 description: Producer which repeatedly publishes a static set of alerts into a Kafka topic
 maintainers:
-  - name: swnelson
-    email: swnelson@uw.edu
+  - name: bsmart
+    email: drbsmart@uw.edu
 appVersion: 1.2.1
 type: application

--- a/services/alert-stream-broker/charts/alert-stream-simulator/README.md
+++ b/services/alert-stream-broker/charts/alert-stream-simulator/README.md
@@ -13,7 +13,7 @@ Producer which repeatedly publishes a static set of alerts into a Kafka topic
 | image.repository | string | `"lsstdm/alert-stream-simulator"` | Source repository for the image which holds the rubin-alert-stream program. |
 | image.tag | string | `"v1.2.1"` | Tag to use for the rubin-alert-stream container. |
 | kafkaUserName | string | `"alert-stream-simulator"` | The username of the Kafka user identity used to connect to the broker. |
-| maxBytesRetained | string | `"100000000000"` | Maximum number of bytes for the replay topic, per partition, per replica. Default is 100GB |
+| maxBytesRetained | string | `"24000000000"` | Maximum number of bytes for the replay topic, per partition, per replica. Default is 100GB |
 | maxMillisecondsRetained | string | `"604800000"` | Maximum amount of time to save simulated alerts in the replay topic, in milliseconds. Default is 7 days. |
 | nameOverride | string | `""` | Explicitly sets the name of the deployment and job. |
 | repeatInterval | int | `37` | How often (in seconds) to repeat the sample data into the replay topic. |

--- a/services/alert-stream-broker/charts/alert-stream-simulator/README.md
+++ b/services/alert-stream-broker/charts/alert-stream-simulator/README.md
@@ -13,7 +13,7 @@ Producer which repeatedly publishes a static set of alerts into a Kafka topic
 | image.repository | string | `"lsstdm/alert-stream-simulator"` | Source repository for the image which holds the rubin-alert-stream program. |
 | image.tag | string | `"v1.2.1"` | Tag to use for the rubin-alert-stream container. |
 | kafkaUserName | string | `"alert-stream-simulator"` | The username of the Kafka user identity used to connect to the broker. |
-| maxBytesRetained | string | `"24000000000"` | Maximum number of bytes for the replay topic, per partition, per replica. Default is 100GB |
+| maxBytesRetained | string | `"24000000000"` | Maximum number of bytes for the replay topic, per partition, per replica. Default is 100GB, but should be lower to not fill storage. |
 | maxMillisecondsRetained | string | `"604800000"` | Maximum amount of time to save simulated alerts in the replay topic, in milliseconds. Default is 7 days. |
 | nameOverride | string | `""` | Explicitly sets the name of the deployment and job. |
 | repeatInterval | int | `37` | How often (in seconds) to repeat the sample data into the replay topic. |

--- a/services/alert-stream-broker/charts/alert-stream-simulator/values.yaml
+++ b/services/alert-stream-broker/charts/alert-stream-simulator/values.yaml
@@ -45,7 +45,7 @@ maxMillisecondsRetained: "604800000"
 
 # -- Maximum number of bytes for the replay topic, per partition, per replica.
 # Default is 100GB
-maxBytesRetained: "100000000000"
+maxBytesRetained: "24000000000"
 
 replayTopicPartitions: 8
 

--- a/services/alert-stream-broker/charts/alert-stream-simulator/values.yaml
+++ b/services/alert-stream-broker/charts/alert-stream-simulator/values.yaml
@@ -44,7 +44,7 @@ repeatInterval: 37
 maxMillisecondsRetained: "604800000"
 
 # -- Maximum number of bytes for the replay topic, per partition, per replica.
-# Default is 100GB
+# Default is 100GB, but should be lower to not fill storage.
 maxBytesRetained: "24000000000"
 
 replayTopicPartitions: 8

--- a/services/alert-stream-broker/values-idfint.yaml
+++ b/services/alert-stream-broker/values-idfint.yaml
@@ -6,9 +6,20 @@ alert-stream-broker:
     # Addresses based on the state as of 2021-12-02; these were assigned by
     # Google and now we're pinning them.
     externalListener:
+      tls:
+        enabled: true
       bootstrap:
-        ip: 35.224.176.103
+        ip: "35.224.176.103"
         host: alert-stream-int.lsst.cloud
+      brokers:
+        - ip: "34.28.80.188"
+          host: alert-stream-int-broker-0.lsst.cloud
+        - ip: "35.188.136.140"
+          host: alert-stream-int-broker-1.lsst.cloud
+        - ip: "35.238.84.221"
+          host: alert-stream-int-broker-2.lsst.cloud
+
+
     storage:
       size: 1500Gi
 

--- a/services/alert-stream-broker/values.yaml
+++ b/services/alert-stream-broker/values.yaml
@@ -1,6 +1,7 @@
 strimzi-registry-operator:
   # Should match the cluster name used by the alert-stream-broker
   clusterName: alert-broker
+  clusterNamespace: alert-stream-broker
   # Should match the namespace where the alert-broker cluster runs
   watchNamespace: alert-stream-broker
 


### PR DESCRIPTION
Add TLS auth
Added static broker IPs
Reduce kafka retention

Static broker IPs are needed to access the alert-broker from the outside, otherwise every time Kafka is restarted a new is is assigned and the SSL certificates no longer get validated. TLS auth is also needed for the brokers to be able to talk with users.  cluserNamespace is was updated for the strimzi-registry to properly build. Reduced the topic level retention for alert-stream-simulator to 24 GB to prevent the current storage from filling up.