### PR TITLE
DM-39400: Test tutorial notebooks on data-dev and data-int

### DIFF
--- a/applications/mobu/values-idfdev.yaml
+++ b/applications/mobu/values-idfdev.yaml
@@ -37,6 +37,25 @@ config:
           url_prefix: "/n3"
           use_cachemachine: false
         restart: true
+    - name: "tutorial"
+      count: 1
+      users:
+        - username: "bot-mobu-tutorial"
+      scopes:
+        - "exec:notebook"
+        - "exec:portal"
+        - "read:image"
+        - "read:tap"
+      business:
+        type: "NotebookRunner"
+        options:
+          repo_url: "https://github.com/rubin-dp0/tutorial-notebooks.git"
+          repo_branch: "prod"
+          max_executions: 1
+          working_directory: "notebooks/tutorial-notebooks"
+          use_cachemachine: false
+          url_prefix: "/n3"
+        restart: true
     - name: "tap"
       count: 1
       users:

--- a/applications/mobu/values-idfint.yaml
+++ b/applications/mobu/values-idfint.yaml
@@ -52,6 +52,25 @@ config:
           use_cachemachine: false
           url_prefix: "/n3"
         restart: true
+    - name: "tutorial"
+      count: 1
+      users:
+        - username: "bot-mobu-tutorial"
+      scopes:
+        - "exec:notebook"
+        - "exec:portal"
+        - "read:image"
+        - "read:tap"
+      business:
+        type: "NotebookRunner"
+        options:
+          repo_url: "https://github.com/rubin-dp0/tutorial-notebooks.git"
+          repo_branch: "prod"
+          max_executions: 1
+          working_directory: "notebooks/tutorial-notebooks"
+          use_cachemachine: false
+          url_prefix: "/n3"
+        restart: true
     - name: "tap"
       count: 1
       users:


### PR DESCRIPTION
Now that the tutorial notebooks should work on the data-dev and data-int environments, start testing them there with mobu using Nublado v3.