### PR TITLE
[DM-26505] Linter version to 0.1.5

### DIFF
--- a/services/linters/Chart.yaml
+++ b/services/linters/Chart.yaml
@@ -4,4 +4,4 @@ version: 1.0.0
 description: Linters running for operational reasons
 sources:
   - https://github.com/lsst-sqre/ops-linters
-appVersion: 0.1.3
+appVersion: 0.1.5

--- a/services/linters/templates/cronjob-dns-linter.yaml
+++ b/services/linters/templates/cronjob-dns-linter.yaml
@@ -36,7 +36,7 @@ spec:
                     - "all"
                 readOnlyRootFilesystem: true
               volumeMounts:
-                - name: "aws-secret"
+                - name: "secret"
                   mountPath: "/etc/linters/secrets"
                   readOnly: true
           securityContext:
@@ -44,7 +44,7 @@ spec:
             runAsUser: 1000
             runAsGroup: 1000
           volumes:
-            - name: "aws-secret"
+            - name: "secret"
               secret:
                 secretName: {{ template "linters.fullname" . }}-secret
           {{- with .Values.nodeSelector }}


### PR DESCRIPTION
Since now the vault secret also has the slack webhook, I got rid of the aws part there