### PR TITLE
DM-38554: Add Slack alerting support to Nublado

### DIFF
--- a/applications/nublado/README.md
+++ b/applications/nublado/README.md
@@ -38,6 +38,7 @@ JupyterHub and custom spawner for the Rubin Science Platform
 | controller.nodeSelector | object | `{}` | Node selector rules for the lab controller pod |
 | controller.podAnnotations | object | `{}` | Annotations for the lab controller pod |
 | controller.resources | object | `{}` | Resource limits and requests for the lab controller pod |
+| controller.slackAlerts | bool | `false` | Whether to enable Slack alerts. If set to true, `slack_webhook` must be set in the corresponding Nublado Vault secret. |
 | controller.tolerations | list | `[]` | Tolerations for the lab controller pod |
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |

--- a/applications/nublado/templates/controller-deployment.yaml
+++ b/applications/nublado/templates/controller-deployment.yaml
@@ -41,6 +41,13 @@ spec:
               value: "pull-secret"
             - name: EXTERNAL_INSTANCE_URL
               value: {{ .Values.global.baseUrl | quote }}
+            {{- if .Values.controller.slackAlerts }}
+            - name: "NUBLADO_SLACK_WEBHOOK"
+              valueFrom:
+                secretKeyRef:
+                  name: "nublado-secret"
+                  key: "slack-webhook"
+            {{- end }}
           ports:
             - name: "http"
               containerPort: 8080

--- a/applications/nublado/templates/vault-secrets.yaml
+++ b/applications/nublado/templates/vault-secrets.yaml
@@ -21,6 +21,9 @@ spec:
     hub.config.JupyterHub.cookie_secret: "{% .Secrets.crypto_key %}"
     hub.config.CryptKeeper.keys: "{% .Secrets.cryptkeeper_key %}"
     hub.config.ConfigurableHTTPProxy.auth_token: "{% .Secrets.proxy_token %}"
+    {{- if .Values.controller.slackAlerts }}
+    slack-webhook: "{% .Secrets.slack_webhook %}"
+    {{- end }}
 ---
 apiVersion: ricoberger.de/v1alpha1
 kind: VaultSecret

--- a/applications/nublado/values-idfdev.yaml
+++ b/applications/nublado/values-idfdev.yaml
@@ -3,6 +3,7 @@ controller:
     tag: "tickets-DM-38279-queue"
     pullPolicy: "Always"
   googleServiceAccount: "nublado-controller@science-platform-dev-7696.iam.gserviceaccount.com"
+  slackAlerts: true
   config:
     images:
       source:

--- a/applications/nublado/values.yaml
+++ b/applications/nublado/values.yaml
@@ -37,6 +37,11 @@ controller:
   # @default -- None, must be set when using Google Artifact Registry
   googleServiceAccount: ""
 
+  # -- Whether to enable Slack alerts. If set to true, `slack_webhook` must be
+  # set in the corresponding Nublado Vault secret.
+  slackAlerts: false
+
+  # Passed as YAML to the lab controller.
   config:
     images:
       # -- Source for prepulled images. For Docker, set `type` to `docker`,

--- a/installer/generate_secrets.py
+++ b/installer/generate_secrets.py
@@ -47,6 +47,7 @@ class SecretGenerator:
         self._argo_sso_secret()
         self._postgres()
         self._tap()
+        self._nublado()
         self._nublado2()
         self._mobu()
         self._gafaelfawr()
@@ -157,6 +158,21 @@ class SecretGenerator:
         self._set_generated(
             "postgres", "narrativelog_password", secrets.token_hex(32)
         )
+
+    def _nublado(self):
+        self._set_generated("nublado", "crypto_key", secrets.token_hex(32))
+        self._set_generated("nublado", "proxy_token", secrets.token_hex(32))
+        self._set_generated(
+            "nublado", "cryptkeeper_key", secrets.token_hex(32)
+        )
+
+        # Pluck the password out of the postgres portion.
+        db_password = self.secrets["postgres"]["jupyterhub_password"]
+        self.secrets["nublado"]["hub_db_password"] = db_password
+
+        slack_webhook = self._get_current("rsp-alerts", "slack-webhook")
+        if slack_webhook:
+            self._set("nublado", "slack_webhook", slack_webhook)
 
     def _nublado2(self):
         crypto_key = secrets.token_hex(32)


### PR DESCRIPTION
Add the Slack webhook to the secret for the new Nublado and inject it into the lab controller pod if Slack alerting is enabled. Enable Slack alerting on IDF dev.