### PR TITLE
DM-38116: Add coManageRegistryUrl value (Squareone 0.9.0)

### DIFF
--- a/applications/squareone/Chart.yaml
+++ b/applications/squareone/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
     url: https://github.com/jonathansick
 
 # The default version tag of the squareone docker image
-appVersion: "0.8.1"
+appVersion: "0.9.0"

--- a/applications/squareone/README.md
+++ b/applications/squareone/README.md
@@ -17,6 +17,7 @@ Squareone is the homepage UI for the Rubin Science Platform.
 | autoscaling.maxReplicas | int | `100` |  |
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
+| config.coManageRegistryUrl | string | `nil` | URL to the COmanage registry, if the environment uses COmanage for identity. @default null disables the COmanage integration |
 | config.semaphoreUrl | string | `nil` | URL to the Semaphore (user notifications) API service. @default null disables the Semaphore integration |
 | config.siteDescription | string | `"Access Rubin Observatory Legacy Survey of Space and Time data.\n"` | Site description, used in meta tags |
 | config.siteName | string | `"Rubin Science Platform"` | Name of the site, used in the title and meta tags. |

--- a/applications/squareone/templates/configmap.yaml
+++ b/applications/squareone/templates/configmap.yaml
@@ -15,3 +15,6 @@ data:
     {{- if .Values.config.timesSquareUrl }}
     timesSquareUrl: {{ .Values.config.timesSquareUrl | quote }}
     {{- end}}
+    {{- if .Values.config.coManageRegistryUrl }}
+    coManageRegistryUrl: {{ .Values.config.coManageRegistryUrl | quote }}
+    {{- end}}

--- a/applications/squareone/values-idfdev.yaml
+++ b/applications/squareone/values-idfdev.yaml
@@ -6,3 +6,4 @@ config:
   siteName: "Rubin Science Platform @ data-dev"
   semaphoreUrl: "https://data-dev.lsst.cloud/semaphore"
   timesSquareUrl: "https://data-dev.lsst.cloud/times-square/api"
+  coManageRegistryUrl: "https://id-dev.lsst.cloud"

--- a/applications/squareone/values-idfint.yaml
+++ b/applications/squareone/values-idfint.yaml
@@ -1,3 +1,4 @@
 config:
   siteName: "Rubin Science Platform @ data-int"
   semaphoreUrl: "https://data-int.lsst.cloud/semaphore"
+  coManageRegistryUrl: "https://id-int.lsst.cloud"

--- a/applications/squareone/values-idfprod.yaml
+++ b/applications/squareone/values-idfprod.yaml
@@ -3,3 +3,4 @@ replicaCount: 3
 config:
   siteName: "Rubin Science Platform"
   semaphoreUrl: "https://data.lsst.cloud/semaphore"
+  coManageRegistryUrl: "https://id.lsst.cloud"

--- a/applications/squareone/values.yaml
+++ b/applications/squareone/values.yaml
@@ -34,7 +34,8 @@ ingress:
   # if TLS is managed elsewhere, such as in an ingress-nginx app.
   tls: true
 
-resources: {}
+resources:
+  {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -75,6 +76,10 @@ config:
   # -- URL to the Times Square (parameterized notebooks) API service.
   # @default null disables the Times Square integration
   timesSquareUrl: null
+
+  # -- URL to the COmanage registry, if the environment uses COmanage for identity.
+  # @default null disables the COmanage integration
+  coManageRegistryUrl: null
 
 # Global parameters are set by parameters injected by the Argo CD Application
 # and should not be set in the individual environment values files.


### PR DESCRIPTION
This value can be set to the COmanage URL for environments that use COmanage (i.e. https://id.lsst.cloud for the IDF).