### PR TITLE
DM-39043: Deploy squarebot to roundtable-dev

### DIFF
--- a/applications/kubernetes-replicator/Chart.yaml
+++ b/applications/kubernetes-replicator/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: kubernetes-replicator
+version: 1.0.0
+description: Kafka secret replicator
+home: https://github.com/mittwald/kubernetes-replicator
+sources:
+  - https://github.com/mittwald/kubernetes-replicator
+dependencies:
+  - name: kubernetes-replicator
+    version: v2.8.0
+    repository: https://helm.mittwald.de

--- a/applications/kubernetes-replicator/README.md
+++ b/applications/kubernetes-replicator/README.md
@@ -1,0 +1,28 @@
+# kubernetes-replicator
+
+Kafka secret replicator
+
+**Homepage:** <https://github.com/mittwald/kubernetes-replicator>
+
+## Source Code
+
+* <https://github.com/mittwald/kubernetes-replicator>
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| kubernetes-replicator.podSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
+| kubernetes-replicator.podSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |
+| kubernetes-replicator.podSecurityContext.readOnlyRootFilesystem | bool | `true` |  |
+| kubernetes-replicator.securityContext.runAsGroup | int | `1000` |  |
+| kubernetes-replicator.securityContext.runAsNonRoot | bool | `true` |  |
+| kubernetes-replicator.securityContext.runAsUser | int | `1000` |  |
+| kubernetes-replicator.serviceAccount.annotations | object | `{}` |  |
+| kubernetes-replicator.serviceAccount.create | bool | `true` |  |
+| kubernetes-replicator.serviceAccount.name | string | `nil` |  |
+| kubernetes-replicator.serviceAccount.privileges[0].apiGroups[0] | string | `""` |  |
+| kubernetes-replicator.serviceAccount.privileges[0].apiGroups[1] | string | `"apps"` |  |
+| kubernetes-replicator.serviceAccount.privileges[0].apiGroups[2] | string | `"extensions"` |  |
+| kubernetes-replicator.serviceAccount.privileges[0].resources[0] | string | `"secrets"` |  |
+| kubernetes-replicator.serviceAccount.privileges[0].resources[1] | string | `"configmaps"` |  |

--- a/applications/kubernetes-replicator/values.yaml
+++ b/applications/kubernetes-replicator/values.yaml
@@ -1,0 +1,20 @@
+kubernetes-replicator:
+  serviceAccount:
+    create: true
+    annotations: {}
+    name:
+    privileges:
+      - apiGroups: ["", "apps", "extensions"]
+        resources: ["secrets", "configmaps"]
+
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
+
+  podSecurityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true

--- a/applications/sasquatch/Chart.yaml
+++ b/applications/sasquatch/Chart.yaml
@@ -38,6 +38,9 @@ dependencies:
   - name: rest-proxy
     condition: rest-proxy.enabled
     version: 1.0.0
+  - name: square-events
+    condition: squareEvents.enabled
+    version: 1.0.0
 
 annotations:
   phalanx.lsst.io/docs: |

--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -72,6 +72,7 @@ Rubin Observatory's telemetry service.
 | kapacitor.resources.requests.cpu | int | `1` |  |
 | kapacitor.resources.requests.memory | string | `"1Gi"` |  |
 | rest-proxy | object | `{"enabled":false}` | Override rest-proxy configuration. |
+| squareEvents.enabled | bool | `false` | Enable the Square Events subchart with topic and user configurations. |
 | strimzi-kafka | object | `{}` | Override strimzi-kafka configuration. |
 | strimzi-registry-operator | object | `{"clusterName":"sasquatch","clusterNamespace":"sasquatch","operatorNamespace":"sasquatch"}` | strimzi-registry-operator configuration. |
 | telegraf-kafka-consumer | object | `{"enabled":false}` | Override telegraf-kafka-consumer configuration. |

--- a/applications/sasquatch/charts/square-events/Chart.yaml
+++ b/applications/sasquatch/charts/square-events/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: square-events
+version: 1.0.0
+appVersion: "1.0.0"
+description: Kafka topics and users for SQuaRE Events.
+type: application

--- a/applications/sasquatch/charts/square-events/README.md
+++ b/applications/sasquatch/charts/square-events/README.md
@@ -1,0 +1,9 @@
+# square-events
+
+Kafka topics and users for SQuaRE Events.
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| cluster.name | string | `"sasquatch"` |  |

--- a/applications/sasquatch/charts/square-events/templates/squarebot-topics.yaml
+++ b/applications/sasquatch/charts/square-events/templates/squarebot-topics.yaml
@@ -1,0 +1,78 @@
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: "rubin.square.events.squarebot.slack.interaction"
+  labels:
+    strimzi.io/cluster: {{ .Values.cluster.name }}
+spec:
+  partitions: 4
+  replicas: 3
+  config:
+    # http://kafka.apache.org/documentation/#topicconfigs
+    retention.ms: 1800000  # 30 minutes
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: "rubin.square.events.squarebot.app.mention"
+  labels:
+    strimzi.io/cluster: {{ .Values.cluster.name }}
+spec:
+  partitions: 16
+  replicas: 3
+  config:
+    # http://kafka.apache.org/documentation/#topicconfigs
+    retention.ms: 1800000  # 30 minutes
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: "rubin.square.events.squarebot.message.channels"
+  labels:
+    strimzi.io/cluster: {{ .Values.cluster.name }}
+spec:
+  partitions: 16
+  replicas: 3
+  config:
+    # http://kafka.apache.org/documentation/#topicconfigs
+    retention.ms: 1800000  # 30 minutes
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: "rubin.square.events.squarebot.message.groups"
+  labels:
+    strimzi.io/cluster: {{ .Values.cluster.name }}
+spec:
+  partitions: 16
+  replicas: 3
+  config:
+    # http://kafka.apache.org/documentation/#topicconfigs
+    retention.ms: 1800000  # 30 minutes
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: "rubin.square.events.squarebot.message.im"
+  labels:
+    strimzi.io/cluster: {{ .Values.cluster.name }}
+spec:
+  partitions: 16
+  replicas: 3
+  config:
+    # http://kafka.apache.org/documentation/#topicconfigs
+    retention.ms: 1800000  # 30 minutes
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: "rubin.square.events.squarebot.message.mpim"
+  labels:
+    strimzi.io/cluster: {{ .Values.cluster.name }}
+spec:
+  partitions: 16
+  replicas: 3
+  config:
+    # http://kafka.apache.org/documentation/#topicconfigs
+    retention.ms: 1800000  # 30 minutes

--- a/applications/sasquatch/charts/square-events/templates/squarebot-topics.yaml
+++ b/applications/sasquatch/charts/square-events/templates/squarebot-topics.yaml
@@ -2,7 +2,7 @@
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
-  name: "rubin.square.events.squarebot.slack.interaction"
+  name: "lsst.square-events.squarebot.slack.interaction"
   labels:
     strimzi.io/cluster: {{ .Values.cluster.name }}
 spec:
@@ -15,7 +15,7 @@ spec:
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
-  name: "rubin.square.events.squarebot.app.mention"
+  name: "lsst.square-events.squarebot.slack.app.mention"
   labels:
     strimzi.io/cluster: {{ .Values.cluster.name }}
 spec:
@@ -28,7 +28,7 @@ spec:
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
-  name: "rubin.square.events.squarebot.message.channels"
+  name: "lsst.square-events.squarebot.slack.message.channels"
   labels:
     strimzi.io/cluster: {{ .Values.cluster.name }}
 spec:
@@ -41,7 +41,7 @@ spec:
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
-  name: "rubin.square.events.squarebot.message.groups"
+  name: "lsst.square-events.squarebot.slack.message.groups"
   labels:
     strimzi.io/cluster: {{ .Values.cluster.name }}
 spec:
