### PR TITLE
DM-38208: Prepare Phalanx for using merge queues

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,7 @@
 name: CI
 
 "on":
+  merge_group: {}
   pull_request:
     branches:
       - "main"

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,13 +1,10 @@
 name: Docs
 
 "on":
+  merge_group: {}
   pull_request:
-    paths:
-      - "docs/**"
-      - "applications/*/Chart.yaml"
-      - "applications/*/values.yaml"
-      - "applications/gafaelfawr/values-*.yaml"
-      - "environments/values-*.yaml"
+    branches:
+      - "main"
   push:
     branches-ignore:
       # These should always correspond to pull requests, so ignore them for
@@ -20,11 +17,6 @@ name: Docs
       - "u/**"
     tags:
       - "*"
-    paths:
-      - "docs/**"
-      - "applications/*/Chart.yaml"
-      - "applications/*/values.yaml"
-      - "environments/values-*.yaml"
   workflow_dispatch: {}
 
 jobs:
@@ -32,26 +24,43 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Filter paths
+        uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            docs:
+              - "docs/**"
+              - "applications/*/Chart.yaml"
+              - "applications/*/values.yaml"
+              - "applications/gafaelfawr/values-*.yaml"
+              - "environments/values-*.yaml"
 
       - name: Set up Python
+        if: steps.filter.outputs.docs == 'true'
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Python install
+        if: steps.filter.outputs.docs == 'true'
         run: |
           python -m pip install --upgrade pip tox
           python -m pip install -e ".[dev]"
           python -m pip install ltd-conveyor
 
       - name: Install graphviz
+        if: steps.filter.outputs.docs == 'true'
         run: sudo apt-get install graphviz
 
-      - name: Run tox
+      - name: Build docs
+        if: steps.filter.outputs.docs == 'true'
         uses: lsst-sqre/run-tox@v1
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           tox-envs: "docs"
 
       # Only attempt documentation uploads for long-lived branches, tagged
@@ -67,5 +76,7 @@ jobs:
           LTD_USERNAME: ${{ secrets.LTD_USERNAME }}
         run: ltd upload --gh --product phalanx --dir docs/_build/html
         if: >-
-          github.event_name != 'pull_request'
-          || startsWith(github.head_ref, 'tickets/')
+          steps.filter.outputs.docs == 'true'
+          && ((github.event_name != 'pull_request'
+               && github.event_name != 'merge_group')
+              || startsWith(github.head_ref, 'tickets/')

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -39,19 +39,6 @@ jobs:
               - "applications/gafaelfawr/values-*.yaml"
               - "environments/values-*.yaml"
 
-      - name: Set up Python
-        if: steps.filter.outputs.docs == 'true'
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.11"
-
-      - name: Python install
-        if: steps.filter.outputs.docs == 'true'
-        run: |
-          python -m pip install --upgrade pip tox
-          python -m pip install -e ".[dev]"
-          python -m pip install ltd-conveyor
-
       - name: Install graphviz
         if: steps.filter.outputs.docs == 'true'
         run: sudo apt-get install graphviz
@@ -61,22 +48,21 @@ jobs:
         uses: lsst-sqre/run-tox@v1
         with:
           python-version: "3.11"
-          tox-envs: "docs"
+          tox-envs: docs
 
-      # Only attempt documentation uploads for long-lived branches, tagged
-      # releases, and pull requests from ticket branches.  This avoids version
-      # clutter in the docs and failures when a PR doesn't have access to
-      # secrets.  This will still trigger on pull requests from untrusted
-      # repositories whose branch names match our tickets/* branch convention,
-      # but in this case the build will fail with an error since the secret
-      # won't be set.
-      - name: Upload
-        env:
-          LTD_PASSWORD: ${{ secrets.LTD_PASSWORD }}
-          LTD_USERNAME: ${{ secrets.LTD_USERNAME }}
-        run: ltd upload --gh --product phalanx --dir docs/_build/html
+      # Only attempt documentation uploads for tagged releases and pull
+      # requests from ticket branches in the same repository. This avoids
+      # version clutter in the docs and failures when a PR doesn't have access
+      # to secrets.
+      - name: Upload to LSST the Docs
+        uses: lsst-sqre/ltd-upload@v1
+        with:
+          project: "phalanx"
+          dir: "docs/_build/html"
+          username: ${{ secrets.LTD_PASSWORD }}
+          password: ${{ secrets.LTD_USERNAME }}
         if: >-
           steps.filter.outputs.docs == 'true'
           && ((github.event_name != 'pull_request'
                && github.event_name != 'merge_group')
-              || startsWith(github.head_ref, 'tickets/')
+              || startsWith(github.head_ref, 'tickets/'))

--- a/.github/workflows/linkcheck.yaml
+++ b/.github/workflows/linkcheck.yaml
@@ -1,0 +1,51 @@
+# This is a separate documentation build just to check links.  We don't check
+# links as part of the normal documentation build since, unlike Sphinx errors
+# and warnings, we don't want broken links to block a merge.  (Sometimes they
+# will be fixed by the same merge, sometimes they're temporary rate limit
+# issues.)
+#
+# Instead, we do an advisory run of link checking on relevant PRs that doesn't
+# block merging, and we do a weekly link check to catch any links that have
+# gone stale.
+
+name: Link Check
+
+"on":
+  push:
+    branches-ignore:
+      # These should always correspond to pull requests, so ignore them for
+      # the push trigger and let them be triggered by the pull_request
+      # trigger, avoiding running the workflow twice.  This is a minor
+      # optimization so there's no need to ensure this is comprehensive.
+      - "dependabot/**"
+      - "renovate/**"
+      - "tickets/**"
+      - "u/**"
+    tags:
+      - "*"
+    paths:
+      - "docs/**"
+      - "applications/*/Chart.yaml"
+      - "applications/*/values.yaml"
+      - "applications/gafaelfawr/values-*.yaml"
+      - "environments/values-*.yaml"
+  schedule:
+    - cron: "0 12 * * 1"
+  workflow_dispatch: {}
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install graphviz
+        run: sudo apt-get install graphviz
+
+      - name: Check links
+        uses: lsst-sqre/run-tox@v1
+        with:
+          python-version: "3.11"
+          tox-envs: docs-linkcheck


### PR DESCRIPTION
GitHub has a new feature called merge queues that allows one to queue up a number of PRs for merging, and each will be properly rebased and merged when their tests pass. In order to use it, it has to be mandatory for merges and GitHub Actions that may block a merge have to trigger on `merge_group`.

Take this opportunity to rework the documentation build a bit:

- Always run the documentation build but skip the work if the documentation hasn't changed. This allows us to block merges on documentation syntax errors or missing metadata for new applications or environments.
- Re-add the documentation link check, which we'd disabled in January, as a separate CI workflow so that it doesn't block merges. Run it on pushes and once a week.
- Update to Python 3.11 for documentation builds.
- Use the new shared actions for documentation builds and uploads.