### PR TITLE
DM-38795: Add Butler secret to data-int

### DIFF
--- a/applications/nublado/values-idfint.yaml
+++ b/applications/nublado/values-idfint.yaml
@@ -16,6 +16,9 @@ controller:
     lab:
       env:
         AUTO_REPO_SPECS: "https://github.com/lsst-sqre/system-test@prod,https://github.com/rubin-dp0/tutorial-notebooks@prod"
+        AWS_SHARED_CREDENTIALS_FILE: "/opt/lsst/software/jupyterlab/secrets/aws-credentials.ini"
+        PGPASSFILE: "/opt/lsst/software/jupyterlab/secrets/postgres-credentials.txt"
+        GOOGLE_APPLICATION_CREDENTIALS: "/opt/lsst/software/jupyterlab/secrets/butler-gcs-idf-creds.json"
         DAF_BUTLER_REPOSITORY_INDEX: "s3://butler-us-central1-repo-locations/data-repos.yaml"
         S3_ENDPOINT_URL: "https://storage.googleapis.com"
         PANDA_AUTH: oidc
@@ -64,6 +67,15 @@ controller:
           serverPath: "/share1/scratch"
           server: "10.22.240.130"
           mode: "rw"
+      secrets:
+        - secretName: "nublado-secret"
+          secretKey: "aws-credentials.ini"
+        - secretName: "nublado-secret"
+          secretKey: "butler-gcs-idf-creds.json"
+        - secretName: "nublado-secret"
+          secretKey: "butler-hmac-idf-creds.json"
+        - secretName: "nublado-secret"
+          secretKey: "postgres-credentials.txt"
 
 jupyterhub:
   hub:


### PR DESCRIPTION
The new Nublado requires explicitly specifying the secrets to mount in the container and uses a different path by default. Adjust the IDF int configuration accordingly.