### PR TITLE
Deploy a repairer connector

### DIFF
--- a/applications/sasquatch/charts/kafka-connect-manager/README.md
+++ b/applications/sasquatch/charts/kafka-connect-manager/README.md
@@ -20,8 +20,9 @@ A subchart to deploy the Kafka connectors used by Sasquatch.
 | influxdbSink.connectInfluxRetryInterval | string | `"60000"` | The interval, in milliseconds, between retries. Only valid when the connectInfluxErrorPolicy is set to `RETRY`. |
 | influxdbSink.connectInfluxUrl | string | `"http://sasquatch-influxdb.sasquatch:8086"` | InfluxDB URL. |
 | influxdbSink.connectProgressEnabled | bool | `false` | Enables the output for how many records have been processed. |
-| influxdbSink.connectors | object | `{"test":{"enabled":false,"tags":"","topicsRegex":".*Test"}}` | Connector instances to deploy. |
+| influxdbSink.connectors | object | `{"test":{"enabled":false,"repairerConnector":false,"tags":"","topicsRegex":".*Test"}}` | Connector instances to deploy. |
 | influxdbSink.connectors.test.enabled | bool | `false` | Whether this connector instance is deployed. |
+| influxdbSink.connectors.test.repairerConnector | bool | `false` | Whether to deploy a repairer connector in addition to the original connector instance. |
 | influxdbSink.connectors.test.tags | string | `""` | Fields in the Avro payload that are treated as InfluxDB tags. |
 | influxdbSink.connectors.test.topicsRegex | string | `".*Test"` | Regex to select topics from Kafka. |
 | influxdbSink.excludedTopicsRegex | string | `""` | Regex to exclude topics from the list of selected topics from Kafka. |

--- a/applications/sasquatch/charts/kafka-connect-manager/templates/influxdb_sink.yaml
+++ b/applications/sasquatch/charts/kafka-connect-manager/templates/influxdb_sink.yaml
@@ -95,4 +95,100 @@ spec:
                 name: sasquatch
                 key: kafka-connect-manager-password
 {{- end }}
