### PR TITLE
Stop running tutorial notebooks on IDF dev

### DIFF
--- a/applications/mobu/values-idfdev.yaml
+++ b/applications/mobu/values-idfdev.yaml
@@ -19,26 +19,6 @@ config:
           repo_branch: "prod"
           use_cachemachine: false
         restart: true
-    - name: "tutorial"
-      count: 1
-      users:
-        - username: "bot-mobu-tutorial"
-      scopes:
-        - "exec:notebook"
-        - "exec:portal"
-        - "read:image"
-        - "read:tap"
-      business:
-        type: "NotebookRunner"
-        options:
-          image:
-            image_class: "latest-weekly"
-          repo_url: "https://github.com/rubin-dp0/tutorial-notebooks.git"
-          repo_branch: "main"
-          max_executions: 1
-          working_directory: "notebooks/tutorial-notebooks"
-          use_cachemachine: false
-        restart: true
     - name: "tap"
       count: 1
       users:


### PR DESCRIPTION
The tutorial notebooks have added DP0.3 notebooks, and DP0.3 isn't available on IDF dev, so disable running tutorial notebooks on IDF dev for now until we can talk about it.