### PR TITLE
Fine tune MM2 configuration for Summit->USDF replication

### DIFF
--- a/applications/sasquatch/charts/strimzi-kafka/README.md
+++ b/applications/sasquatch/charts/strimzi-kafka/README.md
@@ -11,9 +11,9 @@ A subchart to deploy Strimzi Kafka components for Sasquatch.
 | connect.replicas | int | `3` | Number of Kafka Connect replicas to run. |
 | kafka.config."log.retention.bytes" | string | `"429496729600"` | Maximum retained number of bytes for a topic's data. |
 | kafka.config."log.retention.hours" | int | `72` | Number of days for a topic's data to be retained. |
-| kafka.config."message.max.bytes" | int | `655360` | The largest record batch size allowed by Kafka. |
+| kafka.config."message.max.bytes" | int | `10485760` | The largest record batch size allowed by Kafka. |
 | kafka.config."offsets.retention.minutes" | int | `4320` | Number of minutes for a consumer group's offsets to be retained. |
-| kafka.config."replica.fetch.max.bytes" | int | `655360` | The number of bytes of messages to attempt to fetch for each partition. |
+| kafka.config."replica.fetch.max.bytes" | int | `10485760` | The number of bytes of messages to attempt to fetch for each partition. |
 | kafka.externalListener.bootstrap.annotations | object | `{}` | Annotations that will be added to the Ingress, Route, or Service resource. |
 | kafka.externalListener.bootstrap.host | string | `""` | Name used for TLS hostname verification. |
 | kafka.externalListener.bootstrap.loadBalancerIP | string | `""` | The loadbalancer is requested with the IP address specified in this field. This feature depends on whether the underlying cloud provider supports specifying the loadBalancerIP when a load balancer is created. This field is ignored if the cloud provider does not support the feature. Once the IP address is provisioned this option make it possible to pin the IP address. We can request the same IP next time it is provisioned. This is important because it lets us configure a DNS record, associating a hostname with that pinned IP address. |

--- a/applications/sasquatch/charts/strimzi-kafka/templates/mirrormaker2.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/mirrormaker2.yaml
@@ -63,7 +63,7 @@ spec:
         # added to the batch and sent to brokers at the same time.
         # This can improve throughput when you have just a few topic partitions that
         # handle large numbers of messages.
-        producer.override.batch.size: 327680
+        producer.override.batch.size: 524288
         # Use linger.ms to add a wait time in milliseconds to delay produce requests when
         # producer load decreases.
         # The delay means that more records can be added to batches if they are under the
@@ -71,7 +71,9 @@ spec:
         producer.override.linger.ms: 100
         # Accept larger messages.
         # See also message.max.bytes broker configuration.
-        producer.max.request.size: 262144
+        producer.max.request.size: 10485760
+        producer.buffer.memory: 10485760
+
     heartbeatConnector:
       config:
         heartbeats.topic.replication.factor: 3

--- a/applications/sasquatch/charts/strimzi-kafka/values.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/values.yaml
@@ -21,9 +21,9 @@ kafka:
     # -- Maximum retained number of bytes for a topic's data.
     log.retention.bytes: "429496729600"
     # -- The largest record batch size allowed by Kafka.
-    message.max.bytes: 655360
+    message.max.bytes: 10485760
     # -- The number of bytes of messages to attempt to fetch for each partition.
-    replica.fetch.max.bytes: 655360
+    replica.fetch.max.bytes: 10485760
 
   externalListener:
     tls:


### PR DESCRIPTION
MM2 by default consumes the earliest offsets from the source cluster, for the Summit that means ~72h of data for more than 2000 topics.

When we turned on MM2 at USDF we got the following errors and needed to fine-tune the connector to be able to replicate larger amounts of data. 

```2023-03-10 14:18:56,247 WARN [source->target.MirrorSourceConnector|task-1] [Producer clientId=connector-producer-source->target.MirrorSourceConnector-1] Got error produce response in correlation id 2104 on topic-partition lsst.sal.MTM1M3.forceActuatorData-0, splitting and retrying (2147483647 attempts left). Error: MESSAGE_TOO_LARGE (org.apache.kafka.clients.producer.internals.Sender) [kafka-producer-network-thread | connector-producer-source->target.MirrorSourceConnector-1]```

