### PR TITLE
DM-39989: Add periodic pre-commit dependency update

### DIFF
--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -1,0 +1,34 @@
+name: Dependency Update
+
+"on":
+  schedule:
+    - cron: "0 12 * * 1"
+  workflow_dispatch: {}
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Run neophile
+        uses: lsst-sqre/run-tox@v1
+        with:
+          python-version: "3.11"
+          tox-envs: "neophile-update"
+          tox-posargs: "--pr pre-commit"
+        env:
+          NEOPHILE_GITHUB_APP_ID: ${{ secrets.NEOPHILE_APP_ID }}
+          NEOPHILE_GITHUB_PRIVATE_KEY: ${{ secrets.NEOPHILE_PRIVATE_KEY }}
+
+      - name: Report status
+        if: always()
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: ${{ job.status }}
+          notify_when: "failure"
+          notification_title: "Periodic dependency update for {repo} failed"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ALERT_WEBHOOK }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
           # The `./` makes it relative to the chart-search-root set above
           - "--template-files=./helm-docs.md.gotmpl"
 
-  - repo: https://github.com/PyCQA/isort
+  - repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:
       - id: isort
@@ -33,13 +33,13 @@ repos:
     hooks:
       - id: black
 
-  - repo: https://github.com/asottile/blacken-docs
+  - repo: https://github.com/adamchainz/blacken-docs
     rev: 1.13.0
     hooks:
       - id: blacken-docs
         additional_dependencies: [black==23.1.0]
 
-  - repo: https://github.com/PyCQA/flake8
+  - repo: https://github.com/pycqa/flake8
     rev: 6.0.0
     hooks:
       - id: flake8

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,16 @@ description = Run pytest against {envname}.
 extras =
     dev
 
+[testenv:docs]
+description = Build documentation (HTML) with Sphinx.
+commands =
+    sphinx-build --keep-going -n -W -T -b html -d {envtmpdir}/doctrees docs docs/_build/html
+
+[testenv:docs-linkcheck]
+description = Check links in the documentation.
+commands =
+    sphinx-build --keep-going -n -W -T -b linkcheck -d {envtmpdir}/doctrees docs docs/_build/linkcheck
+
 [testenv:py]
 description = Run pytest
 commands =
@@ -22,11 +32,6 @@ commands =
     coverage combine
     coverage report
 
-[testenv:typing]
-description = Run mypy.
-commands =
-    mypy src/phalanx tests
-
 [testenv:lint]
 description = Lint codebase by running pre-commit (Black, isort, Flake8).
 skip_install = true
@@ -34,12 +39,14 @@ deps =
     pre-commit
 commands = pre-commit run --all-files
 
-[testenv:docs]
-description = Build documentation (HTML) with Sphinx.
-commands =
-    sphinx-build --keep-going -n -W -T -b html -d {envtmpdir}/doctrees docs docs/_build/html
+[testenv:neophile-update]
+description = Run neophile to update dependencies
+skip_install = true
+deps =
+    neophile
+commands = neophile update {posargs}
 
-[testenv:docs-linkcheck]
-description = Check links in the documentation.
+[testenv:typing]
+description = Run mypy.
 commands =
-    sphinx-build --keep-going -n -W -T -b linkcheck -d {envtmpdir}/doctrees docs docs/_build/linkcheck
+    mypy src/phalanx tests


### PR DESCRIPTION
Run neophile weekly to update the pre-commit dependencies. Fix the URLs of the existing pre-commit dependencies to use the canonical URLs, since neophile does not yet support fixing those.