### PR TITLE
DM-37480: Add autherror location to each NGINX server

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,6 +81,7 @@ jobs:
               - "science-platform/values-minikube.yaml"
               - "services/*/Chart.yaml"
               - "services/*/templates/**"
+              - "services/*/values.yaml"
               - "services/*/values-minikube.yaml"
 
       - name: Setup Minikube

--- a/services/gafaelfawr/Chart.yaml
+++ b/services/gafaelfawr/Chart.yaml
@@ -5,7 +5,7 @@ description: Authentication and identity system
 home: https://gafaelfawr.lsst.io/
 sources:
   - https://github.com/lsst-sqre/gafaelfawr
-appVersion: 8.0.0
+appVersion: 9.0.0
 
 annotations:
   phalanx.lsst.io/docs: |

--- a/services/ingress-nginx/README.md
+++ b/services/ingress-nginx/README.md
@@ -17,9 +17,10 @@ Ingress controller
 | ingress-nginx.controller.config.large-client-header-buffers | string | `"4 64k"` | Increase the buffer size for client headers because we may have JWTs in the client request |
 | ingress-nginx.controller.config.proxy-body-size | string | `"100m"` | Maximum size of the client request body (needs to be large enough to allow table uploads) |
 | ingress-nginx.controller.config.proxy-buffer-size | string | `"64k"` | Increase the buffer size for responses from backend servers to allow for longer headers |
+| ingress-nginx.controller.config.server-snippet | string | See `values.yaml` | Add additional configuration used by Gafaelfawr to report errors from the authorization layer |
 | ingress-nginx.controller.config.ssl-redirect | string | `"true"` | Redirect all non-SSL access to SSL. |
 | ingress-nginx.controller.config.use-forwarded-headers | string | `"true"` | Enable the `X-Forwarded-For` processing |
 | ingress-nginx.controller.metrics.enabled | bool | `true` | Enable metrics reporting via Prometheus |
-| ingress-nginx.controller.podLabels | object | `{"gafaelfawr.lsst.io/ingress":"true","hub.jupyter.org/network-access-proxy-http":"true"}` | Add labels used by `NetworkPolicy` objects to restrict access to the ingress and thus ensure that auth subrequest handlers run |
+| ingress-nginx.controller.podLabels | object | See `values.yaml` | Add labels used by `NetworkPolicy` objects to restrict access to the ingress and thus ensure that auth subrequest handlers run |
 | ingress-nginx.controller.service.externalTrafficPolicy | string | `"Local"` | Force traffic routing policy to Local so that the external IP in `X-Forwarded-For` will be correct |
 | vaultCertificate.enabled | bool | `false` | Whether to store ingress TLS certificate via vault-secrets-operator.  Typically "squareone" owns it instead in an RSP. |

--- a/services/ingress-nginx/values.yaml
+++ b/services/ingress-nginx/values.yaml
@@ -25,6 +25,20 @@ ingress-nginx:
       # -- Enable the `X-Forwarded-For` processing
       use-forwarded-headers: "true"
 
+      # -- Add additional configuration used by Gafaelfawr to report errors
+      # from the authorization layer
+      # @default -- See `values.yaml`
+      server-snippet: |
+        location @autherror {
+          add_header Cache-Control "no-cache, must-revalidate" always;
+          add_header WWW-Authenticate $auth_www_authenticate always;
+          if ($auth_status = 400) {
+            add_header Content-Type "application/json" always;
+            return 400 $auth_error_body;
+          }
+          return 403;
+        }
+
     service:
       # -- Force traffic routing policy to Local so that the external IP in
       # `X-Forwarded-For` will be correct
@@ -32,6 +46,7 @@ ingress-nginx:
 
     # -- Add labels used by `NetworkPolicy` objects to restrict access to the
     # ingress and thus ensure that auth subrequest handlers run
+    # @default -- See `values.yaml`
     podLabels:
       gafaelfawr.lsst.io/ingress: "true"
       hub.jupyter.org/network-access-proxy-http: "true"

