### PR TITLE
DM-40187: Add githubOrgs config to Times Square

### DIFF
--- a/applications/times-square/Chart.yaml
+++ b/applications/times-square/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 type: application
 
 # The default version tag of the times-square docker image
-appVersion: "0.7.0"
+appVersion: "0.8.0"
 
 dependencies:
   - name: redis

--- a/applications/times-square/README.md
+++ b/applications/times-square/README.md
@@ -24,6 +24,7 @@ An API service for managing and rendering parameterized Jupyter notebooks.
 | config.databaseUrl | string | None, must be set | URL for the PostgreSQL database |
 | config.enableGitHubApp | string | `"False"` | Toggle to enable the GitHub App functionality |
 | config.githubAppId | string | `""` | GitHub application ID |
+| config.githubOrgs | string | `"lsst,lsst-sqre,lsst-dm,lsst-ts,lsst-sitcom,lsst-pst"` | GitHub organizations that can sync repos to Times Square (comma-separated). |
 | config.logLevel | string | `"INFO"` | Logging level: "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL" |
 | config.name | string | `"times-square"` | Name of the service. |
 | config.profile | string | `"production"` | Run profile: "production" or "development" |

--- a/applications/times-square/templates/configmap.yaml
+++ b/applications/times-square/templates/configmap.yaml
@@ -15,3 +15,4 @@ data:
   TS_REDIS_QUEUE_URL: {{ required "config.redisQueueUrl must be set" .Values.config.redisQueueUrl | quote }}
   TS_ENABLE_GITHUB_APP: {{ .Values.config.enableGitHubApp | quote }}
   TS_GITHUB_APP_ID: {{ .Values.config.githubAppId | quote }}
+  TS_GITHUB_ORGS: {{ .Values.config.githubOrgs | quote }}

--- a/applications/times-square/values.yaml
+++ b/applications/times-square/values.yaml
@@ -113,6 +113,9 @@ config:
   # -- Toggle to enable the GitHub App functionality
   enableGitHubApp: "False"
 
+  # -- GitHub organizations that can sync repos to Times Square (comma-separated).
+  githubOrgs: "lsst,lsst-sqre,lsst-dm,lsst-ts,lsst-sitcom,lsst-pst"
+
 cloudsql:
   # -- Enable the Cloud SQL Auth Proxy sidecar, used with CloudSQL databases
   # on Google Cloud


### PR DESCRIPTION
This value configures what GitHub orgs can sync repos to Times Square (provided they've also installed the Times Square GitHub App).