### PR TITLE
DM-39232: Add Nublado v3 configuration for USDF dev

### DIFF
--- a/applications/nublado/Chart.yaml
+++ b/applications/nublado/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nublado
-version: 3.0.0
+version: 1.0.0
 description: JupyterHub and custom spawner for the Rubin Science Platform
 sources:
   - https://github.com/lsst-sqre/jupyterlab-controller

--- a/applications/nublado/README.md
+++ b/applications/nublado/README.md
@@ -83,3 +83,4 @@ JupyterHub and custom spawner for the Rubin Science Platform
 | jupyterhub.singleuser.cloudMetadata.blockWithIptables | bool | `false` | Whether to configure iptables to block cloud metadata endpoints. This is unnecessary in our environments (they are blocked by cluster configuration) and thus is disabled to reduce complexity. |
 | jupyterhub.singleuser.cmd | string | `"/opt/lsst/software/jupyterlab/runlab.sh"` | Start command for labs |
 | jupyterhub.singleuser.defaultUrl | string | `"/lab"` | Default URL prefix for lab endpoints |
+| proxy.ingress.annotations | object | Increase `proxy-read-timeout` and `proxy-send-timeout` to 5m | Additional annotations to add to the proxy ingress (also used to talk to JupyterHub and all user labs) |

--- a/applications/nublado/templates/proxy-ingress.yaml
+++ b/applications/nublado/templates/proxy-ingress.yaml
@@ -1,7 +1,7 @@
 apiVersion: gafaelfawr.lsst.io/v1alpha1
 kind: GafaelfawrIngress
 metadata:
-  name: "hub"
+  name: "proxy"
   labels:
     {{- include "nublado.labels" . | nindent 4 }}
 config:
@@ -14,7 +14,11 @@ config:
     notebook: {}
 template:
   metadata:
-    name: "hub"
+    name: "proxy"
+    {{- with .Values.proxy.ingress.annotations }}
+    annotations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
   spec:
     rules:
       - host: {{ .Values.global.host | quote }}

