### PR TITLE
DM-38554: Remove NO_SUDO from notebook environment

### DIFF
--- a/applications/nublado/values.yaml
+++ b/applications/nublado/values.yaml
@@ -85,7 +85,6 @@ controller:
         FIREFLY_ROUTE: /portal/app
         HUB_ROUTE: /nb/hub
         NO_ACTIVITY_TIMEOUT: "432000"  # Also from group?
-        NO_SUDO: "TRUE"
         S3_ENDPOINT_URL: "https://storage.googleapis.com"
         TAP_ROUTE: /api/tap
 


### PR DESCRIPTION
This was only required for very old images that now are unlikely to work for other reasons.