### PR TITLE
DM-37944: Fix bootstrapping of ingress-nginx

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -116,4 +116,7 @@ jobs:
 
       - name: Get final list of resources
         if: steps.filter.outputs.minikube == 'true'
-        run: kubectl get all -A
+        run: |
+          kubectl get all -A
+          kubectl get ingress -A
+          kubectl logs -n gafaelfawr $(kubectl get -n gafaelfawr pods | awk '{ print $1 }' | grep gafaelfawr | egrep -v '(audit|maintenance|operator|redis)')

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -119,4 +119,11 @@ jobs:
         run: |
           kubectl get all -A
           kubectl get ingress -A
-          kubectl logs -n gafaelfawr $(kubectl get -n gafaelfawr pods | awk '{ print $1 }' | grep gafaelfawr | egrep -v '(audit|maintenance|operator|redis)')
+
+      - name: Wait for all applications to be healthy
+        if: steps.filter.outputs.minikube == 'true'
+        run: |
+          argocd app wait -l "argocd.argoproj.io/instance=science-platform" \
+            --port-forward \
+            --port-forward-namespace argocd \
+            --timeout 300

--- a/applications/gafaelfawr/values-minikube.yaml
+++ b/applications/gafaelfawr/values-minikube.yaml
@@ -11,7 +11,7 @@ config:
     enabled: true
 
   github:
-    clientId: "65b6333a066375091548"
+    clientId: "64d11db34c968448381e"
 
   # Allow access by GitHub team.
   groupMapping:

--- a/applications/ingress-nginx/README.md
+++ b/applications/ingress-nginx/README.md
@@ -14,7 +14,6 @@ Ingress controller
 |-----|------|---------|-------------|
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | ingress-nginx.controller.config.compute-full-forwarded-for | string | `"true"` | Put the complete path in `X-Forwarded-For`, not just the last hop, so that the client IP will be exposed to Gafaelfawr |
-| ingress-nginx.controller.config.http-snippet | string | See `values.yaml` | Add additional global configuration required by `server-snippet` |
 | ingress-nginx.controller.config.proxy-body-size | string | `"100m"` | Maximum size of the client request body (needs to be large enough to allow table uploads) |
 | ingress-nginx.controller.config.server-snippet | string | See `values.yaml` | Add additional per-server configuration used by Gafaelfawr to report errors from the authorization layer |
 | ingress-nginx.controller.config.ssl-redirect | string | `"true"` | Redirect all non-SSL access to SSL. |

--- a/applications/ingress-nginx/README.md
+++ b/applications/ingress-nginx/README.md
@@ -14,8 +14,9 @@ Ingress controller
 |-----|------|---------|-------------|
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | ingress-nginx.controller.config.compute-full-forwarded-for | string | `"true"` | Put the complete path in `X-Forwarded-For`, not just the last hop, so that the client IP will be exposed to Gafaelfawr |
+| ingress-nginx.controller.config.http-snippet | string | See `values.yaml` | Add additional global configuration required by `server-snippet` |
 | ingress-nginx.controller.config.proxy-body-size | string | `"100m"` | Maximum size of the client request body (needs to be large enough to allow table uploads) |
-| ingress-nginx.controller.config.server-snippet | string | See `values.yaml` | Add additional configuration used by Gafaelfawr to report errors from the authorization layer |
+| ingress-nginx.controller.config.server-snippet | string | See `values.yaml` | Add additional per-server configuration used by Gafaelfawr to report errors from the authorization layer |
 | ingress-nginx.controller.config.ssl-redirect | string | `"true"` | Redirect all non-SSL access to SSL. |
 | ingress-nginx.controller.config.use-forwarded-headers | string | `"true"` | Enable the `X-Forwarded-For` processing |
 | ingress-nginx.controller.metrics.enabled | bool | `true` | Enable metrics reporting via Prometheus |

--- a/applications/ingress-nginx/values.yaml
+++ b/applications/ingress-nginx/values.yaml
@@ -17,8 +17,8 @@ ingress-nginx:
       # -- Enable the `X-Forwarded-For` processing
       use-forwarded-headers: "true"
 
-      # -- Add additional configuration used by Gafaelfawr to report errors
-      # from the authorization layer
+      # -- Add additional per-server configuration used by Gafaelfawr to
+      # report errors from the authorization layer
       # @default -- See `values.yaml`
       server-snippet: |
         location @autherror {
@@ -32,6 +32,11 @@ ingress-nginx:
           add_header WWW-Authenticate $auth_www_authenticate always;
           return 403;
         }
+
+      # -- Add additional global configuration required by `server-snippet`
+      # @default -- See `values.yaml`
+      http-snippet: |
+        set $auth_status '';
 
     service:
       # -- Force traffic routing policy to Local so that the external IP in

