### PR TITLE
DM-40169: Times Square and Noteburst debugging on USDF Dev

### DIFF
--- a/applications/noteburst/templates/ingress.yaml
+++ b/applications/noteburst/templates/ingress.yaml
@@ -8,7 +8,7 @@ config:
   baseUrl: {{ .Values.global.baseUrl | quote }}
   scopes:
     all:
-      - "exec:admin"
+      - "exec:notebook"
   loginRedirect: true
 template:
   metadata:

--- a/applications/squareone/templates/ingress-times-square.yaml
+++ b/applications/squareone/templates/ingress-times-square.yaml
@@ -1,0 +1,31 @@
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
+metadata:
+  name: {{ template "squareone.fullname" . }}-times-square
+  labels:
+    {{- include "squareone.labels" . | nindent 4 }}
+config:
+  baseUrl: {{ .Values.global.baseUrl | quote }}
+  scopes:
+    all:
+      - "exec:notebook"
+  loginRedirect: true
+template:
+  metadata:
+    name: {{ template "squareone.fullname" . }}-times-square
+    {{- with .Values.ingress.annotations }}
+    annotations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  spec:
+    rules:
+      - host: {{ required "global.host must be set" .Values.global.host | quote }}
+        http:
+          paths:
+            - path: "/times-square"
+              pathType: "Prefix"
+              backend:
+                service:
+                  name: {{ template "squareone.fullname" . }}
+                  port:
+                    number: 80

--- a/applications/times-square/templates/gafaelfawrtoken.yaml
+++ b/applications/times-square/templates/gafaelfawrtoken.yaml
@@ -9,3 +9,4 @@ spec:
   scopes:
     - "admin:token"
     - "exec:admin"
+    - "exec:notebook"

--- a/applications/times-square/templates/ingress.yaml
+++ b/applications/times-square/templates/ingress.yaml
@@ -8,7 +8,7 @@ config:
   baseUrl: {{ .Values.global.baseUrl | quote }}
   scopes:
     all:
-      - "exec:admin"
+      - "exec:notebook"
   loginRedirect: true
 template:
   metadata:


### PR DESCRIPTION
- Switch to exec:notebook scope for noteburst
- Add an ingress to Squareone specifically for the `/times-square` path prefix to ensure that users are logged in (and auto-redirect them to log in if not).