--- a/services/ingress-nginx/values.yaml
+++ b/services/ingress-nginx/values.yaml
@@ -30,10 +30,10 @@ ingress-nginx:
       # @default -- See `values.yaml`
       server-snippet: |
         location @autherror {
+          default_type application/json;
           if ($auth_status = 400) {
             add_header Cache-Control "no-cache, must-revalidate" always;
             add_header WWW-Authenticate $auth_www_authenticate always;
-            add_header Content-Type "application/json" always;
             return 400 $auth_error_body;
           }
           add_header Cache-Control "no-cache, must-revalidate" always;

--- a/services/ingress-nginx/values.yaml
+++ b/services/ingress-nginx/values.yaml
@@ -30,12 +30,14 @@ ingress-nginx:
       # @default -- See `values.yaml`
       server-snippet: |
         location @autherror {
-          add_header Cache-Control "no-cache, must-revalidate" always;
-          add_header WWW-Authenticate $auth_www_authenticate always;
           if ($auth_status = 400) {
+            add_header Cache-Control "no-cache, must-revalidate" always;
+            add_header WWW-Authenticate $auth_www_authenticate always;
             add_header Content-Type "application/json" always;
             return 400 $auth_error_body;
           }
+          add_header Cache-Control "no-cache, must-revalidate" always;
+          add_header WWW-Authenticate $auth_www_authenticate always;
           return 403;
         }
 

--- a/services/nublado2/README.md
+++ b/services/nublado2/README.md
@@ -62,10 +62,7 @@ JupyterHub for the Rubin Science Platform
 | jupyterhub.hub.resources.limits.cpu | string | `"900m"` |  |
 | jupyterhub.hub.resources.limits.memory | string | `"1Gi"` |  |
 | jupyterhub.imagePullSecrets[0].name | string | `"pull-secret"` |  |
-| jupyterhub.ingress.annotations."nginx.ingress.kubernetes.io/auth-method" | string | `"GET"` |  |
-| jupyterhub.ingress.annotations."nginx.ingress.kubernetes.io/auth-response-headers" | string | `"X-Auth-Request-Token"` |  |
-| jupyterhub.ingress.annotations."nginx.ingress.kubernetes.io/auth-url" | string | `"http://gafaelfawr.gafaelfawr.svc.cluster.local:8080/auth?scope=exec:notebook&notebook=true&minimum_lifetime=2160000"` |  |
-| jupyterhub.ingress.annotations."nginx.ingress.kubernetes.io/configuration-snippet" | string | `"error_page 403 = \"/auth/forbidden?scope=exec:notebook\";\n"` |  |
+| jupyterhub.ingress.annotations | object | See `values.yaml` | Extra annotations to add to the ingress |
 | jupyterhub.ingress.enabled | bool | `true` |  |
 | jupyterhub.ingress.ingressClassName | string | `"nginx"` |  |
 | jupyterhub.ingress.pathSuffix | string | `"*"` |  |

--- a/services/nublado2/values.yaml
+++ b/services/nublado2/values.yaml
@@ -143,12 +143,18 @@ jupyterhub:
   # appropriate fully-qualified URLs for the Gafaelfawr /login route.
   ingress:
     enabled: true
+
+    # -- Extra annotations to add to the ingress
+    # @default -- See `values.yaml`
     annotations:
-      nginx.ingress.kubernetes.io/auth-method: GET
-      nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-Token"
+      nginx.ingress.kubernetes.io/auth-method: "GET"
+      nginx.ingress.kubernetes.io/auth-response-headers: "Authorization,Cookie,X-Auth-Request-Email,X-Auth-Request-User,X-Auth-Request-Token"
       nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr.gafaelfawr.svc.cluster.local:8080/auth?scope=exec:notebook&notebook=true&minimum_lifetime=2160000"
       nginx.ingress.kubernetes.io/configuration-snippet: |
-        error_page 403 = "/auth/forbidden?scope=exec:notebook";
+        auth_request_set $auth_www_authenticate $upstream_http_www_authenticate;
+        auth_request_set $auth_status $upstream_http_x_error_status;
+        auth_request_set $auth_error_body $upstream_http_x_error_body;
+        error_page 403 = @autherror;
     ingressClassName: "nginx"
     pathSuffix: "*"
 


### PR DESCRIPTION
The NGINX support for an auth_request subhandler is very limited. It only allows 401 and 403 returns, and doesn't even include the WWW-Authenticate header on 403 replies.  We want to use it to do many more things, so we need to add some custom configuration.

Use server-snippet to add an autherror block to every server in the NGINX configuration.  This will be used as the target for an error_page directive introduced by Gafaelfawr and will read the actual status and error body out of headers.  It will also always set Cache-Control and WWW-Authenticate.

As is, this block won't be used by anything.  The other half of this change will introduced Ingress annotations that will use the block for Ingresses that are Gafaelfawr-protected.