### PR TITLE
DM-38975: Only allow one lab controller to run at a time

### DIFF
--- a/applications/nublado/templates/controller-deployment.yaml
+++ b/applications/nublado/templates/controller-deployment.yaml
@@ -9,6 +9,8 @@ spec:
   selector:
     matchLabels:
       {{- include "nublado.selectorLabels" . | nindent 6 }}
+  strategy:
+    type: "Recreate"
   template:
     metadata:
       annotations:


### PR DESCRIPTION
The lab controller examines running lab environments and deletes ones that are incomplete, assuming that only one controller is running at a time. Ensure that's the case in Kubernetes for now. Eventually we'll move the necessary data into Redis.