### PR TITLE
DM-38747: Add Kerberos GSSAPI bind support for Gafaelfawr

### DIFF
--- a/applications/gafaelfawr/README.md
+++ b/applications/gafaelfawr/README.md
@@ -47,11 +47,12 @@ Authentication and identity system
 | config.ldap.groupBaseDn | string | None, must be set | Base DN for the LDAP search to find a user's groups |
 | config.ldap.groupMemberAttr | string | `"member"` | Member attribute of the object class. Values must match the username returned in the token from the OpenID Connect authentication server. |
 | config.ldap.groupObjectClass | string | `"posixGroup"` | Object class containing group information |
+| config.ldap.kerberosConfig | string | Use anonymous binds | Enable GSSAPI (Kerberos) binds to LDAP using this `krb5.conf` file. If set, `ldap-keytab` must be set in the Gafaelfawr Vault secret. Set either this or `userDn`, not both. |
 | config.ldap.nameAttr | string | `"displayName"` | Attribute containing the user's full name |
 | config.ldap.uidAttr | string | Get UID from upstream authentication provider | Attribute containing the user's UID number (set to `uidNumber` for most LDAP servers) |
 | config.ldap.url | string | Do not use LDAP | LDAP server URL from which to retrieve user group information |
 | config.ldap.userBaseDn | string | Get user metadata from the upstream authentication provider | Base DN for the LDAP search to find a user's entry |
-| config.ldap.userDn | string | Use anonymous binds | Bind DN for simple bind authentication. If set, `ldap-secret` must be set in the Gafaelfawr secret |
+| config.ldap.userDn | string | Use anonymous binds | Bind DN for simple bind authentication. If set, `ldap-secret` must be set in the Gafaelfawr Vault secret. Set this or `kerberosConfig`, not both. |
 | config.ldap.userSearchAttr | string | `"uid"` | Search attribute containing the user's username |
 | config.loglevel | string | `"INFO"` | Choose from the text form of Python logging levels |
 | config.oidc.audience | string | Value of `config.oidc.clientId` | Audience for the JWT token |

--- a/applications/gafaelfawr/templates/configmap-kerberos.yaml
+++ b/applications/gafaelfawr/templates/configmap-kerberos.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.config.ldap.kerberosConfig }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "gafaelfawr.fullname" . }}-config-kerberos
+  labels:
+    {{- include "gafaelfawr.labels" . | nindent 4 }}
+data:
+  krb5.conf: {{ .Values.config.ldap.kerberosConfig | quote }}
+{{- end }}

--- a/applications/gafaelfawr/templates/configmap.yaml
+++ b/applications/gafaelfawr/templates/configmap.yaml
@@ -117,6 +117,9 @@
       userDn: {{ .Values.config.ldap.userDn | quote }}
       passwordFile: "/etc/gafaelfawr/secrets/ldap-password"
       {{- end }}
+      {{- if .Values.config.ldap.kerberosConfig }}
+      useKerberos: true
+      {{- end }}
       groupObjectClass: {{ .Values.config.ldap.groupObjectClass | quote }}
       groupMemberAttr: {{ .Values.config.ldap.groupMemberAttr | quote }}
       {{- if .Values.config.ldap.userBaseDn }}

--- a/applications/gafaelfawr/templates/cronjob-audit.yaml
+++ b/applications/gafaelfawr/templates/cronjob-audit.yaml
@@ -26,6 +26,12 @@ spec:
           containers:
             - name: "gafaelfawr"
               command:
+                {{- if .Values.config.ldap.kerberosConfig }}
+                - "k5start"
+                - "-aqUFf"
+                - "/etc/krb5.keytab"
+                - "--"
+                {{- end }}
                 - "gafaelfawr"
                 - "audit"
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -47,6 +53,18 @@ spec:
                 - name: "secret"
                   mountPath: "/etc/gafaelfawr/secrets"
                   readOnly: true
