### PR TITLE
DM-39400: Run tutorial notebooks with latest-weekly

### DIFF
--- a/applications/mobu/values-idfdev.yaml
+++ b/applications/mobu/values-idfdev.yaml
@@ -49,6 +49,8 @@ config:
       business:
         type: "NotebookRunner"
         options:
+          image:
+            image_class: "latest-weekly"
           repo_url: "https://github.com/rubin-dp0/tutorial-notebooks.git"
           repo_branch: "main"
           max_executions: 1

--- a/applications/mobu/values-idfint.yaml
+++ b/applications/mobu/values-idfint.yaml
@@ -64,6 +64,8 @@ config:
       business:
         type: "NotebookRunner"
         options:
+          image:
+            image_class: "latest-weekly"
           repo_url: "https://github.com/rubin-dp0/tutorial-notebooks.git"
           repo_branch: "main"
           max_executions: 1


### PR DESCRIPTION
On IDF dev and IDF int, run the tutorial notebooks with latest-weekly since they require the new lsst.rsp package.