### PR TITLE
DM-40256: Add support for cleaning up Vault secrets

### DIFF
--- a/src/phalanx/cli.py
+++ b/src/phalanx/cli.py
@@ -151,6 +151,12 @@ def secrets_static_template(environment: str) -> None:
 @secrets.command("sync")
 @click.argument("environment")
 @click.option(
+    "--delete",
+    default=False,
+    is_flag=True,
+    help="Delete any unexpected secrets in Vault.",
+)
+@click.option(
     "--regenerate",
     default=False,
     is_flag=True,
@@ -163,7 +169,7 @@ def secrets_static_template(environment: str) -> None:
     help="YAML file containing static secrets for this environment.",
 )
 def secrets_sync(
-    environment: str, *, regenerate: bool, secrets: Path | None
+    environment: str, *, delete: bool, regenerate: bool, secrets: Path | None
 ) -> None:
     """Synchronize the secrets for an environment into Vault."""
     static_secrets = None
@@ -171,7 +177,9 @@ def secrets_sync(
         static_secrets = _load_static_secrets(secrets)
     factory = Factory()
     secrets_service = factory.create_secrets_service()
-    secrets_service.sync(environment, static_secrets, regenerate=regenerate)
+    secrets_service.sync(
+        environment, static_secrets, regenerate=regenerate, delete=delete
+    )
 
 
 @secrets.command("vault-secrets")

--- a/src/phalanx/services/secrets.py
+++ b/src/phalanx/services/secrets.py
@@ -67,7 +67,7 @@ class SecretsService:
         # Retrieve all the current secrets from Vault and resolve all of the
         # secrets.
         secrets = environment.all_secrets()
-        vault_secrets = vault_client.get_environment_secrets(environment)
+        vault_secrets = vault_client.get_environment_secrets()
         resolved = self._resolve_secrets(
             secrets=secrets,
             environment=environment,
@@ -101,7 +101,7 @@ class SecretsService:
         if mismatch:
             report += "Incorrect secrets:\n• " + "\n• ".join(mismatch) + "\n"
         if unknown:
-            unknown_str = "\n  ".join(unknown)
+            unknown_str = "\n• ".join(unknown)
             report += "Unknown secrets in Vault:\n• " + unknown_str + "\n"
         return report
 
@@ -169,7 +169,7 @@ class SecretsService:
         """
         environment = self._config.load_environment(env_name)
         vault_client = self._vault.get_vault_client(environment)
-        vault_secrets = vault_client.get_environment_secrets(environment)
+        vault_secrets = vault_client.get_environment_secrets()
         for app_name, values in vault_secrets.items():
             app_secrets: dict[str, str | None] = {}
             for key, secret in values.items():
@@ -209,7 +209,7 @@ class SecretsService:
         environment = self._config.load_environment(env_name)
         vault_client = self._vault.get_vault_client(environment)
         secrets = environment.all_secrets()
-        vault_secrets = vault_client.get_environment_secrets(environment)
+        vault_secrets = vault_client.get_environment_secrets()
 
         # Resolve all of the secrets, regenerating if desired.
         resolved = self._resolve_secrets(
@@ -265,6 +265,7 @@ class SecretsService:
             if application not in resolved:
                 print("Deleted Vault secret for", application)
                 vault_client.delete_application_secret(application)
+                continue
             expected = resolved[application]
             to_delete = set(values.keys()) - set(expected.keys())
             if to_delete:

--- a/tests/cli/secrets_test.py
+++ b/tests/cli/secrets_test.py
@@ -236,8 +236,6 @@ def test_vault_secrets(tmp_path: Path, mock_vault: MockVaultClient) -> None:
     assert result.exit_code == 0
     assert result.output == ""
 
-    # The unknown application will be missing because we only retrieve the
-    # secrets for known applications.
     expected_files = {p.name for p in vault_input_path.iterdir()}
     output_files = {p.name for p in tmp_path.iterdir()}
     assert expected_files == output_files

--- a/tests/data/input/vault/idfdev/unknown.json
+++ b/tests/data/input/vault/idfdev/unknown.json
@@ -1,0 +1,3 @@
+{
+  "some-secret": "secret-for-unknown-application"
+}

--- a/tests/data/output/idfdev/secrets-audit
+++ b/tests/data/output/idfdev/secrets-audit
@@ -14,3 +14,4 @@ Incorrect secrets:
 • postgres nublado3_password
 Unknown secrets in Vault:
 • gafaelfawr cilogon
+• unknown some-secret

--- a/tests/data/output/idfdev/sync-delete-output
+++ b/tests/data/output/idfdev/sync-delete-output
@@ -1,1 +1,2 @@
 Deleted Vault secret for gafaelfawr cilogon
+Deleted Vault secret for unknown

--- a/tests/data/output/idfdev/sync-delete-output
+++ b/tests/data/output/idfdev/sync-delete-output
@@ -1,0 +1,1 @@
+Deleted Vault secret for gafaelfawr cilogon

--- a/tests/support/vault.py
+++ b/tests/support/vault.py
@@ -66,6 +66,25 @@ class MockVaultClient:
         environment = self._paths[base_path]
         self._data[environment][application] = secret
 
+    def delete_latest_version_of_secret(self, path: str) -> None:
+        """Delete the latest version of a Vault secret.
+
+        Parameters
+        ----------
+        path
+            Vault path to the secret.
+
+        Raises
+        ------
+        InvalidPath
+            Raised if the provided Vault path does not exist.
+        """
+        base_path, application = path.rsplit("/", 1)
+        environment = self._paths[base_path]
+        if application not in self._data[environment]:
+            raise InvalidPath(f"Unknown Vault path {path}")
+        del self._data[environment][application]
+
     def read_secret(
         self, path: str, raise_on_deleted_version: bool | None = None
     ) -> dict[str, Any]:
@@ -83,6 +102,11 @@ class MockVaultClient:
         -------
         dict
             Reply matching the Vault client reply structure.
+
+        Raises
+        ------
+        InvalidPath
+            Raised if the provided Vault path does not exist.
         """
         assert raise_on_deleted_version
         base_path, application = path.rsplit("/", 1)
@@ -101,9 +125,16 @@ class MockVaultClient:
             Vault path for the secret.
         secret
             Keys and values to update.
+
+        Raises
+        ------
+        InvalidPath
+            Raised if the provided Vault path does not exist.
         """
         base_path, application = path.rsplit("/", 1)
         environment = self._paths[base_path]
+        if application not in self._data[environment]:
+            raise InvalidPath(f"Unknown Vault path {path}")
         self._data[environment][application].update(secret)
 
 

--- a/tests/support/vault.py
+++ b/tests/support/vault.py
@@ -85,6 +85,22 @@ class MockVaultClient:
             raise InvalidPath(f"Unknown Vault path {path}")
         del self._data[environment][application]
 
+    def list_secrets(self, path: str) -> dict[str, Any]:
+        """List all secrets available under a path.
+
+        Parameters
+        ----------
+        path
+            Vault path to the directory of secrets.
+
+        Returns
+        -------
+        dict
+            Reply matching the Vault client reply structure.
+        """
+        environment = self._paths[path]
+        return {"data": {"keys": list(self._data[environment].keys())}}
+
     def read_secret(
         self, path: str, raise_on_deleted_version: bool | None = None
     ) -> dict[str, Any]:


### PR DESCRIPTION
Add support for a `--delete` flag to `phalanx secrets sync` that removes stray secrets in Vault, either ones for unknown or no-longer-enabled applications or individual keys for applications no longer configured to have a key by that name.

Also fix `phalanx secrets vault-secrets` to read all secrets from Vault, not just the ones that correspond to enabled applications.