### PR TITLE
[DM-40165] Increase Kafka data partition size

### DIFF
--- a/applications/sasquatch/values-base.yaml
+++ b/applications/sasquatch/values-base.yaml
@@ -23,6 +23,7 @@ strimzi-kafka:
   kafka:
     storage:
       storageClassName: rook-ceph-block
+      size: 1Ti
     externalListener:
       tls:
         enabled: true


### PR DESCRIPTION
- Kafka at base has two functions now, it stores topics from the teststand and topics replicated from the summit efd.
- Expand Kafka data partition from 500G to 1T