### PR TITLE
DM-40125: Add support for static secret template

### DIFF
--- a/applications/gafaelfawr/secrets.yaml
+++ b/applications/gafaelfawr/secrets.yaml
@@ -61,6 +61,8 @@ session-secret:
     stored in user web browsers that holds their session token and related
     information. Changing this secret will invalidate all existing Redis data
     and all user authentication cookies.
+  generate:
+    type: fernet-key
 signing-key:
   description: >-
     RSA private key used to sign JWTs issued by Gafaelfawr when it acts as an

--- a/docs/about/introduction.rst
+++ b/docs/about/introduction.rst
@@ -65,7 +65,7 @@ In Phalanx, the word *application* specifically refers to a Helm chart located i
 That Helm chart directory includes the Kubernetes templates and Docker image references to deploy the application, as well as values files to configure the application for each environment.
 
 Argo CD
-=======
+========
 
 `Argo CD`_ manages the Kubernetes deployments of each application's Helm chart from the Phalanx repository.
 Each environment runs its own instance of Argo CD (as Argo CD is itself an application in Phalanx).

--- a/docs/documenteer.toml
+++ b/docs/documenteer.toml
@@ -31,6 +31,7 @@ ignore = [
     '^https://roundtable.lsst.cloud',
     '^https://usdf-rsp.slac.stanford.edu',
     '^https://usdf-rsp-dev.slac.stanford.edu',
+    '^https://usdf-tel-rsp.slac.stanford.edu',
     '^https://github.com/lsst-sqre/phalanx/blob/main/applications/strimzi/values.yaml',
     '^https://github.com/orgs/',
     '^https://ook.lsst.io/',  # FIXME readd when Ook docs are published

--- a/src/phalanx/cli.py
+++ b/src/phalanx/cli.py
@@ -16,6 +16,7 @@ __all__ = [
     "help",
     "secrets_list",
     "secrets_schema",
+    "secrets_static_template",
 ]
 
 
@@ -86,3 +87,12 @@ def secrets_schema(*, output: Path | None) -> None:
         output.write_text(json_schema)
     else:
         sys.stdout.write(json_schema)
+
+
+@secrets.command("static-template")
+@click.argument("environment")
+def secrets_static_template(environment: str) -> None:
+    """Generate a template for providing static secrets for an environment."""
+    factory = Factory()
+    secrets_service = factory.create_secrets_service()
+    sys.stdout.write(secrets_service.generate_static_template(environment))

--- a/src/phalanx/yaml.py
+++ b/src/phalanx/yaml.py
@@ -1,0 +1,32 @@
+"""Utility functions for manipulating YAML.
+
+In several places in the Phalanx code, we want to be able to wrap long strings
+to make them more readable or be able to dump `collections.defaultdict`
+objects without adding special object tagging. This module collects utility
+functions to make this easier.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+import yaml
+from yaml.representer import Representer
+
+__all__ = ["YAMLFoldedString"]
+
+
+class YAMLFoldedString(str):
+    """A string that will be folded when encoded in YAML."""
+
+    __slots__ = ()
+
+
+def _folded_string_representer(
+    dumper: yaml.Dumper, data: YAMLFoldedString
+) -> yaml.Node:
+    return dumper.represent_scalar("tag:yaml.org,2002:str", data, style=">")
+
+
+yaml.add_representer(YAMLFoldedString, _folded_string_representer)
+yaml.add_representer(defaultdict, Representer.represent_dict)

--- a/tests/cli/secrets_test.py
+++ b/tests/cli/secrets_test.py
@@ -11,7 +11,18 @@ from phalanx.cli import main
 from ..support.data import phalanx_test_path, read_output_data
 
 
-def test_generate_schema() -> None:
+def test_list() -> None:
+    input_path = phalanx_test_path()
+    os.chdir(str(input_path))
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["secrets", "list", "idfdev"], catch_exceptions=False
+    )
+    assert result.exit_code == 0
+    assert result.output == read_output_data("idfdev", "secrets-list")
+
+
+def test_schema() -> None:
     runner = CliRunner()
     result = runner.invoke(main, ["secrets", "schema"], catch_exceptions=False)
     assert result.exit_code == 0
@@ -25,12 +36,12 @@ def test_generate_schema() -> None:
     assert result.output == current.read_text()
 
 
-def test_list() -> None:
+def test_static_template() -> None:
     input_path = phalanx_test_path()
     os.chdir(str(input_path))
     runner = CliRunner()
     result = runner.invoke(
-        main, ["secrets", "list", "idfdev"], catch_exceptions=False
+        main, ["secrets", "static-template", "idfdev"], catch_exceptions=False
     )
     assert result.exit_code == 0
-    assert result.output == read_output_data("idfdev", "secrets-list")
+    assert result.output == read_output_data("idfdev", "static-secrets.yaml")

--- a/tests/data/input/applications/gafaelfawr/secrets.yaml
+++ b/tests/data/input/applications/gafaelfawr/secrets.yaml
@@ -61,6 +61,8 @@ session-secret:
     stored in user web browsers that holds their session token and related
     information. Changing this secret will invalidate all existing Redis data
     and all user authentication cookies.
+  generate:
+    type: fernet-key
 signing-key:
   description: >-
     RSA private key used to sign JWTs issued by Gafaelfawr when it acts as an

--- a/tests/data/output/idfdev/static-secrets.yaml
+++ b/tests/data/output/idfdev/static-secrets.yaml
@@ -1,0 +1,58 @@
+argocd:
+  dex.clientSecret:
+    description: >-
+      OAuth 2 or OpenID Connect client secret, used to authenticate to GitHub
+      or Google as part of the authentication flow. This secret can be changed
+      at any time.
+    value: null
+gafaelfawr:
+  cilogon-client-secret:
+    description: >-
+      Secret used to authenticate to CILogon as part of the OpenID Connect
+      login protocol to obtain an identity token for the user. This secret
+      can be changed at any time.
+    value: null
+  database-password:
+    description: >-
+      Password used to authenticate to the PostgreSQL database used to store
+      Gafaelfawr data. This password may be changed at any time.
+    value: null
+  ldap-password:
+    description: >-
+      Password to authenticate to the LDAP server via simple binds to retrieve
+      user and group information. This password can be changed at any time.
+    value: null
+mobu:
+  ALERT_HOOK:
+    description: >-
+      Slack web hook to which mobu should report failures and daily status.
+    value: null
+  app-alert-webhook:
+    description: >-
+      Slack web hook to which to post internal application alerts. This secret
+      is not used directly by mobu, but is copied from here to all of the
+      applications that report internal problems to Slack. It should normally
+      be separate from mobu's own web hook, since the separate identities
+      attached to the messages helps make the type of mesasge clearer, but
+      the same web hook as mobu's own alerts can be used in a pinch.
+    value: null
+nublado:
+  aws-credentials.ini:
+    description: >-
+      Google Cloud Storage credentials to the Butler data store, formatted
+      using AWS syntax for use with boto.
+    value: null
+  butler-gcs-idf-creds.json:
+    description: >-
+      Google Cloud Storage credentials to the Butler data store in the native
+      Google syntax, containing the private asymmetric key.
+    value: null
+  butler-hmac-idf-creds.json:
+    description: >-
+      Google Cloud Storage credentials to the Butler data store in the private
+      key syntax used for HMACs.
+    value: null
+  postgres-credentials.txt:
+    description: >-
+      PostgreSQL credentials in its pgpass format for the Butler database.
+    value: null

--- a/tests/support/data.py
+++ b/tests/support/data.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
+
+import yaml
 
 __all__ = [
     "phalanx_test_path",
@@ -41,3 +44,24 @@ def read_output_data(environment: str, filename: str) -> str:
     """
     base_path = Path(__file__).parent.parent / "data" / "output"
     return (base_path / environment / filename).read_text()
+
+
+def read_output_yaml(environment: str, filename: str) -> dict[str, Any]:
+    """Read test output data as YAML and return the parsed format.
+
+    Parameters
+    ----------
+    environment
+        Name of the environment under :filename:`data/output` that the test
+        output is for.
+    filename
+        File containing the output data.
+
+    Returns
+    -------
+    dict
+        Parsed version of the YAML.
+    """
+    base_path = Path(__file__).parent.parent / "data" / "output"
+    with (base_path / environment / filename).open() as fh:
+        return yaml.safe_load(fh)

--- a/tox.ini
+++ b/tox.ini
@@ -45,7 +45,7 @@ commands = neophile update {posargs}
 [testenv:py]
 description = Run pytest
 commands =
-    coverage run -m pytest {posargs}
+    coverage run -m pytest -vvv {posargs}
 
 [testenv:typing]
 description = Run mypy.


### PR DESCRIPTION
Add a phalanx secrets static-template command that generates a YAML template for the static secrets for an environment.