### PR TITLE
DM-37476: Convert remaining Ingress objects to GafaelfawrIngress

### DIFF
--- a/services/cachemachine/README.md
+++ b/services/cachemachine/README.md
@@ -19,9 +19,8 @@ JupyterLab image prepuller
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the cachemachine image |
 | image.repository | string | `"lsstsqre/cachemachine"` | cachemachine image to use |
 | image.tag | string | The appVersion of the chart | Tag of cachemachine image to use |
-| ingress.annotations | object | `{}` | Additional annotations to add for endpoints that are authenticated. |
-| ingress.anonymousAnnotations | object | `{}` | Additional annotations to add for endpoints that allow anonymous access, such as `/*/available`. |
-| ingress.gafaelfawrAuthQuery | string | `"scope=exec:admin"` | Gafaelfawr auth query string |
+| ingress.annotations | object | `{}` | Additional annotations to add for endpoints that are authenticated |
+| ingress.anonymousAnnotations | object | `{}` | Additional annotations to add for endpoints that allow anonymous access, such as `/*/available` |
 | nameOverride | string | `""` | Override the base name for resources |
 | nodeSelector | object | `{}` | Node selector rules for the cachemachine frontend pod |
 | podAnnotations | object | `{}` | Annotations for the cachemachine frontend pod |

--- a/services/cachemachine/templates/ingress-anonymous.yaml
+++ b/services/cachemachine/templates/ingress-anonymous.yaml
@@ -1,24 +1,30 @@
-apiVersion: networking.k8s.io/v1
-kind: Ingress
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
 metadata:
-  annotations:
-    nginx.ingress.kubernetes.io/use-regex: "true"
-    {{- with .Values.ingress.anonymousAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
   name: {{ template "cachemachine.fullname" . }}-anonymous
   labels:
     {{- include "cachemachine.labels" . | nindent 4 }}
-spec:
-  ingressClassName: "nginx"
-  rules:
-    - host: {{ required "global.host must be set" .Values.global.host | quote }}
-      http:
-        paths:
-          - path: "/cachemachine/.*/(available|desired)"
-            pathType: "ImplementationSpecific"
-            backend:
-              service:
-                name: {{ template "cachemachine.fullname" . }}
-                port:
-                  number: 80
+config:
+  baseUrl: {{ .Values.global.baseUrl | quote }}
+  scopes:
+    anonymous: true
+template:
+  metadata:
+    name: {{ template "cachemachine.fullname" . }}-anonymous
+    annotations:
+      nginx.ingress.kubernetes.io/use-regex: "true"
+      {{- with .Values.ingress.anonymousAnnotations }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+  spec:
+    rules:
+      - host: {{ required "global.host must be set" .Values.global.host | quote }}
+        http:
+          paths:
+            - path: "/cachemachine/.*/(available|desired)"
+              pathType: "ImplementationSpecific"
+              backend:
+                service:
+                  name: {{ template "cachemachine.fullname" . }}
+                  port:
+                    number: 80

--- a/services/cachemachine/templates/ingress.yaml
+++ b/services/cachemachine/templates/ingress.yaml
@@ -1,22 +1,24 @@
-apiVersion: networking.k8s.io/v1
-kind: Ingress
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
 metadata:
-  annotations:
-    {{- if .Values.ingress.gafaelfawrAuthQuery }}
-    nginx.ingress.kubernetes.io/auth-method: "GET"
-    nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-User"
-    nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.global.baseUrl }}/login"
-    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.baseUrl }}/auth?{{ .Values.ingress.gafaelfawrAuthQuery }}"
-    {{- end }}
-    {{- with .Values.ingress.annotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
   name: {{ template "cachemachine.fullname" . }}
   labels:
     {{- include "cachemachine.labels" . | nindent 4 }}
-spec:
-  ingressClassName: "nginx"
-  rules:
+config:
+  baseUrl: {{ .Values.global.baseUrl | quote }}
+  scopes:
+    all:
+      - "exec:admin"
+  loginRedirect: true
+template:
+  metadata:
+    name: {{ template "cachemachine.fullname" . }}
+    {{- with .Values.ingress.annotations }}
+    annotations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  spec:
+    rules:
     - host: {{ required "global.host must be set" .Values.global.host | quote }}
       http:
         paths:

--- a/services/cachemachine/values.yaml
+++ b/services/cachemachine/values.yaml
@@ -27,14 +27,11 @@ serviceAccount:
   annotations: {}
 
 ingress:
-  # -- Gafaelfawr auth query string
-  gafaelfawrAuthQuery: "scope=exec:admin"
-
-  # -- Additional annotations to add for endpoints that are authenticated.
+  # -- Additional annotations to add for endpoints that are authenticated
   annotations: {}
 
   # -- Additional annotations to add for endpoints that allow anonymous
-  # access, such as `/*/available`.
+  # access, such as `/*/available`
   anonymousAnnotations: {}
 
 # -- Resource limits and requests for the cachemachine frontend pod

--- a/services/semaphore/templates/ingress.yaml
+++ b/services/semaphore/templates/ingress.yaml
@@ -17,7 +17,6 @@ template:
       {{- toYaml . | nindent 6 }}
     {{- end }}
   spec:
-    ingressClassName: "nginx"
     rules:
       - host: {{ required "global.host must be set" .Values.global.host | quote }}
         http:

--- a/services/semaphore/templates/ingress.yaml
+++ b/services/semaphore/templates/ingress.yaml
@@ -1,25 +1,32 @@
 {{- if .Values.ingress.enabled -}}
-apiVersion: networking.k8s.io/v1
-kind: Ingress
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
 metadata:
   name: {{ template "semaphore.fullname" . }}
   labels:
     {{- include "semaphore.labels" . | nindent 4 }}
-  annotations:
+config:
+  baseUrl: {{ .Values.global.baseUrl | quote }}
+  scopes:
+    anonymous: true
+template:
+  metadata:
+    name: {{ template "semaphore.fullname" . }}
     {{- with .Values.ingress.annotations }}
-    {{- toYaml . | nindent 4 }}
+    annotations:
+      {{- toYaml . | nindent 6 }}
     {{- end }}
-spec:
-  ingressClassName: "nginx"
-  rules:
-    - host: {{ required "global.host must be set" .Values.global.host | quote }}
-      http:
-        paths:
-          - path: {{ .Values.ingress.path }}
-            pathType: "Prefix"
-            backend:
-              service:
-                name: {{ template "semaphore.fullname" . }}
-                port:
-                  number: 80
+  spec:
+    ingressClassName: "nginx"
+    rules:
+      - host: {{ required "global.host must be set" .Values.global.host | quote }}
+        http:
+          paths:
+            - path: {{ .Values.ingress.path | quote }}
+              pathType: "Prefix"
+              backend:
+                service:
+                  name: {{ template "semaphore.fullname" . }}
+                  port:
+                    number: 80
 {{- end }}

--- a/services/squareone/templates/ingress.yaml
+++ b/services/squareone/templates/ingress.yaml
@@ -1,35 +1,42 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "squareone.fullname" . -}}
-apiVersion: networking.k8s.io/v1
-kind: Ingress
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
 metadata:
   name: {{ $fullName }}
   labels:
     {{- include "squareone.labels" . | nindent 4 }}
