### PR TITLE
DM-37810: Switch to dashes in the environments configuration

### DIFF
--- a/docs/admin/bootstrapping.rst
+++ b/docs/admin/bootstrapping.rst
@@ -28,7 +28,7 @@ Checklist
 
 #. Create a new ``values-<environment>.yaml`` file in `/environments <https://github.com/lsst-sqre/phalanx/tree/main/environments/>`__.
    Start with a template copied from an existing environment that's similar to the new environment.
-   Edit it so that ``environment``, ``fqdn``, and ``vault_path_prefix`` at the top match your new environment.
+   Edit it so that ``environment``, ``fqdn``, and ``vaultPathPrefix`` at the top match your new environment.
    Choose which applications to enable or leave disabled.
 
 #. Decide on your approach to TLS certificates.

--- a/docs/developers/local-development.rst
+++ b/docs/developers/local-development.rst
@@ -99,7 +99,7 @@ The ``install.sh`` script uses your locally-checked out branch of Phalanx, but a
 
 **Minimal set of applications that should be enabled:**
 
-- ``vault_secrets_operator`` (for Vault secrets)
+- ``vault-secrets-operator`` (for Vault secrets)
 - ``gafaelfawr`` (for authentication)
 - ``postgresql`` (for gafaelfawr)
 
@@ -133,7 +133,7 @@ The minikube Argo CD admin password can be retrieved from Vault.
 
 .. code-block:: sh
 
-  VAULT_PATH_PREFIX=`yq -r .vault_path_prefix ../environments/values-minikube.yaml`
+  VAULT_PATH_PREFIX=`yq -r .vaultPathPrefix ../environments/values-minikube.yaml`
   vault kv get --field=argocd.admin.plaintext_password $VAULT_PATH_PREFIX/installer
 
 With Argo CD you can sync your application (see :doc:`/admin/sync-argo-cd`).

--- a/environments/Chart.yaml
+++ b/environments/Chart.yaml
@@ -1,3 +1,3 @@
-apiVersion: v1
+apiVersion: v2
 name: science-platform
 version: 1.0.0

--- a/environments/README.md
+++ b/environments/README.md
@@ -4,39 +4,43 @@
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| alert_stream_broker.enabled | bool | `false` |  |
+| alert-stream-broker.enabled | bool | `false` |  |
+| butlerRepositoryIndex | string | None, must be set | Butler repository index to use for this environment |
 | cachemachine.enabled | bool | `false` |  |
-| cert_manager.enabled | bool | `false` |  |
+| cert-manager.enabled | bool | `false` |  |
 | datalinker.enabled | bool | `false` |  |
+| environment | string | None, must be set | Name of the environment |
 | exposurelog.enabled | bool | `false` |  |
+| fqdn | string | None, must be set | Fully-qualified domain name where the environment is running |
 | gafaelfawr.enabled | bool | `false` |  |
 | hips.enabled | bool | `false` |  |
-| ingress_nginx.enabled | bool | `false` |  |
+| ingress-nginx.enabled | bool | `false` |  |
 | linters.enabled | bool | `false` |  |
 | mobu.enabled | bool | `false` |  |
 | moneypenny.enabled | bool | `false` |  |
 | narrativelog.enabled | bool | `false` |  |
 | noteburst.enabled | bool | `false` |  |
 | nublado2.enabled | bool | `false` |  |
-| onepassword_uuid | string | `"dg5afgiadsffeklfr6jykqymeu"` |  |
-| plot_navigator.enabled | bool | `false` |  |
+| onepasswordUuid | string | `"dg5afgiadsffeklfr6jykqymeu"` | UUID of the 1Password item in which to find Vault tokens |
+| plot-navigator.enabled | bool | `false` |  |
 | portal.enabled | bool | `false` |  |
 | postgres.enabled | bool | `false` |  |
-| production_tools.enabled | bool | `false` |  |
-| repoURL | string | `"https://github.com/lsst-sqre/phalanx.git"` |  |
-| revision | string | `"main"` |  |
+| production-tools.enabled | bool | `false` |  |
+| repoURL | string | `"https://github.com/lsst-sqre/phalanx.git"` | URL of the repository for all applications |
 | sasquatch.enabled | bool | `false` |  |
 | semaphore.enabled | bool | `false` |  |
 | sherlock.enabled | bool | `false` |  |
-| sqlproxy_cross_project.enabled | bool | `false` |  |
+| sqlproxy-cross-project.enabled | bool | `false` |  |
 | squareone.enabled | bool | `false` |  |
-| squash_api.enabled | bool | `false` |  |
+| squash-api.enabled | bool | `false` |  |
+| strimzi-registry-operator.enabled | bool | `false` |  |
 | strimzi.enabled | bool | `false` |  |
-| strimzi_registry_operator.enabled | bool | `false` |  |
+| tap-schema.enabled | bool | `false` |  |
 | tap.enabled | bool | `false` |  |
-| tap_schema.enabled | bool | `false` |  |
+| targetRevision | string | `"main"` | Revision of repository to use for all applications |
 | telegraf-ds.enabled | bool | `false` |  |
 | telegraf.enabled | bool | `false` |  |