@@ -54,7 +54,7 @@ spec:
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
-  name: "rubin.square.events.squarebot.message.im"
+  name: "lsst.square-events.squarebot.slack.message.im"
   labels:
     strimzi.io/cluster: {{ .Values.cluster.name }}
 spec:
@@ -67,7 +67,7 @@ spec:
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
-  name: "rubin.square.events.squarebot.message.mpim"
+  name: "lsst.square-events.squarebot.slack.message.mpim"
   labels:
     strimzi.io/cluster: {{ .Values.cluster.name }}
 spec:

--- a/applications/sasquatch/charts/square-events/templates/squarebot-user.yaml
+++ b/applications/sasquatch/charts/square-events/templates/squarebot-user.yaml
@@ -12,21 +12,56 @@ spec:
     type: simple
     acls:
       - resource:
-          type: group
-          name: "squarebot*"
-          patternType: literal
-        operation: All
-      - resource:
           type: topic
-          name: "rubin.square.events.squarebot.*"
+          name: "rubin.square.events.squarebot.slack.app_mention"
           patternType: literal
         type: allow
         host: "*"
-        operation: "Write"
+        operations:
+          - "Write"
+          - "Describe"
       - resource:
           type: topic
-          name: "rubin.square.events.squarebot.*"
+          name: "rubin.square.events.squarebot.slack.message.channels"
           patternType: literal
         type: allow
         host: "*"
-        operation: "Describe"
+        operations:
+          - "Write"
+          - "Describe"
+      - resource:
+          type: topic
+          name: "rubin.square.events.squarebot.slack.message.groups"
+          patternType: literal
+        type: allow
+        host: "*"
+        operations:
+          - "Write"
+          - "Describe"
+      - resource:
+          type: topic
+          name: "rubin.square.events.squarebot.slack.message.im"
+          patternType: literal
+        type: allow
+        host: "*"
+        operations:
+          - "Write"
+          - "Describe"
+      - resource:
+          type: topic
+          name: "rubin.square.events.squarebot.slack.message.mpim"
+          patternType: literal
+        type: allow
+        host: "*"
+        operations:
+          - "Write"
+          - "Describe"
+      - resource:
+          type: topic
+          name: "rubin.square.events.squarebot.slack.interaction"
+          patternType: literal
+        type: allow
+        host: "*"
+        operations:
+          - "Write"
+          - "Describe"

--- a/applications/sasquatch/charts/square-events/templates/squarebot-user.yaml
+++ b/applications/sasquatch/charts/square-events/templates/squarebot-user.yaml
@@ -19,7 +19,7 @@ spec:
     acls:
       - resource:
           type: topic
-          name: "rubin.square.events.squarebot.slack.app_mention"
+          name: "lsst.square-events.squarebot.slack.app.mention"
           patternType: literal
         type: allow
         host: "*"
@@ -28,7 +28,7 @@ spec:
           - "Describe"
       - resource:
           type: topic
-          name: "rubin.square.events.squarebot.slack.message.channels"
+          name: "lsst.square-events.squarebot.slack.message.channels"
           patternType: literal
         type: allow
         host: "*"
@@ -37,7 +37,7 @@ spec:
           - "Describe"
       - resource:
           type: topic
-          name: "rubin.square.events.squarebot.slack.message.groups"
+          name: "lsst.square-events.squarebot.slack.message.groups"
           patternType: literal
         type: allow
         host: "*"
@@ -46,7 +46,7 @@ spec:
           - "Describe"
       - resource:
           type: topic
-          name: "rubin.square.events.squarebot.slack.message.im"
+          name: "lsst.square-events.squarebot.slack.message.im"
           patternType: literal
         type: allow
         host: "*"
@@ -55,7 +55,7 @@ spec:
           - "Describe"
       - resource:
           type: topic
-          name: "rubin.square.events.squarebot.slack.message.mpim"
+          name: "lsst.square-events.squarebot.slack.message.mpim"
           patternType: literal
         type: allow
         host: "*"
@@ -64,7 +64,7 @@ spec:
           - "Describe"
       - resource:
           type: topic
-          name: "rubin.square.events.squarebot.slack.interaction"
+          name: "lsst.square-events.squarebot.slack.interaction"
           patternType: literal
         type: allow
         host: "*"

--- a/applications/sasquatch/charts/square-events/templates/squarebot-user.yaml
+++ b/applications/sasquatch/charts/square-events/templates/squarebot-user.yaml
@@ -6,6 +6,12 @@ metadata:
   labels:
     strimzi.io/cluster: {{ .Values.cluster.name }}
 spec:
+  template:
+      secret:
+        metadata:
+          annotations:
+            replicator.v1.mittwald.de/replication-allowed: "true"
+            replicator.v1.mittwald.de/replication-allowed-namespaces: "squarebot"
   authentication:
     type: tls
   authorization:

--- a/applications/sasquatch/charts/square-events/templates/squarebot-user.yaml
+++ b/applications/sasquatch/charts/square-events/templates/squarebot-user.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaUser
+metadata:
+  name: squarebot
+  labels:
+    strimzi.io/cluster: {{ .Values.cluster.name }}
+spec:
+  authentication:
+    type: tls
+  authorization:
+    type: simple
+    acls:
+      - resource:
+          type: group
+          name: "squarebot*"
+          patternType: literal
+        operation: All
+      - resource:
+          type: topic
+          name: "rubin.square.events.squarebot.*"
+          patternType: literal
+        type: allow
+        host: "*"
+        operation: "Write"
+      - resource:
+          type: topic
+          name: "rubin.square.events.squarebot.*"
+          patternType: literal
+        type: allow
+        host: "*"
+        operation: "Describe"

--- a/applications/sasquatch/charts/square-events/values.yaml
+++ b/applications/sasquatch/charts/square-events/values.yaml
@@ -1,0 +1,4 @@
+cluster:
+  # The name of the Strimzi cluster. Synchronize this with the cluster name in
+  # the parent Sasquatch chart.
+  name: sasquatch

--- a/applications/sasquatch/values-roundtable-dev.yaml
+++ b/applications/sasquatch/values-roundtable-dev.yaml
@@ -102,3 +102,6 @@ rest-proxy:
 
 chronograf:
   enabled: false
+
+squareEvents:
+  enabled: true

--- a/applications/sasquatch/values.yaml
+++ b/applications/sasquatch/values.yaml
@@ -203,6 +203,10 @@ bucketmapper:
     # -- tag for rubin-influx-tools
     tag: 0.1.23
 
+squareEvents:
+  # -- Enable the Square Events subchart with topic and user configurations.
+  enabled: false
+
 global:
   # -- Base URL for the environment
   # @default -- Set by Argo CD

--- a/applications/squarebot/Chart.yaml
+++ b/applications/squarebot/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: squarebot
 version: 1.0.0
-appVersion: "tickets-DM-39043"
+appVersion: "0.7.0"
 description: Squarebot feeds events from services like Slack and GitHub into the SQuaRE Events Kafka message bus running on Roundtable. Backend apps like Templatebot can subscribe to these events and take domain-specific action.
 type: application
 home: https://squarebot.lsst.io/

--- a/applications/squarebot/Chart.yaml
+++ b/applications/squarebot/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: squarebot
+version: 1.0.0
+appVersion: "tickets-DM-39043"
+description: Squarebot feeds events from services like Slack and GitHub into the SQuaRE Events Kafka message bus running on Roundtable. Backend apps like Templatebot can subscribe to these events and take domain-specific action.
+type: application
+home: https://squarebot.lsst.io/
+sources:
+  - https://github.com/lsst-sqre/squarebot
+maintainers:
+  - name: jonathansick
+    url: https://github.com/jonathansick

