### PR TITLE
DM-38279: Redo how nublado configures JupyterHub

### DIFF
--- a/applications/nublado/README.md
+++ b/applications/nublado/README.md
@@ -46,10 +46,6 @@ JupyterHub and custom spawner for the Rubin Science Platform
 | jupyterhub.cull.users | bool | `true` |  |
 | jupyterhub.hub.authenticatePrometheus | bool | `false` |  |
 | jupyterhub.hub.baseUrl | string | `"/nb"` |  |
-| jupyterhub.hub.config.Authenticator.enable_auth_state | bool | `true` |  |
-| jupyterhub.hub.config.JupyterHub.authenticator_class | string | `"rsp_restspawner.auth.GafaelfawrAuthenticator"` |  |
-| jupyterhub.hub.config.JupyterHub.spawner_class | string | `"rsp_restspawner.RSPRestSpawner"` |  |
-| jupyterhub.hub.config.ServerApp.shutdown_no_activity_timeout | int | `604800` |  |
 | jupyterhub.hub.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
 | jupyterhub.hub.containerSecurityContext.runAsGroup | int | `768` |  |
 | jupyterhub.hub.containerSecurityContext.runAsUser | int | `768` |  |

--- a/applications/nublado/README.md
+++ b/applications/nublado/README.md
@@ -59,16 +59,10 @@ JupyterHub and custom spawner for the Rubin Science Platform
 | jupyterhub.hub.existingSecret | string | `"nublado-secret"` |  |
 | jupyterhub.hub.extraEnv.JUPYTERHUB_CRYPT_KEY.valueFrom.secretKeyRef.key | string | `"hub.config.CryptKeeper.keys"` |  |
 | jupyterhub.hub.extraEnv.JUPYTERHUB_CRYPT_KEY.valueFrom.secretKeyRef.name | string | `"nublado-secret"` |  |
-| jupyterhub.hub.extraFiles."00_hub.py".mountPath | string | `"/usr/local/etc/jupyterhub/jupyterhub_config.d/00_hub.py"` |  |
-| jupyterhub.hub.extraFiles."00_hub.py".stringData | string | `"import rsp_restspawner\ncfg_obj=rsp_restspawner.util.get_config()\n# Turn off concurrent spawn limit\nc.JupyterHub.concurrent_spawn_limit = 0\n# Set internal Hub API URL\nc.JupyterHub.hub_connect_url = (\n  \"http://hub.\" +\n  cfg_obj[\"Release\"][\"Namespace\"] +\n  \":\" +\n  f\"{os.environ['HUB_SERVICE_PORT']}\"\n)\n"` |  |
-| jupyterhub.hub.extraFiles."01_spawner.py".mountPath | string | `"/usr/local/etc/jupyterhub/jupyterhub_config.d/01_spawner.py"` |  |
-| jupyterhub.hub.extraFiles."01_spawner.py".stringData | string | `"# Turn off restart after n consecutive failures\nc.Spawner.consecutive_failure_limit = 0\n# Use JupyterLab by default\nc.Spawner.default_url = \"/lab\"\nc.Spawner.start_timeout = 10 * 60  # 10 minutes\nc.Spawner.http_timeout = 10 * 60   # For debug mode and slow disks\n"` |  |
-| jupyterhub.hub.extraVolumeMounts[0].mountPath | string | `"/etc/jupyterhub/nublado_config.yaml"` |  |
+| jupyterhub.hub.extraVolumeMounts[0].mountPath | string | `"/usr/local/etc/jupyterhub/jupyterhub_config.d"` |  |
 | jupyterhub.hub.extraVolumeMounts[0].name | string | `"nublado-config"` |  |
-| jupyterhub.hub.extraVolumeMounts[0].subPath | string | `"nublado_config.yaml"` |  |
-| jupyterhub.hub.extraVolumeMounts[1].mountPath | string | `"/etc/secret/admin-token"` |  |
+| jupyterhub.hub.extraVolumeMounts[1].mountPath | string | `"/etc/gafaelfawr"` |  |
 | jupyterhub.hub.extraVolumeMounts[1].name | string | `"nublado-gafaelfawr"` |  |
-| jupyterhub.hub.extraVolumeMounts[1].subPath | string | `"token"` |  |
 | jupyterhub.hub.extraVolumes[0].configMap.name | string | `"nublado-config"` |  |
 | jupyterhub.hub.extraVolumes[0].name | string | `"nublado-config"` |  |
 | jupyterhub.hub.extraVolumes[1].name | string | `"nublado-gafaelfawr"` |  |

