### PR TITLE
DM-39989: Remove .git from the yamllint pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
       - id: trailing-whitespace
       - id: check-toml
 
-  - repo: https://github.com/adrienverge/yamllint.git
+  - repo: https://github.com/adrienverge/yamllint
     rev: v1.30.0
     hooks:
       - id: yamllint


### PR DESCRIPTION
neophile can't handle the trailing .git, so remove it so that neophile can properly update the dependency.