### PR TITLE
DM-38798: Update bot names for usdf-dev

### DIFF
--- a/applications/noteburst/values-usdfdev.yaml
+++ b/applications/noteburst/values-usdfdev.yaml
@@ -6,12 +6,8 @@ config:
   worker:
     workerCount: 1
     identities:
-      - username: "bot-noteburst90000"
-      - username: "bot-noteburst90001"
-      - username: "bot-noteburst90002"
-      - username: "bot-noteburst90003"
-      - username: "bot-noteburst90004"
-      - username: "bot-noteburst90005"
+      - username: "bot-noteburst-01"
+      - username: "bot-noteburst-02"
 
 # Use SSD for Redis storage.
 redis:


### PR DESCRIPTION
bot-noteburst 01 to 20 were created at usdfdev; for now only configure the first two to run on dev.