### PR TITLE
Revert Chronograf to version 1.9.4 everywhere

### DIFF
--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -12,7 +12,7 @@ Rubin Observatory's telemetry service.
 | chronograf.enabled | bool | `true` | Enable Chronograf. |
 | chronograf.env | object | `{"BASE_PATH":"/chronograf","CUSTOM_AUTO_REFRESH":"1s=1000","HOST_PAGE_DISABLED":true}` | Chronograf environment variables. |
 | chronograf.envFromSecret | string | `"sasquatch"` | Chronograf secrets, expected keys generic_client_id, generic_client_secret and token_secret. |
-| chronograf.image | object | `{"repository":"quay.io/influxdb/chronograf","tag":"1.10.1"}` | Chronograf image tag. |
+| chronograf.image | object | `{"repository":"quay.io/influxdb/chronograf","tag":"1.9.4"}` | Chronograf image tag. |
 | chronograf.ingress | object | disabled | Chronograf ingress configuration. |
 | chronograf.persistence | object | `{"enabled":true,"size":"100Gi"}` | Chronograf data persistence configuration. |
 | chronograf.resources.limits.cpu | int | `4` |  |

--- a/applications/sasquatch/values.yaml
+++ b/applications/sasquatch/values.yaml
@@ -137,7 +137,7 @@ chronograf:
   # -- Chronograf image tag.
   image:
     repository: "quay.io/influxdb/chronograf"
-    tag: 1.10.1
+    tag: 1.9.4
   # -- Chronograf data persistence configuration.
   persistence:
     enabled: true


### PR DESCRIPTION
- This is due to the annoying ":" bug in the query editor.