### PR TITLE
DM-38554: Move auto-repo and Butler out of Nublado values.yaml

### DIFF
--- a/applications/nublado/values-idfdev.yaml
+++ b/applications/nublado/values-idfdev.yaml
@@ -16,6 +16,10 @@ controller:
       numWeeklies: 2
       numDailies: 3
     lab:
+      env:
+        AUTO_REPO_SPECS: "https://github.com/lsst-sqre/system-test@prod,https://github.com/rubin-dp0/tutorial-notebooks@prod"
+        DAF_BUTLER_REPOSITORY_INDEX: "s3://butler-us-central1-repo-locations/data-repos.yaml"
+        S3_ENDPOINT_URL: "https://storage.googleapis.com"
       initContainers:
         - name: "initdir"
           image: "ghcr.io/lsst-sqre/initdir:0.0.3"

--- a/applications/nublado/values.yaml
+++ b/applications/nublado/values.yaml
@@ -76,17 +76,15 @@ controller:
       # -- Environment variables to set for every user lab.
       # @default -- See `values.yaml`
       env:
-        API_ROUTE: /api
-        AUTO_REPO_SPECS: "https://github.com/lsst-sqre/system-test@prod,https://github.com/rubin-dp0/tutorial-notebooks@prod"
+        API_ROUTE: "/api"
+        AUTO_REPO_SPECS: "https://github.com/lsst-sqre/system-test@prod"
         CULL_KERNEL_IDLE_TIMEOUT: "432000"  # These might be set from group?
         CULL_KERNEL_CONNECTED: "True"
         CULL_KERNEL_INTERVAL: "300"
-        DAF_BUTLER_REPOSITORY_INDEX: "s3://butler-us-central1-repo-locations/data-repos.yaml"
-        FIREFLY_ROUTE: /portal/app
-        HUB_ROUTE: /nb/hub
+        FIREFLY_ROUTE: "/portal/app"
+        HUB_ROUTE: "/nb/hub"
         NO_ACTIVITY_TIMEOUT: "432000"  # Also from group?
-        S3_ENDPOINT_URL: "https://storage.googleapis.com"
-        TAP_ROUTE: /api/tap
+        TAP_ROUTE: "/api/tap"
 
       # -- Containers run as init containers with each user pod. Each should
       # set `name`, `image` (a Docker image reference), and `privileged`, and


### PR DESCRIPTION
Don't pull the tutorial notebooks on every instance by default since they only work at the IDF (and maybe the USDF). Instead, set that in values-idfdev.yaml.

Pull the Butler configuration environment variables that are specific to the IDF out of values.yaml and into values-idfdev.yaml.