### PR TITLE
Revert "Change connector error policy to RETRY"

### DIFF
--- a/applications/sasquatch/charts/kafka-connect-manager/README.md
+++ b/applications/sasquatch/charts/kafka-connect-manager/README.md
@@ -16,8 +16,8 @@ A subchart to deploy the Kafka connectors used by Sasquatch.
 | influxdbSink.autoUpdate | bool | `true` | If autoUpdate is enabled, check for new kafka topics. |
 | influxdbSink.checkInterval | string | `"15000"` | The interval, in milliseconds, to check for new topics and update the connector. |
 | influxdbSink.connectInfluxDb | string | `"efd"` | InfluxDB database to write to. |
-| influxdbSink.connectInfluxErrorPolicy | string | `"RETRY"` | Error policy, see connector documetation for details. |
-| influxdbSink.connectInfluxMaxRetries | string | `"20"` | The maximum number of times a message is retried. |
+| influxdbSink.connectInfluxErrorPolicy | string | `"NOOP"` | Error policy, see connector documetation for details. |
+| influxdbSink.connectInfluxMaxRetries | string | `"10"` | The maximum number of times a message is retried. |
 | influxdbSink.connectInfluxRetryInterval | string | `"60000"` | The interval, in milliseconds, between retries. Only valid when the connectInfluxErrorPolicy is set to `RETRY`. |
 | influxdbSink.connectInfluxUrl | string | `"http://sasquatch-influxdb.sasquatch:8086"` | InfluxDB URL. |
 | influxdbSink.connectProgressEnabled | bool | `false` | Enables the output for how many records have been processed. |

--- a/applications/sasquatch/charts/kafka-connect-manager/values.yaml
+++ b/applications/sasquatch/charts/kafka-connect-manager/values.yaml
@@ -23,9 +23,9 @@ influxdbSink:
   # -- Timestamp field to be used as the InfluxDB time, if not specified use `sys_time()`.
   timestamp: private_efdStamp
   # -- Error policy, see connector documetation for details.
-  connectInfluxErrorPolicy: RETRY
+  connectInfluxErrorPolicy: NOOP
   # -- The maximum number of times a message is retried.
-  connectInfluxMaxRetries: "20"
+  connectInfluxMaxRetries: "10"
   # -- The interval, in milliseconds, between retries. Only valid when the connectInfluxErrorPolicy is set to `RETRY`.
   connectInfluxRetryInterval: "60000"
   # -- Enables the output for how many records have been processed.


### PR DESCRIPTION
The connector for M1M3 breaks with the RETRY error policy. Reverting for now.