### PR TITLE
DM-39014: Configure Kafka/Sasquatch for Roundtable

### DIFF
--- a/applications/sasquatch/Chart.yaml
+++ b/applications/sasquatch/Chart.yaml
@@ -26,6 +26,7 @@ dependencies:
     version: 1.2.5
     repository: https://helm.influxdata.com/
   - name: kapacitor
+    condition: kapacitor.enabled
     version: 1.4.6
     repository: https://helm.influxdata.com/
   - name: kafdrop

--- a/applications/sasquatch/Chart.yaml
+++ b/applications/sasquatch/Chart.yaml
@@ -22,6 +22,7 @@ dependencies:
     condition: kafka-connect-manager.enabled
     version: 1.0.0
   - name: chronograf
+    condition: chronograf.enabled
     version: 1.2.5
     repository: https://helm.influxdata.com/
   - name: kapacitor

--- a/applications/sasquatch/Chart.yaml
+++ b/applications/sasquatch/Chart.yaml
@@ -19,6 +19,7 @@ dependencies:
     version: 2.1.1
     repository: https://helm.influxdata.com/
   - name: kafka-connect-manager
+    condition: kafka-connect-manager.enabled
     version: 1.0.0
   - name: chronograf
     version: 1.2.5

--- a/applications/sasquatch/Chart.yaml
+++ b/applications/sasquatch/Chart.yaml
@@ -11,6 +11,7 @@ dependencies:
     version: 2.1.0
     repository: https://lsst-sqre.github.io/charts/
   - name: influxdb
+    condition: influxdb.enabled
     version: 4.12.1
     repository: https://helm.influxdata.com/
   - name: influxdb2
@@ -33,7 +34,6 @@ dependencies:
   - name: rest-proxy
     condition: rest-proxy.enabled
     version: 1.0.0
-
 
 annotations:
   phalanx.lsst.io/docs: |

--- a/applications/sasquatch/Chart.yaml
+++ b/applications/sasquatch/Chart.yaml
@@ -29,6 +29,7 @@ dependencies:
     version: 1.4.6
     repository: https://helm.influxdata.com/
   - name: kafdrop
+    condition: kafdrop.enabled
     version: 1.0.0
   - name: telegraf-kafka-consumer
     condition: telegraf-kafka-consumer.enabled

--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -9,6 +9,7 @@ Rubin Observatory's telemetry service.
 | bucketmapper.image | object | `{"repository":"ghcr.io/lsst-sqre/rubin-influx-tools","tag":"0.1.23"}` | image for monitoring-related cronjobs |
 | bucketmapper.image.repository | string | `"ghcr.io/lsst-sqre/rubin-influx-tools"` | repository for rubin-influx-tools |
 | bucketmapper.image.tag | string | `"0.1.23"` | tag for rubin-influx-tools |
+| chronograf.enabled | bool | `true` | Enable Chronograf. |
 | chronograf.env | object | `{"BASE_PATH":"/chronograf","CUSTOM_AUTO_REFRESH":"1s=1000","HOST_PAGE_DISABLED":true}` | Chronograf environment variables. |
 | chronograf.envFromSecret | string | `"sasquatch"` | Chronograf secrets, expected keys generic_client_id, generic_client_secret and token_secret. |
 | chronograf.image | object | `{"repository":"quay.io/influxdb/chronograf","tag":"1.10.1"}` | Chronograf image tag. |

--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -22,6 +22,7 @@ Rubin Observatory's telemetry service.
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | influxdb.config | object | `{"continuous_queries":{"enabled":false},"coordinator":{"log-queries-after":"15s","max-concurrent-queries":0,"query-timeout":"0s","write-timeout":"1h"},"data":{"cache-max-memory-size":0,"trace-logging-enabled":true,"wal-fsync-delay":"100ms"},"http":{"auth-enabled":true,"enabled":true,"flux-enabled":true,"max-row-limit":0},"logging":{"level":"debug"}}` | Override InfluxDB configuration. See https://docs.influxdata.com/influxdb/v1.8/administration/config |
+| influxdb.enabled | bool | `true` | Enable InfluxDB. |
 | influxdb.image | object | `{"tag":"1.8.10"}` | InfluxDB image tag. |
 | influxdb.ingress | object | disabled | InfluxDB ingress configuration. |
 | influxdb.initScripts.enabled | bool | `false` | Enable InfluxDB custom initialization script. |

