### PR TITLE
Ignore bogus pipelines releases for tap-schema

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,12 @@
     "config:recommended"
   ],
   "configMigration": true,
+  "packageRules": [
+    {
+      "matchPackageNames": ["lsstsqre/tap-schema-mock"],
+      "allowedVersions": "<10"
+    }
+  ],
   "rebaseWhen": "conflicted",
   "schedule": [
     "before 6am on Monday"


### PR DESCRIPTION
Renovate is picking up the annoying global pipelines release tags for sdm_schemas. Try to exclude them.