### PR TITLE
Replicate topics prefixed by lsst.dm

### DIFF
--- a/applications/sasquatch/values-idfint.yaml
+++ b/applications/sasquatch/values-idfint.yaml
@@ -18,7 +18,7 @@ strimzi-kafka:
     enabled: true
     source:
       bootstrapServer: sasquatch-dev-kafka-bootstrap.lsst.cloud:9094
-      topicsPattern: "registry-schemas, lsst.sal.*"
+      topicsPattern: "registry-schemas, lsst.sal.*, lsst.dm.*"
     resources:
       requests:
         cpu: 2


### PR DESCRIPTION
Topics prefixed by `lsst.dm` correspond to analysis_tools metrics and are managed by the REST proxy v3 API.
