### PR TITLE
DM-38488: Fix vault secrets path for semaphore

### DIFF
--- a/applications/semaphore/templates/vaultsecret.yaml
+++ b/applications/semaphore/templates/vaultsecret.yaml
@@ -5,5 +5,5 @@ metadata:
   labels:
     {{- include "semaphore.labels" . | nindent 4 }}
 spec:
-  path: "{{ .Values.global.vaultSecretsPathPrefix }}/noteburst"
+  path: "{{ .Values.global.vaultSecretsPathPrefix }}/semaphore"
   type: Opaque


### PR DESCRIPTION
This error was introduced in a chart migration. It likely didn't trigger an error because the secret was pre-existing in all environments, however the VaultSecret resource does show a FetchFailed error.