### PR TITLE
DM-39232: Improve nublado documentation and roles

### DIFF
--- a/applications/nublado/README.md
+++ b/applications/nublado/README.md
@@ -52,46 +52,34 @@ JupyterHub and custom spawner for the Rubin Science Platform
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | hub.timeout.spawn | int | `600` | Timeout for the Kubernetes spawn process in seconds. (Allow long enough to pull uncached images if needed.) |
 | hub.timeout.startup | int | `90` | Timeout for JupyterLab to start. Currently this sometimes takes over 60 seconds for reasons we don't understand. |
-| jupyterhub.cull.enabled | bool | `true` |  |
-| jupyterhub.cull.every | int | `600` |  |
-| jupyterhub.cull.maxAge | int | `5184000` |  |
-| jupyterhub.cull.removeNamedServers | bool | `true` |  |
-| jupyterhub.cull.timeout | int | `2592000` |  |
-| jupyterhub.cull.users | bool | `true` |  |
-| jupyterhub.hub.authenticatePrometheus | bool | `false` |  |
-| jupyterhub.hub.baseUrl | string | `"/nb"` |  |
-| jupyterhub.hub.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
-| jupyterhub.hub.containerSecurityContext.runAsGroup | int | `768` |  |
-| jupyterhub.hub.containerSecurityContext.runAsUser | int | `768` |  |
-| jupyterhub.hub.db.password | string | `"true"` |  |
-| jupyterhub.hub.db.type | string | `"postgres"` |  |
-| jupyterhub.hub.db.url | string | `"postgresql://jovyan@postgres.postgres/jupyterhub"` |  |
-| jupyterhub.hub.existingSecret | string | `"nublado-secret"` |  |
-| jupyterhub.hub.extraEnv.JUPYTERHUB_CRYPT_KEY.valueFrom.secretKeyRef.key | string | `"hub.config.CryptKeeper.keys"` |  |
-| jupyterhub.hub.extraEnv.JUPYTERHUB_CRYPT_KEY.valueFrom.secretKeyRef.name | string | `"nublado-secret"` |  |
-| jupyterhub.hub.extraVolumeMounts[0].mountPath | string | `"/usr/local/etc/jupyterhub/jupyterhub_config.d"` |  |
-| jupyterhub.hub.extraVolumeMounts[0].name | string | `"hub-config"` |  |
-| jupyterhub.hub.extraVolumeMounts[1].mountPath | string | `"/etc/gafaelfawr"` |  |
-| jupyterhub.hub.extraVolumeMounts[1].name | string | `"hub-gafaelfawr-token"` |  |
-| jupyterhub.hub.extraVolumes[0].configMap.name | string | `"hub-config"` |  |
-| jupyterhub.hub.extraVolumes[0].name | string | `"hub-config"` |  |
-| jupyterhub.hub.extraVolumes[1].name | string | `"hub-gafaelfawr-token"` |  |
-| jupyterhub.hub.extraVolumes[1].secret.secretName | string | `"hub-gafaelfawr-token"` |  |
-| jupyterhub.hub.image.name | string | `"ghcr.io/lsst-sqre/rsp-restspawner"` |  |
-| jupyterhub.hub.image.tag | string | `"0.2.0"` |  |
-| jupyterhub.hub.loadRoles.self.scopes[0] | string | `"admin:servers!user"` |  |
-| jupyterhub.hub.loadRoles.self.scopes[1] | string | `"read:metrics"` |  |
-| jupyterhub.hub.loadRoles.server.scopes[0] | string | `"inherit"` |  |
-| jupyterhub.hub.networkPolicy.enabled | bool | `false` |  |
-| jupyterhub.hub.resources.limits.cpu | string | `"900m"` |  |
-| jupyterhub.hub.resources.limits.memory | string | `"1Gi"` |  |
-| jupyterhub.ingress.enabled | bool | `false` |  |
-| jupyterhub.prePuller.continuous.enabled | bool | `false` |  |
-| jupyterhub.prePuller.hook.enabled | bool | `false` |  |
-| jupyterhub.proxy.chp.networkPolicy.interNamespaceAccessLabels | string | `"accept"` |  |
-| jupyterhub.proxy.service.type | string | `"ClusterIP"` |  |
-| jupyterhub.scheduling.userPlaceholder.enabled | bool | `false` |  |
-| jupyterhub.scheduling.userScheduler.enabled | bool | `false` |  |
-| jupyterhub.singleuser.cloudMetadata.blockWithIptables | bool | `false` |  |
-| jupyterhub.singleuser.cmd | string | `"/opt/lsst/software/jupyterlab/runlab.sh"` |  |
-| jupyterhub.singleuser.defaultUrl | string | `"/lab"` |  |
+| jupyterhub.cull.enabled | bool | `true` | Enable the lab culler. |
+| jupyterhub.cull.every | int | 600 (10 minutes) | How frequently to check for idle labs in seconds |
+| jupyterhub.cull.maxAge | int | 5184000 (60 days) | Maximum age of a lab regardless of activity |
+| jupyterhub.cull.removeNamedServers | bool | `true` | Whether to remove named servers when culling their lab |
+| jupyterhub.cull.timeout | int | 2592000 (30 days) | Default idle timeout before the lab is automatically deleted in seconds |
+| jupyterhub.cull.users | bool | `true` | Whether to log out the server when culling their lab |
+| jupyterhub.hub.authenticatePrometheus | bool | `false` | Whether to require metrics requests to be authenticated |
+| jupyterhub.hub.baseUrl | string | `"/nb"` | Base URL on which JupyterHub listens |
+| jupyterhub.hub.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"runAsGroup":768,"runAsUser":768}` | Security context for JupyterHub container |
+| jupyterhub.hub.db.password | string | Comes from nublado-secret | Database password (not used) |
+| jupyterhub.hub.db.type | string | `"postgres"` | Type of database to use |
+| jupyterhub.hub.db.url | string | Use the in-cluster PostgreSQL installed by Phalanx | URL of PostgreSQL server |
+| jupyterhub.hub.existingSecret | string | `"nublado-secret"` | Existing secret to use for private keys |
+| jupyterhub.hub.extraEnv | object | Gets `JUPYTERHUB_CRYPT_KEY` from `nublado-secret` | Additional environment variables to set |
+| jupyterhub.hub.extraVolumeMounts | list | `hub-config` and the Gafaelfawr token | Additional volume mounts for JupyterHub |
+| jupyterhub.hub.extraVolumes | list | The `hub-config` `ConfigMap` and the Gafaelfawr token | Additional volumes to make available to JupyterHub |
+| jupyterhub.hub.image.name | string | `"ghcr.io/lsst-sqre/rsp-restspawner"` | Image to use for JupyterHub |
+| jupyterhub.hub.image.tag | string | `"0.2.0"` | Tag of image to use for JupyterHub |
+| jupyterhub.hub.loadRoles.server.scopes | list | `["self"]` | Default scopes for the user's lab, overridden to allow the lab to delete itself (which we use for our added menu items) |
+| jupyterhub.hub.networkPolicy.enabled | bool | `false` | Whether to enable the default `NetworkPolicy` (currently, the upstream one does not work correctly) |
+| jupyterhub.hub.resources | object | `{"limits":{"cpu":"900m","memory":"1Gi"}}` | Resource limits and requests |
+| jupyterhub.ingress.enabled | bool | `false` | Whether to enable the default ingress |
+| jupyterhub.prePuller.continuous.enabled | bool | `false` | Whether to run the JupyterHub continuous prepuller (the Nublado controller does its own prepulling) |
+| jupyterhub.prePuller.hook.enabled | bool | `false` | Whether to run the JupyterHub hook prepuller (the Nublado controller does its own prepulling) |
+| jupyterhub.proxy.chp.networkPolicy.interNamespaceAccessLabels | string | `"accept"` | Enable access to the proxy from other namespaces, since we put each user's lab environment in its own namespace |
+| jupyterhub.proxy.service.type | string | `"ClusterIP"` | Only expose the proxy to the cluster, overriding the default of exposing the proxy directly to the Internet |
+| jupyterhub.scheduling.userPlaceholder.enabled | bool | `false` | Whether to spawn placeholder pods representing fake users to force autoscaling in advance of running out of resources |
+| jupyterhub.scheduling.userScheduler.enabled | bool | `false` | Whether the user scheduler should be enabled |
+| jupyterhub.singleuser.cloudMetadata.blockWithIptables | bool | `false` | Whether to configure iptables to block cloud metadata endpoints. This is unnecessary in our environments (they are blocked by cluster configuration) and thus is disabled to reduce complexity. |
+| jupyterhub.singleuser.cmd | string | `"/opt/lsst/software/jupyterlab/runlab.sh"` | Start command for labs |
+| jupyterhub.singleuser.defaultUrl | string | `"/lab"` | Default URL prefix for lab endpoints |

--- a/applications/nublado/values.yaml
+++ b/applications/nublado/values.yaml
@@ -269,32 +269,57 @@ hub:
 # Configuration for the Zero to JupyterHub subchart.
 jupyterhub:
   hub:
+    # -- Whether to require metrics requests to be authenticated
     authenticatePrometheus: false
+
     image:
+      # -- Image to use for JupyterHub
       name: ghcr.io/lsst-sqre/rsp-restspawner
+
+      # -- Tag of image to use for JupyterHub
       tag: 0.2.0
+
+    # -- Resource limits and requests
     resources:
       limits:
         cpu: 900m
         memory: 1Gi  # Should support about 200 users
+
     db:
-      # Password comes from the nublado-secret.
+      # -- Type of database to use
       type: "postgres"
+
+      # -- Database password (not used)
+      # @default -- Comes from nublado-secret
       password: "true"
+
+      # -- URL of PostgreSQL server
+      # @default -- Use the in-cluster PostgreSQL installed by Phalanx
       url: "postgresql://jovyan@postgres.postgres/jupyterhub"
+
+    # -- Security context for JupyterHub container
     containerSecurityContext:
       runAsUser: 768
       runAsGroup: 768
       allowPrivilegeEscalation: false
+
+    # -- Base URL on which JupyterHub listens
     baseUrl: "/nb"
+
+    # -- Existing secret to use for private keys
     existingSecret: "nublado-secret"
-    # This will need work
+
+    # -- Additional environment variables to set
+    # @default -- Gets `JUPYTERHUB_CRYPT_KEY` from `nublado-secret`
     extraEnv:
       JUPYTERHUB_CRYPT_KEY:
         valueFrom:
           secretKeyRef:
             name: "nublado-secret"
             key: "hub.config.CryptKeeper.keys"
+
+    # -- Additional volumes to make available to JupyterHub
+    # @default -- The `hub-config` `ConfigMap` and the Gafaelfawr token
     extraVolumes:
       - name: "hub-config"
         configMap:
@@ -302,41 +327,62 @@ jupyterhub:
       - name: "hub-gafaelfawr-token"
         secret:
           secretName: "hub-gafaelfawr-token"
+
+    # -- Additional volume mounts for JupyterHub
+    # @default -- `hub-config` and the Gafaelfawr token
     extraVolumeMounts:
       - name: "hub-config"
         mountPath: "/usr/local/etc/jupyterhub/jupyterhub_config.d"
       - name: "hub-gafaelfawr-token"
         mountPath: "/etc/gafaelfawr"
-    # We still have to use our own, enabled at the top level, which is
-    #  similar but not identical.  This one still doesn't work, even if
-    #  you explicitly enable port 8081 so the labs can talk to the Hub.
+
     networkPolicy:
+      # -- Whether to enable the default `NetworkPolicy` (currently, the
+      # upstream one does not work correctly)
       enabled: false
+
     loadRoles:
-      self:
-        scopes: ['admin:servers!user', 'read:metrics']
       server:
-        scopes: ['inherit']  # Let server use API like user
+        # -- Default scopes for the user's lab, overridden to allow the lab to
+        # delete itself (which we use for our added menu items)
+        scopes: ["self"]
 
   prePuller:
     continuous:
+      # -- Whether to run the JupyterHub continuous prepuller (the Nublado
+      # controller does its own prepulling)
       enabled: false
+
     hook:
+      # -- Whether to run the JupyterHub hook prepuller (the Nublado
+      # controller does its own prepulling)
       enabled: false
 
   singleuser:
     cloudMetadata:
+      # -- Whether to configure iptables to block cloud metadata endpoints.
+      # This is unnecessary in our environments (they are blocked by cluster
+      # configuration) and thus is disabled to reduce complexity.
       blockWithIptables: false
+
+    # -- Start command for labs
     cmd: "/opt/lsst/software/jupyterlab/runlab.sh"
+
+    # -- Default URL prefix for lab endpoints
     defaultUrl: "/lab"
 
   proxy:
     service:
+      # -- Only expose the proxy to the cluster, overriding the default of
+      # exposing the proxy directly to the Internet
       type: ClusterIP
-    # Replace with traefik
+
     chp:
       networkPolicy:
+        # -- Enable access to the proxy from other namespaces, since we put
+        # each user's lab environment in its own namespace
         interNamespaceAccessLabels: accept
+
         # This currently causes Minikube deployment in GH-actions to fail.
         # We want it sometime but it's not critical; it will help with
         # scale-down
@@ -344,25 +390,44 @@ jupyterhub:
         #   enabled: true
         #   minAvailable: 1
 
-  # Rather than using the JupyterHub-provided ingress, which requires us
-  # to repeat the global host name, we just use a GafaelfawrIngress of
-  # our own, found in templates.  That also means the annotations are
-  # automatically in sync.
+  # Rather than using the JupyterHub-provided ingress, which requires us to
+  # repeat the global host name and manually configure authentication, we
+  # instead install our own GafaelfawrIngress.
   ingress:
+    # -- Whether to enable the default ingress
     enabled: false
 
   cull:
+    # -- Enable the lab culler.
     enabled: true
-    timeout: 2592000  # 30 days -- shorten later
-    every: 600  # Check every ten minutes
-    users: true  # log out user when we cull
-    removeNamedServers: true  # Post-stop hook may already do this
-    maxAge: 5184000  # 60 days -- shorten later
+
+    # -- Default idle timeout before the lab is automatically deleted in
+    # seconds
+    # @default -- 2592000 (30 days)
+    timeout: 2592000
+
+    # -- How frequently to check for idle labs in seconds
+    # @default -- 600 (10 minutes)
+    every: 600
+
+    # -- Whether to log out the server when culling their lab
+    users: true
+
+    # -- Whether to remove named servers when culling their lab
+    removeNamedServers: true
+
+    # -- Maximum age of a lab regardless of activity
+    # @default -- 5184000 (60 days)
+    maxAge: 5184000
 
   scheduling:
     userScheduler:
+      # -- Whether the user scheduler should be enabled
       enabled: false
+
     userPlaceholder:
+      # -- Whether to spawn placeholder pods representing fake users to force
+      # autoscaling in advance of running out of resources
       enabled: false
 
 # The following will be set by parameters injected by Argo CD and should not


### PR DESCRIPTION
Add helm-docs comments to all of the overrides for Zero to JupyterHub configuration so that we get more useful chart documentation.

Delete the creation of a new self role. So far as I can tell, this was never used or assigned to anything, and therefore wasn't doing anything. I think this was an earlier attempt to solve a problem that was solved by setting authenticatePrometheus to false.

Change the default permissions of the server role (for spawned labs) to self rather than inherit. This only affects labs spawned by JupyterHub administrators and ensures that the lab token only inherits their regular user permissions and not their admin permissions.