+                {{- if .Values.config.ldap.kerberosConfig }}
+                - name: "keytab"
+                  mountPath: "/etc/krb5.keytab"
+                  readOnly: true
+                  subPath: "ldap-keytab"
+                - name: "kerberos-config"
+                  mountPath: "/etc/krb5.conf"
+                  readOnly: true
+                  subPath: "krb5.conf"
+                - name: "tmp"
+                  mountPath: "/tmp"
+                {{- end }}
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
@@ -58,6 +76,16 @@ spec:
             - name: "secret"
               secret:
                 secretName: {{ template "gafaelfawr.fullname" . }}-secret
+            {{- if .Values.config.ldap.kerberosConfig }}
+            - name: "keytab"
+              secret:
+                secretName: {{ template "gafaelfawr.fullname" . }}-keytab
+            - name: "kerberos-config"
+              configMap:
+                name: {{ template "gafaelfawr.fullname" . }}-config-kerberos
+            - name: "tmp"
+              emptyDir: {}
+            {{- end }}
           {{- with .Values.maintenance.nodeSelector }}
           nodeSelector:
             {{- toYaml . | nindent 12 }}

--- a/applications/gafaelfawr/templates/cronjob-maintenance.yaml
+++ b/applications/gafaelfawr/templates/cronjob-maintenance.yaml
@@ -25,6 +25,12 @@ spec:
           containers:
             - name: "gafaelfawr"
               command:
+                {{- if .Values.config.ldap.kerberosConfig }}
+                - "k5start"
+                - "-aqUFf"
+                - "/etc/krb5.keytab"
+                - "--"
+                {{- end }}
                 - "gafaelfawr"
                 - "maintenance"
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -46,6 +52,18 @@ spec:
                 - name: "secret"
                   mountPath: "/etc/gafaelfawr/secrets"
                   readOnly: true
+                {{- if .Values.config.ldap.kerberosConfig }}
+                - name: "keytab"
+                  mountPath: "/etc/krb5.keytab"
+                  readOnly: true
+                  subPath: "ldap-keytab"
+                - name: "kerberos-config"
+                  mountPath: "/etc/krb5.conf"
+                  readOnly: true
+                  subPath: "krb5.conf"
+                - name: "tmp"
+                  mountPath: "/tmp"
+                {{- end }}
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
@@ -57,6 +75,16 @@ spec:
             - name: "secret"
               secret:
                 secretName: {{ template "gafaelfawr.fullname" . }}-secret
+            {{- if .Values.config.ldap.kerberosConfig }}
+            - name: "keytab"
+              secret:
+                secretName: {{ template "gafaelfawr.fullname" . }}-keytab
+            - name: "kerberos-config"
+              configMap:
+                name: {{ template "gafaelfawr.fullname" . }}-config-kerberos
+            - name: "tmp"
+              emptyDir: {}
+            {{- end }}
           {{- with .Values.maintenance.nodeSelector }}
           nodeSelector:
             {{- toYaml . | nindent 12 }}

--- a/applications/gafaelfawr/templates/deployment-operator.yaml
+++ b/applications/gafaelfawr/templates/deployment-operator.yaml
@@ -26,6 +26,12 @@ spec:
       containers:
         - name: "gafaelfawr"
           command:
+            {{- if .Values.config.ldap.kerberosConfig }}
+            - "k5start"
+            - "-aqUFf"
+            - "/etc/krb5.keytab"
+            - "--"
+            {{- end }}
             - "kopf"
             - "run"
             - "-A"
@@ -51,6 +57,18 @@ spec:
             - name: "secret"
               mountPath: "/etc/gafaelfawr/secrets"
               readOnly: true
