### PR TITLE
DM-39325: Test both Nublado v2 and v3 with mobu

### DIFF
--- a/applications/mobu/values-idfdev.yaml
+++ b/applications/mobu/values-idfdev.yaml
@@ -1,3 +1,6 @@
+image:
+  tag: "tickets-DM-39325"
+  pullPolicy: "Always"
 config:
   debug: true
   autostart:

--- a/applications/mobu/values-idfdev.yaml
+++ b/applications/mobu/values-idfdev.yaml
@@ -1,7 +1,20 @@
 config:
   debug: true
   autostart:
-    - name: "python"
+    - name: "nublado2"
+      count: 1
+      users:
+        - username: "bot-mobu-nublado2"
+      scopes: ["exec:notebook"]
+      business:
+        type: "JupyterPythonLoop"
+        options:
+          image:
+            image_class: "latest-weekly"
+            size: "Small"
+            debug: true
+        restart: true
+    - name: "nublado3"
       count: 1
       users:
         - username: "bot-mobu-user"
@@ -13,6 +26,8 @@ config:
             image_class: "latest-weekly"
             size: "Small"
             debug: true
+          use_cachemachine: false
+          url_prefix: "/n3"
         restart: true
     - name: "tap"
       count: 1


### PR DESCRIPTION
On IDF dev, test both Nublado v2 and v3 with mobu by default, using the new support for configuring cachemachine in the business options.