### PR TITLE
DM-38798: Deploy Times Square and Noteburst on usdfdev

### DIFF
--- a/applications/noteburst/values-usdfdev.yaml
+++ b/applications/noteburst/values-usdfdev.yaml
@@ -1,0 +1,19 @@
+image:
+  pullPolicy: Always
+
+config:
+  logLevel: "DEBUG"
+  worker:
+    workerCount: 1
+    identities:
+      - username: "bot-noteburst90000"
+      - username: "bot-noteburst90001"
+      - username: "bot-noteburst90002"
+      - username: "bot-noteburst90003"
+      - username: "bot-noteburst90004"
+      - username: "bot-noteburst90005"
+
+# Use SSD for Redis storage.
+redis:
+  persistence:
+    storageClass: "wekafs--sdf-k8s01"

--- a/applications/postgres/templates/deployment.yaml
+++ b/applications/postgres/templates/deployment.yaml
@@ -99,6 +99,17 @@ spec:
                   name: "postgres"
                   key: "gafaelfawr_password"
             {{- end }}
+            {{- with .Values.timessquare_db }}
+            - name: "VRO_DB_TIMESSQUARE_USER"
+              value: {{ .user | quote }}
+            - name: "VRO_DB_TIMESSQUARE_DB"
+              value: {{ .db | quote }}
+            - name: "VRO_DB_TIMESSQUARE_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  name: "postgres"
+                  key: "timessquare_password"
+            {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           ports:

--- a/applications/postgres/values-usdfdev.yaml
+++ b/applications/postgres/values-usdfdev.yaml
@@ -7,5 +7,8 @@ nublado3_db:
 gafaelfawr_db:
   user: 'gafaelfawr'
   db: 'gafaelfawr'
+timessquare_db:
+  user: "timessquare"
+  db: "timessquare"
 
 postgresStorageClass: 'wekafs--sdf-k8s01'

--- a/applications/times-square/values-usdfdev.yaml
+++ b/applications/times-square/values-usdfdev.yaml
@@ -1,0 +1,12 @@
+image:
+  pullPolicy: Always
+config:
+  logLevel: "DEBUG"
+  databaseUrl: "postgresql://timessquare@postgres.postgres/timessquare"
+  githubAppId: "327289"
+  enableGitHubApp: "True"
+cloudsql:
+  enabled: false
+redis:
+  persistence:
+    storageClass: "wekafs--sdf-k8s01"

--- a/environments/values-usdfdev.yaml
+++ b/environments/values-usdfdev.yaml
@@ -31,7 +31,7 @@ moneypenny:
 narrativelog:
   enabled: false
 noteburst:
-  enabled: false
+  enabled: true
 nublado:
   enabled: true
 nublado2:

--- a/environments/values-usdfdev.yaml
+++ b/environments/values-usdfdev.yaml
@@ -75,7 +75,7 @@ telegraf:
 telegraf-ds:
   enabled: false
 times-square:
-  enabled: false
+  enabled: true
 vault-secrets-operator:
   enabled: true
 vo-cutouts:


### PR DESCRIPTION
This deploys both `times-square` and `noteburst` on usdfdev. Also configures a `timessquare` database in the in-cluster postgres database.

This PR is pending the deployment of Nublado v3 on usdfdev.