-| times_square.enabled | bool | `false` |  |
-| vault_secrets_operator.enabled | bool | `false` |  |
-| vo_cutouts.enabled | bool | `false` |  |
+| times-square.enabled | bool | `false` |  |
+| vault-secrets-operator.enabled | bool | `false` |  |
+| vaultPathPrefix | string | None, must be set | Prefix for Vault secrets for this environment |
+| vo-cutouts.enabled | bool | `false` |  |

--- a/environments/templates/_helpers.tpl
+++ b/environments/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/* vim: set filetype=mustache: */}}
-{{- define "enabled_services" -}}
+{{- define "enabledServices" -}}
 argocd
   {{- range $okey, $oval := .Values }}
     {{- $otype := typeOf $oval -}}

--- a/environments/templates/alert-stream-broker-application.yaml
+++ b/environments/templates/alert-stream-broker-application.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.alert_stream_broker.enabled -}}
+{{- if (index .Values "alert-stream-broker" "enabled") -}}
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/environments/templates/argocd-application.yaml
+++ b/environments/templates/argocd-application.yaml
@@ -17,7 +17,7 @@ spec:
     helm:
       parameters:
         - name: "global.vaultSecretsPath"
-          value: {{ .Values.vault_path_prefix | quote }}
+          value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
         - "values-{{ .Values.environment }}.yaml"

--- a/environments/templates/cachemachine-application.yaml
+++ b/environments/templates/cachemachine-application.yaml
@@ -30,7 +30,7 @@ spec:
         - name: "global.baseUrl"
           value: "https://{{ .Values.fqdn }}"
         - name: "global.vaultSecretsPath"
-          value: {{ .Values.vault_path_prefix | quote }}
+          value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
         - "values-{{ .Values.environment }}.yaml"

--- a/environments/templates/cert-manager-application.yaml
+++ b/environments/templates/cert-manager-application.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.cert_manager.enabled -}}
+{{- if (index .Values "cert-manager" "enabled") -}}
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -26,7 +26,7 @@ spec:
     helm:
       parameters:
         - name: "global.vaultSecretsPath"
-          value: {{ .Values.vault_path_prefix | quote }}
+          value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
         - "values-{{ .Values.environment }}.yaml"

--- a/environments/templates/datalinker-application.yaml
+++ b/environments/templates/datalinker-application.yaml
@@ -32,7 +32,7 @@ spec:
         - name: "global.host"
           value: {{ .Values.fqdn | quote }}
         - name: "global.vaultSecretsPath"
-          value: {{ .Values.vault_path_prefix | quote }}
+          value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
         - "values-{{ .Values.environment }}.yaml"

--- a/environments/templates/exposurelog-application.yaml
+++ b/environments/templates/exposurelog-application.yaml
@@ -27,7 +27,7 @@ spec:
         - name: "global.baseUrl"
           value: "https://{{ .Values.fqdn }}"
         - name: "global.vaultSecretsPath"
-          value: {{ .Values.vault_path_prefix | quote }}
+          value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
         - "values-{{ .Values.environment }}.yaml"

--- a/environments/templates/gafaelfawr-application.yaml
+++ b/environments/templates/gafaelfawr-application.yaml
@@ -30,7 +30,7 @@ spec:
         - name: "global.baseUrl"
           value: "https://{{ .Values.fqdn }}"
         - name: "global.vaultSecretsPath"
-          value: {{ .Values.vault_path_prefix | quote }}
+          value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
         - "values-{{ .Values.environment }}.yaml"

--- a/environments/templates/ingress-nginx-application.yaml
+++ b/environments/templates/ingress-nginx-application.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress_nginx.enabled -}}
+{{- if (index .Values "ingress-nginx" "enabled") -}}
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -26,7 +26,7 @@ spec:
     helm:
       parameters:
         - name: "global.vaultSecretsPath"
-          value: {{ .Values.vault_path_prefix | quote }}
+          value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
         - "values-{{ .Values.environment }}.yaml"

--- a/environments/templates/linters-application.yaml
+++ b/environments/templates/linters-application.yaml
@@ -30,7 +30,7 @@ spec:
         - name: "global.baseUrl"
           value: "https://{{ .Values.fqdn }}"
         - name: "global.vaultSecretsPath"
-          value: {{ .Values.vault_path_prefix | quote }}
+          value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
         - "values-{{ .Values.environment }}.yaml"

--- a/environments/templates/mobu-application.yaml
+++ b/environments/templates/mobu-application.yaml
@@ -30,7 +30,7 @@ spec:
         - name: "global.baseUrl"
           value: "https://{{ .Values.fqdn }}"
         - name: "global.vaultSecretsPath"
-          value: {{ .Values.vault_path_prefix | quote }}
+          value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
         - "values-{{ .Values.environment }}.yaml"

--- a/environments/templates/moneypenny-application.yaml
+++ b/environments/templates/moneypenny-application.yaml
@@ -30,7 +30,7 @@ spec:
         - name: "global.baseUrl"
           value: "https://{{ .Values.fqdn }}"
         - name: "global.vaultSecretsPath"
-          value: {{ .Values.vault_path_prefix | quote }}
+          value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
         - "values-{{ .Values.environment }}.yaml"

--- a/environments/templates/narrativelog-application.yaml
+++ b/environments/templates/narrativelog-application.yaml
@@ -27,7 +27,7 @@ spec:
         - name: "global.baseUrl"
           value: "https://{{ .Values.fqdn }}"
         - name: "global.vaultSecretsPath"