-  annotations:
+config:
+  baseUrl: {{ .Values.global.baseUrl | quote }}
+  scopes:
+    anonymous: true
+template:
+  metadata:
+    name: {{ $fullName }}
+    annotations:
+      {{- if .Values.ingress.tls }}
+      cert-manager.io/cluster-issuer: "letsencrypt-dns"
+      {{- end }}
+      {{- with .Values.ingress.annotations }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+  spec:
+    ingressClassName: "nginx"
     {{- if .Values.ingress.tls }}
-    cert-manager.io/cluster-issuer: "letsencrypt-dns"
+    tls:
+      - hosts:
+          - {{ required "global.host must be set" .Values.global.host | quote }}
+        secretName: "squareone-tls"
     {{- end }}
-    {{- with .Values.ingress.annotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-spec:
-  ingressClassName: "nginx"
-  {{- if .Values.ingress.tls }}
-  tls:
-    - hosts:
-        - {{ required "global.host must be set" .Values.global.host | quote }}
-      secretName: squareone-tls
-  {{- end }}
-  rules:
-    - host: {{ required "global.host must be set" .Values.global.host | quote }}
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ $fullName }}
-                port:
-                  number: 80
-  {{- end }}
+    rules:
+      - host: {{ required "global.host must be set" .Values.global.host | quote }}
+        http:
+          paths:
+            - path: "/"
+              pathType: "Prefix"
+              backend:
+                service:
+                  name: {{ $fullName }}
+                  port:
+                    number: 80
+{{- end }}

--- a/services/squareone/templates/ingress.yaml
+++ b/services/squareone/templates/ingress.yaml
@@ -21,7 +21,6 @@ template:
       {{- toYaml . | nindent 6 }}
       {{- end }}
   spec:
-    ingressClassName: "nginx"
     {{- if .Values.ingress.tls }}
     tls:
       - hosts:

--- a/services/tap/templates/tap-ingress-anonymous.yaml
+++ b/services/tap/templates/tap-ingress-anonymous.yaml
@@ -1,31 +1,37 @@
-apiVersion: networking.k8s.io/v1
-kind: Ingress
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
 metadata:
   name: {{ template "cadc-tap.fullname" . }}-anonymous
   labels:
     {{- include "cadc-tap.labels" . | nindent 4 }}
-  annotations:
-    nginx.ingress.kubernetes.io/proxy-connect-timeout: "900"
-    nginx.ingress.kubernetes.io/proxy-send-timeout: "900"
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "900"
-    nginx.ingress.kubernetes.io/rewrite-target: "/tap/$1"
-    nginx.ingress.kubernetes.io/proxy-redirect-from: "http://$host/tap/"
-    nginx.ingress.kubernetes.io/proxy-redirect-to: "https://$host/api/tap/"
-    nginx.ingress.kubernetes.io/ssl-redirect: "true"
-    nginx.ingress.kubernetes.io/use-regex: "true"
-    {{- with .Values.ingress.anonymousAnnotations }}
-    {{- toYaml . | indent 4}}
-    {{- end }}
-spec:
-  ingressClassName: "nginx"
-  rules:
-    - host: {{ required "global.host must be set" .Values.global.host | quote }}
-      http:
-        paths:
-          - path: "/api/tap/(availability|capabilities|swagger-ui.*)"
-            pathType: "ImplementationSpecific"
-            backend:
-              service:
-                name: {{ template "cadc-tap.fullname" . }}
-                port:
-                  number: 80
+config:
+  baseUrl: {{ .Values.global.baseUrl | quote }}
+  scopes:
+    anonymous: true
+template:
+  metadata:
+    name: {{ template "cadc-tap.fullname" . }}-anonymous
+    annotations:
+      nginx.ingress.kubernetes.io/proxy-connect-timeout: "900"
+      nginx.ingress.kubernetes.io/proxy-send-timeout: "900"
+      nginx.ingress.kubernetes.io/proxy-read-timeout: "900"
+      nginx.ingress.kubernetes.io/rewrite-target: "/tap/$1"
+      nginx.ingress.kubernetes.io/proxy-redirect-from: "http://$host/tap/"
+      nginx.ingress.kubernetes.io/proxy-redirect-to: "https://$host/api/tap/"
+      nginx.ingress.kubernetes.io/ssl-redirect: "true"
+      nginx.ingress.kubernetes.io/use-regex: "true"
+      {{- with .Values.ingress.anonymousAnnotations }}
+      {{- toYaml . | indent 4}}
+      {{- end }}
+  spec:
+    rules:
+      - host: {{ required "global.host must be set" .Values.global.host | quote }}
+        http:
+          paths:
+            - path: "/api/tap/(availability|capabilities|swagger-ui.*)"
+              pathType: "ImplementationSpecific"
+              backend:
+                service:
+                  name: {{ template "cadc-tap.fullname" . }}
+                  port:
+                    number: 80

--- a/services/times-square/templates/ingress-webhooks.yaml
+++ b/services/times-square/templates/ingress-webhooks.yaml
@@ -1,23 +1,30 @@
-apiVersion: networking.k8s.io/v1
-kind: Ingress
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
 metadata:
   name: {{ include "times-square.fullname" . }}-github-webhook
   labels:
     {{- include "times-square.labels" . | nindent 4 }}
-  annotations:
+config:
+  baseUrl: {{ .Values.global.baseUrl | quote }}
+  scopes:
+    anonymous: true
+template:
+  metadata:
+    name: {{ include "times-square.fullname" . }}-github-webhook
     {{- with .Values.ingress.annotations }}
-    {{- toYaml . | nindent 4 }}
+    annotations:
+      {{- toYaml . | nindent 6 }}
     {{- end }}
-spec:
-  ingressClassName: "nginx"
-  rules:
-    - host: {{ required "global.host must be set" .Values.global.host | quote }}
-      http:
-        paths:
-          - path: "{{ .Values.ingress.path }}/github"
-            pathType: "Prefix"
-            backend:
-              service:
-                name: {{ include "times-square.fullname" . }}
-                port:
-                  number: {{ .Values.service.port }}
+  spec:
+    ingressClassName: "nginx"
+    rules:
+      - host: {{ required "global.host must be set" .Values.global.host | quote }}
+        http:
+          paths:
+            - path: "{{ .Values.ingress.path }}/github"
+              pathType: "Prefix"
+              backend:
+                service:
+                  name: {{ include "times-square.fullname" . }}
+                  port:
+                    number: {{ .Values.service.port }}


### PR DESCRIPTION
Make use of the new anonymous ingress support and convert all remaining Ingress objects in Phalanx to GafaelfawrIngress. This doesn't change the ingresses installed by third-party charts.