### PR TITLE
DM-38203: Enable DP0.2 access from IDF dev

### DIFF
--- a/applications/nublado/values-idfdev.yaml
+++ b/applications/nublado/values-idfdev.yaml
@@ -21,7 +21,10 @@ controller:
     lab:
       env:
         AUTO_REPO_SPECS: "https://github.com/lsst-sqre/system-test@prod,https://github.com/rubin-dp0/tutorial-notebooks@prod"
-        DAF_BUTLER_REPOSITORY_INDEX: "s3://butler-us-central1-repo-locations/data-repos.yaml"
+        AWS_SHARED_CREDENTIALS_FILE: "/opt/lsst/software/jupyterlab/secrets/aws-credentials.ini"
+        PGPASSFILE: "/opt/lsst/software/jupyterlab/secrets/postgres-credentials.txt"
+        DAF_BUTLER_REPOSITORY_INDEX: "s3://butler-us-central1-repo-locations/data-dev-repos.yaml"
+        GOOGLE_APPLICATION_CREDENTIALS: "/opt/lsst/software/jupyterlab/secrets/butler-gcs-idf-creds.json"
         S3_ENDPOINT_URL: "https://storage.googleapis.com"
       initContainers:
         - name: "initdir"
@@ -35,6 +38,15 @@ controller:
                 serverPath: "/share1/home"
                 server: "10.87.86.26"
 
+      secrets:
+        - secretName: "nublado-lab-secret"
+          secretKey: "aws-credentials.ini"
+        - secretName: "nublado-lab-secret"
+          secretKey: "butler-gcs-idf-creds.json"
+        - secretName: "nublado-lab-secret"
+          secretKey: "butler-hmac-idf-creds.json"
+        - secretName: "nublado-lab-secret"
+          secretKey: "postgres-credentials.txt"
       volumes:
         - containerPath: "/home"
           mode: "rw"

--- a/applications/nublado/values-idfint.yaml
+++ b/applications/nublado/values-idfint.yaml
@@ -56,6 +56,15 @@ controller:
                 serverPath: "/share1/home"
                 server: "10.22.240.130"
                 type: "nfs"
+      secrets:
+        - secretName: "nublado-lab-secret"
+          secretKey: "aws-credentials.ini"
+        - secretName: "nublado-lab-secret"
+          secretKey: "butler-gcs-idf-creds.json"
+        - secretName: "nublado-lab-secret"
+          secretKey: "butler-hmac-idf-creds.json"
+        - secretName: "nublado-lab-secret"
+          secretKey: "postgres-credentials.txt"
       volumes:
         - containerPath: "/home"
           mode: "rw"
@@ -75,15 +84,6 @@ controller:
             serverPath: "/share1/scratch"
             server: "10.22.240.130"
             type: "nfs"
-      secrets:
-        - secretName: "nublado-lab-secret"
-          secretKey: "aws-credentials.ini"
-        - secretName: "nublado-lab-secret"
-          secretKey: "butler-gcs-idf-creds.json"
-        - secretName: "nublado-lab-secret"
-          secretKey: "butler-hmac-idf-creds.json"
-        - secretName: "nublado-lab-secret"
-          secretKey: "postgres-credentials.txt"
 
 jupyterhub:
   hub:

--- a/applications/nublado2/values-idfdev.yaml
+++ b/applications/nublado2/values-idfdev.yaml
@@ -29,7 +29,7 @@ config:
     AWS_SHARED_CREDENTIALS_FILE: "/opt/lsst/software/jupyterlab/butler-secret/aws-credentials.ini"
     S3_ENDPOINT_URL: "https://storage.googleapis.com"
     GOOGLE_APPLICATION_CREDENTIALS: "/opt/lsst/software/jupyterlab/butler-secret/butler-gcs-idf-creds.json"
-    DAF_BUTLER_REPOSITORY_INDEX: "s3://butler-us-central1-repo-locations/data-int-repos.yaml"
+    DAF_BUTLER_REPOSITORY_INDEX: "s3://butler-us-central1-repo-locations/data-dev-repos.yaml"
     AUTO_REPO_URLS: https://github.com/lsst-sqre/system-test,https://github.com/rubin-dp0/tutorial-notebooks
     AUTO_REPO_BRANCH: prod
     AUTO_REPO_SPECS: https://github.com/lsst-sqre/system-test@prod,https://github.com/rubin-dp0/tutorial-notebooks@prod

--- a/environments/values-idfdev.yaml
+++ b/environments/values-idfdev.yaml
@@ -1,7 +1,7 @@
 environment: idfdev
 fqdn: data-dev.lsst.cloud
 vaultPathPrefix: secret/k8s_operator/data-dev.lsst.cloud
-butlerRepositoryIndex: "s3://butler-us-central1-repo-locations/data-int-repos.yaml"
+butlerRepositoryIndex: "s3://butler-us-central1-repo-locations/data-dev-repos.yaml"
 
 alert-stream-broker:
   enabled: false

--- a/installer/generate_secrets.py
+++ b/installer/generate_secrets.py
@@ -174,6 +174,10 @@ class SecretGenerator:
         if slack_webhook:
             self._set("nublado", "slack_webhook", slack_webhook)
 
+        # Grab lab secrets from the Butler secret.
+        butler = self.secrets["butler-secret"].copy()
+        self.secrets["nublado-lab-secret"] = butler
+
     def _nublado2(self):
         crypto_key = secrets.token_hex(32)
         self._set_generated("nublado2", "crypto_key", crypto_key)


### PR DESCRIPTION
Add the required secrets and configuration for both Nublado v2 and v3 access to DP0.2 from IDF dev using the Cloud SQL Proxy for cross-project access.