+{{- if $value.repairerConnector }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sasquatch-influxdb-sink-{{ $key }}-repairer
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kafka-connect-manager
+  template:
+    metadata:
+      labels:
+        app: kafka-connect-manager
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+      containers:
+      - name:  kafkaconnect
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - "all"
+          readOnlyRootFilesystem: true
+        image: {{ $.Values.image.repository }}:{{ $.Values.image.tag }}
+        imagePullPolicy:  {{ $.Values.image.pullPolicy }}
+        command:
+          - kafkaconnect
+          - create
+          - influxdb-sink
+          {{- if $.Values.influxdbSink.autoUpdate }}
+          - --auto-update
+          {{- end }}
+        env:
+          - name: KAFKA_CONNECT_NAME
+            value: influxdb-sink-{{ $key }}-repairer
+          - name: KAFKA_CONNECT_INFLUXDB_URL
+            value: {{ $.Values.influxdbSink.connectInfluxUrl | quote }}
+          - name: KAFKA_CONNECT_DATABASE
+            {{- if $value.connectInfluxDb }}
+            value: {{ $value.connectInfluxDb | quote }}
+            {{- else }}
+            value: {{ $.Values.influxdbSink.connectInfluxDb | quote }}
+            {{- end }}
+          - name: KAFKA_CONNECT_INFLUXDB_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: sasquatch
+                key: influxdb-user
+          - name: KAFKA_CONNECT_INFLUXDB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: sasquatch
+                key: influxdb-password
+          - name: KAFKA_CONNECT_TASKS_MAX
+            value: {{ $.Values.influxdbSink.tasksMax | quote }}
+          - name: KAFKA_CONNECT_TOPIC_REGEX
+            value: {{ $value.topicsRegex | quote }}
+          - name: KAFKA_CONNECT_CHECK_INTERVAL
+            value: {{ $.Values.influxdbSink.checkInterval | quote  }}
+          - name: KAFKA_CONNECT_EXCLUDED_TOPIC_REGEX
+            value: {{ $.Values.influxdbSink.excludedTopicsRegex | quote }}
+          - name: KAFKA_CONNECT_INFLUXDB_TIMESTAMP
+            {{- if $value.timestamp }}
+            value: {{ $value.timestamp | quote }}
+            {{- else }}
+            value: {{ $.Values.influxdbSink.timestamp | quote }}
+            {{- end }}
+            {{- if $value.tags }}
+          - name: KAFKA_CONNECT_INFLUXDB_TAGS
+            value: {{ $value.tags | quote }}
+            {{- end }}
+          - name: KAFKA_CONNECT_ERROR_POLICY
+            value: {{ $.Values.influxdbSink.connectInfluxErrorPolicy | quote }}
+          - name: KAFKA_CONNECT_MAX_RETRIES
+            value: {{ $.Values.influxdbSink.connectInfluxMaxRetries | quote }}
+          - name: KAFKA_CONNECT_RETRY_INTERVAL
+            value: {{ $.Values.influxdbSink.connectInfluxRetryInterval | quote }}
+          - name: KAFKA_CONNECT_PROGRESS_ENABLED
+            value: {{ $.Values.influxdbSink.connectProgressEnabled | quote }}
+          - name: KAFKA_BROKER_URL
+            value: {{ $.Values.env.kafkaBrokerUrl | quote }}
+          - name: KAFKA_CONNECT_URL
+            value: {{ $.Values.env.kafkaConnectUrl | quote }}
+          - name: KAFKA_USERNAME
+            value: {{ $.Values.env.kafkaUsername | quote }}
+          - name: KAFKA_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: sasquatch
+                key: kafka-connect-manager-password
+{{- end }}
 {{- end }}

--- a/applications/sasquatch/charts/kafka-connect-manager/values.yaml
+++ b/applications/sasquatch/charts/kafka-connect-manager/values.yaml
@@ -33,6 +33,8 @@ influxdbSink:
     test:
       # -- Whether this connector instance is deployed.
       enabled: false
+      # -- Whether to deploy a repairer connector in addition to the original connector instance.
+      repairerConnector: false
       # -- Regex to select topics from Kafka.
       topicsRegex: ".*Test"
       # -- Fields in the Avro payload that are treated as InfluxDB tags.

--- a/applications/sasquatch/values-summit.yaml
+++ b/applications/sasquatch/values-summit.yaml
@@ -34,70 +34,70 @@ kafka-connect-manager:
     connectors:
       auxtel:
         enabled: true
-        repairerConnector: true
+        repairerConnector: false
         topicsRegex: ".*ATAOS|.*ATDome|.*ATDomeTrajectory|.*ATHexapod|.*ATPneumatics|.*ATPtg|.*ATMCS"
       maintel:
         enabled: true
-        repairerConnector: true
+        repairerConnector: false
         topicsRegex: ".*MTAOS|.*MTDome|.*MTDomeTrajectory|.*MTPtg"
       mtmount:
         enabled: true
-        repairerConnector: true
+        repairerConnector: false
         topicsRegex: ".*MTMount"
       comcam:
         enabled: true
-        repairerConnector: true
+        repairerConnector: false
         topicsRegex: ".*CCCamera|.*CCHeaderService|.*CCOODS"
       eas:
         enabled: true
-        repairerConnector: true
+        repairerConnector: false
         topicsRegex: ".*DIMM|.*DSM|.*ESS|.*HVAC|.*WeatherForecast"
       latiss:
         enabled: true
-        repairerConnector: true
+        repairerConnector: false
         topicsRegex: ".*ATCamera|.*ATHeaderService|.*ATOODS|.*ATSpectrograph"
       m1m3:
         enabled: true
-        repairerConnector: true
+        repairerConnector: false
         topicsRegex: ".*MTM1M3"
       m2:
         enabled: true
-        repairerConnector: true
+        repairerConnector: false
         topicsRegex: ".*MTHexapod|.*MTM2|.*MTRotator"
       obssys:
         enabled: true
-        repairerConnector: true
+        repairerConnector: false
         topicsRegex: ".*Scheduler|.*Script|.*ScriptQueue|.*Watcher"
       ocps:
         enabled: true
-        repairerConnector: true
+        repairerConnector: false
         topicsRegex: ".*OCPS"
       test:
         enabled: true
         topicsRegex: ".*Test"
       pmd:
         enabled: true
-        repairerConnector: true
+        repairerConnector: false
         topicsRegex: ".*PMD"
       calsys:
         enabled: true
-        repairerConnector: true
+        repairerConnector: false
         topicsRegex: ".*ATMonochromator|.*ATWhiteLight|.*CBP|.*Electrometer|.*FiberSpectrograph|.*LinearStage|.*TunableLaser"
       mtaircompressor:
         enabled: true
-        repairerConnector: true
+        repairerConnector: false
         topicsRegex: ".*MTAirCompressor"
       genericcamera:
         enabled: true
-        repairerConnector: true
+        repairerConnector: false
         topicsRegex: ".*GCHeaderService|.*GenericCamera"
       gis:
         enabled: true
-        repairerConnector: true
+        repairerConnector: false
         topicsRegex: ".*GIS"
       mtvms:
         enabled: true
-        repairerConnector: true
+        repairerConnector: false
         topicsRegex: ".*MTVMS"
 
 kafdrop:

--- a/applications/sasquatch/values-summit.yaml
+++ b/applications/sasquatch/values-summit.yaml
@@ -34,54 +34,70 @@ kafka-connect-manager:
     connectors:
       auxtel:
         enabled: true
+        repairerConnector: true
         topicsRegex: ".*ATAOS|.*ATDome|.*ATDomeTrajectory|.*ATHexapod|.*ATPneumatics|.*ATPtg|.*ATMCS"
       maintel:
         enabled: true
+        repairerConnector: true
         topicsRegex: ".*MTAOS|.*MTDome|.*MTDomeTrajectory|.*MTPtg"
       mtmount:
         enabled: true
+        repairerConnector: true
         topicsRegex: ".*MTMount"
       comcam:
         enabled: true
+        repairerConnector: true
         topicsRegex: ".*CCCamera|.*CCHeaderService|.*CCOODS"
       eas:
         enabled: true
+        repairerConnector: true
         topicsRegex: ".*DIMM|.*DSM|.*ESS|.*HVAC|.*WeatherForecast"
       latiss:
         enabled: true
+        repairerConnector: true
         topicsRegex: ".*ATCamera|.*ATHeaderService|.*ATOODS|.*ATSpectrograph"
       m1m3:
         enabled: true
+        repairerConnector: true
         topicsRegex: ".*MTM1M3"
       m2:
         enabled: true
+        repairerConnector: true
         topicsRegex: ".*MTHexapod|.*MTM2|.*MTRotator"
       obssys:
         enabled: true
+        repairerConnector: true
         topicsRegex: ".*Scheduler|.*Script|.*ScriptQueue|.*Watcher"
       ocps:
         enabled: true
+        repairerConnector: true
         topicsRegex: ".*OCPS"
       test:
         enabled: true
         topicsRegex: ".*Test"
       pmd:
         enabled: true
+        repairerConnector: true
         topicsRegex: ".*PMD"
       calsys:
         enabled: true
+        repairerConnector: true
         topicsRegex: ".*ATMonochromator|.*ATWhiteLight|.*CBP|.*Electrometer|.*FiberSpectrograph|.*LinearStage|.*TunableLaser"
       mtaircompressor:
         enabled: true
+        repairerConnector: true
         topicsRegex: ".*MTAirCompressor"
       genericcamera:
         enabled: true
+        repairerConnector: true
         topicsRegex: ".*GCHeaderService|.*GenericCamera"
       gis:
         enabled: true
+        repairerConnector: true
         topicsRegex: ".*GIS"
       mtvms:
         enabled: true
+        repairerConnector: true
         topicsRegex: ".*MTVMS"
 
 kafdrop:

--- a/applications/sasquatch/values-usdfdev.yaml
+++ b/applications/sasquatch/values-usdfdev.yaml
@@ -27,74 +27,57 @@ kafka-connect-manager:
     connectors:
       auxtel:
         enabled: true
-        repairerConnector: true
         topicsRegex: ".*ATAOS|.*ATDome|.*ATDomeTrajectory|.*ATHexapod|.*ATPneumatics|.*ATPtg|.*ATMCS"
       maintel:
         enabled: true
-        repairerConnector: true
         topicsRegex: ".*MTAOS|.*MTDome|.*MTDomeTrajectory|.*MTPtg"
       mtmount:
         enabled: true
-        repairerConnector: true
         topicsRegex: ".*MTMount"
       comcam:
         enabled: true
-        repairerConnector: true
         topicsRegex: ".*CCCamera|.*CCHeaderService|.*CCOODS"
       eas:
         enabled: true
-        repairerConnector: true
         topicsRegex: ".*DIMM|.*DSM|.*WeatherForecast|.*WeatherStation"
       latiss:
         enabled: true
-        repairerConnector: true
         topicsRegex: ".*ATCamera|.*ATHeaderService|.*ATOODS|.*ATSpectrograph"
       m1m3:
         enabled: true
-        repairerConnector: true
         topicsRegex: ".*MTM1M3"
       m2:
         enabled: true
-        repairerConnector: true
         topicsRegex: ".*MTHexapod|.*MTM2|.*MTRotator"
       obssys:
         enabled: true
-        repairerConnector: true
         topicsRegex: ".*Scheduler|.*Script|.*ScriptQueue|.*Watcher"
       ocps:
         enabled: true
-        repairerConnector: true
         topicsRegex: ".*OCPS"
       test:
         enabled: true
         topicsRegex: ".*Test"
       pmd:
         enabled: true
-        repairerConnector: true
         topicsRegex: ".*PMD"
       calsys:
         enabled: true
-        repairerConnector: true
         topicsRegex: ".*ATMonochromator|.*ATWhiteLight|.*CBP|.*Electrometer|.*FiberSpectrograph|.*LinearStage|.*TunableLaser"
       mtaircompressor:
         enabled: true
-        repairerConnector: true
         topicsRegex: ".*MTAirCompressor"
       authorize:
         enabled: true
-        repairerConnector: true
         topicsRegex: ".*Authorize"
       lasertracker:
         enabled: true
-        repairerConnector: true
         topicsRegex: ".*LaserTracker"
       genericcamera:
         enabled: true
-        repairerConnector: true
         topicsRegex: ".*GCHeaderService|.*GenericCamera"
       gis:
         enabled: true
-        repairerConnector: true
         topicsRegex: ".*GIS"
       lsstdm:
         enabled: true
@@ -120,7 +103,6 @@ kafka-connect-manager:
         connectInfluxDb: "lsst.rubintv"
         topicsRegex: "lsst.rubintv.*"
         tags: image_type,observation_reason,science_program,filter,disperser
-
 
 kafdrop:
   ingress:

--- a/applications/sasquatch/values-usdfdev.yaml
+++ b/applications/sasquatch/values-usdfdev.yaml
@@ -31,54 +31,70 @@ kafka-connect-manager:
         topicsRegex: ".*ATAOS|.*ATDome|.*ATDomeTrajectory|.*ATHexapod|.*ATPneumatics|.*ATPtg|.*ATMCS"
       maintel:
         enabled: true
+        repairerConnector: true
         topicsRegex: ".*MTAOS|.*MTDome|.*MTDomeTrajectory|.*MTPtg"
       mtmount:
         enabled: true
+        repairerConnector: true
         topicsRegex: ".*MTMount"
       comcam:
         enabled: true
+        repairerConnector: true
         topicsRegex: ".*CCCamera|.*CCHeaderService|.*CCOODS"
       eas:
         enabled: true
+        repairerConnector: true
         topicsRegex: ".*DIMM|.*DSM|.*WeatherForecast|.*WeatherStation"
       latiss:
         enabled: true
+        repairerConnector: true
         topicsRegex: ".*ATCamera|.*ATHeaderService|.*ATOODS|.*ATSpectrograph"
       m1m3:
         enabled: true
+        repairerConnector: true
         topicsRegex: ".*MTM1M3"
       m2:
         enabled: true
+        repairerConnector: true
         topicsRegex: ".*MTHexapod|.*MTM2|.*MTRotator"
       obssys:
         enabled: true
+        repairerConnector: true
         topicsRegex: ".*Scheduler|.*Script|.*ScriptQueue|.*Watcher"
       ocps:
         enabled: true
+        repairerConnector: true
         topicsRegex: ".*OCPS"
       test:
         enabled: true
         topicsRegex: ".*Test"
       pmd:
         enabled: true
+        repairerConnector: true
         topicsRegex: ".*PMD"
       calsys:
         enabled: true
+        repairerConnector: true
         topicsRegex: ".*ATMonochromator|.*ATWhiteLight|.*CBP|.*Electrometer|.*FiberSpectrograph|.*LinearStage|.*TunableLaser"
       mtaircompressor:
         enabled: true
+        repairerConnector: true
         topicsRegex: ".*MTAirCompressor"
       authorize:
         enabled: true
+        repairerConnector: true
         topicsRegex: ".*Authorize"
       lasertracker:
         enabled: true
+        repairerConnector: true
         topicsRegex: ".*LaserTracker"
       genericcamera:
         enabled: true
+        repairerConnector: true
         topicsRegex: ".*GCHeaderService|.*GenericCamera"
       gis:
         enabled: true
+        repairerConnector: true
         topicsRegex: ".*GIS"
       lsstdm:
         enabled: true

--- a/applications/sasquatch/values-usdfdev.yaml
+++ b/applications/sasquatch/values-usdfdev.yaml
@@ -27,6 +27,7 @@ kafka-connect-manager:
     connectors:
       auxtel:
         enabled: true
+        repairerConnector: true
         topicsRegex: ".*ATAOS|.*ATDome|.*ATDomeTrajectory|.*ATHexapod|.*ATPneumatics|.*ATPtg|.*ATMCS"
       maintel:
         enabled: true


### PR DESCRIPTION
- A repairer connector is a new instance of a connector that consumes the earliest offsets and write to InfluxDB at the same time the original connector continue writing the latest offsets.