### PR TITLE
Add a new connector for lsst.rubintv

### DIFF
--- a/applications/sasquatch/values-usdfdev.yaml
+++ b/applications/sasquatch/values-usdfdev.yaml
@@ -97,6 +97,13 @@ kafka-connect-manager:
         connectInfluxDb: "lsst.example"
         topicsRegex: "lsst.example.*"
         tags: dataset_tag,band,instrument,skymap,detector,physical_filter,tract,exposure,patch,visit,run
+      lsstrubintv:
+        enabled: true
+        timestamp: "timestamp"
+        connectInfluxDb: "lsst.rubintv"
+        topicsRegex: "lsst.rubintv.*"
+        tags: observation_type,observation_reason,science_program,filter,disperser
+
 
 kafdrop:
   ingress:


### PR DESCRIPTION
This PR adds a new connector for the lsst.rubintv namespace in Sasquatch at USDF dev.