--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -59,6 +59,7 @@ Rubin Observatory's telemetry service.
 | influxdb2.resources.limits.memory | string | `"96Gi"` |  |
 | influxdb2.resources.requests.cpu | int | `1` |  |
 | influxdb2.resources.requests.memory | string | `"1Gi"` |  |
+| kafdrop.enabled | bool | `true` | Enable Kafdrop. |
 | kafka-connect-manager | object | `{}` | Override kafka-connect-manager configuration. |
 | kapacitor.envVars | object | `{"KAPACITOR_SLACK_ENABLED":true}` | Kapacitor environment variables. |
 | kapacitor.existingSecret | string | `"sasquatch"` | InfluxDB credentials, use influxdb-user and influxdb-password keys from secret. |

--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -61,6 +61,7 @@ Rubin Observatory's telemetry service.
 | influxdb2.resources.requests.memory | string | `"1Gi"` |  |
 | kafdrop.enabled | bool | `true` | Enable Kafdrop. |
 | kafka-connect-manager | object | `{}` | Override kafka-connect-manager configuration. |
+| kapacitor.enabled | bool | `true` | Enable Kapacitor. |
 | kapacitor.envVars | object | `{"KAPACITOR_SLACK_ENABLED":true}` | Kapacitor environment variables. |
 | kapacitor.existingSecret | string | `"sasquatch"` | InfluxDB credentials, use influxdb-user and influxdb-password keys from secret. |
 | kapacitor.image | object | `{"repository":"kapacitor","tag":"1.6.6"}` | Kapacitor image tag. |

--- a/applications/sasquatch/charts/kafka-connect-manager/README.md
+++ b/applications/sasquatch/charts/kafka-connect-manager/README.md
@@ -6,6 +6,7 @@ A subchart to deploy the Kafka connectors used by Sasquatch.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| enabled | bool | `true` | Enable Kafka Connect Manager. |
 | env.kafkaBrokerUrl | string | `"sasquatch-kafka-bootstrap.sasquatch:9092"` | Kafka broker URL. |
 | env.kafkaConnectUrl | string | `"http://sasquatch-connect-api.sasquatch:8083"` | Kafka connnect URL. |
 | env.kafkaUsername | string | `"kafka-connect-manager"` | Username for SASL authentication. |

--- a/applications/sasquatch/charts/kafka-connect-manager/values.yaml
+++ b/applications/sasquatch/charts/kafka-connect-manager/values.yaml
@@ -1,5 +1,9 @@
 # Default values for kafka-connect-manager.
 # See also https://kafka-connect-manager.lsst.io
+
+# -- Enable Kafka Connect Manager.
+enabled: true
+
 image:
   repository: ghcr.io/lsst-sqre/kafkaconnect
   tag: 1.1.0

--- a/applications/sasquatch/charts/strimzi-kafka/README.md
+++ b/applications/sasquatch/charts/strimzi-kafka/README.md
@@ -12,6 +12,7 @@ A subchart to deploy Strimzi Kafka components for Sasquatch.
 | connect.enabled | bool | `true` | Enable Kafka Connect. |
 | connect.image | string | `"ghcr.io/lsst-sqre/strimzi-0.34.0-kafka-3.3.1:1.1.0"` | Custom strimzi-kafka image with connector plugins used by sasquatch. |
 | connect.replicas | int | `3` | Number of Kafka Connect replicas to run. |
