### PR TITLE
[DM-39960] Change URL from http to https

### DIFF
--- a/applications/livetap/values-minikube.yaml
+++ b/applications/livetap/values-minikube.yaml
@@ -4,4 +4,4 @@ tapSchema:
 
 config:
   gcsBucket: "async-results.lsst.codes"
-  gcsBucketUrl: "http://async-results.lsst.codes"
+  gcsBucketUrl: "https://tap-files.lsst.codes"

--- a/applications/livetap/values-usdfdev.yaml
+++ b/applications/livetap/values-usdfdev.yaml
@@ -14,7 +14,7 @@ replicaCount: 2
 
 config:
   gcsBucket: "async-results.lsst.codes"
-  gcsBucketUrl: "http://async-results.lsst.codes"
+  gcsBucketUrl: "https://tap-files.lsst.codes"
   jvmMaxHeapSize: "31G"
 
 pg:

--- a/applications/livetap/values-usdfprod.yaml
+++ b/applications/livetap/values-usdfprod.yaml
@@ -14,7 +14,7 @@ replicaCount: 2
 
 config:
   gcsBucket: "async-results.lsst.codes"
-  gcsBucketUrl: "http://async-results.lsst.codes"
+  gcsBucketUrl: "https://tap-files.lsst.codes"
   jvmMaxHeapSize: "31G"
 
 pg:

--- a/applications/ssotap/values-idfdev.yaml
+++ b/applications/ssotap/values-idfdev.yaml
@@ -12,7 +12,7 @@ resources:
 
 config:
   gcsBucket: "async-results.lsst.codes"
-  gcsBucketUrl: "http://async-results.lsst.codes"
+  gcsBucketUrl: "https://tap-files.lsst.codes"
   jvmMaxHeapSize: "31G"
 
 pg:

--- a/applications/ssotap/values-idfint.yaml
+++ b/applications/ssotap/values-idfint.yaml
@@ -14,7 +14,7 @@ replicaCount: 2
 
 config:
   gcsBucket: "async-results.lsst.codes"
-  gcsBucketUrl: "http://async-results.lsst.codes"
+  gcsBucketUrl: "https://tap-files.lsst.codes"
   jvmMaxHeapSize: "31G"
 
 pg:

--- a/applications/ssotap/values-idfprod.yaml
+++ b/applications/ssotap/values-idfprod.yaml
@@ -14,7 +14,7 @@ replicaCount: 2
 
 config:
   gcsBucket: "async-results.lsst.codes"
-  gcsBucketUrl: "http://async-results.lsst.codes"
+  gcsBucketUrl: "https://tap-files.lsst.codes"
   jvmMaxHeapSize: "31G"
 
 pg:

--- a/applications/ssotap/values-minikube.yaml
+++ b/applications/ssotap/values-minikube.yaml
@@ -4,4 +4,4 @@ tapSchema:
 
 config:
   gcsBucket: "async-results.lsst.codes"
-  gcsBucketUrl: "http://async-results.lsst.codes"
+  gcsBucketUrl: "https://tap-files.lsst.codes"

--- a/applications/ssotap/values-usdfdev.yaml
+++ b/applications/ssotap/values-usdfdev.yaml
@@ -12,7 +12,7 @@ resources:
 
 config:
   gcsBucket: "async-results.lsst.codes"
-  gcsBucketUrl: "http://async-results.lsst.codes"
+  gcsBucketUrl: "https://tap-files.lsst.codes"
   jvmMaxHeapSize: "31G"
 
 pg:

--- a/applications/ssotap/values-usdfprod.yaml
+++ b/applications/ssotap/values-usdfprod.yaml
@@ -14,7 +14,7 @@ replicaCount: 2
 
 config:
   gcsBucket: "async-results.lsst.codes"
-  gcsBucketUrl: "http://async-results.lsst.codes"
+  gcsBucketUrl: "https://tap-files.lsst.codes"
   jvmMaxHeapSize: "31G"
 
 pg:

--- a/applications/tap/values-idfdev.yaml
+++ b/applications/tap/values-idfdev.yaml
@@ -12,7 +12,7 @@ resources:
 
 config:
   gcsBucket: "async-results.lsst.codes"
-  gcsBucketUrl: "http://async-results.lsst.codes"
+  gcsBucketUrl: "https://tap-files.lsst.codes"
   jvmMaxHeapSize: "31G"
 
 qserv:

--- a/applications/tap/values-idfint.yaml
+++ b/applications/tap/values-idfint.yaml
@@ -14,7 +14,7 @@ replicaCount: 2
 
 config:
   gcsBucket: "async-results.lsst.codes"
-  gcsBucketUrl: "http://async-results.lsst.codes"
+  gcsBucketUrl: "https://tap-files.lsst.codes"
   jvmMaxHeapSize: "31G"
 
 qserv:

--- a/applications/tap/values-idfprod.yaml
+++ b/applications/tap/values-idfprod.yaml
@@ -14,7 +14,7 @@ replicaCount: 2
 
 config:
   gcsBucket: "async-results.lsst.codes"
-  gcsBucketUrl: "http://async-results.lsst.codes"
+  gcsBucketUrl: "https://tap-files.lsst.codes"
   jvmMaxHeapSize: "31G"
 
 qserv:

--- a/applications/tap/values-minikube.yaml
+++ b/applications/tap/values-minikube.yaml
@@ -4,4 +4,4 @@ tapSchema:
 
 config:
   gcsBucket: "async-results.lsst.codes"
-  gcsBucketUrl: "http://async-results.lsst.codes"
+  gcsBucketUrl: "https://tap-files.lsst.codes"


### PR DESCRIPTION
Once there is a load balancer set up in front of the bucket, we should use the https URL.  Then if we
really want or need to, we can use an http endpoint, and the loadbalancer will redirect to an https URL.