-          value: {{ .Values.vault_path_prefix | quote }}
+          value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
         - "values-{{ .Values.environment }}.yaml"

--- a/environments/templates/nublado2-application.yaml
+++ b/environments/templates/nublado2-application.yaml
@@ -29,7 +29,7 @@ spec:
         - "values-{{ .Values.environment }}.yaml"
       parameters:
         - name: "global.vaultSecretsPath"
-          value: {{ .Values.vault_path_prefix | quote }}
+          value: {{ .Values.vaultPathPrefix | quote }}
   ignoreDifferences:
     - group: ""
       kind: "Secret"

--- a/environments/templates/plot-navigator-application.yaml
+++ b/environments/templates/plot-navigator-application.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.plot_navigator.enabled -}}
+{{- if (index .Values "plot-navigator" "enabled") -}}
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -27,7 +27,7 @@ spec:
         - name: "global.baseUrl"
           value: "https://{{ .Values.fqdn }}"
         - name: "global.vaultSecretsPath"
-          value: {{ .Values.vault_path_prefix | quote }}
+          value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
         - "values-{{ .Values.environment }}.yaml"

--- a/environments/templates/portal-application.yaml
+++ b/environments/templates/portal-application.yaml
@@ -27,7 +27,7 @@ spec:
         - name: "global.baseUrl"
           value: "https://{{ .Values.fqdn }}"
         - name: "global.vaultSecretsPath"
-          value: {{ .Values.vault_path_prefix | quote }}
+          value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
         - "values-{{ .Values.environment }}.yaml"

--- a/environments/templates/postgres-application.yaml
+++ b/environments/templates/postgres-application.yaml
@@ -23,7 +23,7 @@ spec:
     helm:
       parameters:
         - name: "global.vaultSecretsPath"
-          value: {{ .Values.vault_path_prefix | quote }}
+          value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
         - "values-{{ .Values.environment }}.yaml"

--- a/environments/templates/production-tools-application.yaml
+++ b/environments/templates/production-tools-application.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.production_tools.enabled -}}
+{{- if (index .Values "production-tools" "enabled") -}}
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -27,7 +27,7 @@ spec:
         - name: "global.baseUrl"
           value: "https://{{ .Values.fqdn }}"
         - name: "global.vaultSecretsPath"
-          value: {{ .Values.vault_path_prefix | quote }}
+          value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
       - values.yaml
       - values-{{ .Values.environment }}.yaml

--- a/environments/templates/sasquatch-application.yaml
+++ b/environments/templates/sasquatch-application.yaml
@@ -30,7 +30,7 @@ spec:
         - name: "global.baseUrl"
           value: "https://{{ .Values.fqdn }}"
         - name: "global.vaultSecretsPath"
-          value: {{ .Values.vault_path_prefix | quote }}
+          value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
         - "values-{{ .Values.environment }}.yaml"

--- a/environments/templates/semaphore-application.yaml
+++ b/environments/templates/semaphore-application.yaml
@@ -30,7 +30,7 @@ spec:
         - name: "global.baseUrl"
           value: "https://{{ .Values.fqdn }}"
         - name: "global.vaultSecretsPathPrefix"
-          value: {{ .Values.vault_path_prefix | quote }}
+          value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
         - "values-{{ .Values.environment }}.yaml"

--- a/environments/templates/sherlock-application.yaml
+++ b/environments/templates/sherlock-application.yaml
@@ -30,7 +30,7 @@ spec:
         - name: "global.baseUrl"
           value: "https://{{ .Values.fqdn }}"
         - name: "global.vaultSecretsPath"
-          value: {{ .Values.vault_path_prefix | quote }}
+          value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
         - "values-{{ .Values.environment }}.yaml"

--- a/environments/templates/sqlproxy-cross-project-application.yaml
+++ b/environments/templates/sqlproxy-cross-project-application.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.sqlproxy_cross_project.enabled -}}
+{{- if (index .Values "sqlproxy-cross-project" "enabled") -}}
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/environments/templates/squareone-application.yaml
+++ b/environments/templates/squareone-application.yaml
@@ -30,7 +30,7 @@ spec:
         - name: "global.baseUrl"
           value: "https://{{ .Values.fqdn }}"
         - name: "global.vaultSecretsPathPrefix"
-          value: {{ .Values.vault_path_prefix | quote }}
+          value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
         - "values-{{ .Values.environment }}.yaml"

--- a/environments/templates/strimzi-registry-operator-application.yaml
+++ b/environments/templates/strimzi-registry-operator-application.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.strimzi_registry_operator.enabled -}}
+{{- if (index .Values "strimzi-registry-operator" "enabled") -}}
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/environments/templates/tap-application.yaml
+++ b/environments/templates/tap-application.yaml
@@ -30,7 +30,7 @@ spec:
         - name: "global.baseUrl"
           value: "https://{{ .Values.fqdn }}"
         - name: "global.vaultSecretsPath"
-          value: {{ .Values.vault_path_prefix | quote }}
+          value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
         - "values-{{ .Values.environment }}.yaml"

--- a/environments/templates/tap-schema-application.yaml
+++ b/environments/templates/tap-schema-application.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.tap_schema.enabled -}}
+{{- if (index .Values "tap-schema" "enabled") -}}
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -26,7 +26,7 @@ spec:
     helm:
       parameters:
         - name: "global.vaultSecretsPath"