+| kafka.affinity | object | `{}` | Node affinity for Kafka broker pod assignment. |
 | kafka.config."log.retention.bytes" | string | `"429496729600"` | Maximum retained number of bytes for a topic's data. |
 | kafka.config."log.retention.hours" | int | `72` | Number of days for a topic's data to be retained. |
 | kafka.config."message.max.bytes" | int | `10485760` | The largest record batch size allowed by Kafka. |
@@ -30,12 +31,15 @@ A subchart to deploy Strimzi Kafka components for Sasquatch.
 | kafka.replicas | int | `3` | Number of Kafka broker replicas to run. |
 | kafka.storage.size | string | `"500Gi"` | Size of the backing storage disk for each of the Kafka brokers. |
 | kafka.storage.storageClassName | string | `""` | Name of a StorageClass to use when requesting persistent volumes. |
+| kafka.tolerations | list | `[]` | Tolerations for Kafka broker pod assignment. |
 | kafka.version | string | `"3.3.1"` | Version of Kafka to deploy. |
 | mirrormaker2.enabled | bool | `false` | Enable replication in the target (passive) cluster. |
 | mirrormaker2.source.bootstrapServer | string | `""` | Source (active) cluster to replicate from. |
 | mirrormaker2.source.topicsPattern | string | `"registry-schemas, lsst.sal.*"` | Topic replication from the source cluster defined as a comma-separated list or regular expression pattern. |
 | registry.schemaTopic | string | `"registry-schemas"` | Name of the topic used by the Schema Registry |
 | superusers | list | `["kafka-admin"]` | A list of usernames for users who should have global admin permissions. These users will be created, along with their credentials. |
+| zookeeper.affinity | object | `{}` | Node affinity for Zookeeper pod assignment. |
 | zookeeper.replicas | int | `3` | Number of Zookeeper replicas to run. |
 | zookeeper.storage.size | string | `"100Gi"` | Size of the backing storage disk for each of the Zookeeper instances. |
 | zookeeper.storage.storageClassName | string | `""` | Name of a StorageClass to use when requesting persistent volumes. |
+| zookeeper.tolerations | list | `[]` | Tolerations for Zookeeper pod assignment. |

--- a/applications/sasquatch/charts/strimzi-kafka/README.md
+++ b/applications/sasquatch/charts/strimzi-kafka/README.md
@@ -21,6 +21,9 @@ A subchart to deploy Strimzi Kafka components for Sasquatch.
 | kafka.externalListener.brokers | list | `[]` | Borkers configuration. host is used in the brokers' advertised.brokers configuration and for TLS hostname verification. The format is a list of maps. |
 | kafka.externalListener.tls.certIssuerName | string | `"letsencrypt-dns"` | Name of a ClusterIssuer capable of provisioning a TLS certificate for the broker. |
 | kafka.externalListener.tls.enabled | bool | `false` | Whether TLS encryption is enabled. |
+| kafka.listeners.external.enabled | bool | `true` | Whether external listener is enabled. |
+| kafka.listeners.plain.enabled | bool | `true` | Whether internal plaintext listener is enabled. |
+| kafka.listeners.tls.enabled | bool | `true` | Whether internal TLS listener is enabled. |
 | kafka.replicas | int | `3` | Number of Kafka broker replicas to run. |
 | kafka.storage.size | string | `"500Gi"` | Size of the backing storage disk for each of the Kafka brokers. |
 | kafka.storage.storageClassName | string | `""` | Name of a StorageClass to use when requesting persistent volumes. |

--- a/applications/sasquatch/charts/strimzi-kafka/README.md
+++ b/applications/sasquatch/charts/strimzi-kafka/README.md
@@ -38,6 +38,11 @@ A subchart to deploy Strimzi Kafka components for Sasquatch.
 | mirrormaker2.source.topicsPattern | string | `"registry-schemas, lsst.sal.*"` | Topic replication from the source cluster defined as a comma-separated list or regular expression pattern. |
 | registry.schemaTopic | string | `"registry-schemas"` | Name of the topic used by the Schema Registry |
 | superusers | list | `["kafka-admin"]` | A list of usernames for users who should have global admin permissions. These users will be created, along with their credentials. |
