### PR TITLE
Strimzi operator is crashing at usdf

### DIFF
--- a/applications/strimzi/values-usdfdev.yaml
+++ b/applications/strimzi/values-usdfdev.yaml
@@ -1,4 +1,9 @@
 strimzi-kafka-operator:
+  resources:
+    limits:
+      memory: "1Gi"
+    requests:
+      memory: "512Mi"
   watchNamespaces:
     - "sasquatch"
   logLevel: "DEBUG"

--- a/applications/strimzi/values-usdfprod.yaml
+++ b/applications/strimzi/values-usdfprod.yaml
@@ -1,4 +1,9 @@
 strimzi-kafka-operator:
+  resources:
+    limits:
+      memory: "1Gi"
+    requests:
+      memory: "512Mi"
   watchNamespaces:
     - "sasquatch"
   logLevel: "INFO"


### PR DESCRIPTION
- Getting `Terminating due to java.lang.OutOfMemoryError: Java heap space` on the strimzi operator pod