### PR TITLE
DM-38154: Use structured logging for Cloud SQL Auth Proxy

### DIFF
--- a/applications/gafaelfawr/templates/cloudsql-deployment.yaml
+++ b/applications/gafaelfawr/templates/cloudsql-deployment.yaml
@@ -27,6 +27,8 @@ spec:
           command:
             - "/cloud_sql_proxy"
             - "-ip_address_types=PRIVATE"
+            - "-log_debug_stdout=true"
+            - "-structured_logs=true"
             - "-instances={{ required "cloudsql.instanceConnectionName must be specified" .Values.cloudsql.instanceConnectionName }}=tcp:0.0.0.0:5432"
           image: "{{ .Values.cloudsql.image.repository }}:{{ .Values.cloudsql.image.tag }}"
           imagePullPolicy: {{ .Values.cloudsql.image.pullPolicy | quote }}

--- a/applications/gafaelfawr/templates/deployment.yaml
+++ b/applications/gafaelfawr/templates/deployment.yaml
@@ -33,6 +33,8 @@ spec:
           command:
             - "/cloud_sql_proxy"
             - "-ip_address_types=PRIVATE"
+            - "-log_debug_stdout=true"
+            - "-structured_logs=true"
             - "-instances={{ required "cloudsql.instanceConnectionName must be specified" .Values.cloudsql.instanceConnectionName }}=tcp:5432"
           image: "{{ .Values.cloudsql.image.repository }}:{{ .Values.cloudsql.image.tag }}"
           imagePullPolicy: {{ .Values.cloudsql.image.pullPolicy | quote }}

--- a/applications/times-square/templates/deployment.yaml
+++ b/applications/times-square/templates/deployment.yaml
@@ -52,6 +52,8 @@ spec:
           command:
             - "/cloud_sql_proxy"
             - "-ip_address_types=PRIVATE"
+            - "-log_debug_stdout=true"
+            - "-structured_logs=true"
             - "-instances={{ required "cloudsql.instanceConnectionName must be specified" .Values.cloudsql.instanceConnectionName }}=tcp:5432"
         {{- end }}
         - name: {{ .Chart.Name }}

--- a/applications/times-square/templates/worker-deployment.yaml
+++ b/applications/times-square/templates/worker-deployment.yaml
@@ -52,6 +52,8 @@ spec:
           command:
             - "/cloud_sql_proxy"
             - "-ip_address_types=PRIVATE"
+            - "-log_debug_stdout=true"
+            - "-structured_logs=true"
             - "-instances={{ required "cloudsql.instanceConnectionName must be specified" .Values.cloudsql.instanceConnectionName }}=tcp:5432"
         {{- end }}
         - name: {{ .Chart.Name }}

--- a/applications/vo-cutouts/templates/db-worker-deployment.yaml
+++ b/applications/vo-cutouts/templates/db-worker-deployment.yaml
@@ -44,6 +44,8 @@ spec:
           command:
             - "/cloud_sql_proxy"
             - "-ip_address_types=PRIVATE"
+            - "-log_debug_stdout=true"
+            - "-structured_logs=true"
             - "-instances={{ required "cloudsql.instanceConnectionName must be specified" .Values.cloudsql.instanceConnectionName }}=tcp:5432"
         {{- end }}
         - name: "db-worker"

--- a/applications/vo-cutouts/templates/deployment.yaml
+++ b/applications/vo-cutouts/templates/deployment.yaml
@@ -48,6 +48,8 @@ spec:
           command:
             - "/cloud_sql_proxy"
             - "-ip_address_types=PRIVATE"
+            - "-log_debug_stdout=true"
+            - "-structured_logs=true"
             - "-instances={{ required "cloudsql.instanceConnectionName must be specified" .Values.cloudsql.instanceConnectionName }}=tcp:5432"
         {{- end }}
         - name: "vo-cutouts"


### PR DESCRIPTION
Add flags to Cloud SQL Auth Proxy to use structured logging and send info/debug messages to standard output rather than standard error. This should prevent Google from misclassifying them as errors.