### PR TITLE
Re-add Argo CD configuration for aggregated roles

### DIFF
--- a/applications/argocd/README.md
+++ b/applications/argocd/README.md
@@ -13,6 +13,7 @@ Kubernetes application manager
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| argo-cd.configs.cm."resource.compareoptions" | string | `"ignoreAggregatedRoles: true\n"` | Configure resource comparison |
 | argo-cd.configs.params."server.basehref" | string | `"/argo-cd"` | Base href for `index.html` when running under a reverse proxy |
 | argo-cd.configs.params."server.insecure" | bool | `true` | Do not use TLS (this is terminated at the ingress) |
 | argo-cd.configs.secret.createSecret | bool | `false` | Create the Argo CD secret (we manage this with Vault) |

--- a/applications/argocd/values.yaml
+++ b/applications/argocd/values.yaml
@@ -59,6 +59,11 @@ argo-cd:
       pathType: "ImplementationSpecific"
 
   configs:
+    cm:
+      # -- Configure resource comparison
+      resource.compareoptions: |
+        ignoreAggregatedRoles: true
+
     params:
       # -- Do not use TLS (this is terminated at the ingress)
       server.insecure: true


### PR DESCRIPTION
The documentation was a bit unclear, but I found the right place to put this in the new configuration layout. So far as I can tell, explicitly registering the Helm repositories shouldn't be required, so those are still omitted.