### PR TITLE
DM-39360: Bump version of mobu

### DIFF
--- a/applications/mobu/Chart.yaml
+++ b/applications/mobu/Chart.yaml
@@ -4,4 +4,4 @@ version: 1.0.0
 description: Continuous integration testing
 sources:
   - https://github.com/lsst-sqre/mobu
-appVersion: 6.0.0
+appVersion: 6.1.0


### PR DESCRIPTION
6.1.0 has fixes for timeouts and better error reporting.