### PR TITLE
DM-39579: Add link to DP0.2 tutorials from the Squareone /docs page

### DIFF
--- a/applications/squareone/values.yaml
+++ b/applications/squareone/values.yaml
@@ -158,10 +158,8 @@ config:
           <Card>
             ### Rubin Science Platform
 
-            The Notebook Aspect is a powerful data analysis environment with
-            Jupyter Notebooks and terminals in the browser.
-            Documentation for the Rubin Science Platform, including account set up,
-            portal, notebooks, and API aspects.
+            Guides for setting up an account on the Rubin Science Platform
+            and using the Portal, Notebook, and API Aspects.
           </Card>
         </a>
 

--- a/applications/squareone/values.yaml
+++ b/applications/squareone/values.yaml
@@ -124,12 +124,8 @@ config:
             ### Data Preview 0.2 (DP0.2)
 
             DP0.2 is the second phase of the Data Preview 0 program using
-            precursor data (simulated images from the DESC DC2 data
-            challenge). For the first time, all the derived data products
-            have been generated “in-house” on an early version of the Rubin
-            processing infrastructure using version 23.0 of the LSST Science
-            Pipelines. As a result, the data model is significantly
-            different from the DP0.1 dataset.
+            simulated images from the DESC DC2 data challenge processed with
+            version 23.0 of the LSST Science Pipelines.
           </Card>
         </a>
 

--- a/applications/squareone/values.yaml
+++ b/applications/squareone/values.yaml
@@ -129,6 +129,15 @@ config:
           </Card>
         </a>
 
+        <a href="https://dp0-2.lsst.io/tutorials-examples/index.html">
+          <Card>
+            ### DP0.2 Tutorials
+
+            Tutorials for exploring the DP0.2 dataset on the Rubin Science
+            Platform.
+          </Card>
+        </a>
+
         <a href="https://dm.lsst.org/sdm_schemas/browser/dp02.html">
           <Card>
             ### DP0.2 Catalog Schema

--- a/applications/squareone/values.yaml
+++ b/applications/squareone/values.yaml
@@ -149,7 +149,7 @@ config:
           <Card>
             ### Rubin Science Platform
 
-            The Notebook aspect is a powerful data analysis environment with
+            The Notebook Aspect is a powerful data analysis environment with
             Jupyter Notebooks and terminals in the browser.
             Documentation for the Rubin Science Platform, including account set up,
             portal, notebooks, and API aspects.
@@ -171,7 +171,7 @@ config:
 
             The Science Pipelines include the Butler for accessing LSST data
             and a pipeline framework for processing data. The LSST Science
-            Pipelines Python package is preinstalled in the Notebook aspect.
+            Pipelines is preinstalled in the Notebook Aspect.
           </Card>
         </a>
 


### PR DESCRIPTION
This direct link was suggested by the Users Committee via https://github.com/rubin-dp0/Support/issues/41

<img width="1417" alt="CleanShot 2023-06-07 at 10 45 58@2x" src="https://github.com/lsst-sqre/phalanx/assets/349384/ec2b4926-58e1-4fe6-9fcd-90115bc81001">