--- a/applications/nublado/templates/configmap.yaml
+++ b/applications/nublado/templates/configmap.yaml
@@ -5,6 +5,25 @@ metadata:
   labels:
     {{- include "nublado.labels" . | nindent 4 }}
 data:
-  config.yaml: |-
-  {{- toYaml .Values.controller | nindent 4 }}
+  00_nublado.py: |
+    # Turn off concurrent spawn limit
+    c.JupyterHub.concurrent_spawn_limit = 0
 
+    # Set internal Hub API URL
+    c.JupyterHub.hub_connect_url = (
+        "http://hub.{{ .Release.Namespace }}:"
+        + str(os.environ["HUB_SERVICE_PORT"])
+    )
+
+    # Turn off restart after n consecutive failures
+    c.Spawner.consecutive_failure_limit = 0
+
+    # Use JupyterLab by default
+    c.Spawner.default_url = "/lab"
+
+    # Allow ten minutes for the lab to spawn in case it needs to be pulled
+    c.Spawner.start_timeout = 10 * 60
+    c.Spawner.http_timeout = 10 * 60
+
+    # Configure the URL to the lab controller.
+    c.RSPRestSpawner.controller_url = "{{ .Values.global.baseUrl }}/{{ .Values.controller.safir.rootEndpoint }}"

--- a/applications/nublado/templates/configmap.yaml
+++ b/applications/nublado/templates/configmap.yaml
@@ -6,24 +6,32 @@ metadata:
     {{- include "nublado.labels" . | nindent 4 }}
 data:
   00_nublado.py: |
-    # Turn off concurrent spawn limit
-    c.JupyterHub.concurrent_spawn_limit = 0
+    import rsp_restspawner
 
-    # Set internal Hub API URL
+    # Use our authenticator and spawner.
+    c.JupyterHub.authenticator_class: "rsp_restspawner.GafaelfawrAuthenticator"
+    c.JupyterHub.spawner_class: "rsp_restspawner.RSPRestSpawner"
+
+    # Set internal Hub API URL.
     c.JupyterHub.hub_connect_url = (
         "http://hub.{{ .Release.Namespace }}:"
         + str(os.environ["HUB_SERVICE_PORT"])
     )
 
-    # Turn off restart after n consecutive failures
+    # Turn off concurrent spawn limit.
+    c.JupyterHub.concurrent_spawn_limit = 0
+
+    # Enable stored auth state.
+    c.Authenticator.enable_auth_statue = True
+
+    # Turn off restart after n consecutive failures.
     c.Spawner.consecutive_failure_limit = 0
 
-    # Use JupyterLab by default
+    # Use JupyterLab by default.
     c.Spawner.default_url = "/lab"
 
-    # Allow ten minutes for the lab to spawn in case it needs to be pulled
+    # Allow ten minutes for the lab to spawn in case it needs to be pulled.
     c.Spawner.start_timeout = 10 * 60
-    c.Spawner.http_timeout = 10 * 60
 
     # Configure the URL to the lab controller.
     c.RSPRestSpawner.controller_url = "{{ .Values.global.baseUrl }}/{{ .Values.controller.safir.rootEndpoint }}"

--- a/applications/nublado/values-idfdev.yaml
+++ b/applications/nublado/values-idfdev.yaml
@@ -1,3 +1,11 @@
+image:
+  tag: "tickets-DM-38279-queue"
+  pullPolicy: "Always"
+jupyterhub:
+  hub:
+    image:
+      tag: "tickets-DM-38279-queue"
+      pullPolicy: "Always"
 controller:
   lab:
     volumes:

--- a/applications/nublado/values.yaml
+++ b/applications/nublado/values.yaml
@@ -101,18 +101,18 @@ controller:
     #     mode: rw
     # -- Volumes defined to user lab pods
     volumes:
-    - containerPath: /home
-      serverPath: /share1/home
-      server: 10.13.105.122
-      mode: rw
-    - containerPath: /project
-      serverPath: /share1/project
-      server: 10.13.105.122
-      mode: ro
-    - containerPath: /scratch
-      serverPath: /share1/scratch
-      server: 10.13.105.122
-      mode: rw
+      - containerPath: /home
+        serverPath: /share1/home
+        server: 10.13.105.122
+        mode: rw
+      - containerPath: /project
+        serverPath: /share1/project
+        server: 10.13.105.122
+        mode: ro
+      - containerPath: /scratch
+        serverPath: /share1/scratch
+        server: 10.13.105.122
+        mode: rw
     # -- Environment variables for user lab pods, common to all lab pods
     # in this RSP instance.
     env:
@@ -292,44 +292,18 @@ jupyterhub:
           secretKeyRef:
             name: "nublado-secret"
             key: "hub.config.CryptKeeper.keys"
