### PR TITLE
Allow for topic prefixes in REST proxy config

### DIFF
--- a/applications/sasquatch/charts/rest-proxy/README.md
+++ b/applications/sasquatch/charts/rest-proxy/README.md
@@ -23,7 +23,8 @@ A subchart to deploy Confluent REST proxy for Sasquatch.
 | ingress.path | string | `"/sasquatch-rest-proxy(/|$)(.*)"` | Ingress path. |
 | kafka.bootstrapServers | string | `"SASL_PLAINTEXT://sasquatch-kafka-bootstrap.sasquatch:9092"` | Kafka bootstrap servers, use the internal listerner on port 9092 wit SASL connection. |
 | kafka.cluster.name | string | `"sasquatch"` | Name of the Strimzi Kafka cluster. |
-| kafka.topics | string | `nil` | List of Kafka topics to create and expose through the REST proxy API |
+| kafka.topicPrefixes | string | `nil` | List of topic prefixes to use when exposing Kafka topics to the REST Proxy v2 API. |
+| kafka.topics | string | `nil` | List of Kafka topics to create via Strimzi. Alternatively topics can be created using the REST Proxy v3 API. |
 | nodeSelector | object | `{}` | Node selector configuration. |
 | podAnnotations | object | `{}` | Pod annotations. |
 | replicaCount | int | `1` | Number of Kafka REST proxy pods to run in the deployment. |

--- a/applications/sasquatch/charts/rest-proxy/templates/user.yaml
+++ b/applications/sasquatch/charts/rest-proxy/templates/user.yaml
@@ -20,11 +20,11 @@ spec:
           name: "*"
           patternType: literal
         operation: All
-      {{- range $topic := .Values.kafka.topics }}
+      {{- range $prefix := .Values.kafka.topicPrefixes }}
       - resource:
           type: topic
-          name: {{ $topic }}
-          patternType: literal
+          name: {{ $prefix }}
+          patternType: prefix
         type: allow
         host: "*"
         operation: All

--- a/applications/sasquatch/charts/rest-proxy/values.yaml
+++ b/applications/sasquatch/charts/rest-proxy/values.yaml
@@ -47,8 +47,10 @@ kafka:
     name: sasquatch
   # -- Kafka bootstrap servers, use the internal listerner on port 9092 wit SASL connection.
   bootstrapServers: "SASL_PLAINTEXT://sasquatch-kafka-bootstrap.sasquatch:9092"
-  # -- List of Kafka topics to create and expose through the REST proxy API
+  # -- List of Kafka topics to create via Strimzi. Alternatively topics can be created using the REST Proxy v3 API.
   topics:
+  # -- List of topic prefixes to use when exposing Kafka topics to the REST Proxy v2 API.
+  topicPrefixes:
 
 resources:
   requests:

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -50,8 +50,10 @@ rest-proxy:
     hostname: data-dev.lsst.cloud
   kafka:
     topics:
-      - lsst.dm.sky-flux-visit-statistic-metric
       - test.next-visit
+    topicPrefixes:
+      - test
+      - lsst.dm
 
 chronograf:
   ingress:

--- a/applications/sasquatch/values-summit.yaml
+++ b/applications/sasquatch/values-summit.yaml
@@ -90,8 +90,10 @@ rest-proxy:
     hostname: summit-lsp.lsst.codes
   kafka:
     topics:
-      - lsst.dm.sky-flux-visit-statistic-metric
       - test.next-visit
+    topicPrefixes:
+      - test
+      - lsst.dm
 
 chronograf:
   persistence:

--- a/applications/sasquatch/values-tucson-teststand.yaml
+++ b/applications/sasquatch/values-tucson-teststand.yaml
@@ -168,8 +168,10 @@ rest-proxy:
     hostname: tucson-teststand.lsst.codes
   kafka:
     topics:
-      - lsst.dm.sky-flux-visit-statistic-metric
       - test.next-visit
+    topicPrefixes:
+      - test
+      - lsst.dm
 
 chronograf:
   persistence:


### PR DESCRIPTION
- Use PatternType prefix when associating topics with the rest-proxy user
- Topics created via Strimzi KafaTopic resource or via the REST Proxy v3 API that match that prefix are associated to the rest-proxy user
- Fix the configuration in the environments where the REST Proxy is enabled.