### PR TITLE
DM-39552: Update to mobu 6.1.1

### DIFF
--- a/applications/mobu/Chart.yaml
+++ b/applications/mobu/Chart.yaml
@@ -4,4 +4,4 @@ version: 1.0.0
 description: Continuous integration testing
 sources:
   - https://github.com/lsst-sqre/mobu
-appVersion: 6.1.0
+appVersion: 6.1.1


### PR DESCRIPTION
Improved error reporting and hopefully a fix for the timeouts when summarizing flocks.