--- a/applications/squarebot/README.md
+++ b/applications/squarebot/README.md
@@ -1,0 +1,52 @@
+# squarebot
+
+Squarebot feeds events from services like Slack and GitHub into the SQuaRE Events Kafka message bus running on Roundtable. Backend apps like Templatebot can subscribe to these events and take domain-specific action.
+
+**Homepage:** <https://squarebot.lsst.io/>
+
+## Source Code
+
+* <https://github.com/lsst-sqre/squarebot>
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| autoscaling.enabled | bool | `false` |  |
+| autoscaling.maxReplicas | int | `100` |  |
+| autoscaling.minReplicas | int | `1` |  |
+| autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
+| config.brokerUrl | string | `"sasquatch-kafka-bootstrap.sasquatch:9092"` | Bootstrap URLs for the Kafka brokers |
+| config.enableProducers | bool | `true` | Enable Kafka producers |
+| config.enableSchemas | bool | `true` | Enable Avro schema registration |
+| config.logLevel | string | `"INFO"` | Logging level: "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL" |
+| config.registryUrl | string | `"http://sasquatch-schema-registry.sasquatch:8081"` | Cluster URL for the Confluent Schema Registry |
+| config.subjectCompatibility | string | `"FORWARD"` | Schema subject compatibility. |
+| config.subjectSuffix | string | `""` | Schema subject suffix. Should be empty for production but can be set to a value to create unique subjects in the Confluent Schema Registry for testing. |
+| config.topics.slackAppMention | string | `"rubin.square.events.squarebot.slack.app_mention"` | Kafka topic name for the Slack `app_mention` events |
+| config.topics.slackInteraction | string | `"rubin.square.events.squarebot.slack.interaction"` | Kafka topic for Slack interaction events |
+| config.topics.slackMessageChannels | string | `"rubin.square.events.squarebot.slack.message.channels"` | Kafka topic name for the Slack `message.channels` events (public channels) |
+| config.topics.slackMessageGroups | string | `"rubin.square.events.squarebot.slack.message.groups"` | Kafka topic name for the Slack `message.groups` events (private channels) |
+| config.topics.slackMessageIm | string | `"rubin.square.events.squarebot.slack.message.im"` | Kafka topic name for the Slack `message.im` events (direct message channels) |
+| config.topics.slackMessageMpim | string | `"rubin.square.events.squarebot.slack.message.mpim"` | Kafka topic name for the Slack `message.mpim` events (multi-person direct messages) |
+| fullnameOverride | string | `""` | Override the full name for resources (includes the release name) |
+| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
+| global.host | string | Set by Argo CD | Host name for ingress |
+| image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
+| image.repository | string | `"ghcr.io/lsst-sqre/squarebot"` | Squarebot image repository |
+| image.tag | string | The appVersion of the chart | Tag of the image |
+| imagePullSecrets | list | `[]` | Secret names to use for all Docker pulls |
+| ingress.annotations | object | `{}` | Additional annotations to add to the ingress |
+| ingress.path | string | `"/squarebot"` | Path prefix where Squarebot is hosted |
+| nameOverride | string | `""` | Override the base name for resources |
+| nodeSelector | object | `{}` |  |
+| podAnnotations | object | `{}` | Annotations for API and worker pods |
+| replicaCount | int | `1` | Number of API pods to run |
+| resources | object | `{}` |  |
+| service.port | int | `80` | Port of the service to create and map to the ingress |
+| service.type | string | `"ClusterIP"` | Type of service to create |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| serviceAccount.name | string | `""` |  |
+| tolerations | list | `[]` |  |

--- a/applications/squarebot/README.md
+++ b/applications/squarebot/README.md
@@ -24,12 +24,12 @@ Squarebot feeds events from services like Slack and GitHub into the SQuaRE Event
 | config.registryUrl | string | `"http://sasquatch-schema-registry.sasquatch:8081"` | Cluster URL for the Confluent Schema Registry |
 | config.subjectCompatibility | string | `"FORWARD"` | Schema subject compatibility. |
 | config.subjectSuffix | string | `""` | Schema subject suffix. Should be empty for production but can be set to a value to create unique subjects in the Confluent Schema Registry for testing. |
-| config.topics.slackAppMention | string | `"rubin.square.events.squarebot.slack.app_mention"` | Kafka topic name for the Slack `app_mention` events |
-| config.topics.slackInteraction | string | `"rubin.square.events.squarebot.slack.interaction"` | Kafka topic for Slack interaction events |
-| config.topics.slackMessageChannels | string | `"rubin.square.events.squarebot.slack.message.channels"` | Kafka topic name for the Slack `message.channels` events (public channels) |
-| config.topics.slackMessageGroups | string | `"rubin.square.events.squarebot.slack.message.groups"` | Kafka topic name for the Slack `message.groups` events (private channels) |
-| config.topics.slackMessageIm | string | `"rubin.square.events.squarebot.slack.message.im"` | Kafka topic name for the Slack `message.im` events (direct message channels) |
-| config.topics.slackMessageMpim | string | `"rubin.square.events.squarebot.slack.message.mpim"` | Kafka topic name for the Slack `message.mpim` events (multi-person direct messages) |
+| config.topics.slackAppMention | string | `"lsst.square-events.squarebot.slack.app_mention"` | Kafka topic name for the Slack `app_mention` events |
+| config.topics.slackInteraction | string | `"lsst.square-events.squarebot.slack.interaction"` | Kafka topic for Slack interaction events |
+| config.topics.slackMessageChannels | string | `"lsst.square-events.squarebot.slack.message.channels"` | Kafka topic name for the Slack `message.channels` events (public channels) |
+| config.topics.slackMessageGroups | string | `"lsst.square-events.squarebot.slack.message.groups"` | Kafka topic name for the Slack `message.groups` events (private channels) |
+| config.topics.slackMessageIm | string | `"lsst.square-events.squarebot.slack.message.im"` | Kafka topic name for the Slack `message.im` events (direct message channels) |
+| config.topics.slackMessageMpim | string | `"lsst.square-events.squarebot.slack.message.mpim"` | Kafka topic name for the Slack `message.mpim` events (multi-person direct messages) |
 | fullnameOverride | string | `""` | Override the full name for resources (includes the release name) |
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |

--- a/applications/squarebot/README.md
+++ b/applications/squarebot/README.md
@@ -21,7 +21,7 @@ Squarebot feeds events from services like Slack and GitHub into the SQuaRE Event
 | config.registryUrl | string | `"http://sasquatch-schema-registry.sasquatch:8081"` | Cluster URL for the Confluent Schema Registry |
 | config.subjectCompatibility | string | `"FORWARD"` | Schema subject compatibility. |
 | config.subjectSuffix | string | `""` | Schema subject suffix. Should be empty for production but can be set to a value to create unique subjects in the Confluent Schema Registry for testing. |
-| config.topics.slackAppMention | string | `"lsst.square-events.squarebot.slack.app_mention"` | Kafka topic name for the Slack `app_mention` events |
+| config.topics.slackAppMention | string | `"lsst.square-events.squarebot.slack.app.mention"` | Kafka topic name for the Slack `app_mention` events |
 | config.topics.slackInteraction | string | `"lsst.square-events.squarebot.slack.interaction"` | Kafka topic for Slack interaction events |
 | config.topics.slackMessageChannels | string | `"lsst.square-events.squarebot.slack.message.channels"` | Kafka topic name for the Slack `message.channels` events (public channels) |
 | config.topics.slackMessageGroups | string | `"lsst.square-events.squarebot.slack.message.groups"` | Kafka topic name for the Slack `message.groups` events (private channels) |

