### PR TITLE
DM-38795: Increase JupyterLab startup timeout to 90 seconds

### DIFF
--- a/applications/nublado/README.md
+++ b/applications/nublado/README.md
@@ -44,6 +44,8 @@ JupyterHub and custom spawner for the Rubin Science Platform
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
+| hub.timeout.spawn | int | `600` | Timeout for the Kubernetes spawn process in seconds. (Allow long enough to pull uncached images if needed.) |
+| hub.timeout.startup | int | `90` | Timeout for JupyterLab to start. Currently this sometimes takes over 60 seconds for reasons we don't understand. |
 | jupyterhub.cull.enabled | bool | `true` |  |
 | jupyterhub.cull.every | int | `600` |  |
 | jupyterhub.cull.maxAge | int | `5184000` |  |

--- a/applications/nublado/templates/hub-configmap.yaml
+++ b/applications/nublado/templates/hub-configmap.yaml
@@ -31,7 +31,12 @@ data:
     c.Spawner.default_url = "/lab"
 
     # Allow ten minutes for the lab to spawn in case it needs to be pulled.
-    c.Spawner.start_timeout = 10 * 60
+    c.Spawner.start_timeout = {{ .Values.hub.timeout.spawn }}
+
+    # Allow 90 seconds for JupyterLab to start. For reasons we do not yet
+    # understand, it is often glacially slow and sometimes takes over 60
+    # seconds.
+    c.Spawner.http_timeout = {{ .Values.hub.timeout.startup }}
 
     # Configure the URL to the lab controller.
     c.RSPRestSpawner.controller_url = "{{ .Values.global.baseUrl }}{{ .Values.controller.config.safir.pathPrefix }}"

--- a/applications/nublado/values.yaml
+++ b/applications/nublado/values.yaml
@@ -229,7 +229,19 @@ controller:
       # -- Path prefix that will be routed to the controller
       pathPrefix: "/nublado"
 
-# Configuration for z2jh subchart
+# JupyterHub configuration handled directly by this chart rather than by Zero
+# to JupyterHub.
+hub:
+  timeout:
+    # -- Timeout for the Kubernetes spawn process in seconds. (Allow long
+    # enough to pull uncached images if needed.)
+    spawn: 600
+
+    # -- Timeout for JupyterLab to start. Currently this sometimes takes over
+    # 60 seconds for reasons we don't understand.
+    startup: 90
+
+# Configuration for the Zero to JupyterHub subchart.
 jupyterhub:
   hub:
     authenticatePrometheus: false


### PR DESCRIPTION
For reasons we don't yet understand, JupyterLab startup sometimes takes over 60 seconds. Increase the default timeout to 90 seconds to match what we're currently using in production.

Make the total spawn timeout and the JupyterLab startup timeout easily configurable in values files. Add a new section to the values file for hub configuration that we control rather than that is passed down to Zero to JupyterHub.