### PR TITLE
DM-40298: Add doc links for DP0.3

### DIFF
--- a/applications/squareone/values-idfint.yaml
+++ b/applications/squareone/values-idfint.yaml
@@ -34,20 +34,60 @@ config:
 
       ## Data documentation
 
+      ### DP0.3
+
+      <CardGroup>
+        <a href="https://dp0-3.lsst.io/">
+          <Card>
+            ### Data Preview 0.3 (DP0.3)
+
+            DP0.3 provides a catalog of solar system objects from a
+            simulated LSST ten-year wide-fast-deep survey by the Solar System
+            Science Collaboration.
+          </Card>
+        </a>
+
+        <a href="https://dp0-3.lsst.io/tutorials-dp0-3/index.html">
+          <Card>
+            ### DP0.3 Tutorials
+
+            Tutorials for exploring the DP0.3 solar system object dataset on
+            the Rubin Science Platform.
+          </Card>
+        </a>
+
+        <a href="https://dm.lsst.org/sdm_schemas/browser/dp03.html">
+          <Card>
+            ### DP0.3 Catalog Schema
+
+            Schema reference for the DP0.3 catalog dataset available through
+            the Table Access Protocol (TAP) service.
+          </Card>
+        </a>
+      </CardGroup>
+
+      ### DP0.2
+
       <CardGroup>
         <a href="https://dp0-2.lsst.io/">
           <Card>
             ### Data Preview 0.2 (DP0.2)
 
             DP0.2 is the second phase of the Data Preview 0 program using
-            precursor data (simulated images from the DESC DC2 data
-            challenge). For the first time, all the derived data products
-            have been generated “in-house” on an early version of the Rubin
-            processing infrastructure using version 23.0 of the LSST Science
-            Pipelines. As a result, the data model is significantly
-            different from the DP0.1 dataset.
+            simulated images from the DESC DC2 data challenge processed with
+            version 23.0 of the LSST Science Pipelines.
           </Card>
         </a>
+
+        <a href="https://dp0-2.lsst.io/tutorials-examples/index.html">
+          <Card>
+            ### DP0.2 Tutorials
+
+            Tutorials for exploring the DP0.2 dataset on the Rubin Science
+            Platform.
+          </Card>
+        </a>
+
 
         <a href="https://dm.lsst.org/sdm_schemas/browser/dp02.html">
           <Card>

--- a/applications/squareone/values.yaml
+++ b/applications/squareone/values.yaml
@@ -118,6 +118,40 @@ config:
 
       ## Data documentation
 
+      ### DP0.3
+
+      <CardGroup>
+        <a href="https://dp0-3.lsst.io/">
+          <Card>
+            ### Data Preview 0.3 (DP0.3)
+
+            DP0.3 provides a catalog of solar system objects from a
+            simulated LSST ten-year wide-fast-deep survey by the Solar System
+            Science Collaboration.
+          </Card>
+        </a>
+
+        <a href="https://dp0-3.lsst.io/tutorials-dp0-3/index.html">
+          <Card>
+            ### DP0.3 Tutorials
+
+            Tutorials for exploring the DP0.3 solar system object dataset on
+            the Rubin Science Platform.
+          </Card>
+        </a>
+
+        <a href="https://dm.lsst.org/sdm_schemas/browser/dp03.html">
+          <Card>
+            ### DP0.3 Catalog Schema
+
+            Schema reference for the DP0.3 catalog dataset available through
+            the Table Access Protocol (TAP) service.
+          </Card>
+        </a>
+      </CardGroup>
+
+      ### DP0.2
+
       <CardGroup>
         <a href="https://dp0-2.lsst.io/">
           <Card>
@@ -138,6 +172,7 @@ config:
           </Card>
         </a>
 
+
         <a href="https://dm.lsst.org/sdm_schemas/browser/dp02.html">
           <Card>
             ### DP0.2 Catalog Schema
@@ -147,6 +182,7 @@ config:
           </Card>
         </a>
       </CardGroup>
+
     </Section>
 
     <Section>


### PR DESCRIPTION
Keep DP0.2 since we're hosting both releases at the same time.

<img width="1429" alt="Screenshot 2023-08-03 at 1 52 29 PM" src="https://github.com/lsst-sqre/phalanx/assets/349384/d43b9854-0172-46d6-b98d-07d53b63df6f">
