### PR TITLE
DM-40256: Clear default for Vault address

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -121,7 +121,7 @@ jobs:
           unzip /tmp/vault.zip
           sudo mv vault /usr/local/bin/vault
           sudo chmod +x /usr/local/bin/vault
-          sudo curl -sSL -o /usr/local/bin/argocd https://github.com/argoproj/argo-cd/releases/download/v2.7.8/argocd-linux-amd64
+          sudo curl -sSL -o /usr/local/bin/argocd https://github.com/argoproj/argo-cd/releases/download/v2.7.10/argocd-linux-amd64
           sudo chmod +x /usr/local/bin/argocd
           sudo apt-get install socat
           sudo pip install -r installer/requirements.txt

--- a/applications/vault-secrets-operator/values.yaml
+++ b/applications/vault-secrets-operator/values.yaml
@@ -24,7 +24,7 @@ vault-secrets-operator:
   vault:
     # -- URL of the underlying Vault implementation
     # @default -- Set by Argo CD
-    address: "https://vault.lsst.codes"
+    address: ""
 
     # -- Sync secrets from vault on this cadence
     reconciliationTime: 60

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1,9 +1,9 @@
 #!/bin/bash -e
-USAGE="Usage: ./install.sh ENVIRONMENT VAULT_TOKEN [VAULT_ADDR] [VAULT_TOKEN_LEASE_DURATION]"
+USAGE="Usage: ./install.sh ENVIRONMENT VAULT_TOKEN [VAULT_TOKEN_LEASE_DURATION]"
 ENVIRONMENT=${1:?$USAGE}
 export VAULT_TOKEN=${2:?$USAGE}
-export VAULT_ADDR=${3:-https://vault.lsst.codes}
 export VAULT_TOKEN_LEASE_DURATION=${4:-31536000}
+export VAULT_ADDR=`yq -r .vaultUrl ../environments/values-$ENVIRONMENT.yaml`
 VAULT_PATH_PREFIX=`yq -r .vaultPathPrefix ../environments/values-$ENVIRONMENT.yaml`
 ARGOCD_PASSWORD=`vault kv get --field=argocd.admin.plaintext_password $VAULT_PATH_PREFIX/installer`
 
@@ -36,6 +36,7 @@ helm upgrade vault-secrets-operator ../applications/vault-secrets-operator \
   --install \
   --values ../applications/vault-secrets-operator/values.yaml \
   --values ../applications/vault-secrets-operator/values-$ENVIRONMENT.yaml \
+  --set vault-secrets-operator.vault.address="$VAULT_ADDR" \
   --create-namespace \
   --namespace vault-secrets-operator \
   --timeout 5m \


### PR DESCRIPTION
Stop setting a default for vault-secrets-operator.vault.address to make it more obvious when science-platform hasn't been correctly updated.