+            {{- if .Values.config.ldap.kerberosConfig }}
+            - name: "keytab"
+              mountPath: "/etc/krb5.keytab"
+              readOnly: true
+              subPath: "ldap-keytab"
+            - name: "kerberos-config"
+              mountPath: "/etc/krb5.conf"
+              readOnly: true
+              subPath: "krb5.conf"
+            - name: "tmp"
+              mountPath: "/tmp"
+            {{- end }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
@@ -62,6 +80,16 @@ spec:
         - name: "secret"
           secret:
             secretName: {{ template "gafaelfawr.fullname" . }}-secret
+        {{- if .Values.config.ldap.kerberosConfig }}
+        - name: "keytab"
+          secret:
+            secretName: {{ template "gafaelfawr.fullname" . }}-keytab
+        - name: "kerberos-config"
+          configMap:
+            name: {{ template "gafaelfawr.fullname" . }}-config-kerberos
+        - name: "tmp"
+          emptyDir: {}
+        {{- end }}
       {{- with .Values.operator.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/applications/gafaelfawr/templates/deployment.yaml
+++ b/applications/gafaelfawr/templates/deployment.yaml
@@ -76,6 +76,18 @@ spec:
             - name: "secret"
               mountPath: "/etc/gafaelfawr/secrets"
               readOnly: true
+            {{- if .Values.config.ldap.kerberosConfig }}
+            - name: "keytab"
+              mountPath: "/etc/krb5.keytab"
+              readOnly: true
+              subPath: "ldap-keytab"
+            - name: "kerberos-config"
+              mountPath: "/etc/krb5.conf"
+              readOnly: true
+              subPath: "krb5.conf"
+            - name: "tmp"
+              mountPath: "/tmp"
+            {{- end }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
@@ -87,6 +99,16 @@ spec:
         - name: "secret"
           secret:
             secretName: {{ template "gafaelfawr.fullname" . }}-secret
+        {{- if .Values.config.ldap.kerberosConfig }}
+        - name: "keytab"
+          secret:
+            secretName: {{ template "gafaelfawr.fullname" . }}-keytab
+        - name: "kerberos-config"
+          configMap:
+            name: {{ template "gafaelfawr.fullname" . }}-config-kerberos
+        - name: "tmp"
+          emptyDir: {}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/applications/gafaelfawr/templates/vault-secrets.yaml
+++ b/applications/gafaelfawr/templates/vault-secrets.yaml
@@ -7,3 +7,18 @@ metadata:
 spec:
   path: "{{ .Values.global.vaultSecretsPath }}/gafaelfawr"
   type: Opaque
+---
+{{- if .Values.config.ldap.kerberosConfig }}
+apiVersion: ricoberger.de/v1alpha1
+kind: VaultSecret
+metadata:
+  name: {{ template "gafaelfawr.fullname" . }}-keytab
+  labels:
+    {{- include "gafaelfawr.labels" . | nindent 4 }}
+spec:
+  isBinary: true
+  keys:
+    - "ldap-keytab"
+  path: "{{ .Values.global.vaultSecretsPath }}/gafaelfawr"
+  type: Opaque
+{{- end }}

--- a/applications/gafaelfawr/values.yaml
+++ b/applications/gafaelfawr/values.yaml
@@ -160,9 +160,16 @@ config:
     url: ""
 
     # -- Bind DN for simple bind authentication. If set, `ldap-secret` must be
-    # set in the Gafaelfawr secret
+    # set in the Gafaelfawr Vault secret. Set this or `kerberosConfig`, not
+    # both.
     # @default -- Use anonymous binds
     userDn: ""
+
+    # -- Enable GSSAPI (Kerberos) binds to LDAP using this `krb5.conf` file.
+    # If set, `ldap-keytab` must be set in the Gafaelfawr Vault secret. Set
+    # either this or `userDn`, not both.
+    # @default -- Use anonymous binds
+    kerberosConfig: ""
 
     # -- Base DN for the LDAP search to find a user's groups
     # @default -- None, must be set


### PR DESCRIPTION
Add a new configuration option to set the Kerberos configuration for GSSAPI bind support. If set, create a separate secret for the keytab and mount it in all the containers, and run Gafaelfawr under k5start. Also mount the krb5.conf file and create a /tmp directory, since k5start needs a writable directory to use for ticket caches.