--- a/applications/ingress-nginx/values.yaml
+++ b/applications/ingress-nginx/values.yaml
@@ -36,6 +36,7 @@ ingress-nginx:
       # -- Add additional global configuration required by `server-snippet`
       # @default -- See `values.yaml`
       http-snippet: |
+        set $auth_error_body '';
         set $auth_status '';
 
     service:

--- a/applications/ingress-nginx/values.yaml
+++ b/applications/ingress-nginx/values.yaml
@@ -21,6 +21,8 @@ ingress-nginx:
       # report errors from the authorization layer
       # @default -- See `values.yaml`
       server-snippet: |
+        set $auth_error_body '';
+        set $auth_status '';
         location @autherror {
           default_type application/json;
           if ($auth_status = 400) {
@@ -32,12 +34,6 @@ ingress-nginx:
           add_header WWW-Authenticate $auth_www_authenticate always;
           return 403;
         }
-
-      # -- Add additional global configuration required by `server-snippet`
-      # @default -- See `values.yaml`
-      http-snippet: |
-        set $auth_error_body '';
-        set $auth_status '';
 
     service:
       # -- Force traffic routing policy to Local so that the external IP in

--- a/applications/ingress-nginx/values.yaml
+++ b/applications/ingress-nginx/values.yaml
@@ -23,6 +23,7 @@ ingress-nginx:
       server-snippet: |
         set $auth_error_body '';
         set $auth_status '';
+        set $auth_www_authenticate '';
         location @autherror {
           default_type application/json;
           if ($auth_status = 400) {

--- a/applications/nublado2/values-minikube.yaml
+++ b/applications/nublado2/values-minikube.yaml
@@ -1,4 +1,6 @@
 jupyterhub:
+  hub:
+    resources: {}
   debug:
     enabled: true
   ingress:

--- a/environments/values-minikube.yaml
+++ b/environments/values-minikube.yaml
@@ -27,7 +27,7 @@ narrativelog:
 noteburst:
   enabled: true
 nublado2:
-  enabled: true
+  enabled: false
 plot-navigator:
   enabled: false
 portal:

--- a/environments/values-minikube.yaml
+++ b/environments/values-minikube.yaml
@@ -39,9 +39,9 @@ sasquatch:
 production-tools:
   enabled: false
 semaphore:
-  enabled: true
+  enabled: false
 sherlock:
-  enabled: true
+  enabled: false
 squareone:
   enabled: true
 squash-api:

--- a/environments/values-minikube.yaml
+++ b/environments/values-minikube.yaml
@@ -31,7 +31,7 @@ nublado2:
 plot-navigator:
   enabled: false
 portal:
-  enabled: true
+  enabled: false
 postgres:
   enabled: true
 sasquatch:

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -119,12 +119,6 @@ argocd app sync -l "argocd.argoproj.io/instance=science-platform" \
   --port-forward \
   --port-forward-namespace argocd
 
-echo "Waiting for all apps to be healthy"
-argocd app wait -l "argocd.argoproj.io/instance=science-platform" \
-  --port-forward \
-  --port-forward-namespace argocd \
-  --timeout 300
-
 echo "You can now check on your argo cd installation by running:"
 echo "kubectl port-forward service/argocd-server -n argocd 8080:443"
 echo "For the ArgoCD admin password:"

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -38,7 +38,7 @@ helm upgrade vault-secrets-operator ../applications/vault-secrets-operator \
   --values ../applications/vault-secrets-operator/values-$ENVIRONMENT.yaml \
   --create-namespace \
   --namespace vault-secrets-operator \
-  --timeout 15m \
+  --timeout 5m \
   --wait
 
 echo "Update / install argocd using helm..."
@@ -50,7 +50,7 @@ helm upgrade argocd ../applications/argocd \
   --set global.vaultSecretsPath="$VAULT_PATH_PREFIX" \
   --create-namespace \
   --namespace argocd \
-  --timeout 15m \
+  --timeout 5m \
   --wait
 
 echo "Login to argocd..."

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -119,6 +119,12 @@ argocd app sync -l "argocd.argoproj.io/instance=science-platform" \
   --port-forward \
   --port-forward-namespace argocd
 
+echo "Waiting for all apps to be healthy"
+argocd app wait -l "argocd.argoproj.io/instance=science-platform" \
+  --port-forward \
+  --port-forward-namespace argocd \
+  --timeout 300
+
 echo "You can now check on your argo cd installation by running:"
 echo "kubectl port-forward service/argocd-server -n argocd 8080:443"
 echo "For the ArgoCD admin password:"


### PR DESCRIPTION
Work around the fact that nothing sets $auth_status as a variable until Gafaelfawr runs and creates its first ingress.  The NGINX documentation seems to indicate that you can set the same variable multiple times, so ensure that $auth_status always has a value, which will be overridden by the custom configuration snippets in the locations that Gafaelfawr is protecting.