### PR TITLE
Simplify and document Argo CD configuration

### DIFF
--- a/applications/argocd/README.md
+++ b/applications/argocd/README.md
@@ -13,6 +13,8 @@ Kubernetes application manager
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| argo-cd.configs.params."server.basehref" | string | `"/argo-cd"` | Base href for `index.html` when running under a reverse proxy |
+| argo-cd.configs.params."server.insecure" | bool | `true` | Do not use TLS (this is terminated at the ingress) |
 | argo-cd.configs.secret.createSecret | bool | `false` | Create the Argo CD secret (we manage this with Vault) |
 | argo-cd.controller.metrics.applicationLabels.enabled | bool | `true` | Enable adding additional labels to `argocd_app_labels` metric |
 | argo-cd.controller.metrics.applicationLabels.labels | list | `["name","instance"]` | Labels to add to `argocd_app_labels` metric |
@@ -21,9 +23,6 @@ Kubernetes application manager
 | argo-cd.notifications.metrics.enabled | bool | `true` | Enable notifications metrics service |
 | argo-cd.redis.metrics.enabled | bool | `true` | Enable Redis metrics service |
 | argo-cd.repoServer.metrics.enabled | bool | `true` | Enable repo server metrics service |
-| argo-cd.server.config."helm.repositories" | string | See `values.yaml` | Additional Helm repositories to use |
-| argo-cd.server.config."resource.compareoptions" | string | Ignore aggregated cluster roles | Comparison options for resources |
-| argo-cd.server.extraArgs | list | `["--basehref=/argo-cd","--insecure=true"]` | Extra arguments to pass to the Argo CD server |
 | argo-cd.server.ingress.annotations | object | Rewrite requests to remove `/argo-cd/` prefix | Additional annotations to add to the Argo CD ingress |
 | argo-cd.server.ingress.enabled | bool | `true` | Create an ingress for the Argo CD server |
 | argo-cd.server.ingress.ingressClassName | string | `"nginx"` | Ingress class to use for Argo CD ingress |

--- a/applications/argocd/README.md
+++ b/applications/argocd/README.md
@@ -13,24 +13,21 @@ Kubernetes application manager
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| argo-cd.configs.secret.createSecret | bool | `false` |  |
-| argo-cd.controller.metrics.applicationLabels.enabled | bool | `true` |  |
-| argo-cd.controller.metrics.applicationLabels.labels[0] | string | `"name"` |  |
-| argo-cd.controller.metrics.applicationLabels.labels[1] | string | `"instance"` |  |
-| argo-cd.controller.metrics.enabled | bool | `true` |  |
+| argo-cd.configs.secret.createSecret | bool | `false` | Create the Argo CD secret (we manage this with Vault) |
+| argo-cd.controller.metrics.applicationLabels.enabled | bool | `true` | Enable adding additional labels to `argocd_app_labels` metric |
+| argo-cd.controller.metrics.applicationLabels.labels | list | `["name","instance"]` | Labels to add to `argocd_app_labels` metric |
+| argo-cd.controller.metrics.enabled | bool | `true` | Enable controller metrics service |
 | argo-cd.global.logging.format | string | `"json"` | Set the global logging format. Either: `text` or `json` |
-| argo-cd.notifications.metrics.enabled | bool | `true` |  |
-| argo-cd.redis.enabled | bool | `true` |  |
-| argo-cd.redis.metrics.enabled | bool | `true` |  |
-| argo-cd.repoServer.metrics.enabled | bool | `true` |  |
-| argo-cd.server.config."helm.repositories" | string | `"- url: https://lsst-sqre.github.io/charts/\n  name: lsst-sqre\n- url: https://ricoberger.github.io/helm-charts/\n  name: ricoberger\n- url: https://kubernetes.github.io/ingress-nginx/\n  name: ingress-nginx\n- url: https://charts.helm.sh/stable\n  name: stable\n- url: https://strimzi.io/charts/\n  name: strimzi\n"` |  |
-| argo-cd.server.config."resource.compareoptions" | string | `"ignoreAggregatedRoles: true\n"` |  |
-| argo-cd.server.extraArgs[0] | string | `"--basehref=/argo-cd"` |  |
-| argo-cd.server.extraArgs[1] | string | `"--insecure=true"` |  |
-| argo-cd.server.ingress.annotations."nginx.ingress.kubernetes.io/rewrite-target" | string | `"/$2"` |  |
-| argo-cd.server.ingress.enabled | bool | `true` |  |
-| argo-cd.server.ingress.ingressClassName | string | `"nginx"` |  |
-| argo-cd.server.ingress.pathType | string | `"ImplementationSpecific"` |  |
-| argo-cd.server.ingress.paths[0] | string | `"/argo-cd(/|$)(.*)"` |  |
-| argo-cd.server.metrics.enabled | bool | `true` |  |
+| argo-cd.notifications.metrics.enabled | bool | `true` | Enable notifications metrics service |
+| argo-cd.redis.metrics.enabled | bool | `true` | Enable Redis metrics service |
+| argo-cd.repoServer.metrics.enabled | bool | `true` | Enable repo server metrics service |
+| argo-cd.server.config."helm.repositories" | string | See `values.yaml` | Additional Helm repositories to use |
+| argo-cd.server.config."resource.compareoptions" | string | Ignore aggregated cluster roles | Comparison options for resources |
+| argo-cd.server.extraArgs | list | `["--basehref=/argo-cd","--insecure=true"]` | Extra arguments to pass to the Argo CD server |
+| argo-cd.server.ingress.annotations | object | Rewrite requests to remove `/argo-cd/` prefix | Additional annotations to add to the Argo CD ingress |
+| argo-cd.server.ingress.enabled | bool | `true` | Create an ingress for the Argo CD server |
+| argo-cd.server.ingress.ingressClassName | string | `"nginx"` | Ingress class to use for Argo CD ingress |
+| argo-cd.server.ingress.pathType | string | `"ImplementationSpecific"` | Type of path expression for Argo CD ingress |
+| argo-cd.server.ingress.paths | list | `["/argo-cd(/|$)(.*)"]` | Paths to route to Argo CD |
+| argo-cd.server.metrics.enabled | bool | `true` | Enable server metrics service |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |

