### PR TITLE
Use JSON logging format for cert-manager

### DIFF
--- a/applications/cert-manager/README.md
+++ b/applications/cert-manager/README.md
@@ -12,11 +12,12 @@ TLS certificate manager
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| cert-manager | object | Install CRDs, force use of Google and Cloudfront DNS servers | Configuration for upstream cert-manager chart |
+| cert-manager.cainjector.extraArgs | list | `["--logging-format=json"]` | Additional arguments to the CA injector |
+| cert-manager.extraArgs | list | `["--logging-format=json","--dns01-recursive-nameservers-only","--dns01-recursive-nameservers=8.8.8.8:53,1.1.1.1:53"]` | Additional arguments to the main cert-manager pod |
+| cert-manager.installCRDs | bool | `true` | Whether to install CRDs |
+| cert-manager.webhook.extraArgs | list | `["--logging-format=json"]` | Additional arguments to the webhook pod |
 | config.createIssuer | bool | `true` | Whether to create a Let's Encrypt DNS-based cluster issuer |
 | config.email | string | sqre-admin | Contact email address registered with Let's Encrypt |
 | config.route53.awsAccessKeyId | string | None, must be set if `createIssuer` is true | AWS access key ID for Route 53 (must match `aws-secret-access-key` in Vault secret referenced by `config.vaultSecretPath`) |
 | config.route53.hostedZone | string | None, must be set if `createIssuer` is true | Route 53 hosted zone in which to create challenge records |
-| fullnameOverride | string | `""` | Override the full name for resources (includes the release name) |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
-| nameOverride | string | `""` | Override the base name for resources |

--- a/applications/cert-manager/templates/cluster-issuer.yaml
+++ b/applications/cert-manager/templates/cluster-issuer.yaml
@@ -10,7 +10,7 @@ spec:
     email: {{ required "config.email must be set" .Values.config.email | quote }}
     server: "https://acme-v02.api.letsencrypt.org/directory"
     privateKeySecretRef:
-      name: {{ include "cert-manager.fullname" . }}-letsencrypt
+      name: "cert-manager-letsencrypt"
     solvers:
       - dns01:
           cnameStrategy: "Follow"
@@ -19,6 +19,6 @@ spec:
             accessKeyID: {{ required "config.route53.awsAccessKeyId must be set" .Values.config.route53.awsAccessKeyId | quote }}
             hostedZoneID: {{ required "config.route53.hostedZone must be set" .Values.config.route53.hostedZone | quote }}
             secretAccessKeySecretRef:
-              name: {{ include "cert-manager.fullname" . }}
+              name: "cert-manager"
               key: "aws-secret-access-key"
 {{- end }}

--- a/applications/cert-manager/templates/vault-secrets.yaml
+++ b/applications/cert-manager/templates/vault-secrets.yaml
@@ -2,7 +2,7 @@
 apiVersion: ricoberger.de/v1alpha1
 kind: VaultSecret
 metadata:
-  name: {{ include "cert-manager.fullname" . }}
+  name: "cert-manager"
   labels:
     {{- include "cert-manager.labels" . | nindent 4 }}
 spec:

--- a/applications/cert-manager/values.yaml
+++ b/applications/cert-manager/values.yaml
@@ -1,9 +1,3 @@
-# -- Override the base name for resources
-nameOverride: ""
-
-# -- Override the full name for resources (includes the release name)
-fullnameOverride: ""
-
 config:
   # -- Whether to create a Let's Encrypt DNS-based cluster issuer
   createIssuer: true
@@ -23,13 +17,25 @@ config:
     # @default -- None, must be set if `createIssuer` is true
     hostedZone: ""
 
-# -- Configuration for upstream cert-manager chart
-# @default -- Install CRDs, force use of Google and Cloudfront DNS servers
 cert-manager:
+  # -- Whether to install CRDs
   installCRDs: true
+
+  # -- Additional arguments to the main cert-manager pod
   extraArgs:
+    - "--logging-format=json"
     - "--dns01-recursive-nameservers-only"
     - "--dns01-recursive-nameservers=8.8.8.8:53,1.1.1.1:53"
+
+  cainjector:
+    # -- Additional arguments to the CA injector
+    extraArgs:
+      - "--logging-format=json"
+
+  webhook:
+    # -- Additional arguments to the webhook pod
+    extraArgs:
+      - "--logging-format=json"
 
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.


### PR DESCRIPTION
cert-manager now supports configuring structured logging. Do that, and improve the chart values.yaml documentation. Remove the name overrides, since we don't use them, and simplify the resources we create directly.