### PR TITLE
DM-38279: Restore config.yaml for the lab controller

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: check-toml
 
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.29.0
+    rev: v1.30.0
     hooks:
       - id: yamllint
         args:
@@ -29,7 +29,7 @@ repos:
           - toml
 
   - repo: https://github.com/psf/black
-    rev: 23.1a1
+    rev: 23.1.0
     hooks:
       - id: black
 
@@ -37,7 +37,7 @@ repos:
     rev: 1.13.0
     hooks:
       - id: blacken-docs
-        additional_dependencies: [black==23.1a1]
+        additional_dependencies: [black==23.1.0]
 
   - repo: https://github.com/PyCQA/flake8
     rev: 6.0.0

--- a/applications/nublado/templates/configmap.yaml
+++ b/applications/nublado/templates/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "nublado.fullname" . }}-config
+  name: nublado-config
   labels:
     {{- include "nublado.labels" . | nindent 4 }}
 data:
@@ -35,3 +35,5 @@ data:
 
     # Configure the URL to the lab controller.
     c.RSPRestSpawner.controller_url = "{{ .Values.global.baseUrl }}/{{ .Values.controller.safir.rootEndpoint }}"
+  config.yaml: |-
+    {{- toYaml .Values.controller | nindent 4 }}


### PR DESCRIPTION
JupyterHub no longer uses this file, but we still need it for the lab controller, for which it is the primary configuration file.