### PR TITLE
Fix telegraf config for app renaming

### DIFF
--- a/applications/telegraf/templates/configmap.yaml
+++ b/applications/telegraf/templates/configmap.yaml
@@ -32,7 +32,7 @@ data:
 
     {{- range $raw_app_name, $defn := .Values.prometheus_config }}
       {{- $app_name := replace "-" "_" $raw_app_name }}
-      {{- if has $app_name $enabled_apps }}
+      {{- if has $raw_app_name $enabled_apps }}
         {{- range $component, $endpoint := $defn }}
 
     [[inputs.prometheus]]
@@ -49,7 +49,7 @@ data:
 
     {{- range $raw_app_name, $defn := .Values.prometheus_config }}
       {{- $app_name := replace "-" "_" $raw_app_name }}
-      {{- if has $app_name $enabled_apps }}
+      {{- if has $raw_app_name $enabled_apps }}
         {{- range $component, $endpoint := $defn }}
 
     [[outputs.influxdb_v2]]


### PR DESCRIPTION
Apps are now named with dashes, not underscores, which requires a fix to the ConfigMap logic for telegraf.