### PR TITLE
DM-40060: Change config for Gafaelfawr internal database

### DIFF
--- a/applications/gafaelfawr/README.md
+++ b/applications/gafaelfawr/README.md
@@ -32,7 +32,7 @@ Authentication and identity system
 | config.cilogon.test | bool | `false` | Whether to use the test instance of CILogon |
 | config.cilogon.uidClaim | string | `"uidNumber"` | Claim from which to get the numeric UID (only used if not retrieved from LDAP or Firestore) |
 | config.cilogon.usernameClaim | string | `"uid"` | Claim from which to get the username |
-| config.databaseUrl | string | None, must be set if `cloudsql.enabled` is not true | URL for the PostgreSQL database |
+| config.databaseUrl | string | None, must be set if neither `cloudsql.enabled` | URL for the PostgreSQL database nor `config.internalDatabase` are true |
 | config.errorFooter | string | `""` | HTML footer to add to any login error page (will be enclosed in a <p> tag). |
 | config.firestore.project | string | Firestore support is disabled | If set, assign UIDs and GIDs using Google Firestore in the given project. Cloud SQL must be enabled and the Cloud SQL service account must have read/write access to that Firestore instance. |
 | config.forgerock.url | string | ForgeRock Identity Management support is disabled | If set, obtain the GIDs for groups from this ForgeRock Identity Management server. |
@@ -40,6 +40,7 @@ Authentication and identity system
 | config.github.clientId | string | `""` | GitHub client ID. One and only one of this, `config.cilogon.clientId`, or `config.oidc.clientId` must be set. |
 | config.groupMapping | object | `{}` | Defines a mapping of scopes to groups that provide that scope. See [DMTN-235](https://dmtn-235.lsst.io/) for more details on scopes. |
 | config.initialAdmins | list | `[]` | Usernames to add as administrators when initializing a new database. Used only if there are no administrators. |
+| config.internalDatabase | bool | `false` | Whether to use the PostgreSQL server internal to the Kubernetes cluster |
 | config.knownScopes | object | See the `values.yaml` file | Names and descriptions of all scopes in use. This is used to populate the new token creation page. Only scopes listed here will be options when creating a new token. See [DMTN-235](https://dmtn-235.lsst.io/). |
 | config.ldap.addUserGroup | bool | `false` | Whether to synthesize a user private group for each user with a GID equal to their UID |
 | config.ldap.emailAttr | string | `"mail"` | Attribute containing the user's email address |

--- a/applications/gafaelfawr/templates/configmap.yaml
+++ b/applications/gafaelfawr/templates/configmap.yaml
@@ -194,6 +194,8 @@ data:
   gafaelfawr.yaml: |
     {{- if .Values.cloudsql.enabled }}
     databaseUrl: "postgresql://gafaelfawr@cloud-sql-proxy/gafaelfawr"
+    {{- else if .Values.config.internalDatabase }}
+    databaseUrl: "postgresql://gafaelfawr@postgres.postgres/gafaelfawr"
     {{- else }}
     databaseUrl: {{ required "config.databaseUrl must be set" .Values.config.databaseUrl | quote }}
     {{- end }}
@@ -209,6 +211,8 @@ data:
   gafaelfawr.yaml: |
     {{- if .Values.cloudsql.enabled }}
     databaseUrl: "postgresql://gafaelfawr@localhost/gafaelfawr"
+    {{- else if .Values.config.internalDatabase }}
+    databaseUrl: "postgresql://gafaelfawr@postgres.postgres/gafaelfawr"
     {{- else }}
     databaseUrl: {{ required "config.databaseUrl must be set" .Values.config.databaseUrl | quote }}
     {{- end }}

--- a/applications/gafaelfawr/values-ccin2p3.yaml
+++ b/applications/gafaelfawr/values-ccin2p3.yaml
@@ -6,7 +6,7 @@ redis:
 
 config:
   logLevel: "DEBUG"
-  databaseUrl: "postgresql://gafaelfawr@postgres.postgres/gafaelfawr"
+  internalDatabase: true
 
   # Session length and token expiration (in minutes).
   issuer:

--- a/applications/gafaelfawr/values-minikube.yaml
+++ b/applications/gafaelfawr/values-minikube.yaml
@@ -4,7 +4,7 @@ redis:
     enabled: false
 
 config:
-  databaseUrl: "postgresql://gafaelfawr@postgres.postgres/gafaelfawr"
+  internalDatabase: true
 
   # Support OpenID Connect clients like Chronograf.
   oidcServer:

--- a/applications/gafaelfawr/values-roe.yaml
+++ b/applications/gafaelfawr/values-roe.yaml
@@ -3,7 +3,7 @@ redis:
     enabled: false
 
 config:
-  databaseUrl: "postgresql://gafaelfawr@postgres.postgres/gafaelfawr"
+  internalDatabase: true
 
   github:
     clientId: "10172b4db1b67ee31620"

--- a/applications/gafaelfawr/values-usdfdev.yaml
+++ b/applications/gafaelfawr/values-usdfdev.yaml
@@ -6,7 +6,7 @@ redis:
     storageClass: "wekafs--sdf-k8s01"
 
 config:
-  databaseUrl: "postgresql://gafaelfawr@postgres.postgres/gafaelfawr"
+  internalDatabase: true
 
   oidcServer:
     enabled: true

--- a/applications/gafaelfawr/values-usdfprod.yaml
+++ b/applications/gafaelfawr/values-usdfprod.yaml
@@ -6,7 +6,7 @@ redis:
     storageClass: "wekafs--sdf-k8s01"
 
 config:
-  databaseUrl: "postgresql://gafaelfawr@postgres.postgres/gafaelfawr"
+  internalDatabase: true
 
   oidcServer:
     enabled: true

--- a/applications/gafaelfawr/values.yaml
+++ b/applications/gafaelfawr/values.yaml
@@ -36,8 +36,12 @@ tolerations: []
 affinity: {}
 
 config:
+  # -- Whether to use the PostgreSQL server internal to the Kubernetes cluster
+  internalDatabase: false
+
   # -- URL for the PostgreSQL database
-  # @default -- None, must be set if `cloudsql.enabled` is not true
+  # @default -- None, must be set if neither `cloudsql.enabled`
+  # nor `config.internalDatabase` are true
   databaseUrl: ""
 
   # -- Choose from the text form of Python logging levels


### PR DESCRIPTION
Add a new Helm configuration option for whether Gafaelfawr should use the cluster-internal PostgreSQL database instead of just using the database URI so that we can trigger optional secrets based on whether that configuration option is set.