### PR TITLE
Change TAP schema database pod configuration

### DIFF
--- a/applications/livetap/README.md
+++ b/applications/livetap/README.md
@@ -45,9 +45,14 @@ IVOA TAP service
 | podAnnotations | object | `{}` | Annotations for the Gafaelfawr frontend pod |
 | replicaCount | int | `1` | Number of pods to start |
 | resources | object | `{}` | Resource limits and requests for the Gafaelfawr frontend pod |
-| tap_schema.image.repository | object | `{}` |  |
-| tap_schema.image.tag | string | `"2.0.2"` |  |
-| tap_schema.resources | object | `{}` |  |
+| tapSchema.affinity | object | `{}` | Affinity rules for the mock QServ pod |
+| tapSchema.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the TAP schema image |
+| tapSchema.image.repository | string | `"lsstsqre/tap-schema-idfprod-tap"` | TAP schema image to ue. This must be overridden by each environment with the TAP schema for that environment. |
+| tapSchema.image.tag | string | `"2.0.1"` | Tag of TAP schema image |
+| tapSchema.nodeSelector | object | `{}` | Node selection rules for the mock QServ pod |
+| tapSchema.podAnnotations | object | `{}` | Annotations for the mock QServ pod |
+| tapSchema.resources | object | `{}` | Resource limits and requests for the TAP schema database pod |
+| tapSchema.tolerations | list | `[]` | Tolerations for the mock QServ pod |
 | tolerations | list | `[]` | Tolerations for the Gafaelfawr frontend pod |
 | uws.affinity | object | `{}` | Affinity rules for the UWS database pod |
 | uws.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the UWS database image |

--- a/applications/livetap/README.md
+++ b/applications/livetap/README.md
@@ -47,8 +47,8 @@ IVOA TAP service
 | resources | object | `{}` | Resource limits and requests for the Gafaelfawr frontend pod |
 | tapSchema.affinity | object | `{}` | Affinity rules for the mock QServ pod |
 | tapSchema.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the TAP schema image |
-| tapSchema.image.repository | string | `"lsstsqre/tap-schema-idfprod-tap"` | TAP schema image to ue. This must be overridden by each environment with the TAP schema for that environment. |
-| tapSchema.image.tag | string | `"2.0.1"` | Tag of TAP schema image |
+| tapSchema.image.repository | string | `"lsstsqre/tap-schema-mock"` | TAP schema image to ue. This must be overridden by each environment with the TAP schema for that environment. |
+| tapSchema.image.tag | string | `"2.0.2"` | Tag of TAP schema image |
 | tapSchema.nodeSelector | object | `{}` | Node selection rules for the mock QServ pod |
 | tapSchema.podAnnotations | object | `{}` | Annotations for the mock QServ pod |
 | tapSchema.resources | object | `{}` | Resource limits and requests for the TAP schema database pod |

