### PR TITLE
[DM-27254] Switch mobu -int back to dp0.1

### DIFF
--- a/services/mobu/values-idfint.yaml
+++ b/services/mobu/values-idfint.yaml
@@ -41,4 +41,4 @@ autostart:
     restart: true
     options:
       tap_sync: true
-      tap_query_set: "dp0.2"
+      tap_query_set: "dp0.1"


### PR DESCRIPTION
This should at least let us know if we get errors running the old queries, or is it just the new queries?