-    extraFiles:
-      00_hub.py:
-        mountPath: /usr/local/etc/jupyterhub/jupyterhub_config.d/00_hub.py
-        stringData: |
-          import rsp_restspawner
-          cfg_obj=rsp_restspawner.util.get_config()
-          # Turn off concurrent spawn limit
-          c.JupyterHub.concurrent_spawn_limit = 0
-          # Set internal Hub API URL
-          c.JupyterHub.hub_connect_url = (
-            "http://hub." +
-            cfg_obj["Release"]["Namespace"] +
-            ":" +
-            f"{os.environ['HUB_SERVICE_PORT']}"
-          )
-      01_spawner.py:
-        mountPath: /usr/local/etc/jupyterhub/jupyterhub_config.d/01_spawner.py
-        stringData: |
-          # Turn off restart after n consecutive failures
-          c.Spawner.consecutive_failure_limit = 0
-          # Use JupyterLab by default
-          c.Spawner.default_url = "/lab"
-          c.Spawner.start_timeout = 10 * 60  # 10 minutes
-          c.Spawner.http_timeout = 10 * 60   # For debug mode and slow disks
     extraVolumes:
-    - name: nublado-config
-      configMap:
-        name: nublado-config
-    - name: nublado-gafaelfawr
-      secret:
-        secretName: gafaelfawr-token
+      - name: nublado-config
+        configMap:
+          name: nublado-config
+      - name: nublado-gafaelfawr
+        secret:
+          secretName: gafaelfawr-token
     extraVolumeMounts:
-    - name: nublado-config
-      mountPath: /etc/jupyterhub/nublado_config.yaml
-      subPath: nublado_config.yaml
-    - name: nublado-gafaelfawr
-      mountPath: /etc/secret/admin-token
-      subPath: token
+      - name: nublado-config
+        mountPath: /usr/local/etc/jupyterhub/jupyterhub_config.d
+      - name: nublado-gafaelfawr
+        mountPath: /etc/gafaelfawr
     # We still have to use our own, enabled at the top level, which is
     #  similar but not identical.  This one still doesn't work, even if
     #  you explicitly enable port 8081 so the labs can talk to the Hub.
@@ -389,7 +363,7 @@ jupyterhub:
     maxAge: 5184000  # 60 days -- shorten later
 
   imagePullSecrets:  # This is probably irrelevant with the RESTSpawner
-  - name: pull-secret
+    - name: pull-secret
 
   scheduling:
     userScheduler:

--- a/applications/nublado/values.yaml
+++ b/applications/nublado/values.yaml
@@ -263,14 +263,6 @@ jupyterhub:
       limits:
         cpu: 900m
         memory: 1Gi  # Should support about 200 users
-    config:
-      Authenticator:
-        enable_auth_state: true
-      JupyterHub:
-        authenticator_class: rsp_restspawner.auth.GafaelfawrAuthenticator
-        spawner_class: rsp_restspawner.RSPRestSpawner
-      ServerApp:
-        shutdown_no_activity_timeout: 604800  # one week
     db:
       # Password comes from the nublado-secret.
       type: "postgres"

--- a/environments/templates/nublado2-application.yaml
+++ b/environments/templates/nublado2-application.yaml
@@ -28,15 +28,10 @@ spec:
         - "values.yaml"
         - "values-{{ .Values.environment }}.yaml"
       parameters:
-        - name: "global.host"
-          value: {{ .Values.fqdn | quote }}
-        - name: "global.baseUrl"
-          value: "https://{{ .Values.fqdn }}"
         - name: "global.vaultSecretsPath"
           value: {{ .Values.vaultPathPrefix | quote }}
   ignoreDifferences:
-    - group: ""
-      kind: "Secret"
+    - kind: "Secret"
       jsonPointers:
         - "/data/hub.config.ConfigurableHTTPProxy.auth_token"
         - "/data/hub.config.CryptKeeper.keys"


### PR DESCRIPTION
Rather than injecting static files into JupyterHub as secrets, construct all of our configuration in a ConfigMap and then mount that into /usr/local/etc/jupyterhub/jupyterhub_config.d. Use that configuration to set the new parameters for RSPRestSpawner. We now no longer need a separate Nublado configuration file or all the parsing code and are uniformly using traitlets.

Mount the Gafaelfawr token for JupyterHub on /etc/gafaelfawr without a subpath so that hopefully we now get dynamic token updates.

Pin the images for IDF dev to my current patch queue branches.

Fix the indentation for YAML lists in the nublado values.yaml to be consistent with the rest of Phalanx.