### PR TITLE
DM-38554: Bump versions of Nublado images

### DIFF
--- a/applications/nublado/Chart.yaml
+++ b/applications/nublado/Chart.yaml
@@ -6,7 +6,7 @@ sources:
   - https://github.com/lsst-sqre/jupyterlab-controller
   - https://github.com/lsst-sqre/rsp-restspawner
 home: https://github.com/lsst-sqre/jupyterlab-controller
-appVersion: 0.1.1
+appVersion: 0.2.0
 
 dependencies:
   - name: jupyterhub

--- a/applications/nublado/README.md
+++ b/applications/nublado/README.md
@@ -69,7 +69,7 @@ JupyterHub and custom spawner for the Rubin Science Platform
 | jupyterhub.hub.extraVolumes[1].name | string | `"hub-gafaelfawr-token"` |  |
 | jupyterhub.hub.extraVolumes[1].secret.secretName | string | `"hub-gafaelfawr-token"` |  |
 | jupyterhub.hub.image.name | string | `"ghcr.io/lsst-sqre/rsp-restspawner"` |  |
-| jupyterhub.hub.image.tag | string | `"0.1.2"` |  |
+| jupyterhub.hub.image.tag | string | `"0.2.0"` |  |
 | jupyterhub.hub.loadRoles.self.scopes[0] | string | `"admin:servers!user"` |  |
 | jupyterhub.hub.loadRoles.self.scopes[1] | string | `"read:metrics"` |  |
 | jupyterhub.hub.loadRoles.server.scopes[0] | string | `"inherit"` |  |

--- a/applications/nublado/values.yaml
+++ b/applications/nublado/values.yaml
@@ -230,7 +230,7 @@ jupyterhub:
     authenticatePrometheus: false
     image:
       name: ghcr.io/lsst-sqre/rsp-restspawner
-      tag: 0.1.2
+      tag: 0.2.0
     resources:
       limits:
         cpu: 900m


### PR DESCRIPTION
Update the versions of the images used for Nublado v3 to the 0.2.0 release.