### PR TITLE
Fix prompt-processing user permissions

### DIFF
--- a/applications/sasquatch/charts/strimzi-kafka/templates/users.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/users.yaml
@@ -177,9 +177,9 @@ spec:
         operation: All
       - resource:
           type: topic
-          name: "test.next-visit"
+          name: "lsst.sal.ScriptQueue.logevent_nextVisit"
           patternType: literal
         type: allow
         host: "*"
-        operation: All
+        operation: Read
 


### PR DESCRIPTION
- Give read access for the prompt-processing user on the lsst.sal.ScriptQueue.logevent_nextVisit topic