### PR TITLE
[DM-37254] Go back to dp0.2, but try async

### DIFF
--- a/services/mobu/values-idfint.yaml
+++ b/services/mobu/values-idfint.yaml
@@ -40,5 +40,5 @@ autostart:
     business: "TAPQueryRunner"
     restart: true
     options:
-      tap_sync: true
-      tap_query_set: "dp0.1"
+      tap_sync: false
+      tap_query_set: "dp0.2"


### PR DESCRIPTION
If we're doing async queries, that might get around this connection reset, if the connection reset is between mobu and TAP.  If it is somehow related to qserv, then the problem should persist.