### PR TITLE
[DM-37254] Turn on mobu on data-dev, up debug level

### DIFF
--- a/services/mobu/values-idfdev.yaml
+++ b/services/mobu/values-idfdev.yaml
@@ -11,3 +11,13 @@ autostart:
       jupyter:
         image_size: "Small"
     restart: true
+  - name: "tap"
+    count: 1
+    users:
+      - username: "bot-mobu-tap"
+    scopes: ["read:tap"]
+    business: "TAPQueryRunner"
+    restart: true
+    options:
+      tap_sync: true
+      tap_query_set: "dp0.2"

--- a/services/tap/values-idfdev.yaml
+++ b/services/tap/values-idfdev.yaml
@@ -6,3 +6,6 @@ qserv:
   host: "10.136.1.211:4040"
   mock:
     enabled: false
+
+image:
+  tag: "1.4.1"

--- a/services/tap/values-idfint.yaml
+++ b/services/tap/values-idfint.yaml
@@ -17,3 +17,6 @@ qserv:
   host: "10.136.1.211:4040"
   mock:
     enabled: false
+
+image:
+  tag: "1.4.1"


### PR DESCRIPTION
Turn on mobu TAP queries for data-dev, and up the debug level for data-dev and data-int by using release 1.4.1