### PR TITLE
DM-38654: Add new write:sasquatch scope

### DIFF
--- a/applications/gafaelfawr/values-base.yaml
+++ b/applications/gafaelfawr/values-base.yaml
@@ -88,6 +88,10 @@ config:
       - github:
           organization: "rubin-summit"
           team: "rsp-access"
+    "write:sasquatch":
+      - github:
+          organization: "lsst-sqre"
+          team: "square"
 
   initialAdmins:
     - "afausti"

--- a/applications/gafaelfawr/values-idfdev.yaml
+++ b/applications/gafaelfawr/values-idfdev.yaml
@@ -54,6 +54,8 @@ config:
       - "g_users"
     "read:tap":
       - "g_users"
+    "write:sasquatch":
+      - "g_admins"
 
   initialAdmins:
     - "adam"

--- a/applications/gafaelfawr/values-idfint.yaml
+++ b/applications/gafaelfawr/values-idfint.yaml
@@ -57,6 +57,8 @@ config:
       - "g_users"
     "read:tap":
       - "g_users"
+    "write:sasquatch":
+      - "g_admins"
 
   initialAdmins:
     - "adam"

--- a/applications/gafaelfawr/values-summit.yaml
+++ b/applications/gafaelfawr/values-summit.yaml
@@ -89,6 +89,10 @@ config:
       - github:
           organization: "rubin-summit"
           team: "rsp-access"
+    "write:sasquatch":
+      - github:
+          organization: "lsst-sqre"
+          team: "square"
 
   initialAdmins:
     - "afausti"

--- a/applications/gafaelfawr/values-tucson-teststand.yaml
+++ b/applications/gafaelfawr/values-tucson-teststand.yaml
@@ -19,12 +19,10 @@ config:
       - github:
           organization: "lsst-sqre"
           team: "square"
-      - "lsst-sqre-square"
     "exec:admin":
       - github:
           organization: "lsst-sqre"
           team: "square"
-      - "lsst-sqre-square"
     "exec:internal-tools":
       - github:
           organization: "lsst-sqre"
@@ -97,6 +95,10 @@ config:
       - github:
           organization: "rubin-summit"
           team: "rsp-access"
+    "write:sasquatch":
+      - github:
+          organization: "lsst-sqre"
+          team: "square"
 
   initialAdmins:
     - "afausti"

--- a/applications/gafaelfawr/values-usdfdev.yaml
+++ b/applications/gafaelfawr/values-usdfdev.yaml
@@ -36,7 +36,6 @@ config:
     gidAttr: gidNumber
     nameAttr: gecos
 
-
   groupMapping:
     "admin:token":
     - "rubinmgr"
@@ -208,6 +207,9 @@ config:
     - rubin_users-z
     - rubin_admin_datasets
     - rubin_admin_repos
+    - "unix-admin"
+    "write:sasquatch":
+    - "rubinmgr"
     - "unix-admin"
 
   initialAdmins:

--- a/applications/gafaelfawr/values-usdfprod.yaml
+++ b/applications/gafaelfawr/values-usdfprod.yaml
@@ -211,6 +211,9 @@ config:
     - rubin_admin_datasets
     - rubin_admin_repos
     - "unix-admin"
+    "write:sasquatch":
+    - "rubinmgr"
+    - "unix-admin"
 
   initialAdmins:
   - "afausti"

--- a/applications/gafaelfawr/values.yaml
+++ b/applications/gafaelfawr/values.yaml
@@ -259,6 +259,8 @@ config:
       Retrieve images from project datasets
     "read:tap": >-
       Execute SELECT queries in the TAP interface on project datasets
+    "write:sasquatch": >-
+      "Write access to the Sasquatch telemetry service"
     "user:token": >-
       Can create and modify user tokens
 


### PR DESCRIPTION
Add a new distinguished scope for write access to the telemetry service, since we will eventually want to create service tokens that have access only to that service. For now, add that scope only in the environments that deploy Sasquatch and only for administrators.