### PR TITLE
DM-37583: Update Gafaelfawr group mappings

### DIFF
--- a/services/gafaelfawr/values-base.yaml
+++ b/services/gafaelfawr/values-base.yaml
@@ -19,6 +19,19 @@ config:
       - github:
           organization: "lsst-sqre"
           team: "square"
+    "exec:internal-tools":
+      - github:
+          organization: "lsst-sqre"
+          team: "square"
+      - github:
+          organization: "lsst-sqre"
+          team: "friends"
+      - github:
+          organization: "lsst-ts"
+          team: "base-access"
+      - github:
+          organization: "rubin-summit"
+          team: "rsp-access"
     "exec:notebook":
       - github:
           organization: "lsst-sqre"

--- a/services/gafaelfawr/values-ccin2p3.yaml
+++ b/services/gafaelfawr/values-ccin2p3.yaml
@@ -39,6 +39,8 @@ config:
     "exec:admin": "lsst"
     "read:all":
       - "lsst"
+    "exec:internal-tools":
+      - "lsst"
     "exec:notebook":
       - "lsst"
     "exec:portal":

--- a/services/gafaelfawr/values-idfdev.yaml
+++ b/services/gafaelfawr/values-idfdev.yaml
@@ -37,6 +37,8 @@ config:
       - "g_admins"
     "exec:admin":
       - "g_admins"
+    "exec:internal-tools":
+      - "g_users"
     "exec:notebook":
       - "g_users"
     "exec:portal":

--- a/services/gafaelfawr/values-idfdev.yaml
+++ b/services/gafaelfawr/values-idfdev.yaml
@@ -32,23 +32,23 @@ config:
 
   groupMapping:
     "admin:jupyterlab":
-      - "g_science-platform-idf-dev"
+      - "g_admins"
     "admin:provision":
-      - "g_science-platform-idf-dev"
+      - "g_admins"
     "exec:admin":
-      - "g_science-platform-idf-dev"
+      - "g_admins"
     "exec:notebook":
-      - "g_science-platform-idf-dev"
+      - "g_users"
     "exec:portal":
-      - "g_science-platform-idf-dev"
+      - "g_users"
     "read:image":
-      - "g_science-platform-idf-dev"
+      - "g_users"
     "read:tap":
-      - "g_science-platform-idf-dev"
+      - "g_users"
 
   initialAdmins:
-    - "afausti"
     - "adam"
+    - "afausti"
     - "cbanek"
     - "frossie"
     - "jsick"

--- a/services/gafaelfawr/values-idfint.yaml
+++ b/services/gafaelfawr/values-idfint.yaml
@@ -35,6 +35,8 @@ config:
       - "g_admins"
     "exec:admin":
       - "g_admins"
+    "exec:internal-tools":
+      - "g_users"
     "exec:notebook":
       - "g_users"
     "exec:portal":

--- a/services/gafaelfawr/values-idfint.yaml
+++ b/services/gafaelfawr/values-idfint.yaml
@@ -36,28 +36,20 @@ config:
     "exec:admin":
       - "g_admins"
     "exec:notebook":
-      - "g_admins"
-      - "g_developers"
       - "g_users"
     "exec:portal":
-      - "g_admins"
-      - "g_developers"
       - "g_users"
     "read:alertdb":
       - "g_admins"
       - "g_developers"
     "read:image":
-      - "g_admins"
-      - "g_developers"
       - "g_users"
     "read:tap":
-      - "g_admins"
-      - "g_developers"
       - "g_users"
 
   initialAdmins:
-    - "afausti"
     - "adam"
+    - "afausti"
     - "cbanek"
     - "frossie"
     - "jsick"

--- a/services/gafaelfawr/values-idfprod.yaml
+++ b/services/gafaelfawr/values-idfprod.yaml
@@ -21,6 +21,16 @@ config:
       - github:
           organization: "lsst-sqre"
           team: "square"
+    "exec:internal-tools":
+      - github:
+          organization: "lsst"
+          team: "data-management"
+      - github:
+          organization: "lsst"
+          team: "ops"
+      - github:
+          organization: "lsst-sqre"
+          team: "square"
     "exec:notebook":
       - github:
           organization: "lsst"

--- a/services/gafaelfawr/values-minikube.yaml
+++ b/services/gafaelfawr/values-minikube.yaml
@@ -23,6 +23,10 @@ config:
       - github:
           organization: "lsst-sqre"
           team: "square"
+    "exec:internal-tools":
+      - github:
+          organization: "lsst-sqre"
+          team: "square"
     "exec:notebook":
       - github:
           organization: "lsst-sqre"

--- a/services/gafaelfawr/values-roe.yaml
+++ b/services/gafaelfawr/values-roe.yaml
@@ -18,6 +18,18 @@ config:
       - github:
           organization: "lsp-uk"
           team: "dev"
+    "exec:internal-tools":
+      - github:
+          organization: "lsp-uk"
+          team: "dev"
+    "exec:portal":
+      - github:
+          organization: "lsp-uk"
+          team: "dev"
+    "exec:user":
+      - github:
+          organization: "lsp-uk"
+          team: "dev"
     "read:workspace":
       - github:
           organization: "lsp-uk"
@@ -27,14 +39,6 @@ config:
           organization: "lsp-uk"
           team: "dev"
     "write:workspace/user":
-      - github:
-          organization: "lsp-uk"
-          team: "dev"
-    "exec:portal":
-      - github:
-          organization: "lsp-uk"
-          team: "dev"
-    "exec:user":
       - github:
           organization: "lsp-uk"
           team: "dev"

--- a/services/gafaelfawr/values-summit.yaml
+++ b/services/gafaelfawr/values-summit.yaml
@@ -24,6 +24,19 @@ config:
           organization: "lsst-sqre"
           team: "square"
       - "lsst-sqre-square"
+    "exec:internal-tools":
+      - github:
+          organization: "lsst-sqre"
+          team: "square"
+      - github:
+          organization: "lsst-sqre"
+          team: "friends"
+      - github:
+          organization: "lsst-ts"
+          team: "summit-access"
+      - github:
+          organization: "rubin-summit"
+          team: "rsp-access"
     "exec:notebook":
       - github:
           organization: "lsst-sqre"

--- a/services/gafaelfawr/values-tucson-teststand.yaml
+++ b/services/gafaelfawr/values-tucson-teststand.yaml
@@ -25,6 +25,19 @@ config:
           organization: "lsst-sqre"
           team: "square"
       - "lsst-sqre-square"
+    "exec:internal-tools":
+      - github:
+          organization: "lsst-sqre"
+          team: "square"
+      - github:
+          organization: "lsst-sqre"
+          team: "friends"
+      - github:
+          organization: "lsst-ts"
+          team: "base-access"
+      - github:
+          organization: "rubin-summit"
+          team: "rsp-access"
     "exec:notebook":
       - github:
           organization: "lsst-sqre"

--- a/services/gafaelfawr/values.yaml
+++ b/services/gafaelfawr/values.yaml
@@ -223,6 +223,8 @@ config:
       Can perform privileged user provisioning
     "exec:admin": >-
       Administrative access to all APIs
+    "exec:internal-tools": >-
+      Use project-internal tools.
     "exec:notebook": >-
       Use the Notebook Aspect
     "exec:portal": >-


### PR DESCRIPTION
- Simplify the group mappings on data-dev and data-int to not duplicate all-user access
- Rename groups on data-dev to match the other environments
- Add the `exec:internal-tools` scope