+| users.kafdrop.enabled | bool | `true` | Enable user Kafdrop (deployed by parent Sasquatch chart). |
+| users.kafkaConnectManager.enabled | bool | `true` | Enable user kafka-connect-manager |
+| users.promptProcessing.enabled | bool | `true` | Enable user prompt-processing |
+| users.telegraf.enabled | bool | `true` | Enable user telegraf (deployed by parent Sasquatch chart) |
+| users.tsSalKafka.enabled | bool | `true` | Enable user ts-salkafka. |
 | zookeeper.affinity | object | `{}` | Node affinity for Zookeeper pod assignment. |
 | zookeeper.replicas | int | `3` | Number of Zookeeper replicas to run. |
 | zookeeper.storage.size | string | `"100Gi"` | Size of the backing storage disk for each of the Zookeeper instances. |

--- a/applications/sasquatch/charts/strimzi-kafka/README.md
+++ b/applications/sasquatch/charts/strimzi-kafka/README.md
@@ -1,5 +1,7 @@
 # strimzi-kafka
 
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![AppVersion: 3.1.1](https://img.shields.io/badge/AppVersion-3.1.1-informational?style=flat-square)
+
 A subchart to deploy Strimzi Kafka components for Sasquatch.
 
 ## Values
@@ -7,6 +9,7 @@ A subchart to deploy Strimzi Kafka components for Sasquatch.
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | cluster.name | string | `"sasquatch"` | Name used for the Kafka cluster, and used by Strimzi for many annotations. |
+| connect.enabled | bool | `true` | Enable Kafka Connect. |
 | connect.image | string | `"ghcr.io/lsst-sqre/strimzi-0.34.0-kafka-3.3.1:1.1.0"` | Custom strimzi-kafka image with connector plugins used by sasquatch. |
 | connect.replicas | int | `3` | Number of Kafka Connect replicas to run. |
 | kafka.config."log.retention.bytes" | string | `"429496729600"` | Maximum retained number of bytes for a topic's data. |

--- a/applications/sasquatch/charts/strimzi-kafka/README.md
+++ b/applications/sasquatch/charts/strimzi-kafka/README.md
@@ -1,7 +1,5 @@
 # strimzi-kafka
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![AppVersion: 3.1.1](https://img.shields.io/badge/AppVersion-3.1.1-informational?style=flat-square)
-
 A subchart to deploy Strimzi Kafka components for Sasquatch.
 
 ## Values

--- a/applications/sasquatch/charts/strimzi-kafka/templates/connect.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/connect.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.connect.enabled }}
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaConnect
 metadata:
@@ -79,3 +80,4 @@ spec:
     consumerByteRate: 1073741824
     requestPercentage: 90
     controllerMutationRate: 1000
+{{- end }}

--- a/applications/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
@@ -11,6 +11,15 @@ spec:
           annotations:
             argocd.argoproj.io/compare-options: IgnoreExtraneous
             argocd.argoproj.io/sync-options: Prune=false
+      pod:
+        {{- with .Values.kafka.affinity }}
+        affinity:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.kafka.tolerations }}
+        tolerations:
+          {{- toYaml . | nindent 10 }}
+        {{- end}}
     version: {{ .Values.kafka.version | quote }}
     replicas: {{ .Values.kafka.replicas }}
     listeners:
@@ -110,6 +119,15 @@ spec:
           annotations:
             argocd.argoproj.io/compare-options: IgnoreExtraneous
             argocd.argoproj.io/sync-options: Prune=false
