### PR TITLE
DM-38795: Add separate lab secret

### DIFF
--- a/applications/mobu/values-idfint.yaml
+++ b/applications/mobu/values-idfint.yaml
@@ -1,4 +1,5 @@
 config:
+  useCachemachine: false
   autostart:
     - name: "firefighter"
       count: 1

--- a/applications/nublado/templates/vault-secrets.yaml
+++ b/applications/nublado/templates/vault-secrets.yaml
@@ -1,6 +1,16 @@
 apiVersion: ricoberger.de/v1alpha1
 kind: VaultSecret
 metadata:
+  name: "nublado-lab-secret"
+  labels:
+    {{- include "nublado.labels" . | nindent 4 }}
+spec:
+  path: "{{- .Values.global.vaultSecretsPath }}/nublado-lab-secret"
+  type: Opaque
+---
+apiVersion: ricoberger.de/v1alpha1
+kind: VaultSecret
+metadata:
   name: "nublado-secret"
 spec:
   path: "{{- .Values.global.vaultSecretsPath }}/nublado"

--- a/applications/nublado/values-idfint.yaml
+++ b/applications/nublado/values-idfint.yaml
@@ -19,7 +19,7 @@ controller:
         AWS_SHARED_CREDENTIALS_FILE: "/opt/lsst/software/jupyterlab/secrets/aws-credentials.ini"
         PGPASSFILE: "/opt/lsst/software/jupyterlab/secrets/postgres-credentials.txt"
         GOOGLE_APPLICATION_CREDENTIALS: "/opt/lsst/software/jupyterlab/secrets/butler-gcs-idf-creds.json"
-        DAF_BUTLER_REPOSITORY_INDEX: "s3://butler-us-central1-repo-locations/data-repos.yaml"
+        DAF_BUTLER_REPOSITORY_INDEX: "s3://butler-us-central1-repo-locations/data-int-repos.yaml"
         S3_ENDPOINT_URL: "https://storage.googleapis.com"
         PANDA_AUTH: oidc
         PANDA_VERIFY_HOST: "off"

--- a/applications/nublado/values-idfint.yaml
+++ b/applications/nublado/values-idfint.yaml
@@ -68,13 +68,13 @@ controller:
           server: "10.22.240.130"
           mode: "rw"
       secrets:
-        - secretName: "nublado-secret"
+        - secretName: "nublado-lab-secret"
           secretKey: "aws-credentials.ini"
-        - secretName: "nublado-secret"
+        - secretName: "nublado-lab-secret"
           secretKey: "butler-gcs-idf-creds.json"
-        - secretName: "nublado-secret"
+        - secretName: "nublado-lab-secret"
           secretKey: "butler-hmac-idf-creds.json"
-        - secretName: "nublado-secret"
+        - secretName: "nublado-lab-secret"
           secretKey: "postgres-credentials.txt"
 
 jupyterhub:


### PR DESCRIPTION
The secrets that we inject into the lab shouldn't use nublado-secret since it has a complex templating setup. Instead, create a separate lab-secret VaultSecret to collect secrets we're injecting into labs, and reference that in the IDF int configuration.