### PR TITLE
DM-38466: Bind nublado-controller to a Google service account

### DIFF
--- a/applications/nublado/README.md
+++ b/applications/nublado/README.md
@@ -30,6 +30,7 @@ JupyterHub and custom spawner for the Rubin Science Platform
 | controller.config.lab.volumes | object | `{}` | Volumes that should be mounted in lab pods. Currently this only supports NFS volumes and must specify `containerPath`, `server`, `serverPath`, and `mode` where mode is one of `ro` or `rw`. |
 | controller.config.safir.logLevel | string | `"INFO"` | Level of Python logging |
 | controller.config.safir.pathPrefix | string | `"/nublado"` | Path prefix that will be routed to the controller |
+| controller.googleServiceAccount | string | None, must be set when using Google Artifact Registry | If Google Artifact Registry is used as the image source, the Google service account that has an IAM binding to the `nublado-controller` Kubernetes service account and has the Artifact Registry reader role |
 | controller.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the nublado image |
 | controller.image.repository | string | `"ghcr.io/lsst-sqre/jupyterlab-controller"` | nublado image to use |
 | controller.image.tag | string | The appVersion of the chart | Tag of nublado image to use |

--- a/applications/nublado/templates/controller-serviceaccount.yaml
+++ b/applications/nublado/templates/controller-serviceaccount.yaml
@@ -2,6 +2,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: "nublado-controller"
+  {{- if .Values.controller.googleServiceAccount }}
+  annotations:
+    iam.gke.io/gcp-service-account: {{ .Values.controller.googleServiceAccount | quote }}
+  {{- end }}
   labels:
     {{- include "nublado.labels" . | nindent 4 }}
 ---

--- a/applications/nublado/values-idfdev.yaml
+++ b/applications/nublado/values-idfdev.yaml
@@ -2,6 +2,7 @@ controller:
   image:
     tag: "tickets-DM-38279-queue"
     pullPolicy: "Always"
+  googleServiceAccount: "nublado-controller@science-platform-dev-7696.iam.gserviceaccount.com"
   config:
     images:
       source:

--- a/applications/nublado/values.yaml
+++ b/applications/nublado/values.yaml
@@ -31,6 +31,12 @@ controller:
     # -- Additional annotations to add for the lab controller pod ingress
     annotations: {}
 
+  # -- If Google Artifact Registry is used as the image source, the Google
+  # service account that has an IAM binding to the `nublado-controller`
+  # Kubernetes service account and has the Artifact Registry reader role
+  # @default -- None, must be set when using Google Artifact Registry
+  googleServiceAccount: ""
+
   config:
     images:
       # -- Source for prepulled images. For Docker, set `type` to `docker`,


### PR DESCRIPTION
This is required to be able to access the Google Artifact Registry.