--- a/applications/nublado/values-usdfdev.yaml
+++ b/applications/nublado/values-usdfdev.yaml
@@ -1,0 +1,175 @@
+controller:
+  config:
+    safir:
+      logLevel: "DEBUG"
+
+    images:
+      source:
+        type: "docker"
+        registry: "docker-registry.slac.stanford.edu"
+        repository: "lsstsqre/sciplat-lab"
+      recommendedTag: "recommended"
+      numReleases: 1
+      numWeeklies: 2
+      numDailies: 3
+
+    lab:
+      pullSecret: "pull-secret"
+
+      env:
+        AWS_SHARED_CREDENTIALS_FILE: "/opt/lsst/software/jupyterlab/secrets/aws-credentials.ini"
+        AUTO_REPO_SPECS: "https://github.com/lsst-sqre/system-test@prod,https://github.com/rubin-dp0/tutorial-notebooks@prod"
+        DAF_BUTLER_REPOSITORY_INDEX: "/project/data-repos.yaml"
+        PGPASSFILE: "/opt/lsst/software/jupyterlab/secrets/postgres-credentials.txt"
+        PGUSER: "rubin"
+        S3_ENDPOINT_URL: "https://s3dfrgw.slac.stanford.edu"
+        http_proxy: "http://sdfproxy.sdf.slac.stanford.edu:3128"
+        https_proxy: "http://sdfproxy.sdf.slac.stanford.edu:3128"
+        no_proxy: "hub.nublado,.sdf.slac.stanford.edu,.slac.stanford.edu,localhost,127.0.0.1"
+
+      files:
+        # Add rubin_users group (there is not yet a simpler way to do this).
+        /etc/group:
+          contents: |
+            root:x:0:
+            bin:x:1:
+            daemon:x:2:
+            sys:x:3:
+            adm:x:4:
+            tty:x:5:
+            disk:x:6:
+            lp:x:7:
+            mem:x:8:
+            kmem:x:9:
+            wheel:x:10:
+            cdrom:x:11:
+            mail:x:12:
+            man:x:15:
+            dialout:x:18:
+            floppy:x:19:
+            games:x:20:
+            utmp:x:22:
+            tape:x:33:
+            utempter:x:35:
+            video:x:39:
+            ftp:x:50:
+            lock:x:54:
+            tss:x:59:
+            audio:x:63:
+            dbus:x:81:
+            screen:x:84:
+            nobody:x:99:
+            users:x:100:
+            systemd-journal:x:190:
+            systemd-network:x:192:
+            cgred:x:997:
+            ssh_keys:x:998:
+            input:x:999:
+            rubin_users:x:4085:
+
+      secrets:
+        - secretName: "nublado-lab-secret"
+          secretKey: "aws-credentials.ini"
+        - secretName: "nublado-lab-secret"
+          secretKey: "postgres-credentials.txt"
+
+      volumes:
+        - containerPath: "/home"
+          mode: "rw"
+          source:
+            type: "persistentVolumeClaim"
+            storageClassName: "sdf-home"
+            accessModes:
+              - "ReadWriteMany"
+            resources:
+              requests:
+                storage: "1Gi"
+        - containerPath: "/project"
+          subPath: "g"
+          mode: "rw"
+          source:
+            type: "persistentVolumeClaim"
+            storageClassName: "sdf-group-rubin"
+            accessModes:
+              - "ReadWriteMany"
+            resources:
+              requests:
+                storage: "1Gi"
+        - containerPath: "/sdf/group/rubin"
+          mode: "rw"
+          source:
+            type: "persistentVolumeClaim"
+            storageClassName: "sdf-group-rubin"
+            accessModes:
+              - "ReadWriteMany"
+            resources:
+              requests:
+                storage: "1Gi"
+        - containerPath: "/sdf/data/rubin"
+          mode: "rw"
+          source:
+            type: "persistentVolumeClaim"
+            storageClassName: "sdf-data-rubin"
+            accessModes:
+              - "ReadWriteMany"
+            resources:
+              requests:
+                storage: "1Gi"
+        - containerPath: "/scratch"
+          mode: "rw"
+          source:
+            type: "persistentVolumeClaim"
+            storageClassName: "sdf-scratch"
+            accessModes:
+              - "ReadWriteMany"
+            resources:
+              requests:
+                storage: "1Gi"
+        - containerPath: "/fs/nfs"
+          mode: "rw"
+          source:
+            type: "persistentVolumeClaim"
+            storageClassName: "fs-nfs"
+            accessModes:
+              - "ReadWriteMany"
+            resources:
+              requests:
+                storage: "1Gi"
+        - containerPath: "/fs/ddn/sdf/group/rubin"
+          mode: "rw"
+          source:
+            type: "persistentVolumeClaim"
+            storageClassName: "fs-ddn-sdf-group-rubin"
+            accessModes:
+              - "ReadWriteMany"
+            resources:
+              requests:
+                storage: "1Gi"
+        - containerPath: "/fs/ddn/sdf/group/lsst"
+          mode: "rw"
+          source:
+            type: "persistentVolumeClaim"
+            storageClassName: "fs-ddn-sdf-group-lsst"
+            accessModes:
+              - "ReadWriteMany"
+            resources:
+              requests:
+                storage: "1Gi"
+
+proxy:
+  ingress:
+    annotations:
+      # proxy-body-size is temporary until USDF uses our normal ingress-nginx,
+      # which already configures a larger value.
+      nginx.ingress.kubernetes.io/proxy-body-size: "50m"
+
+      # These are substantially shorter than the default timeouts (it's not
+      # clear why).
+      nginx.ingress.kubernetes.io/proxy-connect-timeout: "30"
+      nginx.ingress.kubernetes.io/proxy-read-timeout: "20"
+
+jupyterhub:
+  cull:
+    timeout: 432000
+    every: 300
+    maxAge: 2160000

--- a/applications/nublado/values.yaml
+++ b/applications/nublado/values.yaml
@@ -266,6 +266,17 @@ hub:
     # 60 seconds for reasons we don't understand.
     startup: 90
 
+# JupyterHub proxy configuration handled directly by this chart rather than by
+# Zero to JupyterHub.
+proxy:
+  ingress:
+    # -- Additional annotations to add to the proxy ingress (also used to talk
+    # to JupyterHub and all user labs)
+    # @default -- Increase `proxy-read-timeout` and `proxy-send-timeout` to 5m
+    annotations:
+      nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
+      nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
+
 # Configuration for the Zero to JupyterHub subchart.
 jupyterhub:
   hub:


### PR DESCRIPTION
Add a new configuration for USDF dev modelled after its nublado2 configuration. USDF overrode the ingress annotations, so add support for setting ingress annotations for the proxy so that it can continue to do this. That uncovered missed annotations that we added to nublado2 and not nublado, which have now been copied over.

Rename the ingress to reflect that it's an ingress for the proxy, not the hub (the proxy routes to either the hub or the lab).