### PR TITLE
Change nginx logs to error

### DIFF
--- a/applications/ingress-nginx/values-idfdev.yaml
+++ b/applications/ingress-nginx/values-idfdev.yaml
@@ -1,4 +1,6 @@
 ingress-nginx:
   controller:
+    config:
+      error-log-level: "error"
     service:
       loadBalancerIP: "35.225.112.77"


### PR DESCRIPTION
nginx produces a lot of spurious warning messages about spooling large request bodies to disk, which we don't care about.