### PR TITLE
DM-38795: Only create nublado-lab-secret if secrets configured

### DIFF
--- a/applications/nublado/templates/vault-secrets.yaml
+++ b/applications/nublado/templates/vault-secrets.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.controller.config.lab.secrets }}
 apiVersion: ricoberger.de/v1alpha1
 kind: VaultSecret
 metadata:
@@ -8,6 +9,7 @@ spec:
   path: "{{- .Values.global.vaultSecretsPath }}/nublado-lab-secret"
   type: Opaque
 ---
+{{- end }}
 apiVersion: ricoberger.de/v1alpha1
 kind: VaultSecret
 metadata:


### PR DESCRIPTION
Rather than unconditionally creating the nublado-lab-secret Vault secret, only create it if we have secrets configured in the lab configuration. This avoids having to create an empty Vault secret just to keep vault-secrets-operator happy.

This is not entirely correct since the secret references in the secrets configuration may not point to this secret, but it will be good enough for now. We can do fancier Helm templating later if needed.