### PR TITLE
[DM-37254] Add resources for data-dev tap

### DIFF
--- a/services/tap/values-idfdev.yaml
+++ b/services/tap/values-idfdev.yaml
@@ -1,3 +1,11 @@
+resources:
+  requests:
+    cpu: 2.0
+    memory: "2G"
+  limits:
+    cpu: 8.0
+    memory: "32G"
+
 config:
   gcsBucket: "async-results.lsst.codes"
   gcsBucketUrl: "http://async-results.lsst.codes"


### PR DESCRIPTION
We're running queries from mobu now, and it has restarted about 2 dozen times over night, and I think that is due to the restrictive default resource limits.  Let's make them the same as int since we're expecting what they are expecting, but keep the replica count at 1.