--- a/applications/squarebot/README.md
+++ b/applications/squarebot/README.md
@@ -17,9 +17,6 @@ Squarebot feeds events from services like Slack and GitHub into the SQuaRE Event
 | autoscaling.maxReplicas | int | `100` |  |
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
-| config.brokerUrl | string | `"sasquatch-kafka-bootstrap.sasquatch:9092"` | Bootstrap URLs for the Kafka brokers |
-| config.enableProducers | bool | `true` | Enable Kafka producers |
-| config.enableSchemas | bool | `true` | Enable Avro schema registration |
 | config.logLevel | string | `"INFO"` | Logging level: "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL" |
 | config.registryUrl | string | `"http://sasquatch-schema-registry.sasquatch:8081"` | Cluster URL for the Confluent Schema Registry |
 | config.subjectCompatibility | string | `"FORWARD"` | Schema subject compatibility. |

--- a/applications/squarebot/templates/_helpers.tpl
+++ b/applications/squarebot/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "squarebot.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "squarebot.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "squarebot.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "squarebot.labels" -}}
+helm.sh/chart: {{ include "squarebot.chart" . }}
+{{ include "squarebot.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "squarebot.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "squarebot.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "squarebot.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "squarebot.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/applications/squarebot/templates/configmap.yaml
+++ b/applications/squarebot/templates/configmap.yaml
@@ -8,14 +8,14 @@ data:
   SAFIR_LOG_LEVEL: {{ .Values.config.logLevel | quote }}
   SAFIR_PATH_PREFIX: {{ .Values.ingress.path | quote }}
   SAFIR_ENVIRONMENT_URL: {{ .Values.global.baseUrl | quote }}
-  SQUAREBOT_ENABLE_SCHEMAS: {{ .Values.config.enableSchemas | quote }}
-  SQUAREBOT_ENABLE_PRODUCERS: {{ .Values.config.enableProducers | quote }}
+  SAFIR_PROFILE: "production"
   SQUAREBOT_REGISTRY_URL: {{ .Values.config.registryUrl | quote }}
-  SQUAREBOT_BROKER_URL: {{ .Values.config.brokerUrl | quote }}
+  SQUAREBOT_SUBJECT_SUFFIX: {{ .Values.config.subjectSuffix | quote }}
+  SQUAREBOT_SUBJECT_COMPATIBILITY: {{ .Values.config.subjectCompatibility | quote }}
+  # SQUAREBOT_BROKER_URL: {{ .Values.config.brokerUrl | quote }}
   SQUAREBOT_TOPIC_APP_MENTION: {{ .Values.config.topics.slackAppMention | quote }}
   SQUAREBOT_TOPIC_MESSAGE_CHANNELS: {{ .Values.config.topics.slackMessageChannels | quote }}
   SQUAREBOT_TOPIC_MESSAGE_GROUPS: {{ .Values.config.topics.slackMessageGroups | quote }}
   SQUAREBOT_TOPIC_MESSAGE_IM: {{ .Values.config.topics.slackMessageIm | quote }}
   SQUAREBOT_TOPIC_MESSAGE_MPIM: {{ .Values.config.topics.slackMessageMpim | quote }}
   SQUAREBOT_TOPIC_MESSAGE_INTERACTION: {{ .Values.config.topics.slackInteraction | quote }}
-  SQUAREBOT_SLACK_APP_ID: {{ .Values.config.slackAppId | quote }}

--- a/applications/squarebot/templates/configmap.yaml
+++ b/applications/squarebot/templates/configmap.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "squarebot.fullname" . }}
+  labels:
+    {{- include "squarebot.labels" . | nindent 4 }}
+data:
+  SAFIR_LOG_LEVEL: {{ .Values.config.logLevel | quote }}
+  SAFIR_PATH_PREFIX: {{ .Values.ingress.path | quote }}
+  SAFIR_ENVIRONMENT_URL: {{ .Values.global.baseUrl | quote }}
+  SQUAREBOT_ENABLE_SCHEMAS: {{ .Values.config.enableSchemas | quote }}
+  SQUAREBOT_ENABLE_PRODUCERS: {{ .Values.config.enableProducers | quote }}
+  SQUAREBOT_REGISTRY_URL: {{ .Values.config.registryUrl | quote }}
+  SQUAREBOT_BROKER_URL: {{ .Values.config.brokerUrl | quote }}
+  SQUAREBOT_TOPIC_APP_MENTION: {{ .Values.config.topics.slackAppMention | quote }}
+  SQUAREBOT_TOPIC_MESSAGE_CHANNELS: {{ .Values.config.topics.slackMessageChannels | quote }}
+  SQUAREBOT_TOPIC_MESSAGE_GROUPS: {{ .Values.config.topics.slackMessageGroups | quote }}
+  SQUAREBOT_TOPIC_MESSAGE_IM: {{ .Values.config.topics.slackMessageIm | quote }}
+  SQUAREBOT_TOPIC_MESSAGE_MPIM: {{ .Values.config.topics.slackMessageMpim | quote }}
+  SQUAREBOT_TOPIC_MESSAGE_INTERACTION: {{ .Values.config.topics.slackInteraction | quote }}
+  SQUAREBOT_SLACK_APP_ID: {{ .Values.config.slackAppId | quote }}

--- a/applications/squarebot/templates/configmap.yaml
+++ b/applications/squarebot/templates/configmap.yaml
@@ -12,7 +12,6 @@ data:
   SQUAREBOT_REGISTRY_URL: {{ .Values.config.registryUrl | quote }}
   SQUAREBOT_SUBJECT_SUFFIX: {{ .Values.config.subjectSuffix | quote }}
   SQUAREBOT_SUBJECT_COMPATIBILITY: {{ .Values.config.subjectCompatibility | quote }}
-  # SQUAREBOT_BROKER_URL: {{ .Values.config.brokerUrl | quote }}
   SQUAREBOT_TOPIC_APP_MENTION: {{ .Values.config.topics.slackAppMention | quote }}
   SQUAREBOT_TOPIC_MESSAGE_CHANNELS: {{ .Values.config.topics.slackMessageChannels | quote }}
   SQUAREBOT_TOPIC_MESSAGE_GROUPS: {{ .Values.config.topics.slackMessageGroups | quote }}

--- a/applications/squarebot/templates/deployment.yaml
+++ b/applications/squarebot/templates/deployment.yaml
@@ -74,6 +74,8 @@ spec:
             # From replicated KafkaUser secret
             - name: "KAFKA_SSL_CLUSTER_CAFILE"
               value: "/etc/kafkauser/ca.crt"
+            - name: "KAFKA_SSL_CLIENT_CAFILE"
+              value: "/etc/kafkauser/ca.crt"
             - name: "KAFKA_SSL_CLIENT_CERTFILE"
               value: "/etc/kafkauser/user.crt"
             - name: "KAFKA_SSL_CLIENT_KEYFILE"

--- a/applications/squarebot/templates/deployment.yaml
+++ b/applications/squarebot/templates/deployment.yaml
@@ -56,6 +56,28 @@ spec:
             - configMapRef:
                 name: {{ include "squarebot.fullname" . }}
           env:
