### PR TITLE
Upgrade roe env (loadbalancer for nginx ingress / new IP's for NFS)

### DIFF
--- a/applications/ingress-nginx/values-roe.yaml
+++ b/applications/ingress-nginx/values-roe.yaml
@@ -3,23 +3,14 @@ ingress-nginx:
     config:
       large-client-header-buffers: "4 64k"
       proxy-buffer-size: "64k"
+      use-proxy-protocol: "false"
+      enable-health-monitor: "false"
     service:
-      externalTrafficPolicy: null
-      type: ClusterIP
-    affinity:
-      nodeAffinity:
-        preferredDuringSchedulingIgnoredDuringExecution:
-        - weight: 1
-          preference:
-            matchExpressions:
-            - key: nodetype
-              operator: In
-              values:
-              - public
-    dnsPolicy: ClusterFirstWithHostNet
-    hostNetwork: true
+      loadBalancerIP: "192.41.122.16"
+      annotations:
+        kubernetes.io/ingress.class: "openstack"
+        loadbalancer.openstack.org/enable-health-monitor: "false"
     extraArgs:
       default-ssl-certificate: ingress-nginx/ingress-certificate
-
 vaultCertificate:
   enabled: true

--- a/applications/moneypenny/values-roe.yaml
+++ b/applications/moneypenny/values-roe.yaml
@@ -11,5 +11,5 @@ orders:
   volumes:
     - name: homedirs
       nfs:
-        server: 10.72.0.23
+        server: 192.41.122.33
         path: /jhome

--- a/applications/nublado2/values-roe.yaml
+++ b/applications/nublado2/values-roe.yaml
@@ -20,15 +20,15 @@ config:
     - name: data
       nfs:
         path: /data
-        server: 10.72.0.23
+        server: 192.41.122.33
     - name: home
       nfs:
         path: /jhome
-        server: 10.72.0.23
+        server: 192.41.122.33
     - name: datasets
       nfs:
         path: /datasets
-        server: 10.72.0.23
+        server: 192.41.122.33
   volume_mounts:
     - name: data
       mountPath: /data


### PR DESCRIPTION
A couple of changes to the roe env:

- Modify NGINX ingress controller to user LoadBalancer, also add the floating IP that is used.
- Change IP's for NFS 