### PR TITLE
DM-37221: Convert to 1Password Connect API

### DIFF
--- a/docs/admin/bootstrapping.rst
+++ b/docs/admin/bootstrapping.rst
@@ -25,7 +25,6 @@ Checklist
 #. Fork the `Phalanx repository`_ if this work is separate from the SQuaRE-managed environments.
 
 #. Create a virtual environment with the tools you will need from the installer's `requirements.txt <https://github.com/lsst-sqre/phalanx/blob/master/installer/requirements.txt>`__.
-   If you are not using 1Password as your source of truth (which, if you are not in a SQuaRE-managed environment, you probably are not) then you may omit ``1password``.
 
 #. Create a new ``values-<environment>.yaml`` file in `/science-platform <https://github.com/lsst-sqre/phalanx/tree/master/science-platform/>`__.
    Start with a template copied from an existing environment that's similar to the new environment.
@@ -58,6 +57,8 @@ Checklist
 
 #. Generate the secrets for the new environment and store them in Vault with `/installer/update_secrets.sh <https://github.com/lsst-sqre/phalanx/blob/master/installer/update_secrets.sh>`__.
    You will need the write key for the Vault enclave you are using for this environment.
+   If you are using 1Password as a source of secrets, you will also need the access token for the 1Password Connect server.
+   (For SQuaRE-managed deployments, this is in the ``SQuaRE Integration Access Token: Argo`` 1Password item in the SQuaRE vault.)
 
 #. Run the installer script at `/installer/install.sh <https://github.com/lsst-sqre/phalanx/blob/master/installer/install.sh>`__.
    Debug any problems.

--- a/docs/developers/add-a-onepassword-secret.rst
+++ b/docs/developers/add-a-onepassword-secret.rst
@@ -14,8 +14,8 @@ This page provides steps for adding an application secret through 1Password.
 
 .. note::
 
-   This document only covers creating a 1Password-backed Secret for the first time for an application.
-   If you want to update a Secret, either by adding new 1Password secrets or by changing their secret values, you should follow the instructions in :doc:`/developers/update-a-onepassword-secret`.
+   This document only covers creating a 1Password-backed secret for the first time for an application.
+   If you want to update a secret, either by adding new 1Password secrets or by changing their secret values, you should follow the instructions in :doc:`/developers/update-a-onepassword-secret`.
 
 Part 1. Open the 1Password vault
 ================================
@@ -61,6 +61,9 @@ Part 3. Sync 1Password items into Vault
 =======================================
 
 Once an application's secrets are stored in 1Password, you need to sync them into Vault.
+
+First, set the ``OP_CONNECT_TOKEN`` environment variable to the access token for the SQuaRE 1Password Connect service.
+This is stored in the SQuaRE 1Password vault under the item named ``SQuaRE Integration Access Token: Argo``.
 
 Open Phalanx's ``installer/`` directory:
 

--- a/installer/requirements.txt
+++ b/installer/requirements.txt
@@ -1,5 +1,5 @@
 bcrypt
 cryptography
+onepasswordconnectsdk
 pyyaml
 yq
-1password

--- a/installer/update_secrets.sh
+++ b/installer/update_secrets.sh
@@ -4,6 +4,12 @@ ENVIRONMENT=$1
 export VAULT_DOC_UUID=`yq -r .onepassword_uuid ../science-platform/values.yaml`
 export VAULT_ADDR=https://vault.lsst.codes
 export VAULT_TOKEN=`./vault_key.py $ENVIRONMENT write`
+export OP_CONNECT_HOST=https://roundtable.lsst.codes/1password
+
+if [ -z "$OP_CONNECT_TOKEN" ]; then
+    echo 'OP_CONNECT_TOKEN must be set to a 1Password Connect token' >&2
+    exit 1
+fi
 
 echo "Clear out any existing secrets"
 rm -rf secrets
@@ -11,7 +17,7 @@ rm -rf secrets
 echo "Reading current secrets from vault"
 ./read_secrets.sh $ENVIRONMENT
 
-echo "Generating missing secrets with values from onepassword"
+echo "Generating missing secrets with values from 1Password"
 ./generate_secrets.py $ENVIRONMENT --op
 
 echo "Writing secrets to vault"

--- a/installer/vault_key.py
+++ b/installer/vault_key.py
@@ -3,14 +3,19 @@ import argparse
 import json
 import os
 
-from onepassword import OnePassword
+from onepasswordconnectsdk import new_client_from_environment
 
 
 class VaultKeyRetriever:
     def __init__(self):
-        self.op = OnePassword()
-        vault_keys_doc = self.op.get_item(uuid=os.environ["VAULT_DOC_UUID"])
-        vault_keys_json = vault_keys_doc["details"]["notesPlain"]
+        self.op = new_client_from_environment()
+        vault_keys = self.op.get_item(
+            os.environ["VAULT_DOC_UUID"], "RSP-Vault"
+        )
+        for field in vault_keys.fields:
+            if field.label == "notesPlain":
+                vault_keys_json = field.value
+                break
         self.vault_keys = json.loads(vault_keys_json)
 
     def retrieve_key(self, environment, key_type):


### PR DESCRIPTION
Rather than using third-party onepassword Python API, which is not pip-installable and doesn't work on all platforms, use the 1Password Connect API against the new server that we're installing on Roundtable.