+      pod:
+        {{- with .Values.zookeeper.affinity }}
+        affinity:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.zookeeper.tolerations }}
+        tolerations:
+          {{- toYaml . | nindent 10 }}
+        {{- end}}
     replicas: {{ .Values.zookeeper.replicas }}
     storage:
       # Note that storage is configured per replica. If there are 3 replicas,

--- a/applications/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
@@ -14,7 +14,8 @@ spec:
     version: {{ .Values.kafka.version | quote }}
     replicas: {{ .Values.kafka.replicas }}
     listeners:
-      # internal istener without tls encryption and with scram-sha-512 authentication
+      {{- if .Values.kafka.listeners.plain.enabled }}
+      # internal listener without tls encryption and with scram-sha-512 authentication
       # used by clients inside the Kubernetes cluster
       - name: plain
         port: 9092
@@ -22,6 +23,8 @@ spec:
         tls: false
         authentication:
           type: scram-sha-512
+      {{- end }}
+      {{- if .Values.kafka.listeners.tls.enabled }}
       # internal listener with tls encryption and mutual tls authentication
       # used by the schema registry and kafka connect clients
       - name: tls
@@ -30,6 +33,8 @@ spec:
         tls: true
         authentication:
           type: tls
+      {{- end }}
+      {{- if .Values.kafka.listeners.external.enabled }}
       # external listener of type loadbalancer with tls encryption and scram-sha-512
       # authentication used by clients outside the Kubernetes cluster
       - name: external
@@ -65,6 +70,7 @@ spec:
             certificate: tls.crt
             key: tls.key
           {{- end }}
+      {{- end }}
 
     authorization:
       type: simple

--- a/applications/sasquatch/charts/strimzi-kafka/templates/tests/test-sasl-authentication.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/tests/test-sasl-authentication.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.kafka.listeners.plain.enabled -}}
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaUser
 metadata:
@@ -78,3 +79,4 @@ spec:
           imagePullPolicy: IfNotPresent
           name: kafka-producer-client
       restartPolicy: "Never"
+{{- end }}

--- a/applications/sasquatch/charts/strimzi-kafka/templates/users.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/users.yaml
@@ -1,3 +1,5 @@
+{{- if .Values.users.tsSalKafka.enabled }}
+---
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaUser
 metadata:
@@ -27,6 +29,8 @@ spec:
     consumerByteRate: 1073741824
     requestPercentage: 90
     controllerMutationRate: 1000
+{{- end }}
+{{- if .Values.mirrormaker2.enabled -}}
 ---
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaUser
@@ -62,6 +66,8 @@ spec:
     consumerByteRate: 1073741824
     requestPercentage: 90
     controllerMutationRate: 1000
+{{- end }}
+{{- if .Values.users.kafkaConnectManager.enabled }}
 ---
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaUser
@@ -92,6 +98,8 @@ spec:
     consumerByteRate: 1073741824
     requestPercentage: 90
     controllerMutationRate: 1000
+{{- end }}
+{{- if .Values.users.kafdrop.enabled }}
 ---
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaUser
@@ -122,6 +130,8 @@ spec:
         type: allow
         host: "*"
         operation: All
+{{- end }}
+{{- if .Values.users.telegraf.enabled }}
 ---
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaUser
@@ -152,6 +162,8 @@ spec:
         type: allow
         host: "*"
         operation: Read
+{{- end }}
+{{- if .Values.users.promptProcessing.enabled }}
 ---
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaUser
@@ -189,4 +201,4 @@ spec:
         type: allow
         host: "*"
         operation: Read
-
+{{- end }}

--- a/applications/sasquatch/charts/strimzi-kafka/values.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/values.yaml
@@ -74,6 +74,12 @@ kafka:
     #     annotations:
     #       metallb.universe.tf/address-pool: sdf-dmz
 
+  # -- Node affinity for Kafka broker pod assignment.
+  affinity: {}
+
+  # -- Tolerations for Kafka broker pod assignment.
+  tolerations: []
+
 zookeeper:
   # -- Number of Zookeeper replicas to run.
   replicas: 3
