### PR TITLE
DM-38058: Add ForgeRock Identity Management support

### DIFF
--- a/applications/gafaelfawr/README.md
+++ b/applications/gafaelfawr/README.md
@@ -34,7 +34,9 @@ Authentication and identity system
 | config.cilogon.usernameClaim | string | `"uid"` | Claim from which to get the username |
 | config.databaseUrl | string | None, must be set if `cloudsql.enabled` is not true | URL for the PostgreSQL database |
 | config.errorFooter | string | `""` | HTML footer to add to any login error page (will be enclosed in a <p> tag). |
-| config.firestore.project | string | Firestore support is disabled | If set, assign UIDs and GIDs using Google Firestore in the given project.  Cloud SQL must be enabled and the Cloud SQL service account must have read/write access to that Firestore instance. |
+| config.firestore.project | string | Firestore support is disabled | If set, assign UIDs and GIDs using Google Firestore in the given project. Cloud SQL must be enabled and the Cloud SQL service account must have read/write access to that Firestore instance. |
+| config.forgerock.url | string | ForgeRock Identity Management support is disabled | If set, obtain the GIDs for groups from this ForgeRock Identity Management server. |
+| config.forgerock.username | string | None, must be set if `config.forgerock.url` is set | Username to use for HTTP Basic authentication to ForgeRock Identity Managemnt. The corresponding password must be in the `forgerock-passsword` key of the Gafaelfawr Vault secret. |
 | config.github.clientId | string | `""` | GitHub client ID. One and only one of this, `config.cilogon.clientId`, or `config.oidc.clientId` must be set. |
 | config.groupMapping | object | `{}` | Defines a mapping of scopes to groups that provide that scope. See [DMTN-235](https://dmtn-235.lsst.io/) for more details on scopes. |
 | config.initialAdmins | list | `[]` | Usernames to add as administrators when initializing a new database. Used only if there are no administrators. |

--- a/applications/gafaelfawr/templates/configmap.yaml
+++ b/applications/gafaelfawr/templates/configmap.yaml
@@ -141,6 +141,13 @@
       project: {{ .Values.config.firestore.project | quote }}
     {{- end }}
 
+    {{- if .Values.config.forgerock.url }}
+    forgerock:
+      url: {{ .Values.config.forgerock.url | quote }}
+      username: {{ .Values.config.forgerock.username | quote }}
+      passwordFile: "/etc/gafaelfawr/secrets/forgerock-password"
+    {{- end }}
+
     {{- if .Values.config.oidcServer.enabled }}
     oidcServer:
       issuer: "https://{{ .Values.global.host }}"

--- a/applications/gafaelfawr/values-ccin2p3.yaml
+++ b/applications/gafaelfawr/values-ccin2p3.yaml
@@ -1,9 +1,8 @@
 replicaCount: 2
-image:
-  # -- tap image to use
-  repository: "gabrimaine/gafaelfawr"
-  tag: "9.0.0-dev"
 
+image:
+  pullPolicy: "Always"
+  tag: "tickets-DM-38058"
 
 redis:
   persistence:

--- a/applications/gafaelfawr/values-ccin2p3.yaml
+++ b/applications/gafaelfawr/values-ccin2p3.yaml
@@ -1,4 +1,9 @@
 replicaCount: 2
+image:
+  # -- tap image to use
+  repository: "gabrimaine/gafaelfawr"
+  tag: "9.0.0-dev"
+
 
 redis:
   persistence:
@@ -26,6 +31,10 @@ config:
     uidClaim: "uid_number"
     groupsClaim: "groups"
     usernameClaim: "preferred_username"
+
+  forgerock:
+    url: "https://idnum.in2p3.fr:8443/openidm/"
+    username: "idnum-client-ldaplsst"
 
   oidcServer:
     enabled: false

--- a/applications/gafaelfawr/values.yaml
+++ b/applications/gafaelfawr/values.yaml
@@ -204,10 +204,22 @@ config:
 
   firestore:
     # -- If set, assign UIDs and GIDs using Google Firestore in the given
-    # project.  Cloud SQL must be enabled and the Cloud SQL service account
+    # project. Cloud SQL must be enabled and the Cloud SQL service account
     # must have read/write access to that Firestore instance.
     # @default -- Firestore support is disabled
     project: ""
+
+  forgerock:
+    # -- If set, obtain the GIDs for groups from this ForgeRock Identity
+    # Management server.
+    # @default -- ForgeRock Identity Management support is disabled
+    url: ""
+
+    # -- Username to use for HTTP Basic authentication to ForgeRock Identity
+    # Managemnt. The corresponding password must be in the
+    # `forgerock-passsword` key of the Gafaelfawr Vault secret.
+    # @default -- None, must be set if `config.forgerock.url` is set
+    username: ""
 
   oidcServer:
     # -- Whether to support OpenID Connect clients. If set to true,


### PR DESCRIPTION
Add Gafaelfawr configuration support for querying a ForgeRock Identity Management server for group GIDs, and add the needed configuration for the CC-IN2P3 environment.
