### PR TITLE
DM-38058: Use the released version of Gafaelfawr

### DIFF
--- a/applications/gafaelfawr/values-ccin2p3.yaml
+++ b/applications/gafaelfawr/values-ccin2p3.yaml
@@ -1,9 +1,5 @@
 replicaCount: 2
 
-image:
-  pullPolicy: "Always"
-  tag: "tickets-DM-38058"
-
 redis:
   persistence:
     enabled: false

--- a/applications/gafaelfawr/values-idfdev.yaml
+++ b/applications/gafaelfawr/values-idfdev.yaml
@@ -1,7 +1,3 @@
-image:
-  pullPolicy: "Always"
-  tag: "tickets-DM-38058"
-
 # Use the CSI storage class so that we can use snapshots.
 redis:
   persistence:

--- a/applications/gafaelfawr/values-minikube.yaml
+++ b/applications/gafaelfawr/values-minikube.yaml
@@ -1,7 +1,3 @@
-image:
-  pullPolicy: "Always"
-  tag: "tickets-DM-38058"
-
 # Reset token storage on every Redis restart.
 redis:
   persistence:


### PR DESCRIPTION
Gafaelfawr 9.1.0 has been released, so switch to the released version for IDF dev, minikube, and CC-IN2P3.