### PR TITLE
Give the linkcheck workflow a unique name

### DIFF
--- a/.github/workflows/linkcheck.yaml
+++ b/.github/workflows/linkcheck.yaml
@@ -35,7 +35,7 @@ name: Link Check
   workflow_dispatch: {}
 
 jobs:
-  docs:
+  linkcheck:
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Don't name the linkcheck workflow docs, because then it becomes a required workflow for merging and the whole point of making it a separate workflow was so that it wouldn't be required.