@@ -82,6 +88,12 @@ zookeeper:
     size: 100Gi
     # -- Name of a StorageClass to use when requesting persistent volumes.
     storageClassName: ""
+
+  # -- Node affinity for Zookeeper pod assignment.
+  affinity: {}
+
+  # -- Tolerations for Zookeeper pod assignment.
+  tolerations: []
 
 connect:
   # -- Enable Kafka Connect.

--- a/applications/sasquatch/charts/strimzi-kafka/values.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/values.yaml
@@ -112,6 +112,27 @@ registry:
 superusers:
   - kafka-admin
 
+users:
+  tsSalKafka:
+    # -- Enable user ts-salkafka.
+    enabled: true
+
+  kafdrop:
+    # -- Enable user Kafdrop (deployed by parent Sasquatch chart).
+    enabled: true
+
+  telegraf:
+    # -- Enable user telegraf (deployed by parent Sasquatch chart)
+    enabled: true
+
+  promptProcessing:
+    # -- Enable user prompt-processing
+    enabled: true
+
+  kafkaConnectManager:
+    # -- Enable user kafka-connect-manager
+    enabled: true
+
 mirrormaker2:
   # -- Enable replication in the target (passive) cluster.
   enabled: false

--- a/applications/sasquatch/charts/strimzi-kafka/values.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/values.yaml
@@ -84,6 +84,8 @@ zookeeper:
     storageClassName: ""
 
 connect:
+  # -- Enable Kafka Connect.
+  enabled: true
   # -- Custom strimzi-kafka image with connector plugins used by sasquatch.
   image: ghcr.io/lsst-sqre/strimzi-0.34.0-kafka-3.3.1:1.1.0
   # -- Number of Kafka Connect replicas to run.

--- a/applications/sasquatch/charts/strimzi-kafka/values.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/values.yaml
@@ -27,6 +27,19 @@ kafka:
     # -- Replica lag time can't be smaller than request.timeout.ms configuration in kafka connect.
     replica.lag.time.max.ms: 120000
 
+  listeners:
+    plain:
+      # -- Whether internal plaintext listener is enabled.
+      enabled: true
+
+    tls:
+      # -- Whether internal TLS listener is enabled.
+      enabled: true
+
+    external:
+      # -- Whether external listener is enabled.
+      enabled: true
+
   externalListener:
     tls:
       # -- Whether TLS encryption is enabled.

--- a/applications/sasquatch/values-roundtable-dev.yaml
+++ b/applications/sasquatch/values-roundtable-dev.yaml
@@ -1,0 +1,104 @@
+strimzi-kafka:
+  kafka:
+    replicas: 3
+    listeners:
+      plain:
+        enabled: false
+      tls:
+        enabled: true
+      external:
+        enabled: false
+    storage:
+      size: 100Gi
+      storageClassName: "premium-rwo"
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: "roundtable.lsst.cloud/pool"
+                  operator: In
+                  values:
+                    - "kafka"
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+                - key: "strimzi.io/cluster"
+                  operator: "In"
+                  values:
+                    - "sasquatch"
+            topologyKey: "kubernetes.io/hostname"
+    tolerations:
+      - key: dedicated
+        operator: Equal
+        value: "kafka"
+        effect: NoExecute
+
+  zookeeper:
+    replicas: 3
+    storage:
+      size: 100Gi
+      storageClassName: "premium-rwo"
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: "roundtable.lsst.cloud/pool"
+                  operator: In
+                  values:
+                    - "zookeeper"
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+                - key: "strimzi.io/cluster"
+                  operator: "In"
+                  values:
+                    - "sasquatch"
+            topologyKey: "kubernetes.io/hostname"
+    tolerations:
+      - key: dedicated
+        operator: Equal
+        value: "zookeeper"
+        effect: NoExecute
+
+  users:
+    tsSalKafka:
+      enabled: false
+    kafdrop:
+      enabled: false
+    telegraf:
+      enabled: false
+    promptProcessing:
+      enabled: false
+    kafkaConnectManager:
+      enabled: false
+
+  connect:
+    enabled: false
+
+  mirrormaker2:
+    enabled: false
+
+influxdb:
+  enabled: false
+
+influxdb2:
+  enabled: false
+
+telegraf-kafka-consumer:
+  enabled: false
+
+kapacitor:
+  enabled: false
+
+kafdrop:
+  enabled: false
+
+rest-proxy:
+  enabled: false
+
+chronograf:
+  enabled: false

