### PR TITLE
DM-38445: Update noteburst

### DIFF
--- a/applications/noteburst/Chart.yaml
+++ b/applications/noteburst/Chart.yaml
@@ -19,7 +19,7 @@ dependencies:
 annotations:
   phalanx.lsst.io/docs: |
     - id: "SQR-065"
-      title: "Design of Noteburst, a programatic JupyterLab notebook execution service for the Rubin Science Platform"
+      title: "Design of Noteburst, a programmatic JupyterLab notebook execution service for the Rubin Science Platform"
       url: "https://sqr-065.lsst.io/"
     - id: "SQR-062"
       title: "The Times Square service for publishing parameterized Jupyter Notebooks in the Rubin Science platform"

--- a/applications/noteburst/Chart.yaml
+++ b/applications/noteburst/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: noteburst
 version: 1.0.0
-appVersion: "0.6.0"
+appVersion: "0.6.1"
 description: Noteburst is a notebook execution service for the Rubin Science Platform.
 type: application
 home: https://noteburst.lsst.io/

--- a/applications/noteburst/values-idfdev.yaml
+++ b/applications/noteburst/values-idfdev.yaml
@@ -4,7 +4,7 @@ image:
 config:
   logLevel: "DEBUG"
   worker:
-    workerCount: 1
+    workerCount: 0
     identities:
       - username: "bot-noteburst90000"
       - username: "bot-noteburst90001"

--- a/applications/noteburst/values-idfdev.yaml
+++ b/applications/noteburst/values-idfdev.yaml
@@ -1,6 +1,5 @@
-# image:
-#   pullPolicy: Always
-#   tag: tickets-DM-37857
+image:
+  pullPolicy: Always
 
 config:
   logLevel: "DEBUG"


### PR DESCRIPTION
This 0.7.0 release of noteburst improves compatibility with the JupyterLab Controller.