### PR TITLE
DM-37390: Convert noteburst and times-square to new Redis chart

### DIFF
--- a/services/noteburst/Chart.yaml
+++ b/services/noteburst/Chart.yaml
@@ -11,11 +11,10 @@ maintainers:
   - name: jonathansick
     url: https://github.com/jonathansick
 
-# Additional charts that this chart uses
 dependencies:
   - name: redis
-    version: 17.4.0
-    repository: https://charts.bitnami.com/bitnami
+    version: 0.1.4
+    repository: https://lsst-sqre.github.io/charts/
 
 annotations:
   phalanx.lsst.io/docs: |

--- a/services/noteburst/README.md
+++ b/services/noteburst/README.md
@@ -38,7 +38,15 @@ Noteburst is a notebook execution service for the Rubin Science Platform.
 | nameOverride | string | `""` | Override the base name for resources |
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` | Annotations for API and worker pods |
-| redis.auth.enabled | bool | `false` |  |
+| redis.affinity | object | `{}` | Affinity rules for the Redis pod |
+| redis.nodeSelector | object | `{}` | Node selection rules for the Redis pod |
+| redis.persistence.enabled | bool | `true` | Whether to persist Redis storage and thus tokens. Setting this to false will use `emptyDir` and reset all tokens on every restart. Only use this for a test deployment. |
+| redis.persistence.size | string | `"8Gi"` | Amount of persistent storage to request |
+| redis.persistence.storageClass | string | `""` | Class of storage to request |
+| redis.persistence.volumeClaimName | string | `""` | Use an existing PVC, not dynamic provisioning. If this is set, the size, storageClass, and accessMode settings are ignored. |
+| redis.podAnnotations | object | `{}` | Pod annotations for the Redis pod |
+| redis.resources | object | See `values.yaml` | Resource limits and requests for the Redis pod |
+| redis.tolerations | list | `[]` | Tolerations for the Redis pod |
 | replicaCount | int | `1` | Number of API pods to run |
 | resources | object | `{}` |  |
 | service.port | int | `80` | Port of the service to create and map to the ingress |

--- a/services/noteburst/templates/configmap.yaml
+++ b/services/noteburst/templates/configmap.yaml
@@ -8,4 +8,4 @@ data:
   SAFIR_LOG_LEVEL: {{ .Values.config.logLevel | quote }}
   NOTEBURST_PATH_PREFIX: {{ .Values.ingress.path | quote }}
   NOTEBURST_ENVIRONMENT_URL: {{ .Values.global.baseUrl | quote }}
-  NOTEBURST_REDIS_URL: "redis://{{ include "noteburst.fullname" . }}-redis-master.{{ .Release.Namespace }}:{{ .Values.redis.master.service.ports.redis }}/0"
+  NOTEBURST_REDIS_URL: "redis://{{ include "noteburst.fullname" . }}-redis.{{ .Release.Namespace }}:6379/0"

--- a/services/noteburst/templates/deployment.yaml
+++ b/services/noteburst/templates/deployment.yaml
@@ -20,6 +20,7 @@ spec:
         {{- end }}
       labels:
         {{- include "noteburst.selectorLabels" . | nindent 8 }}
+        noteburst-redis-client: "true"
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/services/noteburst/templates/worker-configmap.yaml
+++ b/services/noteburst/templates/worker-configmap.yaml
@@ -7,8 +7,8 @@ metadata:
 data:
   SAFIR_LOG_LEVEL: {{ .Values.config.logLevel | quote }}
   NOTEBURST_ENVIRONMENT_URL: {{ .Values.global.baseUrl | quote }}
-  NOTEBURST_REDIS_URL: "redis://{{ include "noteburst.fullname" . }}-redis-master.{{ .Release.Namespace }}:{{ .Values.redis.master.service.ports.redis }}/0"
-  NOTEBURST_WORKER_LOCK_REDIS_URL: "redis://{{ include "noteburst.fullname" . }}-redis-master.{{ .Release.Namespace }}:{{ .Values.redis.master.service.ports.redis }}/1"
+  NOTEBURST_REDIS_URL: "redis://{{ include "noteburst.fullname" . }}-redis.{{ .Release.Namespace }}:6379/0"
+  NOTEBURST_WORKER_LOCK_REDIS_URL: "redis://{{ include "noteburst.fullname" . }}-redis.{{ .Release.Namespace }}:6379/1"
   NOTEBURST_WORKER_JOB_TIMEOUT: {{ .Values.config.worker.jobTimeout | quote }}
   NOTEBURST_WORKER_TOKEN_LIFETIME: {{ .Values.config.worker.tokenLifetime | quote }}
   NOTEBURST_WORKER_IMAGE_SELECTOR: {{ .Values.config.worker.imageSelector | quote  }}

--- a/services/noteburst/templates/worker-deployment.yaml
+++ b/services/noteburst/templates/worker-deployment.yaml
@@ -20,6 +20,7 @@ spec:
         {{- end }}
       labels:
         {{- include "noteburst.selectorLabels" . | nindent 8 }}
+        noteburst-redis-client: "true"
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/services/noteburst/values-idfdev.yaml
+++ b/services/noteburst/values-idfdev.yaml
@@ -13,3 +13,8 @@ config:
       - username: "bot-noteburst90003"
       - username: "bot-noteburst90004"
       - username: "bot-noteburst90005"
+
+# Use SSD for Redis storage.
+redis:
+  persistence:
+    storageClass: "premium-rwo"

--- a/services/noteburst/values.yaml
+++ b/services/noteburst/values.yaml
@@ -120,5 +120,36 @@ config:
     keepAlive: "normal"
 
 redis:
-  auth:
-    enabled: false
+  persistence:
+    # -- Whether to persist Redis storage and thus tokens. Setting this to
+    # false will use `emptyDir` and reset all tokens on every restart. Only
+    # use this for a test deployment.
+    enabled: true
+
+    # -- Amount of persistent storage to request
+    size: "8Gi"
+
+    # -- Class of storage to request
+    storageClass: ""
+
+    # -- Use an existing PVC, not dynamic provisioning. If this is set, the
+    # size, storageClass, and accessMode settings are ignored.
+    volumeClaimName: ""
+
+  # -- Resource limits and requests for the Redis pod
+  # @default -- See `values.yaml`
+  resources:
+    limits:
+      cpu: "1"
+
+  # -- Pod annotations for the Redis pod
+  podAnnotations: {}
+
+  # -- Node selection rules for the Redis pod
+  nodeSelector: {}
+
+  # -- Tolerations for the Redis pod
+  tolerations: []
+
+  # -- Affinity rules for the Redis pod
+  affinity: {}

--- a/services/times-square/Chart.yaml
+++ b/services/times-square/Chart.yaml
@@ -12,8 +12,8 @@ appVersion: "0.6.0"
 
 dependencies:
   - name: redis
-    version: 17.4.0
-    repository: https://charts.bitnami.com/bitnami
+    version: 0.1.4
+    repository: https://lsst-sqre.github.io/charts/
 
 annotations:
   phalanx.lsst.io/docs: |

--- a/services/times-square/README.md
+++ b/services/times-square/README.md
@@ -27,8 +27,8 @@ An API service for managing and rendering parameterized Jupyter notebooks.
 | config.logLevel | string | `"INFO"` | Logging level: "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL" |
 | config.name | string | `"times-square"` | Name of the service. |
 | config.profile | string | `"production"` | Run profile: "production" or "development" |
-| config.queueRedisUrl | string | Points to embedded Redis | URL for Redis arq queue database |
-| config.redisUrl | string | Points to embedded Redis | URL for Redis html / noteburst job cache database |
+| config.redisCacheUrl | string | Points to embedded Redis | URL for Redis html / noteburst job cache database |
+| config.redisQueueUrl | string | Points to embedded Redis | URL for Redis arq queue database |
 | fullnameOverride | string | `""` | Override the full name for resources (includes the release name) |
 | global.baseUrl | string | Set by times-square Argo CD Application | Base URL for the environment |
 | global.host | string | Set by times-square Argo CD Application | Host name for ingress |
@@ -42,8 +42,15 @@ An API service for managing and rendering parameterized Jupyter notebooks.
 | nameOverride | string | `""` | Override the base name for resources |
 | nodeSelector | object | `{}` | Node selection rules for the times-square deployment pod |
 | podAnnotations | object | `{}` | Annotations for the times-square deployment pod |
-| redis.auth.enabled | bool | `false` |  |
-| redis.fullnameOverride | string | `"times-square-redis"` |  |
+| redis.affinity | object | `{}` | Affinity rules for the Redis pod |
+| redis.nodeSelector | object | `{}` | Node selection rules for the Redis pod |
+| redis.persistence.enabled | bool | `true` | Whether to persist Redis storage and thus tokens. Setting this to false will use `emptyDir` and reset all tokens on every restart. Only use this for a test deployment. |
+| redis.persistence.size | string | `"8Gi"` | Amount of persistent storage to request |
+| redis.persistence.storageClass | string | `""` | Class of storage to request |
+| redis.persistence.volumeClaimName | string | `""` | Use an existing PVC, not dynamic provisioning. If this is set, the size, storageClass, and accessMode settings are ignored. |
+| redis.podAnnotations | object | `{}` | Pod annotations for the Redis pod |
+| redis.resources | object | See `values.yaml` | Resource limits and requests for the Redis pod |
+| redis.tolerations | list | `[]` | Tolerations for the Redis pod |
 | replicaCount.api | int | `1` | Number of API deployment pods to start |
 | replicaCount.worker | int | `1` | Number of worker deployment pods to start |
 | resources | object | `{}` | Resource limits and requests for the times-square deployment pod |

--- a/services/times-square/templates/deployment.yaml
+++ b/services/times-square/templates/deployment.yaml
@@ -20,6 +20,7 @@ spec:
         {{- end }}
       labels:
         {{- include "times-square.selectorLabels" . | nindent 8 }}
+        times-square-redis-client: "true"
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/services/times-square/templates/worker-deployment.yaml
+++ b/services/times-square/templates/worker-deployment.yaml
@@ -20,6 +20,7 @@ spec:
         {{- end }}
       labels:
         {{- include "times-square.selectorLabels" . | nindent 8 }}
+        times-square-redis-client: "true"
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/services/times-square/values-idfdev.yaml
+++ b/services/times-square/values-idfdev.yaml
@@ -5,9 +5,10 @@ config:
   databaseUrl: "postgresql://times-square@localhost/times-square"
   githubAppId: "196798"
   enableGitHubApp: "True"
-  redisCacheUrl: "redis://times-square-redis-master:6379/0"
-  redisQueueUrl: "redis://times-square-redis-master:6379/1"
 cloudsql:
   enabled: true
   instanceConnectionName: "science-platform-dev-7696:us-central1:science-platform-dev-e9e11de2"
   serviceAccount: "times-square@science-platform-dev-7696.iam.gserviceaccount.com"
+redis:
+  persistence:
+    storageClass: "premium-rwo"

--- a/services/times-square/values.yaml
+++ b/services/times-square/values.yaml
@@ -101,11 +101,11 @@ config:
 
   # -- URL for Redis html / noteburst job cache database
   # @default -- Points to embedded Redis
-  redisUrl: "redis://times-square-redis-master:6379/0"
+  redisCacheUrl: "redis://times-square-redis:6379/0"
 
   # -- URL for Redis arq queue database
   # @default -- Points to embedded Redis
-  queueRedisUrl: "redis://times-square-redis-master:6379/1"
+  redisQueueUrl: "redis://times-square-redis:6379/1"
 
   # -- GitHub application ID
   githubAppId: ""
@@ -136,10 +136,39 @@ cloudsql:
   serviceAccount: ""
 
 redis:
-  fullnameOverride: times-square-redis
+  persistence:
+    # -- Whether to persist Redis storage and thus tokens. Setting this to
+    # false will use `emptyDir` and reset all tokens on every restart. Only
+    # use this for a test deployment.
+    enabled: true
 
-  auth:
-    enabled: false
+    # -- Amount of persistent storage to request
+    size: "8Gi"
+
+    # -- Class of storage to request
+    storageClass: ""
+
+    # -- Use an existing PVC, not dynamic provisioning. If this is set, the
+    # size, storageClass, and accessMode settings are ignored.
+    volumeClaimName: ""
+
+  # -- Resource limits and requests for the Redis pod
+  # @default -- See `values.yaml`
+  resources:
+    limits:
+      cpu: "1"
+
+  # -- Pod annotations for the Redis pod
+  podAnnotations: {}
+
+  # -- Node selection rules for the Redis pod
+  nodeSelector: {}
+
+  # -- Tolerations for the Redis pod
+  tolerations: []
+
+  # -- Affinity rules for the Redis pod
+  affinity: {}
 
 global:
   # -- Base URL for the environment


### PR DESCRIPTION
Use the new internal Redis chart that only creates a single instance, since in practice we were only using the master created by the Bitnami chart.  Use SSD storage for Redis on IDF dev.

Although authentication was enabled in values.yaml for noteburst, Redis authentication was not actually in use so far as I could determine, so do not configure authentication and rely on the NetworkPolicy to control access.  (Ideally we should add a secret, but we can tackle this later after we simplify secret management.)