### PR TITLE
DM-39400: Use new JupyterHub and Nublado controller images

### DIFF
--- a/applications/nublado/Chart.yaml
+++ b/applications/nublado/Chart.yaml
@@ -6,7 +6,7 @@ sources:
   - https://github.com/lsst-sqre/jupyterlab-controller
   - https://github.com/lsst-sqre/rsp-restspawner
 home: https://github.com/lsst-sqre/jupyterlab-controller
-appVersion: 0.5.0
+appVersion: 0.6.0
 
 dependencies:
   - name: jupyterhub

--- a/applications/nublado/README.md
+++ b/applications/nublado/README.md
@@ -69,7 +69,7 @@ JupyterHub and custom spawner for the Rubin Science Platform
 | jupyterhub.hub.extraVolumeMounts | list | `hub-config` and the Gafaelfawr token | Additional volume mounts for JupyterHub |
 | jupyterhub.hub.extraVolumes | list | The `hub-config` `ConfigMap` and the Gafaelfawr token | Additional volumes to make available to JupyterHub |
 | jupyterhub.hub.image.name | string | `"ghcr.io/lsst-sqre/rsp-restspawner"` | Image to use for JupyterHub |
-| jupyterhub.hub.image.tag | string | `"0.3.0"` | Tag of image to use for JupyterHub |
+| jupyterhub.hub.image.tag | string | `"0.3.1"` | Tag of image to use for JupyterHub |
 | jupyterhub.hub.loadRoles.server.scopes | list | `["self"]` | Default scopes for the user's lab, overridden to allow the lab to delete itself (which we use for our added menu items) |
 | jupyterhub.hub.networkPolicy.enabled | bool | `false` | Whether to enable the default `NetworkPolicy` (currently, the upstream one does not work correctly) |
 | jupyterhub.hub.resources | object | `{"limits":{"cpu":"900m","memory":"1Gi"}}` | Resource limits and requests |

--- a/applications/nublado/values.yaml
+++ b/applications/nublado/values.yaml
@@ -288,7 +288,7 @@ jupyterhub:
       name: ghcr.io/lsst-sqre/rsp-restspawner
 
       # -- Tag of image to use for JupyterHub
-      tag: 0.3.0
+      tag: 0.3.1
 
     # -- Resource limits and requests
     resources:


### PR DESCRIPTION
Pick up the 0.3.1 release of the REST spawner and the 0.6.0 release of the Nublado controller.