### PR TITLE
Bump Portal version on other environments

### DIFF
--- a/applications/portal/Chart.yaml
+++ b/applications/portal/Chart.yaml
@@ -5,7 +5,7 @@ description: Rubin Science Platform Portal Aspect
 sources:
   - https://github.com/lsst/suit
   - https://github.com/Caltech-IPAC/firefly
-appVersion: "suit-2022.5.5"
+appVersion: "suit-2022.6.0"
 
 dependencies:
   - name: redis

--- a/applications/portal/values-idfdev.yaml
+++ b/applications/portal/values-idfdev.yaml
@@ -1,8 +1,5 @@
 replicaCount: 2
 
-image:
-  tag: "suit-2022.6.0"
-
 config:
   volumes:
     workareaNfs:

--- a/applications/portal/values-idfint.yaml
+++ b/applications/portal/values-idfint.yaml
@@ -1,8 +1,5 @@
 replicaCount: 4
 
-image:
-  tag: "suit-2022.6.0"
-
 config:
   volumes:
     workareaNfs:


### PR DESCRIPTION
Bump the Portal version to the version that had been pinned on IDF dev and IDF int.