### PR TITLE
DM-37659: Handle apps with names that have _ in values

### DIFF
--- a/src/phalanx/docs/models.py
+++ b/src/phalanx/docs/models.py
@@ -326,11 +326,15 @@ class Environment:
                 apps.append(app)
                 continue
 
-            try:
+            if app.name in values:
                 if values[app.name]["enabled"] is True:
                     apps.append(app)
-            except KeyError:
-                continue
+            elif (app_name_underscore := app.name.replace("-", "_")) in values:
+                # Many keys in an env's values.yaml use underscores instead of
+                # dashes, so they don't match the actual application name
+                if values[app_name_underscore]["enabled"] is True:
+                    apps.append(app)
+
         apps.sort(key=lambda a: a.name)
 
         return Environment(


### PR DESCRIPTION
It was a practice in the environment values.yaml files to use `_` in place of `-` in app names. e.g.

```yaml
times_square:
  enabled: true
```

Instead of using the actual app name:

```yaml
times-square:
  enabled: true
```

This change handles that situation so that many missing apps with `-` in their names but that use `_` in the environment values.yaml files now appear in documentation homepages for environments..