### PR TITLE
DM-38650: Deploy Times Square 0.7.0 Update

### DIFF
--- a/applications/times-square/Chart.yaml
+++ b/applications/times-square/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 type: application
 
 # The default version tag of the times-square docker image
-appVersion: "0.6.0"
+appVersion: "0.7.0"
 
 dependencies:
   - name: redis

--- a/applications/times-square/templates/deployment.yaml
+++ b/applications/times-square/templates/deployment.yaml
@@ -4,6 +4,8 @@ metadata:
   name: {{ include "times-square.fullname" . }}
   labels:
     {{- include "times-square.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
+    app.kubernetes.io/part-of: "times-square"
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount.api }}
@@ -21,6 +23,8 @@ spec:
       labels:
         {{- include "times-square.selectorLabels" . | nindent 8 }}
         times-square-redis-client: "true"
+        app.kubernetes.io/component: "server"
+        app.kubernetes.io/part-of: "times-square"
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/applications/times-square/templates/worker-deployment.yaml
+++ b/applications/times-square/templates/worker-deployment.yaml
@@ -4,6 +4,8 @@ metadata:
   name: {{ include "times-square.fullname" . }}-worker
   labels:
     {{- include "times-square.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "worker"
+    app.kubernetes.io/part-of: "times-square"
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount.worker }}
@@ -21,6 +23,8 @@ spec:
       labels:
         {{- include "times-square.selectorLabels" . | nindent 8 }}
         times-square-redis-client: "true"
+        app.kubernetes.io/component: "worker"
+        app.kubernetes.io/part-of: "times-square"
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
This version updates Times Square to use safir.redis and safir.github.