-          value: {{ .Values.vault_path_prefix | quote }}
+          value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
         - "values-{{ .Values.environment }}.yaml"

--- a/environments/templates/telegraf-application.yaml
+++ b/environments/templates/telegraf-application.yaml
@@ -1,4 +1,3 @@
-
 {{- if .Values.telegraf.enabled -}}
 apiVersion: v1
 kind: Namespace
@@ -26,12 +25,12 @@ spec:
     targetRevision: {{ .Values.targetRevision }}
     helm:
       parameters:
-        - name: "global.enabled_services"
-          value: {{ include "enabled_services" . | quote }}
+        - name: "global.enabledServices"
+          value: {{ include "enabledServices" . | quote }}
         - name: "global.host"
           value: {{ .Values.fqdn | quote }}
         - name: "global.vaultSecretsPath"
-          value: {{ .Values.vault_path_prefix | quote }}
+          value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - values.yaml
         - values-{{ .Values.environment }}.yaml

--- a/environments/templates/telegraf-ds-application.yaml
+++ b/environments/templates/telegraf-ds-application.yaml
@@ -25,12 +25,12 @@ spec:
     targetRevision: {{ .Values.targetRevision }}
     helm:
       parameters:
-        - name: "global.enabled_services"
-          value: {{ include "enabled_services" . | quote }}
+        - name: "global.enabledServices"
+          value: {{ include "enabledServices" . | quote }}
         - name: "global.host"
           value: {{ .Values.fqdn | quote }}
         - name: "global.vaultSecretsPath"
-          value: {{ .Values.vault_path_prefix | quote }}
+          value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - values.yaml
         - values-{{ .Values.environment }}.yaml

--- a/environments/templates/times-square-application.yaml
+++ b/environments/templates/times-square-application.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.times_square.enabled -}}
+{{- if (index .Values "times-square" "enabled") -}}
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -30,7 +30,7 @@ spec:
         - name: "global.baseUrl"
           value: "https://{{ .Values.fqdn }}"
         - name: "global.vaultSecretsPathPrefix"
-          value: {{ .Values.vault_path_prefix | quote }}
+          value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
         - "values-{{ .Values.environment }}.yaml"

--- a/environments/templates/vault-secrets-operator-application.yaml
+++ b/environments/templates/vault-secrets-operator-application.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.vault_secrets_operator.enabled -}}
+{{- if (index .Values "vault-secrets-operator" "enabled") -}}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:

--- a/environments/templates/vo-cutouts-application.yaml
+++ b/environments/templates/vo-cutouts-application.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.vo_cutouts.enabled -}}
+{{- if (index .Values "vo-cutouts" "enabled") -}}
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -32,7 +32,7 @@ spec:
         - name: "global.host"
           value: {{ .Values.fqdn | quote }}
         - name: "global.vaultSecretsPath"
-          value: {{ .Values.vault_path_prefix | quote }}
+          value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
         - "values-{{ .Values.environment }}.yaml"

--- a/environments/values-base.yaml
+++ b/environments/values-base.yaml
@@ -1,12 +1,12 @@
 environment: base
 fqdn: base-lsp.lsst.codes
-vault_path_prefix: secret/k8s_operator/base-lsp.lsst.codes
+vaultPathPrefix: secret/k8s_operator/base-lsp.lsst.codes
 
-alert_stream_broker:
+alert-stream-broker:
   enabled: false
 cachemachine:
   enabled: true
-cert_manager:
+cert-manager:
   enabled: true
 datalinker:
   enabled: false
@@ -16,7 +16,7 @@ gafaelfawr:
   enabled: true
 hips:
   enabled: false
-ingress_nginx:
+ingress-nginx:
   enabled: true
 mobu:
   enabled: false
@@ -28,7 +28,7 @@ noteburst:
   enabled: false
 nublado2:
   enabled: true
-plot_navigator:
+plot-navigator:
   enabled: false
 portal:
   enabled: true
@@ -36,29 +36,29 @@ postgres:
   enabled: true
 sasquatch:
   enabled: false
-production_tools:
+production-tools:
   enabled: false
 semaphore:
   enabled: false
 squareone:
   enabled: true
-squash_api:
+squash-api:
   enabled: false
 strimzi:
   enabled: false
-strimzi_registry_operator:
+strimzi-registry-operator:
   enabled: false
 tap:
   enabled: false
-tap_schema:
+tap-schema:
   enabled: false
 telegraf:
   enabled: true
 telegraf-ds:
   enabled: true
-times_square:
+times-square:
   enabled: false
-vault_secrets_operator:
+vault-secrets-operator:
   enabled: true
-vo_cutouts:
+vo-cutouts:
   enabled: false

--- a/environments/values-ccin2p3.yaml
+++ b/environments/values-ccin2p3.yaml
@@ -1,12 +1,12 @@
 environment: ccin2p3
 fqdn: data-dev.lsst.eu
-vault_path_prefix: secret/k8s_operator/rsp-cc
+vaultPathPrefix: secret/k8s_operator/rsp-cc
 
-alert_stream_broker:
+alert-stream-broker:
   enabled: false
 cachemachine:
   enabled: true
-cert_manager:
+cert-manager:
   enabled: true
 datalinker:
   enabled: true
@@ -18,7 +18,7 @@ mobu:
   enabled: false
 moneypenny:
   enabled: true
