### PR TITLE
DM-37589: Add Butler configuration for IDF dev

### DIFF
--- a/science-platform/values-idfdev.yaml
+++ b/science-platform/values-idfdev.yaml
@@ -1,6 +1,7 @@
 environment: idfdev
 fqdn: data-dev.lsst.cloud
 vault_path_prefix: secret/k8s_operator/data-dev.lsst.cloud
+butlerRepositoryIndex: "s3://butler-us-central1-repo-locations/data-int-repos.yaml"
 
 alert_stream_broker:
   enabled: false


### PR DESCRIPTION
Allow Butler applications such as vo-cutouts to be deployed on IDF dev using the same Butler as IDF int.