### PR TITLE
Updates to roe environment (S3 buckets, default hips url, fixed Qserv)

### DIFF
--- a/applications/portal/values-roe.yaml
+++ b/applications/portal/values-roe.yaml
@@ -1,3 +1,8 @@
+replicaCount: 2
+
 resources:
   limits:
     memory: "8Gi"
+
+config:
+  hipsUrl: "http://alasky.cds.unistra.fr/DSS/DSSColor"

--- a/applications/tap/values-roe.yaml
+++ b/applications/tap/values-roe.yaml
@@ -1,4 +1,10 @@
+config:
+  gcsBucket: "async"
+  gcsBucketUrl: "https://somerville.ed.ac.uk:6780"
+  gcsBucketType: "S3"
+  jvmMaxHeapSize: "31G"
+
 qserv:
-  host: "192.41.122.228:30040"
+  host: "192.41.122.79:30040"
   mock:
     enabled: false


### PR DESCRIPTION
Changes include:

- Modify portal/values-roe.yaml to scale up replicas & set a default hipsUrl
- Modify tap/values-roe.yaml to change QServ IP & setup S3 buckets for async