-ingress_nginx:
+ingress-nginx:
   enabled: true
 narrativelog:
   enabled: false
@@ -26,7 +26,7 @@ noteburst:
   enabled: false
 nublado2:
   enabled: true
-plot_navigator:
+plot-navigator:
   enabled: false
 portal:
   enabled: true
@@ -34,7 +34,7 @@ postgres:
   enabled: true
 sasquatch:
   enabled: false
-production_tools:
+production-tools:
   enabled: false
 semaphore:
   enabled: false
@@ -42,23 +42,23 @@ sherlock:
   enabled: false
 squareone:
   enabled: true
-squash_api:
+squash-api:
   enabled: false
 strimzi:
   enabled: false
-strimzi_registry_operator:
+strimzi-registry-operator:
   enabled: false
 tap:
   enabled: true
-tap_schema:
+tap-schema:
   enabled: true
 telegraf:
   enabled: false
 telegraf-ds:
   enabled: false
-times_square:
+times-square:
   enabled: false
-vault_secrets_operator:
+vault-secrets-operator:
   enabled: true
-vo_cutouts:
+vo-cutouts:
   enabled: false

--- a/environments/values-idfdev.yaml
+++ b/environments/values-idfdev.yaml
@@ -1,13 +1,13 @@
 environment: idfdev
 fqdn: data-dev.lsst.cloud
-vault_path_prefix: secret/k8s_operator/data-dev.lsst.cloud
+vaultPathPrefix: secret/k8s_operator/data-dev.lsst.cloud
 butlerRepositoryIndex: "s3://butler-us-central1-repo-locations/data-int-repos.yaml"
 
-alert_stream_broker:
+alert-stream-broker:
   enabled: false
 cachemachine:
   enabled: true
-cert_manager:
+cert-manager:
   enabled: true
 datalinker:
   enabled: true
@@ -17,7 +17,7 @@ gafaelfawr:
   enabled: true
 hips:
   enabled: true
-ingress_nginx:
+ingress-nginx:
   enabled: true
 mobu:
   enabled: true
@@ -29,7 +29,7 @@ noteburst:
   enabled: true
 nublado2:
   enabled: true
-plot_navigator:
+plot-navigator:
   enabled: false
 portal:
   enabled: true
@@ -37,7 +37,7 @@ postgres:
   enabled: true
 sasquatch:
   enabled: true
-production_tools:
+production-tools:
   enabled: false
 semaphore:
   enabled: true
@@ -45,25 +45,25 @@ sherlock:
   enabled: true
 squareone:
   enabled: true
-squash_api:
+squash-api:
   enabled: false
-sqlproxy_cross_project:
+sqlproxy-cross-project:
   enabled: true
 strimzi:
   enabled: true
-strimzi_registry_operator:
+strimzi-registry-operator:
   enabled: false
 tap:
   enabled: true
-tap_schema:
+tap-schema:
   enabled: true
 telegraf:
   enabled: true
 telegraf-ds:
   enabled: true
-times_square:
+times-square:
   enabled: true
-vault_secrets_operator:
+vault-secrets-operator:
   enabled: true
-vo_cutouts:
+vo-cutouts:
   enabled: true

--- a/environments/values-idfint.yaml
+++ b/environments/values-idfint.yaml
@@ -1,13 +1,13 @@
 environment: idfint
 fqdn: data-int.lsst.cloud
-vault_path_prefix: secret/k8s_operator/data-int.lsst.cloud
+vaultPathPrefix: secret/k8s_operator/data-int.lsst.cloud
 butlerRepositoryIndex: "s3://butler-us-central1-repo-locations/data-int-repos.yaml"
 
-alert_stream_broker:
+alert-stream-broker:
   enabled: true
 cachemachine:
   enabled: true
-cert_manager:
+cert-manager:
   enabled: true
 datalinker:
   enabled: true
@@ -17,7 +17,7 @@ gafaelfawr:
   enabled: true
 hips:
   enabled: true
-ingress_nginx:
+ingress-nginx:
   enabled: true
 linters:
   enabled: true
@@ -31,7 +31,7 @@ noteburst:
   enabled: false
 nublado2:
   enabled: true
-plot_navigator:
+plot-navigator:
   enabled: true
 portal:
   enabled: true
@@ -39,7 +39,7 @@ postgres:
   enabled: true
 sasquatch:
   enabled: true
-production_tools:
+production-tools:
   enabled: true
 semaphore:
   enabled: true
@@ -49,19 +49,19 @@ squareone:
   enabled: true
 strimzi:
   enabled: true
-strimzi_registry_operator:
+strimzi-registry-operator:
   enabled: false
 tap:
   enabled: true
-tap_schema:
+tap-schema:
   enabled: true
 telegraf:
   enabled: true
 telegraf-ds:
   enabled: true
-times_square:
+times-square:
   enabled: false
-vault_secrets_operator:
+vault-secrets-operator:
   enabled: true
-vo_cutouts:
+vo-cutouts:
   enabled: true

--- a/environments/values-idfprod.yaml
+++ b/environments/values-idfprod.yaml
@@ -1,13 +1,13 @@
 environment: idfprod
 fqdn: data.lsst.cloud
-vault_path_prefix: secret/k8s_operator/data.lsst.cloud
+vaultPathPrefix: secret/k8s_operator/data.lsst.cloud
 butlerRepositoryIndex: "s3://butler-us-central1-repo-locations/data-repos.yaml"
 