+            # Writeable directory for concatenating certs. See "tmp" volume.
+            - name: "KAFKA_CERT_TEMP_DIR"
+              value: "/tmp/kafka_certs"
+            # From KafkaAccess
+            - name: "KAFKA_BOOTSTRAP_SERVERS"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "squarebot.fullname" . }}-kafka
+                  key: "bootstrapServers"
+            - name: "KAFKA_SECURITY_PROTOCOL"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "squarebot.fullname" . }}-kafka
+                  key: "securityProtocol"
+            # From replicated KafkaUser secret
+            - name: "KAFKA_SSL_CLUSTER_CAFILE"
+              value: "/etc/kafkauser/ca.crt"
+            - name: "KAFKA_SSL_CLIENT_CERTFILE"
+              value: "/etc/kafkauser/user.crt"
+            - name: "KAFKA_SSL_CLIENT_KEYFILE"
+              value: "/etc/kafkauser/user.key"
+            # From Vault secrets
             - name: "SQUAREBOT_SLACK_APP_ID"
               valueFrom:
                 secretKeyRef:
@@ -77,6 +99,18 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: "kafka-user"
+              mountPath: "/etc/kafkauser/ca.crt"
+              subPath: "ca.crt"
+            - name: "kafka-user"
+              mountPath: "/etc/kafkauser/user.crt"
+              subPath: "user.crt"
+            - name: "kafka-user"
+              mountPath: "/etc/kafkauser/user.key"
+              subPath: "user.key"
+            - name: "tmp"
+              mountPath: "/tmp/kafka_certs"
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -89,3 +123,9 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      volumes:
+        - name: "kafka-user"
+          secret:
+            secretName: {{ template "squarebot.fullname" . }}-kafka-user
+        - name: "tmp"
+          emptyDir: {}

--- a/applications/squarebot/templates/deployment.yaml
+++ b/applications/squarebot/templates/deployment.yaml
@@ -1,0 +1,91 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "squarebot.fullname" . }}
+  labels:
+    {{- include "squarebot.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
+    app.kubernetes.io/part-of: "squarebot"
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "squarebot.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "squarebot.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: "server"
+        app.kubernetes.io/part-of: "squarebot"
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "squarebot.serviceAccountName" . }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "squarebot.fullname" . }}
+          env:
+            - name: "SQUAREBOT_SLACK_APP_ID"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "squarebot.fullname" . }}
+                  key: "SQUAREBOT_SLACK_APP_ID"
+            - name: "SQUAREBOT_SLACK_SIGNING"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "squarebot.fullname" . }}
+                  key: "SQUAREBOT_SLACK_SIGNING"
+            - name: "SQUAREBOT_SLACK_TOKEN"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "squarebot.fullname" . }}
+                  key: "SQUAREBOT_SLACK_TOKEN"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/applications/squarebot/templates/deployment.yaml
+++ b/applications/squarebot/templates/deployment.yaml
@@ -73,7 +73,7 @@ spec:
               #     key: "securityProtocol"
             # From replicated KafkaUser secret
             - name: "KAFKA_SSL_CLUSTER_CAFILE"
-              value: "/etc/kafkauser/ca.crt"
+              value: "/etc/kafkacluster/ca.crt"
             - name: "KAFKA_SSL_CLIENT_CAFILE"
               value: "/etc/kafkauser/ca.crt"
             - name: "KAFKA_SSL_CLIENT_CERTFILE"
@@ -103,6 +103,9 @@ spec:
                 - ALL
             readOnlyRootFilesystem: true
           volumeMounts:
+            - name: "{{ template "squarebot.fullname" . }}"
+              mountPath: "/etc/kafkacluster/ca.crt"
+              subPath: "ca.crt"
             - name: "kafka-user"
               mountPath: "/etc/kafkauser/ca.crt"
               subPath: "ca.crt"
@@ -130,5 +133,8 @@ spec:
         - name: "kafka-user"
           secret:
             secretName: {{ template "squarebot.fullname" . }}-kafka-user
+        - name: "{{ template "squarebot.fullname" . }}"
+          secret:
+            secretName: {{ template "squarebot.fullname" . }}
         - name: "tmp"
           emptyDir: {}

--- a/applications/squarebot/templates/deployment.yaml
+++ b/applications/squarebot/templates/deployment.yaml
@@ -66,10 +66,11 @@ spec:
                   name: {{ template "squarebot.fullname" . }}-kafka
                   key: "bootstrapServers"
             - name: "KAFKA_SECURITY_PROTOCOL"
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "squarebot.fullname" . }}-kafka
-                  key: "securityProtocol"
+              value: "SSL"
+              # valueFrom:
+              #   secretKeyRef:
+              #     name: {{ template "squarebot.fullname" . }}-kafka
+              #     key: "securityProtocol"
             # From replicated KafkaUser secret
             - name: "KAFKA_SSL_CLUSTER_CAFILE"
               value: "/etc/kafkauser/ca.crt"

--- a/applications/squarebot/templates/hpa.yaml
+++ b/applications/squarebot/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "squarebot.fullname" . }}
+  labels:
+    {{- include "squarebot.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "squarebot.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/applications/squarebot/templates/ingress-anonymous.yaml
+++ b/applications/squarebot/templates/ingress-anonymous.yaml
@@ -1,0 +1,29 @@
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
+metadata:
+  name: {{ template "squarebot.fullname" . }}-anonymous
+  labels:
+    {{- include "squarebot.labels" . | nindent 4 }}
+config:
+  baseUrl: {{ .Values.global.baseUrl | quote }}
+  scopes:
+    anonymous: true
+template:
+  metadata:
+    name: {{ template "squarebot.fullname" . }}
+    {{- with .Values.ingress.annotations }}
+    annotations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  spec:
+    rules:
+      - host: {{ required "global.host must be set" .Values.global.host | quote }}
+        http:
+          paths:
+            - path: {{ .Values.ingress.path | quote }}
+              pathType: "Prefix"
+              backend:
+                service:
+                  name: {{ template "squarebot.fullname" . }}
+                  port:
+                    number: {{ .Values.service.port }}

--- a/applications/squarebot/templates/kafkaaccess.yaml
+++ b/applications/squarebot/templates/kafkaaccess.yaml
@@ -1,0 +1,14 @@
+apiVersion: access.strimzi.io/v1alpha1
+kind: KafkaAccess
+metadata:
+  name: squarebot
+spec:
+  kafka:
+    name: sasquatch
+    namespace: sasquatch
+    listener: tls
+  user:
+    kind: KafkaUser
+    apiGroup: kafka.strimzi.io
+    name: squarebot
+    namespace: sasquatch

--- a/applications/squarebot/templates/kafkaaccess.yaml
+++ b/applications/squarebot/templates/kafkaaccess.yaml
@@ -1,7 +1,7 @@
 apiVersion: access.strimzi.io/v1alpha1
 kind: KafkaAccess
 metadata:
-  name: squarebot
+  name: {{ include "squarebot.fullname" . }}-kafka
 spec:
   kafka:
     name: sasquatch

--- a/applications/squarebot/templates/kafkauser-secret.yaml
+++ b/applications/squarebot/templates/kafkauser-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "squarebot.fullname" . }}-kafka-user
+  annotations:
+    replicator.v1.mittwald.de/replicate-from: sasquatch/squarebot
+    replicator.v1.mittwald.de/strip-labels: "true"
+data: {}

--- a/applications/squarebot/templates/networkpolicy.yaml
+++ b/applications/squarebot/templates/networkpolicy.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "squarebot.fullname" . }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "squarebot.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    # Allow inbound access from pods (in any namespace) labeled
+    # gafaelfawr.lsst.io/ingress: true.
+    - from:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              gafaelfawr.lsst.io/ingress: "true"
+      ports:
+        - protocol: "TCP"
+          port: 8080

