### PR TITLE
DM-38154: Enable structured logging for Argo CD

### DIFF
--- a/applications/argocd/README.md
+++ b/applications/argocd/README.md
@@ -18,6 +18,7 @@ Kubernetes application manager
 | argo-cd.controller.metrics.applicationLabels.labels[0] | string | `"name"` |  |
 | argo-cd.controller.metrics.applicationLabels.labels[1] | string | `"instance"` |  |
 | argo-cd.controller.metrics.enabled | bool | `true` |  |
+| argo-cd.global.logging.format | string | `"json"` | Set the global logging format. Either: `text` or `json` |
 | argo-cd.notifications.metrics.enabled | bool | `true` |  |
 | argo-cd.redis.enabled | bool | `true` |  |
 | argo-cd.redis.metrics.enabled | bool | `true` |  |

--- a/applications/argocd/values.yaml
+++ b/applications/argocd/values.yaml
@@ -1,6 +1,12 @@
-## Argo CD configuration
-## https://github.com/argoproj/argo-helm/blob/main/charts/argo-cd/values.yaml
+# Argo CD configuration
+# https://github.com/argoproj/argo-helm/blob/main/charts/argo-cd/values.yaml
+
 argo-cd:
+  global:
+    logging:
+      # -- Set the global logging format. Either: `text` or `json`
+      format: "json"
+
   redis:
     enabled: true
     metrics:


### PR DESCRIPTION
See if this prevents Google Log Explorer from misclassifying the Argo CD log messages.