### PR TITLE
Test prod tutorial branch on IDF dev and int

### DIFF
--- a/applications/mobu/values-idfdev.yaml
+++ b/applications/mobu/values-idfdev.yaml
@@ -19,6 +19,26 @@ config:
           repo_branch: "prod"
           use_cachemachine: false
         restart: true
+    - name: "tutorial"
+      count: 1
+      users:
+        - username: "bot-mobu-tutorial"
+      scopes:
+        - "exec:notebook"
+        - "exec:portal"
+        - "read:image"
+        - "read:tap"
+      business:
+        type: "NotebookRunner"
+        options:
+          image:
+            image_class: "latest-weekly"
+          repo_url: "https://github.com/rubin-dp0/tutorial-notebooks.git"
+          repo_branch: "prod"
+          max_executions: 1
+          working_directory: "notebooks/tutorial-notebooks"
+          use_cachemachine: false
+        restart: true
     - name: "tap"
       count: 1
       users:

--- a/applications/mobu/values-idfint.yaml
+++ b/applications/mobu/values-idfint.yaml
@@ -66,7 +66,7 @@ config:
           image:
             image_class: "latest-weekly"
           repo_url: "https://github.com/rubin-dp0/tutorial-notebooks.git"
-          repo_branch: "main"
+          repo_branch: "prod"
           max_executions: 1
           working_directory: "notebooks/tutorial-notebooks"
           use_cachemachine: false


### PR DESCRIPTION
Re-enable tutorial notebook testing on IDF dev and switch the IDF int testing to the prod branch from main, since the prod branch is currently broken.