### PR TITLE
DM-39336: Add JupyterHub URL configurations to Noteburst

### DIFF
--- a/applications/noteburst/Chart.yaml
+++ b/applications/noteburst/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: noteburst
 version: 1.0.0
-appVersion: "0.6.3"
+appVersion: "0.7.0"
 description: Noteburst is a notebook execution service for the Rubin Science Platform.
 type: application
 home: https://noteburst.lsst.io/

--- a/applications/noteburst/README.md
+++ b/applications/noteburst/README.md
@@ -17,7 +17,9 @@ Noteburst is a notebook execution service for the Rubin Science Platform.
 | autoscaling.maxReplicas | int | `100` |  |
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
+| config.hubPathPrefix | string | `"/nb"` | URL path prefix for the JupyterHub service |
 | config.logLevel | string | `"INFO"` | Logging level: "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL" |
+| config.nubladoControllerPathPrefix | string | `"/nublado"` | URL path prefix for the Nublado JupyterLab Controller service |
 | config.worker.identities | list | `[]` | Science Platform user identities that workers can acquire. Each item is an object with username and uuid keys |
 | config.worker.imageReference | string | `""` | Nublado image reference, applicable when imageSelector is "reference" |
 | config.worker.imageSelector | string | `"weekly"` | Nublado image stream to select: "recommended", "weekly" or "reference" |

--- a/applications/noteburst/templates/configmap.yaml
+++ b/applications/noteburst/templates/configmap.yaml
@@ -9,3 +9,5 @@ data:
   NOTEBURST_PATH_PREFIX: {{ .Values.ingress.path | quote }}
   NOTEBURST_ENVIRONMENT_URL: {{ .Values.global.baseUrl | quote }}
   NOTEBURST_REDIS_URL: "redis://{{ include "noteburst.fullname" . }}-redis.{{ .Release.Namespace }}:6379/0"
+  NOTEBURST_JUPYTERHUB_PATH_PREFIX: {{ .Values.config.hubPathPrefix | quote }}
+  NOTEBURST_NUBLADO_CONTROLLER_PATH_PREFIX: {{ .Values.config.nubladoControllerPathPrefix | quote }}

--- a/applications/noteburst/templates/worker-configmap.yaml
+++ b/applications/noteburst/templates/worker-configmap.yaml
@@ -8,6 +8,8 @@ data:
   SAFIR_LOG_LEVEL: {{ .Values.config.logLevel | quote }}
   NOTEBURST_ENVIRONMENT_URL: {{ .Values.global.baseUrl | quote }}
   NOTEBURST_REDIS_URL: "redis://{{ include "noteburst.fullname" . }}-redis.{{ .Release.Namespace }}:6379/0"
+  NOTEBURST_JUPYTERHUB_PATH_PREFIX: {{ .Values.config.hubPathPrefix | quote }}
+  NOTEBURST_NUBLADO_CONTROLLER_PATH_PREFIX: {{ .Values.config.nubladoControllerPathPrefix | quote }}
   NOTEBURST_WORKER_LOCK_REDIS_URL: "redis://{{ include "noteburst.fullname" . }}-redis.{{ .Release.Namespace }}:6379/1"
   NOTEBURST_WORKER_JOB_TIMEOUT: {{ .Values.config.worker.jobTimeout | quote }}
   NOTEBURST_WORKER_TOKEN_LIFETIME: {{ .Values.config.worker.tokenLifetime | quote }}

--- a/applications/noteburst/values-idfdev.yaml
+++ b/applications/noteburst/values-idfdev.yaml
@@ -3,6 +3,7 @@ image:
 
 config:
   logLevel: "DEBUG"
+  hubPathPrefix: "/n3"
   worker:
     workerCount: 1
     identities:

--- a/applications/noteburst/values.yaml
+++ b/applications/noteburst/values.yaml
@@ -64,7 +64,8 @@ ingress:
   # -- Path prefix where noteburst is hosted
   path: "/noteburst"
 
-resources: {}
+resources:
+  {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -92,6 +93,12 @@ affinity: {}
 config:
   # -- Logging level: "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"
   logLevel: "INFO"
+
+  # -- URL path prefix for the JupyterHub service
+  hubPathPrefix: "/nb"
+
+  # -- URL path prefix for the Nublado JupyterLab Controller service
+  nubladoControllerPathPrefix: "/nublado"
 
   worker:
     # -- Science Platform user identities that workers can acquire. Each item


### PR DESCRIPTION
This adds `config.hubPathPrefix` and `config.nubladoControllerPathPrefix` values to the noteburst chart.