--- a/applications/argocd/values.yaml
+++ b/applications/argocd/values.yaml
@@ -58,32 +58,14 @@ argo-cd:
       # -- Type of path expression for Argo CD ingress
       pathType: "ImplementationSpecific"
 
-    # -- Extra arguments to pass to the Argo CD server
-    extraArgs:
-      - "--basehref=/argo-cd"
-      - "--insecure=true"
-
-    config:
-      # -- Additional Helm repositories to use
-      # @default -- See `values.yaml`
-      helm.repositories: |
-        - url: https://lsst-sqre.github.io/charts/
-          name: lsst-sqre
-        - url: https://ricoberger.github.io/helm-charts/
-          name: ricoberger
-        - url: https://kubernetes.github.io/ingress-nginx/
-          name: ingress-nginx
-        - url: https://charts.helm.sh/stable
-          name: stable
-        - url: https://strimzi.io/charts/
-          name: strimzi
-
-      # -- Comparison options for resources
-      # @default -- Ignore aggregated cluster roles
-      resource.compareoptions: |
-        ignoreAggregatedRoles: true
-
   configs:
+    params:
+      # -- Do not use TLS (this is terminated at the ingress)
+      server.insecure: true
+
+      # -- Base href for `index.html` when running under a reverse proxy
+      server.basehref: "/argo-cd"
+
     secret:
       # -- Create the Argo CD secret (we manage this with Vault)
       createSecret: false

--- a/applications/argocd/values.yaml
+++ b/applications/argocd/values.yaml
@@ -8,42 +8,64 @@ argo-cd:
       format: "json"
 
   redis:
-    enabled: true
     metrics:
+      # -- Enable Redis metrics service
       enabled: true
 
   controller:
     metrics:
+      # -- Enable controller metrics service
       enabled: true
+
       applicationLabels:
+        # -- Enable adding additional labels to `argocd_app_labels` metric
         enabled: true
+
+        # -- Labels to add to `argocd_app_labels` metric
         labels: ["name", "instance"]
 
   repoServer:
     metrics:
+      # -- Enable repo server metrics service
       enabled: true
 
   notifications:
     metrics:
+      # -- Enable notifications metrics service
       enabled: true
 
   server:
     metrics:
+      # -- Enable server metrics service
       enabled: true
+
     ingress:
+      # -- Create an ingress for the Argo CD server
       enabled: true
+
+      # -- Additional annotations to add to the Argo CD ingress
+      # @default -- Rewrite requests to remove `/argo-cd/` prefix
       annotations:
         nginx.ingress.kubernetes.io/rewrite-target: "/$2"
+
+      # -- Ingress class to use for Argo CD ingress
       ingressClassName: "nginx"
+
+      # -- Paths to route to Argo CD
       paths:
         - "/argo-cd(/|$)(.*)"
+
+      # -- Type of path expression for Argo CD ingress
       pathType: "ImplementationSpecific"
 
+    # -- Extra arguments to pass to the Argo CD server
     extraArgs:
       - "--basehref=/argo-cd"
       - "--insecure=true"
 
     config:
+      # -- Additional Helm repositories to use
+      # @default -- See `values.yaml`
       helm.repositories: |
         - url: https://lsst-sqre.github.io/charts/
           name: lsst-sqre
@@ -55,11 +77,15 @@ argo-cd:
           name: stable
         - url: https://strimzi.io/charts/
           name: strimzi
+
+      # -- Comparison options for resources
+      # @default -- Ignore aggregated cluster roles
       resource.compareoptions: |
         ignoreAggregatedRoles: true
 
   configs:
     secret:
+      # -- Create the Argo CD secret (we manage this with Vault)
       createSecret: false
 
 # The following will be set by parameters injected by Argo CD and should not


### PR DESCRIPTION
Make our documentation a little bit nicer. Remove a few settings that matched the defaults. Use `config.params` to configure the server instead of adding command-line arguments. Drop the Helm repository configuration, which appears to not be used or needed where it was.