### PR TITLE
[DM-38110] Begin trying to configure databases

### DIFF
--- a/applications/obstap/templates/tap-deployment.yaml
+++ b/applications/obstap/templates/tap-deployment.yaml
@@ -28,15 +28,9 @@ spec:
           env:
             - name: CATALINA_OPTS
               value: >-
-                -Dqservuser.jdbc.username=qsmaster
-                -Dqservuser.jdbc.password=
-                -Dqservuser.jdbc.driverClassName=com.mysql.cj.jdbc.Driver
-                -Dqservuser.jdbc.url=jdbc:mysql://{{ .Values.pg.host }}/
-                -Dqservuser.maxActive=100
-                -Dtapuser.jdbc.username=TAP_SCHEMA
-                -Dtapuser.jdbc.password=TAP_SCHEMA
-                -Dtapuser.jdbc.driverClassName=com.mysql.cj.jdbc.Driver
-                -Dtapuser.jdbc.url=jdbc:mysql://{{ .Values.config.tapSchemaAddress }}/
+                -Dtap.username=tapuser
+                -Dtap.password=pw-tapuser
+                -Dtap.url=jdbc:mysql://{{ .Values.pg.host }}/
                 -Dtap.maxActive=100
                 -Duws.maxActive=100
                 -Dca.nrc.cadc.reg.client.RegistryClient.local=true


### PR DESCRIPTION
This part is unlike the lsst-tap-service, and I'll have to do additional work to connect to the tap-schema as well as the normal database.  Let's just try to use the mock pg database which should hopefully have a tap schema setup to start.