### PR TITLE
DM-37721: Fix some secret generation bugs

### DIFF
--- a/installer/generate_secrets.py
+++ b/installer/generate_secrets.py
@@ -434,7 +434,14 @@ class OnePasswordSecretGenerator(SecretGenerator):
                 elif field.purpose == "PASSWORD":
                     secret_password = field.value
 
+            if not key:
+                continue
+
             secret_value = secret_notes or secret_password
+
+            if not secret_value:
+                logging.error("No value found for %s", item.title)
+                continue
 
             logging.debug("Environments are %s for %s", environments, item.id)
 


### PR DESCRIPTION
Ignore 1Password items with no generate_secrets_key field, since there are several that are used for other purposes.  Warn about items with a generate_secrets_key but no value.