### PR TITLE
Add lsst.rubintv namespace

### DIFF
--- a/applications/sasquatch/values-usdfdev.yaml
+++ b/applications/sasquatch/values-usdfdev.yaml
@@ -123,6 +123,7 @@ rest-proxy:
       - lsst.dm
       - lsst.debug
       - lsst.example
+      - lsst.rubintv
 
 chronograf:
   ingress:


### PR DESCRIPTION
- Configure the REST Proxy to expose topics with the lsst.rubintv prefix