### PR TITLE
DM-39435: Add values-level support for adding SSO TAP to Portal menu

### DIFF
--- a/applications/portal/README.md
+++ b/applications/portal/README.md
@@ -15,6 +15,7 @@ Rubin Science Platform Portal Aspect
 | config.cleanupInterval | string | `"36h"` | How long results should be retained before being deleted |
 | config.debug | string | `"FALSE"` | Set to `TRUE` to enable service debugging |
 | config.hipsUrl | string | `/api/hips/images/color_gri` in the local Science Platform | URL for default HiPS service |
+| config.ssotap | string | `""` | Endpoint under `/api/` for the DP0.3 SSO TAP service on the instance, if present |
 | config.visualizeFitsSearchPath | string | `"/datasets"` | Search path for FITS files |
 | config.volumes.configHostPath | string | Use an `emptyDir` | hostPath to mount as configuration.  Set either this of `configNfs`, not both. |
 | config.volumes.configNfs | object | Use an `emptyDir` | NFS information for a configuration.  If set, must have keys for path and server, Set either this of `configHostPath`, not both. |

--- a/applications/portal/templates/deployment.yaml
+++ b/applications/portal/templates/deployment.yaml
@@ -61,7 +61,8 @@ spec:
                    },
                    "tap" : {
                       "additional": {
-                          "services": [ {
+                          "services": [
+                            {
                                "label": "LSST RSP",
                                "value": "{{ .Values.global.baseUrl }}/api/tap",
                                {{- if .Values.config.hipsUrl }}
@@ -71,7 +72,18 @@ spec:
                                {{- end }}
                                "centerWP": "62;-37;EQ_J2000",
                                "fovDeg": 10
-                          } ]
+                            }
+                            {{- if .Values.config.ssotap }}
+                            ,
+                            {
+                               "label": "DP0.3 SSO",
+                               "value": "{{ .Values.global.baseUrl }}/api/{{ .Values.config.ssotap}}",
+                               "hipsUrl": "{{ .Values.global.baseUrl }}/api/hips/images/color_gri",
+                               "centerWP": "0;0;ECL",
+                               "fovDeg": 10
+                            }
+                            {{- end }}
+                          ]
                       }
                    },
                    "hips": {

--- a/applications/portal/values-idfint.yaml
+++ b/applications/portal/values-idfint.yaml
@@ -5,6 +5,7 @@ config:
     workareaNfs:
       path: "/share1/home/firefly/shared-workarea"
       server: "10.22.240.130"
+  ssotap: "ssotap"
 
 resources:
   limits:

--- a/applications/portal/values.yaml
+++ b/applications/portal/values.yaml
@@ -61,6 +61,9 @@ config:
   # -- Search path for FITS files
   visualizeFitsSearchPath: "/datasets"
 
+  # -- Endpoint under `/api/` for the DP0.3 SSO TAP service on the instance, if present
+  ssotap: ""
+
   volumes:
     # -- hostPath to mount as a shared work area.  Set either this or
     # `workareaNfs`, not both.


### PR DESCRIPTION
Allows turning on the SSO TAP service in the Portal on a per-instance basis, initially for data-int.