### PR TITLE
DM-37857: Update noteburst 0.6.0

### DIFF
--- a/applications/noteburst/Chart.yaml
+++ b/applications/noteburst/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: noteburst
 version: 1.0.0
-appVersion: "0.5.0"
+appVersion: "0.6.0"
 description: Noteburst is a notebook execution service for the Rubin Science Platform.
 type: application
 home: https://noteburst.lsst.io/

--- a/applications/noteburst/templates/gafaelfawrtoken.yaml
+++ b/applications/noteburst/templates/gafaelfawrtoken.yaml
@@ -7,6 +7,6 @@ metadata:
 spec:
   service: "bot-noteburst"
   scopes:
+    - "admin:jupyterlab"
     - "admin:token"
-    - "admin:notebook"
     - "exec:admin"

--- a/applications/noteburst/templates/gafaelfawrtoken.yaml
+++ b/applications/noteburst/templates/gafaelfawrtoken.yaml
@@ -8,4 +8,5 @@ spec:
   service: "bot-noteburst"
   scopes:
     - "admin:token"
+    - "admin:notebook"
     - "exec:admin"

--- a/applications/noteburst/values-idfdev.yaml
+++ b/applications/noteburst/values-idfdev.yaml
@@ -1,6 +1,6 @@
 image:
   pullPolicy: Always
-  # tag: tickets-DM-33025
+  tag: tickets-DM-37857
 
 config:
   logLevel: "DEBUG"

--- a/applications/noteburst/values-idfdev.yaml
+++ b/applications/noteburst/values-idfdev.yaml
@@ -1,6 +1,6 @@
-image:
-  pullPolicy: Always
-  tag: tickets-DM-37857
+# image:
+#   pullPolicy: Always
+#   tag: tickets-DM-37857
 
 config:
   logLevel: "DEBUG"


### PR DESCRIPTION
This noteburst update (will be 0.6.0) provides support for JupyterLab Controller.