--- a/applications/sasquatch/values.yaml
+++ b/applications/sasquatch/values.yaml
@@ -10,6 +10,8 @@ strimzi-registry-operator:
   operatorNamespace: sasquatch
 
 influxdb:
+  # -- Enable InfluxDB.
+  enabled: true
   # -- InfluxDB image tag.
   image:
     tag: "1.8.10"

--- a/applications/sasquatch/values.yaml
+++ b/applications/sasquatch/values.yaml
@@ -166,6 +166,8 @@ chronograf:
       cpu: 4
 
 kapacitor:
+  # -- Enable Kapacitor.
+  enabled: true
   # -- Kapacitor image tag.
   image:
     repository: kapacitor

--- a/applications/sasquatch/values.yaml
+++ b/applications/sasquatch/values.yaml
@@ -189,6 +189,10 @@ kapacitor:
       memory: 16Gi
       cpu: 4
 
+kafdrop:
+  # -- Enable Kafdrop.
+  enabled: true
+
 bucketmapper:
   # -- image for monitoring-related cronjobs
   image:

--- a/applications/sasquatch/values.yaml
+++ b/applications/sasquatch/values.yaml
@@ -132,6 +132,8 @@ rest-proxy:
   enabled: false
 
 chronograf:
+  # -- Enable Chronograf.
+  enabled: true
   # -- Chronograf image tag.
   image:
     repository: "quay.io/influxdb/chronograf"

--- a/applications/strimzi/values-roundtable-dev.yaml
+++ b/applications/strimzi/values-roundtable-dev.yaml
@@ -1,0 +1,9 @@
+strimzi-kafka-operator:
+  resources:
+    limits:
+      memory: "1Gi"
+    requests:
+      memory: "512Mi"
+  watchNamespaces:
+    - "sasquatch"
+  logLevel: "INFO"

--- a/environments/values-roundtable-dev.yaml
+++ b/environments/values-roundtable-dev.yaml
@@ -39,7 +39,7 @@ portal:
 postgres:
   enabled: false
 sasquatch:
-  enabled: false
+  enabled: true
 production-tools:
   enabled: false
 semaphore:
@@ -53,7 +53,7 @@ squash-api:
 sqlproxy-cross-project:
   enabled: false
 strimzi:
-  enabled: false
+  enabled: true
 strimzi-registry-operator:
   enabled: false
 tap:


### PR DESCRIPTION
This PR configures a Kafka cluster for Roundtable. We're doing this by configuring Sasquatch so that down the road we can easily add Sasquatch's monitoring capabilities to Roundtable given that Sasquatch itself is also Kafka based.

- [x] Adds toggle configurations to Sasquatch to turn off individual components. This lets us initially deploy only Kafka infrastructure
- [x] Adds toggles to enable specific Kafka listeners. Initially Roundtable will only use the internal TLS-based listeners.
- [x] Adds toggles to enable specific default users.
- [x] Adds configurations to enable Kafka brokers and Zookeeper servers to tolerate taints on node pools.
- ~~[ ] Configures Kafdrop to use TLS authentication~~ May need to be done later.

The Sasquatch deployment on roundtable-dev is here: https://roundtable-dev.lsst.cloud/argo-cd/applications/argocd/sasquatch