### PR TITLE
DM-39435: Restore DP0.2 TAP as the default service

### DIFF
--- a/applications/portal/templates/deployment.yaml
+++ b/applications/portal/templates/deployment.yaml
@@ -62,6 +62,15 @@ spec:
                    "tap" : {
                       "additional": {
                           "services": [
+                            {{- if .Values.config.ssotap }}
+                            {
+                               "label": "DP0.3 SSO",
+                               "value": "{{ .Values.global.baseUrl }}/api/{{ .Values.config.ssotap}}",
+                               "hipsUrl": "{{ .Values.global.baseUrl }}/api/hips/images/color_gri",
+                               "centerWP": "0;0;ECL",
+                               "fovDeg": 10
+                            },
+                            {{- end }}
                             {
                                "label": "LSST RSP",
                                "value": "{{ .Values.global.baseUrl }}/api/tap",
@@ -73,16 +82,6 @@ spec:
                                "centerWP": "62;-37;EQ_J2000",
                                "fovDeg": 10
                             }
-                            {{- if .Values.config.ssotap }}
-                            ,
-                            {
-                               "label": "DP0.3 SSO",
-                               "value": "{{ .Values.global.baseUrl }}/api/{{ .Values.config.ssotap}}",
-                               "hipsUrl": "{{ .Values.global.baseUrl }}/api/hips/images/color_gri",
-                               "centerWP": "0;0;ECL",
-                               "fovDeg": 10
-                            }
-                            {{- end }}
                           ]
                       }
                    },


### PR DESCRIPTION
Change order of RSP TAP service entries to keep DP0.2 first, and DP0.3 / SSOTAP as the second.  (Workaround for surprising behavior of Firefly configuration language.)