### PR TITLE
DM-38103: Increase timeout on nublado ingress

### DIFF
--- a/applications/nublado2/values.yaml
+++ b/applications/nublado2/values.yaml
@@ -155,6 +155,8 @@ jupyterhub:
         auth_request_set $auth_status $upstream_http_x_error_status;
         auth_request_set $auth_error_body $upstream_http_x_error_body;
         error_page 403 = @autherror;
+      nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
+      nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
     ingressClassName: "nginx"
     pathSuffix: "*"
 


### PR DESCRIPTION
We're seeing a lot of web socket closed errors on data.lsst.cloud that may be ingress-nginx timeouts on cells that take a long time to run. Try increasing the proxy timeout to five minutes.