-alert_stream_broker:
+alert-stream-broker:
   enabled: false
 cachemachine:
   enabled: true
-cert_manager:
+cert-manager:
   enabled: true
 datalinker:
   enabled: true
@@ -17,7 +17,7 @@ gafaelfawr:
   enabled: true
 hips:
   enabled: true
-ingress_nginx:
+ingress-nginx:
   enabled: true
 mobu:
   enabled: true
@@ -29,7 +29,7 @@ noteburst:
   enabled: false
 nublado2:
   enabled: true
-plot_navigator:
+plot-navigator:
   enabled: false
 portal:
   enabled: true
@@ -37,7 +37,7 @@ postgres:
   enabled: true
 sasquatch:
   enabled: false
-production_tools:
+production-tools:
   enabled: false
 semaphore:
   enabled: true
@@ -45,23 +45,23 @@ sherlock:
   enabled: true
 squareone:
   enabled: true
-squash_api:
+squash-api:
   enabled: false
 strimzi:
   enabled: false
-strimzi_registry_operator:
+strimzi-registry-operator:
   enabled: false
 tap:
   enabled: true
-tap_schema:
+tap-schema:
   enabled: true
 telegraf:
   enabled: true
 telegraf-ds:
   enabled: true
-times_square:
+times-square:
   enabled: false
-vault_secrets_operator:
+vault-secrets-operator:
   enabled: true
-vo_cutouts:
+vo-cutouts:
   enabled: true

--- a/environments/values-minikube.yaml
+++ b/environments/values-minikube.yaml
@@ -1,12 +1,12 @@
 environment: minikube
 fqdn: minikube.lsst.codes
-vault_path_prefix: secret/k8s_operator/minikube.lsst.codes
+vaultPathPrefix: secret/k8s_operator/minikube.lsst.codes
 
-alert_stream_broker:
+alert-stream-broker:
   enabled: false
 cachemachine:
   enabled: true
-cert_manager:
+cert-manager:
   enabled: true
 datalinker:
   enabled: true
@@ -16,7 +16,7 @@ gafaelfawr:
   enabled: true
 hips:
   enabled: true
-ingress_nginx:
+ingress-nginx:
   enabled: true
 mobu:
   enabled: true
@@ -28,7 +28,7 @@ noteburst:
   enabled: true
 nublado2:
   enabled: true
-plot_navigator:
+plot-navigator:
   enabled: false
 portal:
   enabled: true
@@ -36,7 +36,7 @@ postgres:
   enabled: true
 sasquatch:
   enabled: false
-production_tools:
+production-tools:
   enabled: false
 semaphore:
   enabled: true
@@ -44,23 +44,23 @@ sherlock:
   enabled: true
 squareone:
   enabled: true
-squash_api:
+squash-api:
   enabled: false
 strimzi:
   enabled: false
-strimzi_registry_operator:
+strimzi-registry-operator:
   enabled: false
 tap:
   enabled: true
-tap_schema:
+tap-schema:
   enabled: true
 telegraf:
   enabled: false
 telegraf-ds:
   enabled: false
-times_square:
+times-square:
   enabled: false
-vault_secrets_operator:
+vault-secrets-operator:
   enabled: true
-vo_cutouts:
+vo-cutouts:
   enabled: false

--- a/environments/values-roe.yaml
+++ b/environments/values-roe.yaml
@@ -1,12 +1,12 @@
 environment: roe
 fqdn: rsp.lsst.ac.uk
-vault_path_prefix: secret/k8s_operator/roe
+vaultPathPrefix: secret/k8s_operator/roe
 
-alert_stream_broker:
+alert-stream-broker:
   enabled: false
 cachemachine:
   enabled: true
-cert_manager:
+cert-manager:
   enabled: true
 datalinker:
   enabled: false
@@ -16,7 +16,7 @@ gafaelfawr:
   enabled: true
 hips:
   enabled: false
-ingress_nginx:
+ingress-nginx:
   enabled: true
 mobu:
   enabled: true
@@ -28,7 +28,7 @@ noteburst:
   enabled: false
 nublado2:
   enabled: true
-plot_navigator:
+plot-navigator:
   enabled: false
 portal:
   enabled: true
@@ -36,27 +36,27 @@ postgres:
   enabled: true
 sasquatch:
   enabled: false
-production_tools:
+production-tools:
   enabled: false
 semaphore:
   enabled: false
 squareone:
   enabled: true
-squash_api:
+squash-api:
   enabled: false
-strimzi_registry_operator:
+strimzi-registry-operator:
   enabled: false
 tap:
   enabled: true
-tap_schema:
+tap-schema:
   enabled: true
 telegraf:
   enabled: false
 telegraf-ds:
   enabled: false
-times_square:
+times-square:
   enabled: false
-vault_secrets_operator:
+vault-secrets-operator:
   enabled: true
-vo_cutouts:
+vo-cutouts:
   enabled: false

--- a/environments/values-summit.yaml
+++ b/environments/values-summit.yaml
@@ -1,12 +1,12 @@
 environment: summit
 fqdn: summit-lsp.lsst.codes
-vault_path_prefix: secret/k8s_operator/summit-lsp.lsst.codes
+vaultPathPrefix: secret/k8s_operator/summit-lsp.lsst.codes
 
