### PR TITLE
DM-40188: Deploy Times Square 0.9.0

### DIFF
--- a/applications/times-square/Chart.yaml
+++ b/applications/times-square/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 type: application
 
 # The default version tag of the times-square docker image
-appVersion: "0.8.0"
+appVersion: "0.9.0"
 
 dependencies:
   - name: redis


### PR DESCRIPTION
This deploys the new Times Square behaviour where the first code cell is replaced by Times Square with Python code that sets parameters are variables. No other Python code cells are treated as templates. https://github.com/lsst-sqre/times-square/releases/tag/0.9.0