--- a/applications/livetap/templates/tap-schema-db-deployment.yaml
+++ b/applications/livetap/templates/tap-schema-db-deployment.yaml
@@ -11,7 +11,7 @@ spec:
       {{- include "cadc-tap.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
+      {{- with .Values.tapSchema.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -31,26 +31,26 @@ spec:
               value: "TAP_SCHEMA"
             - name: MYSQL_ROOT_HOST
               value: "%"
-          image: "{{ .Values.tap_schema.image.repository }}:{{ .Values.tap_schema.image.tag}}"
-          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          image: "{{ .Values.tapSchema.image.repository }}:{{ .Values.tapSchema.image.tag}}"
+          imagePullPolicy: {{ .Values.tapSchema.image.pullPolicy | quote }}
           ports:
             - containerPort: 3306
               protocol: "TCP"
-          {{- with .Values.tap_schema.resources }}
+          {{- with .Values.tapSchema.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
       imagePullSecrets:
         - name: "pull-secret"
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.tapSchema.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with .Values.tapSchema.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with .Values.tapSchema.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/applications/livetap/values-minikube.yaml
+++ b/applications/livetap/values-minikube.yaml
@@ -1,3 +1,7 @@
+tapSchema:
+  image:
+    repository: "lsstsqre/tap-schema-usdf-prod-livetap"
+
 config:
   gcsBucket: "async-results.lsst.codes"
   gcsBucketUrl: "http://async-results.lsst.codes"

--- a/applications/livetap/values-usdfdev.yaml
+++ b/applications/livetap/values-usdfdev.yaml
@@ -1,4 +1,4 @@
-tap_schema:
+tapSchema:
   image:
     repository: "lsstsqre/tap-schema-usdf-dev-livetap"
 

--- a/applications/livetap/values-usdfprod.yaml
+++ b/applications/livetap/values-usdfprod.yaml
@@ -1,4 +1,4 @@
-tap_schema:
+tapSchema:
   image:
     repository: "lsstsqre/tap-schema-usdf-prod-livetap"
 

--- a/applications/livetap/values.yaml
+++ b/applications/livetap/values.yaml
@@ -124,13 +124,13 @@ tapSchema:
   image:
     # -- TAP schema image to ue. This must be overridden by each environment
     # with the TAP schema for that environment.
-    repository: "lsstsqre/tap-schema-idfprod-tap"
+    repository: "lsstsqre/tap-schema-mock"
 
     # -- Pull policy for the TAP schema image
     pullPolicy: "IfNotPresent"
 
     # -- Tag of TAP schema image
-    tag: "2.0.1"
+    tag: "2.0.2"
 
   # -- Resource limits and requests for the TAP schema database pod
   resources: {}

--- a/applications/livetap/values.yaml
+++ b/applications/livetap/values.yaml
@@ -120,11 +120,32 @@ pg:
     # -- Affinity rules for the mock postgres pod
     affinity: {}
 
-tap_schema:
+tapSchema:
   image:
-    repository: {}
-    tag: "2.0.2"
+    # -- TAP schema image to ue. This must be overridden by each environment
+    # with the TAP schema for that environment.
+    repository: "lsstsqre/tap-schema-idfprod-tap"
+
+    # -- Pull policy for the TAP schema image
+    pullPolicy: "IfNotPresent"
+
+    # -- Tag of TAP schema image
+    tag: "2.0.1"
+
+  # -- Resource limits and requests for the TAP schema database pod
   resources: {}
+
+  # -- Annotations for the mock QServ pod
+  podAnnotations: {}
+
+  # -- Node selection rules for the mock QServ pod
+  nodeSelector: {}
+
+  # -- Tolerations for the mock QServ pod
+  tolerations: []
+
+  # -- Affinity rules for the mock QServ pod
+  affinity: {}
 
 uws:
   image:

--- a/applications/ssotap/README.md
+++ b/applications/ssotap/README.md
@@ -45,9 +45,14 @@ IVOA TAP service
 | podAnnotations | object | `{}` | Annotations for the Gafaelfawr frontend pod |
 | replicaCount | int | `1` | Number of pods to start |
 | resources | object | `{}` | Resource limits and requests for the Gafaelfawr frontend pod |
-| tap_schema.image.repository | object | `{}` |  |
-| tap_schema.image.tag | string | `"2.0.1"` |  |
-| tap_schema.resources | object | `{}` |  |
+| tapSchema.affinity | object | `{}` | Affinity rules for the mock QServ pod |
+| tapSchema.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the TAP schema image |
+| tapSchema.image.repository | string | `"lsstsqre/tap-schema-idfprod-tap"` | TAP schema image to ue. This must be overridden by each environment with the TAP schema for that environment. |
+| tapSchema.image.tag | string | `"2.0.1"` | Tag of TAP schema image |
+| tapSchema.nodeSelector | object | `{}` | Node selection rules for the mock QServ pod |
+| tapSchema.podAnnotations | object | `{}` | Annotations for the mock QServ pod |
+| tapSchema.resources | object | `{}` | Resource limits and requests for the TAP schema database pod |
+| tapSchema.tolerations | list | `[]` | Tolerations for the mock QServ pod |
 | tolerations | list | `[]` | Tolerations for the Gafaelfawr frontend pod |
 | uws.affinity | object | `{}` | Affinity rules for the UWS database pod |
 | uws.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the UWS database image |

--- a/applications/ssotap/README.md
+++ b/applications/ssotap/README.md
@@ -47,8 +47,8 @@ IVOA TAP service
 | resources | object | `{}` | Resource limits and requests for the Gafaelfawr frontend pod |
 | tapSchema.affinity | object | `{}` | Affinity rules for the mock QServ pod |
 | tapSchema.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the TAP schema image |
-| tapSchema.image.repository | string | `"lsstsqre/tap-schema-idfprod-tap"` | TAP schema image to ue. This must be overridden by each environment with the TAP schema for that environment. |
-| tapSchema.image.tag | string | `"2.0.1"` | Tag of TAP schema image |
+| tapSchema.image.repository | string | `"lsstsqre/tap-schema-mock"` | TAP schema image to ue. This must be overridden by each environment with the TAP schema for that environment. |
+| tapSchema.image.tag | string | `"2.0.2"` | Tag of TAP schema image |
 | tapSchema.nodeSelector | object | `{}` | Node selection rules for the mock QServ pod |
 | tapSchema.podAnnotations | object | `{}` | Annotations for the mock QServ pod |
 | tapSchema.resources | object | `{}` | Resource limits and requests for the TAP schema database pod |

--- a/applications/ssotap/templates/tap-schema-db-deployment.yaml
+++ b/applications/ssotap/templates/tap-schema-db-deployment.yaml
@@ -11,7 +11,7 @@ spec:
       {{- include "cadc-tap.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
+      {{- with .Values.tapSchema.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -31,26 +31,26 @@ spec:
               value: "TAP_SCHEMA"
             - name: MYSQL_ROOT_HOST
               value: "%"
-          image: "{{ .Values.tap_schema.image.repository }}:{{ .Values.tap_schema.image.tag}}"
-          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          image: "{{ .Values.tapSchema.image.repository }}:{{ .Values.tapSchema.image.tag}}"
+          imagePullPolicy: {{ .Values.tapSchema.image.pullPolicy | quote }}
           ports:
             - containerPort: 3306
               protocol: "TCP"
-          {{- with .Values.tap_schema.resources }}
+          {{- with .Values.tapSchema.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
       imagePullSecrets:
         - name: "pull-secret"
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.tapSchema.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with .Values.tapSchema.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with .Values.tapSchema.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/applications/ssotap/values-idfdev.yaml
+++ b/applications/ssotap/values-idfdev.yaml
@@ -1,4 +1,4 @@
-tap_schema:
+tapSchema:
   image:
     repository: "lsstsqre/tap-schema-idfdev-sso"
 

--- a/applications/ssotap/values-idfint.yaml
+++ b/applications/ssotap/values-idfint.yaml
@@ -1,4 +1,4 @@
-tap_schema:
+tapSchema:
   image:
     repository: "lsstsqre/tap-schema-idfint-sso"
 

--- a/applications/ssotap/values-idfprod.yaml
+++ b/applications/ssotap/values-idfprod.yaml
@@ -1,4 +1,4 @@
-tap_schema:
+tapSchema:
   image:
     repository: "lsstsqre/tap-schema-idfprod-sso"
 

--- a/applications/ssotap/values-minikube.yaml
+++ b/applications/ssotap/values-minikube.yaml
@@ -1,4 +1,4 @@
-tap_schema:
+tapSchema:
   image:
     repository: "lsstsqre/tap-schema-idfprod-sso"
 

--- a/applications/ssotap/values-usdfdev.yaml
+++ b/applications/ssotap/values-usdfdev.yaml
@@ -1,4 +1,4 @@
-tap_schema:
+tapSchema:
   image:
     repository: "lsstsqre/tap-schema-usdf-dev-sso"
 

--- a/applications/ssotap/values-usdfprod.yaml
+++ b/applications/ssotap/values-usdfprod.yaml
@@ -1,4 +1,4 @@
-tap_schema:
+tapSchema:
   image:
     repository: "lsstsqre/tap-schema-usdf-prod-sso"
 

--- a/applications/ssotap/values.yaml
+++ b/applications/ssotap/values.yaml
@@ -124,13 +124,13 @@ tapSchema:
   image:
     # -- TAP schema image to ue. This must be overridden by each environment
     # with the TAP schema for that environment.
-    repository: "lsstsqre/tap-schema-idfprod-tap"
+    repository: "lsstsqre/tap-schema-mock"
 
     # -- Pull policy for the TAP schema image
     pullPolicy: "IfNotPresent"
 
     # -- Tag of TAP schema image
-    tag: "2.0.1"
+    tag: "2.0.2"
 
   # -- Resource limits and requests for the TAP schema database pod
   resources: {}

--- a/applications/ssotap/values.yaml
+++ b/applications/ssotap/values.yaml
@@ -120,11 +120,32 @@ pg:
     # -- Affinity rules for the mock postgres pod
     affinity: {}
 
-tap_schema:
+tapSchema:
   image:
-    repository: {}
+    # -- TAP schema image to ue. This must be overridden by each environment
+    # with the TAP schema for that environment.
+    repository: "lsstsqre/tap-schema-idfprod-tap"
+
+    # -- Pull policy for the TAP schema image
+    pullPolicy: "IfNotPresent"
+
+    # -- Tag of TAP schema image
     tag: "2.0.1"
+
+  # -- Resource limits and requests for the TAP schema database pod
   resources: {}
+
+  # -- Annotations for the mock QServ pod
+  podAnnotations: {}
+
+  # -- Node selection rules for the mock QServ pod
+  nodeSelector: {}
+
+  # -- Tolerations for the mock QServ pod
+  tolerations: []
+
+  # -- Affinity rules for the mock QServ pod
+  affinity: {}
 
 uws:
   image:

--- a/applications/tap/README.md
+++ b/applications/tap/README.md
@@ -45,8 +45,8 @@ IVOA TAP service
 | resources | object | `{}` | Resource limits and requests for the Gafaelfawr frontend pod |
 | tapSchema.affinity | object | `{}` | Affinity rules for the mock QServ pod |
 | tapSchema.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the TAP schema image |
-| tapSchema.image.repository | string | `"lsstsqre/tap-schema-idfprod-tap"` | TAP schema image to ue. This must be overridden by each environment with the TAP schema for that environment. |
-| tapSchema.image.tag | string | `"2.0.1"` | Tag of TAP schema image |
+| tapSchema.image.repository | string | `"lsstsqre/tap-schema-mock"` | TAP schema image to ue. This must be overridden by each environment with the TAP schema for that environment. |
+| tapSchema.image.tag | string | `"2.0.2"` | Tag of TAP schema image |
 | tapSchema.nodeSelector | object | `{}` | Node selection rules for the mock QServ pod |
 | tapSchema.podAnnotations | object | `{}` | Annotations for the mock QServ pod |
 | tapSchema.resources | object | `{}` | Resource limits and requests for the TAP schema database pod |

--- a/applications/tap/README.md
+++ b/applications/tap/README.md
@@ -43,9 +43,14 @@ IVOA TAP service
 | qserv.mock.tolerations | list | `[]` | Tolerations for the mock QServ pod |
 | replicaCount | int | `1` | Number of pods to start |
 | resources | object | `{}` | Resource limits and requests for the Gafaelfawr frontend pod |
-| tap_schema.image.repository | object | `{}` |  |
-| tap_schema.image.tag | string | `"2.0.1"` |  |
-| tap_schema.resources | object | `{}` |  |
+| tapSchema.affinity | object | `{}` | Affinity rules for the mock QServ pod |
+| tapSchema.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the TAP schema image |
+| tapSchema.image.repository | string | `"lsstsqre/tap-schema-idfprod-tap"` | TAP schema image to ue. This must be overridden by each environment with the TAP schema for that environment. |
+| tapSchema.image.tag | string | `"2.0.1"` | Tag of TAP schema image |
+| tapSchema.nodeSelector | object | `{}` | Node selection rules for the mock QServ pod |
+| tapSchema.podAnnotations | object | `{}` | Annotations for the mock QServ pod |
+| tapSchema.resources | object | `{}` | Resource limits and requests for the TAP schema database pod |
+| tapSchema.tolerations | list | `[]` | Tolerations for the mock QServ pod |
 | tolerations | list | `[]` | Tolerations for the Gafaelfawr frontend pod |
 | uws.affinity | object | `{}` | Affinity rules for the UWS database pod |
 | uws.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the UWS database image |

--- a/applications/tap/templates/tap-schema-db-deployment.yaml
+++ b/applications/tap/templates/tap-schema-db-deployment.yaml
@@ -11,7 +11,7 @@ spec:
       {{- include "cadc-tap.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
+      {{- with .Values.tapSchema.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -31,26 +31,26 @@ spec:
               value: "TAP_SCHEMA"
             - name: MYSQL_ROOT_HOST
               value: "%"
-          image: "{{ .Values.tap_schema.image.repository }}:{{ .Values.tap_schema.image.tag}}"
-          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          image: "{{ .Values.tapSchema.image.repository }}:{{ .Values.tapSchema.image.tag}}"
+          imagePullPolicy: {{ .Values.tapSchema.image.pullPolicy | quote }}
           ports:
             - containerPort: 3306
               protocol: "TCP"
-          {{- with .Values.tap_schema.resources }}
+          {{- with .Values.tapSchema.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
       imagePullSecrets:
         - name: "pull-secret"
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.tapSchema.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with .Values.tapSchema.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with .Values.tapSchema.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/applications/tap/values-ccin2p3.yaml
+++ b/applications/tap/values-ccin2p3.yaml
@@ -1,4 +1,4 @@
-tap_schema:
+tapSchema:
   image:
     repository: "lsstsqre/tap-schema-idfprod-tap"
 

--- a/applications/tap/values-idfdev.yaml
+++ b/applications/tap/values-idfdev.yaml
@@ -1,4 +1,4 @@
-tap_schema:
+tapSchema:
   image:
     repository: "lsstsqre/tap-schema-idfdev-tap"
 

--- a/applications/tap/values-idfint.yaml
+++ b/applications/tap/values-idfint.yaml
@@ -1,4 +1,4 @@
-tap_schema:
+tapSchema:
   image:
     repository: "lsstsqre/tap-schema-idfint-tap"
 

--- a/applications/tap/values-idfprod.yaml
+++ b/applications/tap/values-idfprod.yaml
@@ -1,4 +1,4 @@
-tap_schema:
+tapSchema:
   image:
     repository: "lsstsqre/tap-schema-idfprod-tap"
 

--- a/applications/tap/values-minikube.yaml
+++ b/applications/tap/values-minikube.yaml
@@ -1,4 +1,4 @@
-tap_schema:
+tapSchema:
   image:
     repository: "lsstsqre/tap-schema-idfprod-tap"
 

--- a/applications/tap/values-roe.yaml
+++ b/applications/tap/values-roe.yaml
@@ -1,4 +1,4 @@
-tap_schema:
+tapSchema:
   image:
     repository: "lsstsqre/tap-schema-idfprod-tap"
 

--- a/applications/tap/values-usdfdev.yaml
+++ b/applications/tap/values-usdfdev.yaml
@@ -1,4 +1,4 @@
-tap_schema:
+tapSchema:
   image:
     repository: "lsstsqre/tap-schema-usdf-dev-tap"
 

--- a/applications/tap/values-usdfprod.yaml
+++ b/applications/tap/values-usdfprod.yaml
@@ -1,4 +1,4 @@
-tap_schema:
+tapSchema:
   image:
     repository: "lsstsqre/tap-schema-usdf-prod-tap"
 

--- a/applications/tap/values.yaml
+++ b/applications/tap/values.yaml
@@ -118,13 +118,13 @@ tapSchema:
   image:
     # -- TAP schema image to ue. This must be overridden by each environment
     # with the TAP schema for that environment.
-    repository: "lsstsqre/tap-schema-idfprod-tap"
+    repository: "lsstsqre/tap-schema-mock"
 
     # -- Pull policy for the TAP schema image
     pullPolicy: "IfNotPresent"
 
     # -- Tag of TAP schema image
-    tag: "2.0.1"
+    tag: "2.0.2"
 
   # -- Resource limits and requests for the TAP schema database pod
   resources: {}

--- a/applications/tap/values.yaml
+++ b/applications/tap/values.yaml
@@ -114,11 +114,32 @@ qserv:
     # -- Affinity rules for the mock QServ pod
     affinity: {}
 
-tap_schema:
+tapSchema:
   image:
-    repository: {}
+    # -- TAP schema image to ue. This must be overridden by each environment
+    # with the TAP schema for that environment.
+    repository: "lsstsqre/tap-schema-idfprod-tap"
+
+    # -- Pull policy for the TAP schema image
+    pullPolicy: "IfNotPresent"
+
+    # -- Tag of TAP schema image
     tag: "2.0.1"
+
+  # -- Resource limits and requests for the TAP schema database pod
   resources: {}
+
+  # -- Annotations for the mock QServ pod
+  podAnnotations: {}
+
+  # -- Node selection rules for the mock QServ pod
+  nodeSelector: {}
+
+  # -- Tolerations for the mock QServ pod
+  tolerations: []
+
+  # -- Affinity rules for the mock QServ pod
+  affinity: {}
 
 uws:
   image:


### PR DESCRIPTION
Make the TAP schema database pod configuration consistent with other deployments and Helm values style:

* Use tapSchema rather than tap_schema since Helm uses camelCase
* Add and use podAnnotations, nodeSelector, tolerations, and affinity rather than using the ones for the base TAP server
* Add image.pullPolicy configuration

Also set a default image.repository for tapSchema. It would be nice to have Helm force this to be set, but unfortunately it breaks Renovate discovery of the latest image tag version, which we want as a reminder when the image is out of date. Use the same image name that we use for minikube as the default, but document that it must be set for each environment.