### PR TITLE
idf-dev, idf-int, and usdf-dev -> nublado3 by default

### DIFF
--- a/applications/mobu/values-idfdev.yaml
+++ b/applications/mobu/values-idfdev.yaml
@@ -34,7 +34,7 @@ config:
             image_class: "latest-weekly"
           repo_url: "https://github.com/lsst-sqre/system-test.git"
           repo_branch: "prod"
-          url_prefix: "/n3"
+          url_prefix: "/nb"
           use_cachemachine: false
         restart: true
     - name: "tutorial"
@@ -56,7 +56,7 @@ config:
           max_executions: 1
           working_directory: "notebooks/tutorial-notebooks"
           use_cachemachine: false
-          url_prefix: "/n3"
+          url_prefix: "/nb"
         restart: true
     - name: "tap"
       count: 1

--- a/applications/mobu/values-idfint.yaml
+++ b/applications/mobu/values-idfint.yaml
@@ -31,7 +31,7 @@ config:
           repo_url: "https://github.com/lsst-sqre/system-test.git"
           repo_branch: "prod"
           use_cachemachine: false
-          url_prefix: "/n3"
+          url_prefix: "/nb"
         restart: true
     - name: "weekly"
       count: 1
@@ -50,7 +50,7 @@ config:
           repo_url: "https://github.com/lsst-sqre/system-test.git"
           repo_branch: "prod"
           use_cachemachine: false
-          url_prefix: "/n3"
+          url_prefix: "/nb"
         restart: true
     - name: "tutorial"
       count: 1
@@ -71,7 +71,7 @@ config:
           max_executions: 1
           working_directory: "notebooks/tutorial-notebooks"
           use_cachemachine: false
-          url_prefix: "/n3"
+          url_prefix: "/nb"
         restart: true
     - name: "tap"
       count: 1

--- a/applications/noteburst/values-idfdev.yaml
+++ b/applications/noteburst/values-idfdev.yaml
@@ -3,7 +3,6 @@ image:
 
 config:
   logLevel: "DEBUG"
-  hubPathPrefix: "/n3"
   worker:
     workerCount: 1
     identities:

--- a/applications/noteburst/values-usdfdev.yaml
+++ b/applications/noteburst/values-usdfdev.yaml
@@ -3,7 +3,6 @@ image:
 
 config:
   logLevel: "DEBUG"
-  hubPathPrefix: "/n3"
   worker:
     workerCount: 1
     identities:

--- a/applications/nublado/values-idfdev.yaml
+++ b/applications/nublado/values-idfdev.yaml
@@ -68,6 +68,5 @@ controller:
             server: "10.87.86.26"
 jupyterhub:
   hub:
-    baseUrl: "/n3"
     db:
       url: "postgresql://nublado3@postgres.postgres/nublado3"

--- a/applications/nublado/values-idfint.yaml
+++ b/applications/nublado/values-idfint.yaml
@@ -89,7 +89,6 @@ controller:
 
 jupyterhub:
   hub:
-    baseUrl: "/n3"
     config:
       ServerApp:
         shutdown_no_activity_timeout: 432000

--- a/applications/nublado/values-usdfdev.yaml
+++ b/applications/nublado/values-usdfdev.yaml
@@ -25,7 +25,7 @@ controller:
         AWS_SHARED_CREDENTIALS_FILE: "/opt/lsst/software/jupyterlab/secrets/aws-credentials.ini"
         AUTO_REPO_SPECS: "https://github.com/lsst-sqre/system-test@prod,https://github.com/rubin-dp0/tutorial-notebooks@prod"
         DAF_BUTLER_REPOSITORY_INDEX: "/project/data-repos.yaml"
-        HUB_ROUTE: "/n3/hub"
+        HUB_ROUTE: "/nb/hub"
         PGPASSFILE: "/opt/lsst/software/jupyterlab/secrets/postgres-credentials.txt"
         PGUSER: "rubin"
         S3_ENDPOINT_URL: "https://s3dfrgw.slac.stanford.edu"

--- a/applications/nublado2/values-idfdev.yaml
+++ b/applications/nublado2/values-idfdev.yaml
@@ -1,5 +1,6 @@
 jupyterhub:
   hub:
+    baseUrl: "/n2"
     config:
       ServerApp:
         shutdown_no_activity_timeout: 432000

--- a/applications/nublado2/values-idfint.yaml
+++ b/applications/nublado2/values-idfint.yaml
@@ -1,5 +1,6 @@
 jupyterhub:
   hub:
+    baseUrl: "/n2"
     config:
       ServerApp:
         shutdown_no_activity_timeout: 432000

--- a/applications/nublado2/values-usdfdev.yaml
+++ b/applications/nublado2/values-usdfdev.yaml
@@ -1,6 +1,7 @@
 jupyterhub:
 
   hub:
+    baseUrl: "/n2"
     config:
       ServerApp:
         shutdown_no_activity_timeout: 432000


### PR DESCRIPTION
This moves nublado3 to /nb on idf-dev, -int, and usdf-dev, while relocating nublado2 to /n2 on the same environments, as requested by Frossie on 5 July 2023.