--- a/applications/squarebot/templates/service.yaml
+++ b/applications/squarebot/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "squarebot.fullname" . }}
+  labels:
+    {{- include "squarebot.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "squarebot.selectorLabels" . | nindent 4 }}

--- a/applications/squarebot/templates/serviceaccount.yaml
+++ b/applications/squarebot/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "squarebot.serviceAccountName" . }}
+  labels:
+    {{- include "squarebot.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/applications/squarebot/templates/tests/test-connection.yaml
+++ b/applications/squarebot/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "squarebot.fullname" . }}-test-connection"
+  labels:
+    {{- include "squarebot.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "squarebot.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/applications/squarebot/templates/vaultsecret.yaml
+++ b/applications/squarebot/templates/vaultsecret.yaml
@@ -1,0 +1,9 @@
+apiVersion: ricoberger.de/v1alpha1
+kind: VaultSecret
+metadata:
+  name: {{ include "squarebot.fullname" . }}
+  labels:
+    {{- include "squarebot.labels" . | nindent 4 }}
+spec:
+  path: "{{ .Values.global.vaultSecretsPathPrefix }}/squarebot"
+  type: Opaque

--- a/applications/squarebot/values-roundtable-dev.yaml
+++ b/applications/squarebot/values-roundtable-dev.yaml
@@ -1,0 +1,5 @@
+image:
+  pullPolicy: Always
+
+config:
+  logLevel: "DEBUG"

--- a/applications/squarebot/values.yaml
+++ b/applications/squarebot/values.yaml
@@ -107,7 +107,7 @@ config:
 
   topics:
     # -- Kafka topic name for the Slack `app_mention` events
-    slackAppMention: "lsst.square-events.squarebot.slack.app_mention"
+    slackAppMention: "lsst.square-events.squarebot.slack.app.mention"
 
     # -- Kafka topic name for the Slack `message.channels` events (public channels)
     slackMessageChannels: "lsst.square-events.squarebot.slack.message.channels"

--- a/applications/squarebot/values.yaml
+++ b/applications/squarebot/values.yaml
@@ -116,19 +116,19 @@ config:
 
   topics:
     # -- Kafka topic name for the Slack `app_mention` events
-    slackAppMention: "rubin.square.events.squarebot.slack.app_mention"
+    slackAppMention: "lsst.square-events.squarebot.slack.app_mention"
 
     # -- Kafka topic name for the Slack `message.channels` events (public channels)
-    slackMessageChannels: "rubin.square.events.squarebot.slack.message.channels"
+    slackMessageChannels: "lsst.square-events.squarebot.slack.message.channels"
 
     # -- Kafka topic name for the Slack `message.groups` events (private channels)
-    slackMessageGroups: "rubin.square.events.squarebot.slack.message.groups"
+    slackMessageGroups: "lsst.square-events.squarebot.slack.message.groups"
 
     # -- Kafka topic name for the Slack `message.im` events (direct message channels)
-    slackMessageIm: "rubin.square.events.squarebot.slack.message.im"
+    slackMessageIm: "lsst.square-events.squarebot.slack.message.im"
 
     # -- Kafka topic name for the Slack `message.mpim` events (multi-person direct messages)
-    slackMessageMpim: "rubin.square.events.squarebot.slack.message.mpim"
+    slackMessageMpim: "lsst.square-events.squarebot.slack.message.mpim"
 
     # -- Kafka topic for Slack interaction events
-    slackInteraction: "rubin.square.events.squarebot.slack.interaction"
+    slackInteraction: "lsst.square-events.squarebot.slack.interaction"

--- a/applications/squarebot/values.yaml
+++ b/applications/squarebot/values.yaml
@@ -94,17 +94,8 @@ config:
   # -- Logging level: "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"
   logLevel: "INFO"
 
-  # -- Enable Avro schema registration
-  enableSchemas: true
-
-  # -- Enable Kafka producers
-  enableProducers: true
-
   # -- Cluster URL for the Confluent Schema Registry
   registryUrl: "http://sasquatch-schema-registry.sasquatch:8081"
-
-  # -- Bootstrap URLs for the Kafka brokers
-  brokerUrl: "sasquatch-kafka-bootstrap.sasquatch:9092"
 
   # -- Schema subject suffix. Should be empty for production but can be set
   # to a value to create unique subjects in the Confluent Schema Registry

--- a/applications/squarebot/values.yaml
+++ b/applications/squarebot/values.yaml
@@ -1,0 +1,134 @@
+# Default values for squarebot.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+#
+# Global parameters will be set by parameters injected by Argo CD and should
+# not be set in the individual environment values files.
+global:
+  # -- Base URL for the environment
+  # @default -- Set by Argo CD
+  baseUrl: ""
+
+  # -- Host name for ingress
+  # @default -- Set by Argo CD
+  host: ""
+
+# -- Number of API pods to run
+replicaCount: 1
+
+image:
+  # -- Squarebot image repository
+  repository: ghcr.io/lsst-sqre/squarebot
+
+  # -- Image pull policy
+  pullPolicy: IfNotPresent
+
+  # -- Tag of the image
+  # @default -- The appVersion of the chart
+  tag: ""
+
+# -- Secret names to use for all Docker pulls
+imagePullSecrets: []
+
+# -- Override the base name for resources
+nameOverride: ""
+
+# -- Override the full name for resources (includes the release name)
+fullnameOverride: ""
+
+serviceAccount:
+  # -- Specifies whether a service account should be created
+  create: true
+
+  # -- Annotations to add to the service account
+  annotations: {}
+
+  # The name of the service account to use.
+  # @default -- Generated using the fullname template
+  name: ""
+
+# -- Annotations for API and worker pods
+podAnnotations: {}
+
+service:
+  # -- Type of service to create
+  type: ClusterIP
+
+  # -- Port of the service to create and map to the ingress
+  port: 80
+
+ingress:
+  # -- Additional annotations to add to the ingress
+  annotations: {}
+
+  # -- Path prefix where Squarebot is hosted
+  path: "/squarebot"
+
+resources:
+  {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+config:
+  # -- Logging level: "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"
+  logLevel: "INFO"
+
+  # -- Enable Avro schema registration
+  enableSchemas: true
+
+  # -- Enable Kafka producers
+  enableProducers: true
+
+  # -- Cluster URL for the Confluent Schema Registry
+  registryUrl: "http://sasquatch-schema-registry.sasquatch:8081"
+
+  # -- Bootstrap URLs for the Kafka brokers
+  brokerUrl: "sasquatch-kafka-bootstrap.sasquatch:9092"
+
+  # -- Schema subject suffix. Should be empty for production but can be set
+  # to a value to create unique subjects in the Confluent Schema Registry
+  # for testing.
+  subjectSuffix: ""
+
+  # -- Schema subject compatibility.
+  subjectCompatibility: "FORWARD"
+
+  topics:
+    # -- Kafka topic name for the Slack `app_mention` events
+    slackAppMention: "rubin.square.events.squarebot.slack.app_mention"
+
+    # -- Kafka topic name for the Slack `message.channels` events (public channels)
+    slackMessageChannels: "rubin.square.events.squarebot.slack.message.channels"
+
+    # -- Kafka topic name for the Slack `message.groups` events (private channels)
+    slackMessageGroups: "rubin.square.events.squarebot.slack.message.groups"
+
+    # -- Kafka topic name for the Slack `message.im` events (direct message channels)
+    slackMessageIm: "rubin.square.events.squarebot.slack.message.im"
+
+    # -- Kafka topic name for the Slack `message.mpim` events (multi-person direct messages)
+    slackMessageMpim: "rubin.square.events.squarebot.slack.message.mpim"
+
+    # -- Kafka topic for Slack interaction events
+    slackInteraction: "rubin.square.events.squarebot.slack.interaction"

--- a/docs/applications/index.rst
+++ b/docs/applications/index.rst
@@ -60,3 +60,9 @@ To learn how to develop applications for Phalanx, see the :doc:`/developers/inde
    strimzi-registry-operator/index
    telegraf/index
    telegraf-ds/index
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Roundtable
+
+   squarebot/index

--- a/docs/applications/index.rst
+++ b/docs/applications/index.rst
@@ -65,4 +65,5 @@ To learn how to develop applications for Phalanx, see the :doc:`/developers/inde
    :maxdepth: 1
    :caption: Roundtable
 
+   kubernetes-replicator/index
    squarebot/index

--- a/docs/applications/kubernetes-replicator/index.rst
+++ b/docs/applications/kubernetes-replicator/index.rst
@@ -1,0 +1,17 @@
+.. px-app:: kubernetes-replicator
+
+#################################################
+kubernetes-replicator - Cross-namespace resources
+#################################################
+
+kubernetes-replicator is a Kubernetes operator that replicates resources across namespaces.
+
+.. jinja:: kubernetes-replicator
+   :file: applications/_summary.rst.jinja
+
+Guides
+======
+
+.. toctree::
+
+   values

--- a/docs/applications/kubernetes-replicator/values.md
+++ b/docs/applications/kubernetes-replicator/values.md
@@ -1,0 +1,12 @@
+```{px-app-values} kubernetes-replicator
+```
+
+# Kubernetes Helm values reference
+
+Helm values reference table for the {px-app}`kubernetes-replicator` application.
+
+```{include} ../../../applications/kubernetes-replicator/README.md
+---
+start-after: "## Values"
+---
+```

--- a/docs/applications/squarebot/index.rst
+++ b/docs/applications/squarebot/index.rst
@@ -1,0 +1,18 @@
+.. px-app:: squarebot
+
+###############################
+squarebot — Kafka event gateway
+###############################
+
+Squarebot feeds events from services like Slack and GitHub into the SQuaRE Events Kafka message bus running on Roundtable. Backend apps like Templatebot can subscribe to these events and take domain-specific action.
+
+.. jinja:: squarebot
+   :file: applications/_summary.rst.jinja
+
+Guides
+======
+
+.. toctree::
+   :maxdepth: 1
+
+   values

--- a/docs/applications/squarebot/values.md
+++ b/docs/applications/squarebot/values.md
@@ -1,0 +1,12 @@
+```{px-app-values} squarebot
+```
+
+# Squarebot Helm values reference
+
+Helm values reference table for the {px-app}`squarebot` application.
+
+```{include} ../../../applications/squarebot/README.md
+---
+start-after: "## Values"
+---
+```

--- a/environments/README.md
+++ b/environments/README.md
@@ -35,6 +35,7 @@
 | semaphore.enabled | bool | `false` |  |
 | sherlock.enabled | bool | `false` |  |
 | sqlproxy-cross-project.enabled | bool | `false` |  |
+| squarebot.enabled | bool | `false` |  |
 | squareone.enabled | bool | `false` |  |
 | squash-api.enabled | bool | `false` |  |
 | ssotap.enabled | bool | `false` |  |

--- a/environments/README.md
+++ b/environments/README.md
@@ -16,6 +16,7 @@
 | gafaelfawr.enabled | bool | `false` |  |
 | hips.enabled | bool | `false` |  |
 | ingress-nginx.enabled | bool | `false` |  |
+| kubernetes-replicator.enabled | bool | `false` |  |
 | linters.enabled | bool | `false` |  |
 | mobu.enabled | bool | `false` |  |
 | moneypenny.enabled | bool | `false` |  |

--- a/environments/templates/kubernetes-replicator-application.yaml
+++ b/environments/templates/kubernetes-replicator-application.yaml
@@ -1,0 +1,37 @@
+{{- if (index .Values "kubernetes-replicator" "enabled") -}}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "kubernetes-replicator"
+spec:
+  finalizers:
+    - "kubernetes"
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: "kubernetes-replicator"
+  namespace: "argocd"
+  finalizers:
+    - "resources-finalizer.argocd.argoproj.io"
+spec:
+  destination:
+    namespace: "kubernetes-replicator"
+    server: "https://kubernetes.default.svc"
+  project: "default"
+  source:
+    path: "applications/kubernetes-replicator"
+    repoURL: {{ .Values.repoURL | quote }}
+    targetRevision: {{ .Values.targetRevision | quote }}
+    helm:
+      parameters:
+        - name: "global.host"
+          value: {{ .Values.fqdn | quote }}
+        - name: "global.baseUrl"
+          value: "https://{{ .Values.fqdn }}"
+        - name: "global.vaultSecretsPath"
+          value: {{ .Values.vaultPathPrefix | quote }}
+      valueFiles:
+        - "values.yaml"
+        - "values-{{ .Values.environment }}.yaml"
+{{- end -}}

--- a/environments/templates/squarebot-application.yaml
+++ b/environments/templates/squarebot-application.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.squarebot.enabled -}}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "squarebot"
+spec:
+  finalizers:
+    - "kubernetes"
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: "squarebot"
+  namespace: "argocd"
+  finalizers:
+    - "resources-finalizer.argocd.argoproj.io"
+spec:
+  destination:
+    namespace: "squarebot"
+    server: "https://kubernetes.default.svc"
+  project: "default"
+  source:
+    path: "applications/squarebot"
+    repoURL: {{ .Values.repoURL | quote }}
+    targetRevision: {{ .Values.targetRevision | quote }}
+    helm:
+      parameters:
+        - name: "global.host"
+          value: {{ .Values.fqdn | quote }}
+        - name: "global.baseUrl"
+          value: "https://{{ .Values.fqdn }}"
+        - name: "global.vaultSecretsPathPrefix"
+          value: {{ .Values.vaultPathPrefix | quote }}
+      valueFiles:
+        - "values.yaml"
+        - "values-{{ .Values.environment }}.yaml"
+{{- end -}}

--- a/environments/values-base.yaml
+++ b/environments/values-base.yaml
@@ -20,6 +20,8 @@ hips:
   enabled: false
 ingress-nginx:
   enabled: true
+kubernetes-replicator:
+  enabled: false
 mobu:
   enabled: false
 moneypenny:

--- a/environments/values-base.yaml
+++ b/environments/values-base.yaml
@@ -44,6 +44,8 @@ production-tools:
   enabled: false
 semaphore:
   enabled: false
+squarebot:
+  enabled: false
 squareone:
   enabled: true
 squash-api:

--- a/environments/values-ccin2p3.yaml
+++ b/environments/values-ccin2p3.yaml
@@ -22,6 +22,8 @@ moneypenny:
   enabled: true
 ingress-nginx:
   enabled: true
+kubernetes-replicator:
+  enabled: false
 narrativelog:
   enabled: false
 noteburst:

--- a/environments/values-ccin2p3.yaml
+++ b/environments/values-ccin2p3.yaml
@@ -44,6 +44,8 @@ semaphore:
   enabled: false
 sherlock:
   enabled: false
+squarebot:
+  enabled: false
 squareone:
   enabled: true
 squash-api:

--- a/environments/values-idfdev.yaml
+++ b/environments/values-idfdev.yaml
@@ -49,6 +49,8 @@ sherlock:
   enabled: true
 squareone:
   enabled: true
+squarebot:
+  enabled: false
 squash-api:
   enabled: false
 sqlproxy-cross-project:

--- a/environments/values-idfdev.yaml
+++ b/environments/values-idfdev.yaml
@@ -21,6 +21,8 @@ hips:
   enabled: true
 ingress-nginx:
   enabled: true
+kubernetes-replicator:
+  enabled: false
 mobu:
   enabled: true
 moneypenny:

--- a/environments/values-idfint.yaml
+++ b/environments/values-idfint.yaml
@@ -53,6 +53,8 @@ semaphore:
   enabled: true
 sherlock:
   enabled: true
+squarebot:
+  enabled: false
 squareone:
   enabled: true
 strimzi:

--- a/environments/values-idfint.yaml
+++ b/environments/values-idfint.yaml
@@ -21,6 +21,8 @@ hips:
   enabled: true
 ingress-nginx:
   enabled: true
+kubernetes-replicator:
+  enabled: false
 linters:
   enabled: true
 mobu:

--- a/environments/values-idfprod.yaml
+++ b/environments/values-idfprod.yaml
@@ -47,6 +47,8 @@ semaphore:
   enabled: true
 sherlock:
   enabled: true
+squarebot:
+  enabled: false
 squareone:
   enabled: true
 squash-api:

--- a/environments/values-idfprod.yaml
+++ b/environments/values-idfprod.yaml
@@ -21,6 +21,8 @@ hips:
   enabled: true
 ingress-nginx:
   enabled: true
+kubernetes-replicator:
+  enabled: false
 mobu:
   enabled: true
 moneypenny:

--- a/environments/values-minikube.yaml
+++ b/environments/values-minikube.yaml
@@ -20,6 +20,8 @@ hips:
   enabled: true
 ingress-nginx:
   enabled: true
+kubernetes-replicator:
+  enabled: false
 mobu:
   enabled: true
 moneypenny:

--- a/environments/values-minikube.yaml
+++ b/environments/values-minikube.yaml
@@ -46,6 +46,8 @@ semaphore:
   enabled: false
 sherlock:
   enabled: false
+squarebot:
+  enabled: false
 squareone:
   enabled: true
 squash-api:

--- a/environments/values-roe.yaml
+++ b/environments/values-roe.yaml
@@ -20,6 +20,8 @@ hips:
   enabled: false
 ingress-nginx:
   enabled: true
+kubernetes-replicator:
+  enabled: false
 mobu:
   enabled: true
 moneypenny:

--- a/environments/values-roe.yaml
+++ b/environments/values-roe.yaml
@@ -44,6 +44,8 @@ production-tools:
   enabled: false
 semaphore:
   enabled: false
+squarebot:
+  enabled: false
 squareone:
   enabled: true
 squash-api:

--- a/environments/values-roundtable-dev.yaml
+++ b/environments/values-roundtable-dev.yaml
@@ -46,6 +46,8 @@ semaphore:
   enabled: false
 sherlock:
   enabled: false
+squarebot:
+  enabled: true
 squareone:
   enabled: true
 squash-api:

--- a/environments/values-roundtable-dev.yaml
+++ b/environments/values-roundtable-dev.yaml
@@ -20,6 +20,8 @@ hips:
   enabled: false
 ingress-nginx:
   enabled: true
+kubernetes-replicator:
+  enabled: true
 mobu:
   enabled: false
 moneypenny:

--- a/environments/values-roundtable-prod.yaml
+++ b/environments/values-roundtable-prod.yaml
@@ -20,6 +20,8 @@ hips:
   enabled: false
 ingress-nginx:
   enabled: true
+kubernetes-replicator:
+  enabled: false
 mobu:
   enabled: false
 moneypenny:

--- a/environments/values-roundtable-prod.yaml
+++ b/environments/values-roundtable-prod.yaml
@@ -46,6 +46,8 @@ semaphore:
   enabled: false
 sherlock:
   enabled: false
+squarebot:
+  enabled: false
 squareone:
   enabled: true
 squash-api:

--- a/environments/values-summit.yaml
+++ b/environments/values-summit.yaml
@@ -20,6 +20,8 @@ hips:
   enabled: false
 ingress-nginx:
   enabled: true
+kubernetes-replicator:
+  enabled: false
 mobu:
   enabled: false
 moneypenny:

--- a/environments/values-summit.yaml
+++ b/environments/values-summit.yaml
@@ -46,6 +46,8 @@ semaphore:
   enabled: false
 sherlock:
   enabled: false
+squarebot:
+  enabled: false
 squareone:
   enabled: true
 squash-api:

--- a/environments/values-tucson-teststand.yaml
+++ b/environments/values-tucson-teststand.yaml
@@ -20,6 +20,8 @@ hips:
   enabled: false
 ingress-nginx:
   enabled: true
+kubernetes-replicator:
+  enabled: false
 mobu:
   enabled: false
 moneypenny:

--- a/environments/values-tucson-teststand.yaml
+++ b/environments/values-tucson-teststand.yaml
@@ -44,6 +44,8 @@ production-tools:
   enabled: false
 semaphore:
   enabled: false
+squarebot:
+  enabled: false
 squareone:
   enabled: true
 squash-api:

--- a/environments/values-usdfdev.yaml
+++ b/environments/values-usdfdev.yaml
@@ -52,6 +52,8 @@ semaphore:
   enabled: true
 sherlock:
   enabled: false
+squarebot:
+  enabled: false
 squareone:
   enabled: true
 squash-api:

--- a/environments/values-usdfdev.yaml
+++ b/environments/values-usdfdev.yaml
@@ -22,6 +22,8 @@ hips:
   enabled: false
 ingress-nginx:
   enabled: false
+kubernetes-replicator:
+  enabled: false
 mobu:
   enabled: true
 moneypenny:

--- a/environments/values-usdfprod.yaml
+++ b/environments/values-usdfprod.yaml
@@ -50,6 +50,8 @@ semaphore:
   enabled: true
 sherlock:
   enabled: false
+squarebot:
+  enabled: false
 squareone:
   enabled: true
 squash-api:

--- a/environments/values-usdfprod.yaml
+++ b/environments/values-usdfprod.yaml
@@ -22,6 +22,8 @@ hips:
   enabled: false
 ingress-nginx:
   enabled: false
+kubernetes-replicator:
+  enabled: false
 mobu:
   enabled: true
 moneypenny:

--- a/environments/values.yaml
+++ b/environments/values.yaml
@@ -70,6 +70,8 @@ sherlock:
   enabled: false
 sqlproxy-cross-project:
   enabled: false
+squarebot:
+  enabled: false
 squareone:
   enabled: false
 squash-api:

--- a/environments/values.yaml
+++ b/environments/values.yaml
@@ -34,6 +34,8 @@ hips:
   enabled: false
 ingress-nginx:
   enabled: false
+kubernetes-replicator:
+  enabled: false
 linters:
   enabled: false
 mobu:

--- a/installer/update_secrets.sh
+++ b/installer/update_secrets.sh
@@ -1,10 +1,10 @@
 #!/bin/bash -e
 ENVIRONMENT=$1
 
+export OP_CONNECT_HOST=https://roundtable.lsst.codes/1password
 export VAULT_DOC_UUID=`yq -r .onepasswordUuid ../environments/values.yaml`
 export VAULT_ADDR=https://vault.lsst.codes
 export VAULT_TOKEN=`./vault_key.py $ENVIRONMENT write`
-export OP_CONNECT_HOST=https://roundtable.lsst.codes/1password
 
 if [ -z "$OP_CONNECT_TOKEN" ]; then
     echo 'OP_CONNECT_TOKEN must be set to a 1Password Connect token' >&2


### PR DESCRIPTION
This enables the deployment of https://github.com/lsst-sqre/squarebot onto roundtable-dev for development.

- Adds a `square-events` subchart to sasquatch to maintain all Roundtable SQuaRE Events-related Kafka users and topics. This subchart is disabled by default.
- Adds a `squarebot` application that uses a `KafkaAccess` resource
- Adds a `kubernetes-replicator` application that enables an app to replicator secrets across namespaces. This is needed because the strimzi-access-operator doesn't currently replicate TLS certs. This app can be retired when strimzi-access-operator is released. https://github.com/mittwald/kubernetes-replicator

Merge after #2147