### PR TITLE
DM-38425: Enable Jupyter lab debugging on IDF dev

### DIFF
--- a/applications/mobu/values-idfdev.yaml
+++ b/applications/mobu/values-idfdev.yaml
@@ -17,6 +17,7 @@ config:
           image:
             image_class: "latest-weekly"
             size: "Small"
+            debug: true
         restart: true
     - name: "tap"
       count: 1


### PR DESCRIPTION
In the mobu image spec, enable debugging for the Jupyter lab tests on IDF dev.