### PR TITLE
Expand influxdb-source PV to 10TB at base

### DIFF
--- a/applications/sasquatch/values-base.yaml
+++ b/applications/sasquatch/values-base.yaml
@@ -64,7 +64,7 @@ source-influxdb:
   enabled: true
   persistence:
     storageClass: rook-ceph-block
-    size: 5Ti
+    size: 10Ti
   ingress:
     enabled: true
     hostname: base-lsp.lsst.codes


### PR DESCRIPTION
- This is required for restoring historical EFD data