-alert_stream_broker:
+alert-stream-broker:
   enabled: false
 cachemachine:
   enabled: true
-cert_manager:
+cert-manager:
   enabled: true
 datalinker:
   enabled: false
@@ -16,7 +16,7 @@ gafaelfawr:
   enabled: true
 hips:
   enabled: false
-ingress_nginx:
+ingress-nginx:
   enabled: true
 mobu:
   enabled: false
@@ -28,7 +28,7 @@ noteburst:
   enabled: false
 nublado2:
   enabled: true
-plot_navigator:
+plot-navigator:
   enabled: false
 portal:
   enabled: true
@@ -36,7 +36,7 @@ postgres:
   enabled: true
 sasquatch:
   enabled: true
-production_tools:
+production-tools:
   enabled: false
 semaphore:
   enabled: false
@@ -44,23 +44,23 @@ sherlock:
   enabled: true
 squareone:
   enabled: true
-squash_api:
+squash-api:
   enabled: false
 strimzi:
   enabled: true
-strimzi_registry_operator:
+strimzi-registry-operator:
   enabled: false
 tap:
   enabled: false
-tap_schema:
+tap-schema:
   enabled: false
 telegraf:
   enabled: true
 telegraf-ds:
   enabled: true
-times_square:
+times-square:
   enabled: false
-vault_secrets_operator:
+vault-secrets-operator:
   enabled: true
-vo_cutouts:
+vo-cutouts:
   enabled: false

--- a/environments/values-tucson-teststand.yaml
+++ b/environments/values-tucson-teststand.yaml
@@ -1,12 +1,12 @@
 environment: tucson-teststand
 fqdn: tucson-teststand.lsst.codes
-vault_path_prefix: secret/k8s_operator/tucson-teststand.lsst.codes
+vaultPathPrefix: secret/k8s_operator/tucson-teststand.lsst.codes
 
-alert_stream_broker:
+alert-stream-broker:
   enabled: false
 cachemachine:
   enabled: true
-cert_manager:
+cert-manager:
   enabled: true
 datalinker:
   enabled: false
@@ -16,7 +16,7 @@ gafaelfawr:
   enabled: true
 hips:
   enabled: false
-ingress_nginx:
+ingress-nginx:
   enabled: true
 mobu:
   enabled: false
@@ -28,7 +28,7 @@ noteburst:
   enabled: false
 nublado2:
   enabled: true
-plot_navigator:
+plot-navigator:
   enabled: false
 portal:
   enabled: true
@@ -36,29 +36,29 @@ postgres:
   enabled: false
 sasquatch:
   enabled: true
-production_tools:
+production-tools:
   enabled: false
 semaphore:
   enabled: false
 squareone:
   enabled: true
-squash_api:
+squash-api:
   enabled: false
 strimzi:
   enabled: true
-strimzi_registry_operator:
+strimzi-registry-operator:
   enabled: false
 tap:
   enabled: false
-tap_schema:
+tap-schema:
   enabled: false
 telegraf:
   enabled: true
 telegraf-ds:
   enabled: true
-times_square:
+times-square:
   enabled: false
-vault_secrets_operator:
+vault-secrets-operator:
   enabled: true
-vo_cutouts:
+vo-cutouts:
   enabled: false

--- a/environments/values.yaml
+++ b/environments/values.yaml
@@ -1,8 +1,26 @@
-alert_stream_broker:
+# These four settings should be set in each environment values-*.yaml file.
+
+# -- Name of the environment
+# @default -- None, must be set
+environment: ""
+
+# -- Fully-qualified domain name where the environment is running
+# @default -- None, must be set
+fqdn: ""
+
+# -- Prefix for Vault secrets for this environment
+# @default -- None, must be set
+vaultPathPrefix: ""
+
+# -- Butler repository index to use for this environment
+# @default -- None, must be set
+butlerRepositoryIndex: ""
+
+alert-stream-broker:
   enabled: false
 cachemachine:
   enabled: false
-cert_manager:
+cert-manager:
   enabled: false
 datalinker:
   enabled: false
@@ -12,7 +30,7 @@ gafaelfawr:
   enabled: false
 hips:
   enabled: false
-ingress_nginx:
+ingress-nginx:
   enabled: false
 linters:
   enabled: false
@@ -26,7 +44,7 @@ noteburst:
   enabled: false
 nublado2:
   enabled: false
-plot_navigator:
+plot-navigator:
   enabled: false
 portal:
   enabled: false
@@ -34,37 +52,42 @@ postgres:
   enabled: false
 sasquatch:
   enabled: false
-production_tools:
+production-tools:
   enabled: false
 semaphore:
   enabled: false
 sherlock:
   enabled: false
-sqlproxy_cross_project:
+sqlproxy-cross-project:
   enabled: false
 squareone:
   enabled: false
-squash_api:
+squash-api:
   enabled: false
 strimzi:
   enabled: false
-strimzi_registry_operator:
+strimzi-registry-operator:
   enabled: false
 tap:
   enabled: false
-tap_schema:
+tap-schema:
   enabled: false
 telegraf:
   enabled: false
 telegraf-ds:
   enabled: false
-times_square:
+times-square:
   enabled: false
-vault_secrets_operator:
+vault-secrets-operator:
   enabled: false
-vo_cutouts:
+vo-cutouts:
   enabled: false
 
