### PR TITLE
DM-38339: Update to latest mobu

### DIFF
--- a/applications/mobu/Chart.yaml
+++ b/applications/mobu/Chart.yaml
@@ -4,4 +4,4 @@ version: 1.0.0
 description: Continuous integration testing
 sources:
   - https://github.com/lsst-sqre/mobu
-appVersion: 4.5.0
+appVersion: 5.0.0

--- a/applications/mobu/README.md
+++ b/applications/mobu/README.md
@@ -12,6 +12,7 @@ Continuous integration testing
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules for the mobu frontend pod |
 | config.autostart | list | `[]` | Autostart specification. Must be a list of mobu flock specifications. Each flock listed will be automatically started when mobu is started. |
+| config.debug | bool | `false` | If set to true, include the output from all flocks in the main mobu log and disable structured JSON logging. |
 | config.useCachemachine | bool | `true` | Whether to use cachemachine. Set to false on environments using the Nublado lab controller. |
 | fullnameOverride | string | `""` | Override the full name for resources (includes the release name) |
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |

--- a/applications/mobu/README.md
+++ b/applications/mobu/README.md
@@ -13,6 +13,7 @@ Continuous integration testing
 | affinity | object | `{}` | Affinity rules for the mobu frontend pod |
 | config.autostart | list | `[]` | Autostart specification. Must be a list of mobu flock specifications. Each flock listed will be automatically started when mobu is started. |
 | config.debug | bool | `false` | If set to true, include the output from all flocks in the main mobu log and disable structured JSON logging. |
+| config.disableSlackAlerts | bool | `false` | If set to true, do not configure mobu to send alerts to Slack. |
 | config.useCachemachine | bool | `true` | Whether to use cachemachine. Set to false on environments using the Nublado lab controller. |
 | fullnameOverride | string | `""` | Override the full name for resources (includes the release name) |
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |

--- a/applications/mobu/README.md
+++ b/applications/mobu/README.md
@@ -11,8 +11,8 @@ Continuous integration testing
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules for the mobu frontend pod |
-| autostart | list | `[]` | Autostart specification. Must be a list of mobu flock specifications. Each flock listed will be automatically started when mobu is started. |
-| cachemachineImagePolicy | string | `"available"` | Cachemachine image policy.  Must be one of `desired` or `available`.  Determines whether cachemachine reports the images it has or the ones it wants.  Should be `desired` in environments with image streaming enabled (e.g. IDF). |
+| config.autostart | list | `[]` | Autostart specification. Must be a list of mobu flock specifications. Each flock listed will be automatically started when mobu is started. |
+| config.useCachemachine | bool | `true` | Whether to use cachemachine. Set to false on environments using the Nublado lab controller. |
 | fullnameOverride | string | `""` | Override the full name for resources (includes the release name) |
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |

