### PR TITLE
DM-39400: Revert "Turn the tutorial notebook tests off again"

### DIFF
--- a/applications/mobu/values-idfdev.yaml
+++ b/applications/mobu/values-idfdev.yaml
@@ -37,6 +37,25 @@ config:
           url_prefix: "/n3"
           use_cachemachine: false
         restart: true
+    - name: "tutorial"
+      count: 1
+      users:
+        - username: "bot-mobu-tutorial"
+      scopes:
+        - "exec:notebook"
+        - "exec:portal"
+        - "read:image"
+        - "read:tap"
+      business:
+        type: "NotebookRunner"
+        options:
+          repo_url: "https://github.com/rubin-dp0/tutorial-notebooks.git"
+          repo_branch: "main"
+          max_executions: 1
+          working_directory: "notebooks/tutorial-notebooks"
+          use_cachemachine: false
+          url_prefix: "/n3"
+        restart: true
     - name: "tap"
       count: 1
       users:

--- a/applications/mobu/values-idfint.yaml
+++ b/applications/mobu/values-idfint.yaml
@@ -52,6 +52,25 @@ config:
           use_cachemachine: false
           url_prefix: "/n3"
         restart: true
+    - name: "tutorial"
+      count: 1
+      users:
+        - username: "bot-mobu-tutorial"
+      scopes:
+        - "exec:notebook"
+        - "exec:portal"
+        - "read:image"
+        - "read:tap"
+      business:
+        type: "NotebookRunner"
+        options:
+          repo_url: "https://github.com/rubin-dp0/tutorial-notebooks.git"
+          repo_branch: "main"
+          max_executions: 1
+          working_directory: "notebooks/tutorial-notebooks"
+          use_cachemachine: false
+          url_prefix: "/n3"
+        restart: true
     - name: "tap"
       count: 1
       users:


### PR DESCRIPTION
This reverts commit 749fa424ae3d421623ba68b89ca3ee77def4a86a. The assert preventing tutorial notebooks to run in other environments has reportedly been removed on main.