### PR TITLE
Use tasksMax config for repairer connectors

### DIFF
--- a/applications/sasquatch/charts/kafka-connect-manager/templates/influxdb_sink.yaml
+++ b/applications/sasquatch/charts/kafka-connect-manager/templates/influxdb_sink.yaml
@@ -166,7 +166,11 @@ spec:
                 name: sasquatch
                 key: influxdb-password
           - name: KAFKA_CONNECT_TASKS_MAX
+            {{- if $value.tasksMax }}
+            value: {{ $value.tasksMax | quote }}
+            {{- else }}
             value: {{ $.Values.influxdbSink.tasksMax | quote }}
+            {{- end }}
           - name: KAFKA_CONNECT_TOPIC_REGEX
             value: {{ $value.topicsRegex | quote }}
           - name: KAFKA_CONNECT_CHECK_INTERVAL


### PR DESCRIPTION
- Use tasksMax config parameter when deploying repairer connectors