### PR TITLE
DM-37588: Drop NGINX header buffer changes on minikube, IDF dev

### DIFF
--- a/services/ingress-nginx/README.md
+++ b/services/ingress-nginx/README.md
@@ -14,9 +14,7 @@ Ingress controller
 |-----|------|---------|-------------|
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | ingress-nginx.controller.config.compute-full-forwarded-for | string | `"true"` | Put the complete path in `X-Forwarded-For`, not just the last hop, so that the client IP will be exposed to Gafaelfawr |
-| ingress-nginx.controller.config.large-client-header-buffers | string | `"4 64k"` | Increase the buffer size for client headers because we may have JWTs in the client request |
 | ingress-nginx.controller.config.proxy-body-size | string | `"100m"` | Maximum size of the client request body (needs to be large enough to allow table uploads) |
-| ingress-nginx.controller.config.proxy-buffer-size | string | `"64k"` | Increase the buffer size for responses from backend servers to allow for longer headers |
 | ingress-nginx.controller.config.server-snippet | string | See `values.yaml` | Add additional configuration used by Gafaelfawr to report errors from the authorization layer |
 | ingress-nginx.controller.config.ssl-redirect | string | `"true"` | Redirect all non-SSL access to SSL. |
 | ingress-nginx.controller.config.use-forwarded-headers | string | `"true"` | Enable the `X-Forwarded-For` processing |

--- a/services/ingress-nginx/values-base.yaml
+++ b/services/ingress-nginx/values-base.yaml
@@ -1,4 +1,7 @@
 ingress-nginx:
   controller:
+    config:
+      large-client-header-buffers: "4 64k"
+      proxy-buffer-size: "64k"
     service:
       loadBalancerIP: "139.229.146.150"

--- a/services/ingress-nginx/values-ccin2p3.yaml
+++ b/services/ingress-nginx/values-ccin2p3.yaml
@@ -10,14 +10,9 @@ ingress-nginx:
         effect: "NoSchedule"
 
     config:
-      compute-full-forwarded-for: "true"
       large-client-header-buffers: "4 64k"
-      proxy-body-size: "100m"
       proxy-buffer-size: "64k"
-      ssl-redirect: "true"
-      use-forwarded-headers: "true"
     service:
-      externalTrafficPolicy: Local
       externalIPs:
         - 134.158.237.2
       type: NodePort

--- a/services/ingress-nginx/values-idfint.yaml
+++ b/services/ingress-nginx/values-idfint.yaml
@@ -1,4 +1,7 @@
 ingress-nginx:
   controller:
+    config:
+      large-client-header-buffers: "4 64k"
+      proxy-buffer-size: "64k"
     service:
       loadBalancerIP: "35.238.192.49"

--- a/services/ingress-nginx/values-idfprod.yaml
+++ b/services/ingress-nginx/values-idfprod.yaml
@@ -1,4 +1,7 @@
 ingress-nginx:
   controller:
+    config:
+      large-client-header-buffers: "4 64k"
+      proxy-buffer-size: "64k"
     service:
       loadBalancerIP: "35.202.181.164"

--- a/services/ingress-nginx/values-roe.yaml
+++ b/services/ingress-nginx/values-roe.yaml
@@ -1,12 +1,8 @@
 ingress-nginx:
   controller:
     config:
-      compute-full-forwarded-for: "true"
       large-client-header-buffers: "4 64k"
-      proxy-body-size: "100m"
       proxy-buffer-size: "64k"
-      ssl-redirect: "true"
-      use-forwarded-headers: "true"
     service:
       externalTrafficPolicy: null
       type: ClusterIP
@@ -24,7 +20,6 @@ ingress-nginx:
     hostNetwork: true
     extraArgs:
       default-ssl-certificate: ingress-nginx/ingress-certificate
-    podLabels:
-      hub.jupyter.org/network-access-proxy-http: "true"
+
 vaultCertificate:
   enabled: true

--- a/services/ingress-nginx/values-summit.yaml
+++ b/services/ingress-nginx/values-summit.yaml
@@ -1,4 +1,7 @@
 ingress-nginx:
   controller:
+    config:
+      large-client-header-buffers: "4 64k"
+      proxy-buffer-size: "64k"
     service:
       loadBalancerIP: "139.229.160.150"

--- a/services/ingress-nginx/values-tucson-teststand.yaml
+++ b/services/ingress-nginx/values-tucson-teststand.yaml
@@ -1,4 +1,7 @@
 ingress-nginx:
   controller:
+    config:
+      large-client-header-buffers: "4 64k"
+      proxy-buffer-size: "64k"
     service:
       loadBalancerIP: "140.252.146.50"

--- a/services/ingress-nginx/values.yaml
+++ b/services/ingress-nginx/values.yaml
@@ -7,17 +7,9 @@ ingress-nginx:
       # so that the client IP will be exposed to Gafaelfawr
       compute-full-forwarded-for: "true"
 
-      # -- Increase the buffer size for client headers because we may have
-      # JWTs in the client request
-      large-client-header-buffers: "4 64k"
-
       # -- Maximum size of the client request body (needs to be large enough
       # to allow table uploads)
       proxy-body-size: "100m"
-
-      # -- Increase the buffer size for responses from backend servers to
-      # allow for longer headers
-      proxy-buffer-size: "64k"
 
       # -- Redirect all non-SSL access to SSL.
       ssl-redirect: "true"


### PR DESCRIPTION
Move the header buffer changes out of values.yaml into the per-environment values files and leave them off of IDF dev and minikube so that we can test whether they're needed.

Clean up some duplicated settings in the values files for ccin2p3 and roe.