### PR TITLE
Update the TAP_SCHEMA repository for the roe environment

### DIFF
--- a/applications/tap/values-roe.yaml
+++ b/applications/tap/values-roe.yaml
@@ -1,6 +1,6 @@
 tapSchema:
   image:
-    repository: "lsstsqre/tap-schema-idfprod-tap"
+    repository: "stvoutsin/tap-schema-roe"
 
 config:
   gcsBucket: "async"


### PR DESCRIPTION
This PR changes the image repository for the roe env to: stvoutsin/tap-schema-roe. At ROE we have a different set of databases/catalogs that do not appear in the idfprod schema image, so for now we've created a new Docker image for TAP_SCHEMA. Perhaps down the road these schema files can be included in the sdm_schemas repo & build scripts.