### PR TITLE
DM-39594: Update Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,8 +2,10 @@
   "extends": [
     "config:base"
   ],
-  "prConcurrentLimit": 5,
+  "configMigration": true,
+  "rebaseWhen": "conflicted",
   "schedule": [
     "before 6am on Monday"
-  ]
+  ],
+  "timezone": "America/Los_Angeles"
 }


### PR DESCRIPTION
Enable automated config migration. Disable rebasing of non-conflicted PRs; we use the merge queue, which will rebase them anyway, so these extra rebases are wasted effort and testing cycles. Set the time zone to push weekly updates a bit later into the middle of the night on Monday instead of starting to show up Sunday evening.