### PR TITLE
DM-39435: Update to match the new `suit` default TAP service label

### DIFF
--- a/applications/portal/templates/deployment.yaml
+++ b/applications/portal/templates/deployment.yaml
@@ -63,7 +63,7 @@ spec:
                       "additional": {
                           "services": [
                             {
-                               "label": "LSST RSP",
+                               "label": "LSST DP0.2 DC2",
                                "value": "{{ .Values.global.baseUrl }}/api/tap",
                                {{- if .Values.config.hipsUrl }}
                                "hipsUrl": "{{ .Values.config.hipsUrl }}",


### PR DESCRIPTION
Required for the final public-facing configuration we want:
* LSST DP0.2 DC2
* LSST DP0.3 SSO