### PR TITLE
[DM-40075] Enable backup of InfluxDB to another persistent volume

### DIFF
--- a/applications/sasquatch/values-tucson-teststand.yaml
+++ b/applications/sasquatch/values-tucson-teststand.yaml
@@ -25,6 +25,15 @@ influxdb:
   ingress:
     enabled: true
     hostname: tucson-teststand.lsst.codes
+  backup:
+    enabled: true
+    persistence:
+      enabled: true
+      storageClass: rook-ceph-block
+      size: 1Ti
+    schedule: "45 12 * * *"
+    s3:
+      endpointUrl: ""
 
 influxdb2:
   enabled: true


### PR DESCRIPTION
An initial attempt to dump an InfluxDB backup to another PV so that Velero could copy the data to S3.