--- a/applications/mobu/templates/configmap-autostart.yaml
+++ b/applications/mobu/templates/configmap-autostart.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.autostart -}}
+{{- if .Values.config.autostart -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,5 +7,5 @@ metadata:
     {{- include "mobu.labels" . | nindent 4 }}
 data:
   autostart.yaml: |
-    {{- toYaml .Values.autostart | nindent 4 }}
+    {{- toYaml .Values.config.autostart | nindent 4 }}
 {{- end }}

--- a/applications/mobu/templates/deployment.yaml
+++ b/applications/mobu/templates/deployment.yaml
@@ -24,11 +24,13 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           env:
+            {{- if (not .Values.config.disableSlackAlerts) }}
             - name: "ALERT_HOOK"
               valueFrom:
                 secretKeyRef:
                   name: {{ template "mobu.fullname" . }}-secret
                   key: "ALERT_HOOK"
+            {{- end }}
             {{- if .Values.config.autostart }}
             - name: "AUTOSTART"
               value: "/etc/mobu/autostart.yaml"

--- a/applications/mobu/templates/deployment.yaml
+++ b/applications/mobu/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
                 secretKeyRef:
                   name: {{ template "mobu.fullname" . }}-secret
                   key: "ALERT_HOOK"
-            {{- if .Values.autostart }}
+            {{- if .Values.config.autostart }}
             - name: "AUTOSTART"
               value: "/etc/mobu/autostart.yaml"
             {{- end }}
@@ -40,6 +40,10 @@ spec:
                 secretKeyRef:
                   name: {{ template "mobu.fullname" . }}-gafaelfawr-token
                   key: "token"
+            {{- if (not .Values.config.useCachemachine) }}
+            - name: "USE_CACHEMACHINE"
+              value: "false"
+            {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
           ports:
@@ -62,7 +66,7 @@ spec:
                 - ALL
             readOnlyRootFilesystem: true
           volumeMounts:
-            {{- if .Values.autostart }}
+            {{- if .Values.config.autostart }}
             - name: "autostart"
               mountPath: "/etc/mobu"
               readOnly: true
@@ -74,7 +78,7 @@ spec:
         runAsUser: 1000
         runAsGroup: 1000
       volumes:
-        {{- if .Values.autostart }}
+        {{- if .Values.config.autostart }}
         - name: "autostart"
           configMap:
             name: {{ include "mobu.fullname" . }}-autostart

--- a/applications/mobu/templates/deployment.yaml
+++ b/applications/mobu/templates/deployment.yaml
@@ -56,7 +56,7 @@ spec:
               protocol: "TCP"
           readinessProbe:
             httpGet:
-              path: "/mobu/flocks"
+              path: "/"
               port: "http"
             timeoutSeconds: 10
           {{- with .Values.resources }}

--- a/applications/mobu/templates/deployment.yaml
+++ b/applications/mobu/templates/deployment.yaml
@@ -44,6 +44,10 @@ spec:
             - name: "USE_CACHEMACHINE"
               value: "false"
             {{- end }}
+            {{- if (not .Values.config.debug) }}
+            - name: "SAFIR_PROFILE"
+              value: "production"
+            {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
           ports:

--- a/applications/mobu/values-idfdev.yaml
+++ b/applications/mobu/values-idfdev.yaml
@@ -3,6 +3,7 @@ image:
   pullPolicy: "Always"
 config:
   useCachemachine: false
+  debug: true
   autostart:
     - name: "python"
       count: 1

--- a/applications/mobu/values-idfdev.yaml
+++ b/applications/mobu/values-idfdev.yaml
@@ -1,26 +1,28 @@
 image:
-  repository: "docker.io/lsstsqre/mobu"
-  tag: "ajt-dev"
+  tag: "tickets-DM-38408"
   pullPolicy: "Always"
-autostart:
-  - name: "python"
-    count: 1
-    users:
-      - username: "bot-mobu-user"
-    scopes: ["exec:notebook"]
-    business: "JupyterPythonLoop"
-    options:
-      jupyter:
-        image_class: "latest-weekly"
-        image_size: "Small"
-    restart: true
-  - name: "tap"
-    count: 1
-    users:
-      - username: "bot-mobu-tap"
-    scopes: ["read:tap"]
-    business: "TAPQueryRunner"
-    restart: true
-    options:
-      tap_sync: true
-      tap_query_set: "dp0.2"
+config:
+  useCachemachine: false
+  autostart:
+    - name: "python"
+      count: 1
+      users:
+        - username: "bot-mobu-user"
+      scopes: ["exec:notebook"]
+      business:
+        type: "JupyterPythonLoop"
+        options:
+          image:
+            image_class: "latest-weekly"
+            size: "Small"
+        restart: true
+    - name: "tap"
+      count: 1
+      users:
+        - username: "bot-mobu-tap"
+      scopes: ["read:tap"]
+      business:
+        type: "TAPQueryRunner"
+        options:
+          query_set: "dp0.2"
+        restart: true

--- a/applications/mobu/values-idfint.yaml
+++ b/applications/mobu/values-idfint.yaml
@@ -1,44 +1,45 @@
-cachemachineImagePolicy: "desired"
-
-autostart:
-  - name: "firefighter"
-    count: 1
-    users:
-      - username: "bot-mobu-recommended"
-    scopes:
-      - "exec:notebook"
-      - "exec:portal"
-      - "read:image"
-      - "read:tap"
-    business: "NotebookRunner"
-    options:
-      repo_url: "https://github.com/lsst-sqre/system-test.git"
-      repo_branch: "prod"
-      max_executions: 1
-    restart: true
-  - name: "weekly"
-    count: 1
-    users:
-      - username: "bot-mobu-weekly"
-    scopes:
-      - "exec:notebook"
-      - "exec:portal"
-      - "read:image"
-      - "read:tap"
-    business: "NotebookRunner"
-    options:
-      jupyter:
-        image_class: "latest-weekly"
-      repo_url: "https://github.com/lsst-sqre/system-test.git"
-      repo_branch: "prod"
-    restart: true
-  - name: "tap"
-    count: 1
-    users:
-      - username: "bot-mobu-tap"
-    scopes: ["read:tap"]
-    business: "TAPQueryRunner"
-    restart: true
-    options:
-      tap_sync: false
-      tap_query_set: "dp0.2"
+config:
+  autostart:
+    - name: "firefighter"
+      count: 1
+      users:
+        - username: "bot-mobu-recommended"
+      scopes:
+        - "exec:notebook"
+        - "exec:portal"
+        - "read:image"
+        - "read:tap"
+      business:
+        type: "NotebookRunner"
+        options:
+          repo_url: "https://github.com/lsst-sqre/system-test.git"
+          repo_branch: "prod"
+          max_executions: 1
+        restart: true
+    - name: "weekly"
+      count: 1
+      users:
+        - username: "bot-mobu-weekly"
+      scopes:
+        - "exec:notebook"
+        - "exec:portal"
+        - "read:image"
+        - "read:tap"
+      business:
+        type: "NotebookRunner"
+        options:
+          image:
+            image_class: "latest-weekly"
+          repo_url: "https://github.com/lsst-sqre/system-test.git"
+          repo_branch: "prod"
+        restart: true
+    - name: "tap"
+      count: 1
+      users:
+        - username: "bot-mobu-tap"
+      scopes: ["read:tap"]
+      business:
+        type: "TAPQueryRunner"
+        options:
+          query_set: "dp0.2"
+        restart: true

--- a/applications/mobu/values-idfprod.yaml
+++ b/applications/mobu/values-idfprod.yaml
@@ -1,60 +1,62 @@
-cachemachineImagePolicy: "desired"
-
-autostart:
-  - name: "firefighter"
-    count: 5
-    user_spec:
-      username_prefix: "bot-mobu-recommended"
-    scopes:
-      - "exec:notebook"
-      - "exec:portal"
-      - "read:image"
-      - "read:tap"
-    business: "NotebookRunner"
-    options:
-      repo_url: "https://github.com/lsst-sqre/system-test.git"
-      repo_branch: "prod"
-      max_executions: 1
-    restart: true
-  - name: "quickbeam"
-    count: 1
-    users:
-      - username: "bot-mobu-persistent"
-    scopes:
-      - "exec:notebook"
-      - "exec:portal"
-      - "read:image"
-      - "read:tap"
-    business: "NotebookRunner"
-    options:
-      repo_url: "https://github.com/lsst-sqre/system-test.git"
-      repo_branch: "prod"
-      idle_time: 900
-      delete_lab: false
-    restart: true
-  - name: "tutorial"
-    count: 1
-    users:
-      - username: "bot-mobu-tutorial"
-    scopes:
-      - "exec:notebook"
-      - "exec:portal"
-      - "read:image"
-      - "read:tap"
-    business: "NotebookRunner"
-    options:
-      repo_url: "https://github.com/rubin-dp0/tutorial-notebooks.git"
-      repo_branch: "prod"
-      max_executions: 1
-      working_directory: "notebooks/tutorial-notebooks"
-    restart: true
-  - name: "tap"
-    count: 1
-    users:
-      - username: "bot-mobu-tap"
-    scopes: ["read:tap"]
-    business: "TAPQueryRunner"
-    options:
-      tap_sync: true
-      tap_query_set: "dp0.2"
-    restart: true
+config:
+  autostart:
+    - name: "firefighter"
+      count: 5
+      user_spec:
+        username_prefix: "bot-mobu-recommended"
+      scopes:
+        - "exec:notebook"
+        - "exec:portal"
+        - "read:image"
+        - "read:tap"
+      business:
+        type: "NotebookRunner"
+        options:
+          repo_url: "https://github.com/lsst-sqre/system-test.git"
+          repo_branch: "prod"
+          max_executions: 1
+        restart: true
+    - name: "quickbeam"
+      count: 1
+      users:
+        - username: "bot-mobu-persistent"
+      scopes:
+        - "exec:notebook"
+        - "exec:portal"
+        - "read:image"
+        - "read:tap"
+      business:
+        type: "NotebookRunner"
+        options:
+          repo_url: "https://github.com/lsst-sqre/system-test.git"
+          repo_branch: "prod"
+          idle_time: 900
+          delete_lab: false
+        restart: true
+    - name: "tutorial"
+      count: 1
+      users:
+        - username: "bot-mobu-tutorial"
+      scopes:
+        - "exec:notebook"
+        - "exec:portal"
+        - "read:image"
+        - "read:tap"
+      business:
+        type: "NotebookRunner"
+        options:
+          repo_url: "https://github.com/rubin-dp0/tutorial-notebooks.git"
+          repo_branch: "prod"
+          max_executions: 1
+          working_directory: "notebooks/tutorial-notebooks"
+        restart: true
+    - name: "tap"
+      count: 1
+      users:
+        - username: "bot-mobu-tap"
+      scopes: ["read:tap"]
+      business:
+        type: "TAPQueryRunner"
+        options:
+          query_set: "dp0.2"
+        restart: true

--- a/applications/mobu/values-minikube.yaml
+++ b/applications/mobu/values-minikube.yaml
@@ -1,0 +1,3 @@
+image:
+  tag: "tickets-DM-38408"
+  pullPolicy: "Always"

--- a/applications/mobu/values-minikube.yaml
+++ b/applications/mobu/values-minikube.yaml
@@ -1,3 +1,5 @@
 image:
   tag: "tickets-DM-38408"
   pullPolicy: "Always"
+config:
+  disableSlackAlerts: true

--- a/applications/mobu/values-roe.yaml
+++ b/applications/mobu/values-roe.yaml
@@ -1,28 +1,31 @@
-autostart:
-  - name: "firefighter"
-    count: 1
-    users:
-      - username: "bot-mobu-recommended"
-        uidnumber: 74768
-        gidnumber: 74768
-    scopes: ["exec:notebook", "exec:portal", "read:image", "read:tap"]
-    business: "NotebookRunner"
-    options:
-      repo_url: "https://github.com/SimonKrughoff/system-test.git"
-      repo_branch: "prod"
-      max_executions: 1
-    restart: true
-  - name: "weekly"
-    count: 1
-    users:
-      - username: "bot-mobu-weekly"
-        uidnumber: 74769
-        gidnumber: 74769
-    scopes: ["exec:notebook", "exec:portal", "read:image", "read:tap"]
-    business: "NotebookRunner"
-    options:
-      jupyter:
-        image_class: "latest-weekly"
-      repo_url: "https://github.com/lsst-sqre/system-test.git"
-      repo_branch: "prod"
-    restart: true
+config:
+  autostart:
+    - name: "firefighter"
+      count: 1
+      users:
+        - username: "bot-mobu-recommended"
+          uidnumber: 74768
+          gidnumber: 74768
+      scopes: ["exec:notebook", "exec:portal", "read:image", "read:tap"]
+      business:
+        type: "NotebookRunner"
+        options:
+          repo_url: "https://github.com/lsst-sqre/system-test.git"
+          repo_branch: "prod"
+          max_executions: 1
+        restart: true
+    - name: "weekly"
+      count: 1
+      users:
+        - username: "bot-mobu-weekly"
+          uidnumber: 74769
+          gidnumber: 74769
+      scopes: ["exec:notebook", "exec:portal", "read:image", "read:tap"]
+      business:
+        type: "NotebookRunner"
+        options:
+          image:
+            image_class: "latest-weekly"
+          repo_url: "https://github.com/lsst-sqre/system-test.git"
+          repo_branch: "prod"
+        restart: true

--- a/applications/mobu/values-usdfdev.yaml
+++ b/applications/mobu/values-usdfdev.yaml
@@ -1,1 +1,0 @@
-cachemachineImagePolicy: "desired"

--- a/applications/mobu/values-usdfprod.yaml
+++ b/applications/mobu/values-usdfprod.yaml
@@ -1,1 +1,0 @@
-cachemachineImagePolicy: "desired"

--- a/applications/mobu/values.yaml
+++ b/applications/mobu/values.yaml
@@ -6,16 +6,6 @@ nameOverride: ""
 # -- Override the full name for resources (includes the release name)
 fullnameOverride: ""
 
-# -- Autostart specification. Must be a list of mobu flock specifications.
-# Each flock listed will be automatically started when mobu is started.
-autostart: []
-
-# -- Cachemachine image policy.  Must be one of `desired` or
-# `available`.  Determines whether cachemachine reports the images it
-# has or the ones it wants.  Should be `desired` in environments with
-# image streaming enabled (e.g. IDF).
-cachemachineImagePolicy: "available"
-
 image:
   # -- mobu image to use
   repository: "ghcr.io/lsst-sqre/mobu"
@@ -30,6 +20,15 @@ image:
 ingress:
   # -- Additional annotations to add to the ingress
   annotations: {}
+
+config:
+  # -- Autostart specification. Must be a list of mobu flock specifications.
+  # Each flock listed will be automatically started when mobu is started.
+  autostart: []
+
+  # -- Whether to use cachemachine. Set to false on environments using the
+  # Nublado lab controller.
+  useCachemachine: true
 
 # -- Resource limits and requests for the mobu frontend pod
 resources: {}

--- a/applications/mobu/values.yaml
+++ b/applications/mobu/values.yaml
@@ -30,6 +30,9 @@ config:
   # and disable structured JSON logging.
   debug: false
 
+  # -- If set to true, do not configure mobu to send alerts to Slack.
+  disableSlackAlerts: false
+
   # -- Whether to use cachemachine. Set to false on environments using the
   # Nublado lab controller.
   useCachemachine: true

--- a/applications/mobu/values.yaml
+++ b/applications/mobu/values.yaml
@@ -26,6 +26,10 @@ config:
   # Each flock listed will be automatically started when mobu is started.
   autostart: []
 
+  # -- If set to true, include the output from all flocks in the main mobu log
+  # and disable structured JSON logging.
+  debug: false
+
   # -- Whether to use cachemachine. Set to false on environments using the
   # Nublado lab controller.
   useCachemachine: true

--- a/environments/templates/nublado-users-application.yaml
+++ b/environments/templates/nublado-users-application.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.nublado2.enabled -}}
+{{- if (or .Values.nublado.enabled .Values.nublado2.enabled) -}}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:


### PR DESCRIPTION
Update the mobu configuration for the new 5.0.0 release, which changes the structure of the flock specifications. Pin IDF dev and minikube to the testing branch for right now.

Remove the cachemachineImagePolicy setting, since it didn't actually do anything and cachemachine is going away.

Switch the TAP queries on IDF int back to sync so that we can test the timeout problems that we are seeing in IDF prod.