-repoURL: "https://github.com/lsst-sqre/phalanx.git"
-revision: "main"
-onepassword_uuid: "dg5afgiadsffeklfr6jykqymeu"
+# -- URL of the repository for all applications
+repoURL: https://github.com/lsst-sqre/phalanx.git
+
+# -- Revision of repository to use for all applications
+targetRevision: "main"
+
+# -- UUID of the 1Password item in which to find Vault tokens
+onepasswordUuid: "dg5afgiadsffeklfr6jykqymeu"

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -3,7 +3,7 @@ USAGE="Usage: ./install.sh ENVIRONMENT VAULT_TOKEN"
 ENVIRONMENT=${1:?$USAGE}
 export VAULT_TOKEN=${2:?$USAGE}
 export VAULT_ADDR=https://vault.lsst.codes
-VAULT_PATH_PREFIX=`yq -r .vault_path_prefix ../environments/values-$ENVIRONMENT.yaml`
+VAULT_PATH_PREFIX=`yq -r .vaultPathPrefix ../environments/values-$ENVIRONMENT.yaml`
 ARGOCD_PASSWORD=`vault kv get --field=argocd.admin.plaintext_password $VAULT_PATH_PREFIX/installer`
 
 GIT_URL=`git config --get remote.origin.url`
@@ -79,7 +79,7 @@ argocd app sync science-platform \
   --port-forward-namespace argocd
 
 echo "Syncing critical early applications"
-if [ $(yq -r .ingress_nginx.enabled ../environments/values-$ENVIRONMENT.yaml) == "true" ];
+if [ $(yq -r '."ingress-nginx".enabled' ../environments/values-$ENVIRONMENT.yaml) == "true" ];
 then
   echo "Syncing ingress-nginx..."
   argocd app sync ingress-nginx \
@@ -89,7 +89,7 @@ fi
 
 # Wait for the cert-manager's webhook to finish deploying by running
 # kubectl, argocd's sync doesn't seem to wait for this to finish.
-if [ $(yq -r .cert_manager.enabled ../environments/values-$ENVIRONMENT.yaml) == "true" ];
+if [ $(yq -r '."cert-manager".enabled' ../environments/values-$ENVIRONMENT.yaml) == "true" ];
 then
   echo "Syncing cert-manager..."
   argocd app sync cert-manager \

--- a/installer/update_secrets.sh
+++ b/installer/update_secrets.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 ENVIRONMENT=$1
 
-export VAULT_DOC_UUID=`yq -r .onepassword_uuid ../environments/values.yaml`
+export VAULT_DOC_UUID=`yq -r .onepasswordUuid ../environments/values.yaml`
 export VAULT_ADDR=https://vault.lsst.codes
 export VAULT_TOKEN=`./vault_key.py $ENVIRONMENT write`
 export OP_CONNECT_HOST=https://roundtable.lsst.codes/1password

--- a/src/phalanx/docs/models.py
+++ b/src/phalanx/docs/models.py
@@ -148,14 +148,8 @@ class Application:
         for env_name, env_configs in env_values.items():
             if app_name == "argocd":
                 active_environments.append(env_name)
-                continue
-
-            try:
-                reformatted_name = app_name.replace("-", "_")
-                if env_configs[reformatted_name]["enabled"] is True:
-                    active_environments.append(env_name)
-            except KeyError:
-                pass
+            elif env_configs.get(app_name, {}).get("enabled", False):
+                active_environments.append(env_name)
         active_environments.sort()
 
         # Open the Application Helm definition to get namespace info
@@ -324,13 +318,8 @@ class Environment:
             if app.name == "argocd":
                 # argocd is a special case because it's not toggled per env
                 apps.append(app)
-                continue
-
-            try:
-                if values[app.name]["enabled"] is True:
-                    apps.append(app)
-            except KeyError:
-                continue
+            elif values.get(app.name, {}).get("enabled", False):
+                apps.append(app)
         apps.sort(key=lambda a: a.name)
 
         return Environment(

--- a/src/phalanx/docs/models.py
+++ b/src/phalanx/docs/models.py
@@ -326,15 +326,11 @@ class Environment:
                 apps.append(app)
                 continue
 
-            if app.name in values:
+            try:
                 if values[app.name]["enabled"] is True:
                     apps.append(app)
-            elif (app_name_underscore := app.name.replace("-", "_")) in values:
-                # Many keys in an env's values.yaml use underscores instead of
-                # dashes, so they don't match the actual application name
-                if values[app_name_underscore]["enabled"] is True:
-                    apps.append(app)
-
+            except KeyError:
+                continue
         apps.sort(key=lambda a: a.name)
 
         return Environment(

--- a/src/phalanx/docs/models.py
+++ b/src/phalanx/docs/models.py
@@ -325,7 +325,7 @@ class Environment:
         return Environment(
             name=name,
             domain=values["fqdn"],
-            vault_path_prefix=values["vault_path_prefix"],
+            vault_path_prefix=values["vaultPathPrefix"],
             apps=apps,
         )
 


### PR DESCRIPTION
Previously, we used an underscore form of the application name when configuring its enabled status in the values files in the environments directory. Switch to using a name matching the application directory and chart name in all cases, and use the mildly more complex Helm and `yq` syntax required to handle names containing dashes. Revert the docs change to handle underscores as now unneeded.

Also change some other settings to use camelCase for consistency with Helm conventions, and set the version of the science-platform chart for Helm v3.