### PR TITLE
DM-25701: Add phalanx vault audit command

### DIFF
--- a/src/phalanx/cli.py
+++ b/src/phalanx/cli.py
@@ -205,6 +205,22 @@ def vault() -> None:
     """Vault management commands."""
 
 
+@vault.command("audit")
+@click.argument("environment")
+def vault_audit(environment: str) -> None:
+    """Audit the Vault credentials for the given environment.
+
+    The environment variable VAULT_TOKEN must be set to a token with access to
+    read policies, AppRoles, tokens, and token accessors.
+    """
+    factory = Factory()
+    vault_service = factory.create_vault_service()
+    report = vault_service.audit(environment)
+    if report:
+        sys.stdout.write(report)
+        sys.exit(1)
+
+
 @vault.command("create-read-approle")
 @click.argument("environment")
 def vault_create_read_approle(environment: str) -> None:

--- a/src/phalanx/constants.py
+++ b/src/phalanx/constants.py
@@ -6,9 +6,15 @@ actual configuration options.
 
 from __future__ import annotations
 
+from datetime import timedelta
+
 __all__ = [
     "VAULT_WRITE_TOKEN_LIFETIME",
+    "VAULT_WRITE_TOKEN_WARNING_LIFETIME",
 ]
 
 VAULT_WRITE_TOKEN_LIFETIME = "3650d"
 """Default lifetime to set for Vault write tokens."""
+
+VAULT_WRITE_TOKEN_WARNING_LIFETIME = timedelta(days=7)
+"""Remaining lifetime at which to warn that a token is about to expire."""

--- a/src/phalanx/models/environments.py
+++ b/src/phalanx/models/environments.py
@@ -23,6 +23,43 @@ class EnvironmentVaultConfig(CamelCaseModel):
     vault_path_prefix: str
     """Prefix of Vault paths, including the Kv2 mount point."""
 
+    @property
+    def vault_path(self) -> str:
+        """Vault path without the initial Kv2 mount point."""
+        _, path = self.vault_path_prefix.split("/", 1)
+        return path
+
+    @property
+    def vault_read_approle(self) -> str:
+        """Name of the Vault read AppRole for this environment."""
+        # AppRole names cannot contain /, so we'll use only the final
+        # component of the path for the AppRole name.
+        vault_path = self.vault_path
+        if "/" in vault_path:
+            _, approle_name = vault_path.rsplit("/", 1)
+            return approle_name
+        else:
+            return vault_path
+
+    @property
+    def vault_write_token(self) -> str:
+        """Display name of the Vault write token for this environment.
+
+        Unlike AppRole names, this could include a slash, but use the same
+        name as the AppRole for consistency and simplicity.
+        """
+        return self.vault_read_approle
+
+    @property
+    def vault_read_policy(self) -> str:
+        """Name of the Vault read policy for this environment."""
+        return f"{self.vault_path}/read"
+
+    @property
+    def vault_write_policy(self) -> str:
+        """Name of the Vault write policy for this environment."""
+        return f"{self.vault_path}/write"
+
 
 class EnvironmentConfig(EnvironmentVaultConfig):
     """Configuration for a Phalanx environment.

--- a/src/phalanx/models/vault.py
+++ b/src/phalanx/models/vault.py
@@ -2,17 +2,31 @@
 
 from __future__ import annotations
 
+from datetime import datetime
+
 import yaml
 from pydantic import BaseModel
 
-__all__ = ["VaultToken"]
+__all__ = [
+    "VaultAppRole",
+    "VaultAppRoleMetadata",
+    "VaultToken",
+    "VaultTokenMetadata",
+]
 
 
-class VaultAppRole(BaseModel):
-    """Newly-created Vault AppRole for secret access."""
+class VaultAppRoleMetadata(BaseModel):
+    """Metadata about a new or existing Vault AppRole."""
 
     role_id: str
     """Unique identifier of the AppRole."""
+
+    policies: list[str]
+    """Policies applied to this AppRole."""
+
+
+class VaultAppRole(VaultAppRoleMetadata):
+    """Newly-created Vault AppRole for secret access."""
 
     secret_id: str
     """Authentication credentials for the AppRole."""
@@ -20,25 +34,32 @@ class VaultAppRole(BaseModel):
     secret_id_accessor: str
     """Accessor for the AppRole authentication credentials."""
 
-    policies: list[str]
-    """Policies applied to this AppRole."""
-
     def to_yaml(self) -> str:
         """Format the data in YAML."""
         return yaml.dump(self.dict())
 
 
-class VaultToken(BaseModel):
-    """Newly-created Vault token for secret access."""
+class VaultTokenMetadata(BaseModel):
+    """Metadata about a new or existing Vault token."""
 
-    token: str
-    """Secret token."""
+    display_name: str
+    """Display name of the token."""
 
     accessor: str
     """Accessor for the token, used to get metadata or revoke it."""
 
+    expires: datetime
+    """When the token expires."""
+
     policies: list[str]
     """Policies applied to this token."""
+
+
+class VaultToken(VaultTokenMetadata):
+    """Newly-created Vault token for secret access."""
+
+    token: str
+    """Secret token."""
 
     def to_yaml(self) -> str:
         """Format the data in YAML."""

--- a/src/phalanx/services/vault.py
+++ b/src/phalanx/services/vault.py
@@ -1,18 +1,21 @@
-"""Service to manage Vault tokens and policies."""
+"""Service to manage Vault authentication."""
 
 from __future__ import annotations
 
 import jinja2
+from safir.datetime import current_datetime, format_datetime_for_logging
 
-from ..models.vault import VaultAppRole, VaultToken
+from ..constants import VAULT_WRITE_TOKEN_WARNING_LIFETIME
+from ..models.environments import EnvironmentConfig
+from ..models.vault import VaultAppRole, VaultToken, VaultTokenMetadata
 from ..storage.config import ConfigStorage
-from ..storage.vault import VaultStorage
+from ..storage.vault import VaultClient, VaultStorage
 
 __all__ = ["VaultService"]
 
 
 class VaultService:
-    """Service to manage Vault tokens and policies.
+    """Service to manage Vault authentication.
 
     Parameters
     ----------
@@ -32,6 +35,30 @@ class VaultService:
             undefined=jinja2.StrictUndefined,
             autoescape=jinja2.select_autoescape(disabled_extensions=["tmpl"]),
         )
+
+    def audit(self, environment: str) -> str:
+        """Audit the Vault authentication configuration for an environment.
+
+        Parameters
+        ----------
+        environment
+            Name of the environment.
+
+        Returns
+        -------
+        str
+            Human-readable text report of any problems found.
+        """
+        config = self._config.load_environment_config(environment)
+        vault_client = self._vault.get_vault_client(config)
+        report = ""
+        result = self._audit_read_approle(vault_client, config)
+        if result:
+            report += result
+        result = self._audit_write_token(vault_client, config)
+        if result:
+            report += result
+        return report
 
     def create_read_approle(self, environment: str) -> VaultAppRole:
         """Create a new Vault read AppRole for the given environment.
@@ -56,24 +83,14 @@ class VaultService:
         VaultAppRole
             Newly-created Vault AppRole.
         """
-        environment_config = self._config.load_environment_config(environment)
-        vault_client = self._vault.get_vault_client(environment_config)
-
-        # The first component of the Vault secrets path is the mount. The rest
-        # is the path in Vault to the secrets, which we will also use for the
-        # policy name. AppRole names cannot contain /, so we'll use only the
-        # final component of the path for the AppRole name.
-        _, vault_path = environment_config.vault_path_prefix.split("/", 1)
-        policy_name = f"{vault_path}/read"
-        if "/" in vault_path:
-            _, approle_name = vault_path.rsplit("/", 1)
-        else:
-            approle_name = vault_path
-
+        config = self._config.load_environment_config(environment)
+        vault_client = self._vault.get_vault_client(config)
         template = self._templates.get_template("vault-read-policy.tmpl")
-        policy = template.render({"path": vault_path})
-        vault_client.create_policy(policy_name, policy)
-        return vault_client.create_approle(approle_name, [policy_name])
+        policy = template.render({"path": config.vault_path})
+        vault_client.create_policy(config.vault_read_policy, policy)
+        return vault_client.create_approle(
+            config.vault_read_approle, [config.vault_read_policy]
+        )
 
     def create_write_token(
         self, environment: str, lifetime: str
@@ -96,16 +113,152 @@ class VaultService:
         VaultToken
             Newly-created Vault token.
         """
-        environment_config = self._config.load_environment_config(environment)
-        vault_client = self._vault.get_vault_client(environment_config)
+        config = self._config.load_environment_config(environment)
+        vault_client = self._vault.get_vault_client(config)
+        template = self._templates.get_template("vault-write-policy.tmpl")
+        policy = template.render({"path": config.vault_path})
+        vault_client.create_policy(config.vault_write_policy, policy)
+        return vault_client.create_token(
+            config.vault_write_token, [config.vault_write_policy], lifetime
+        )
 
-        # The first component of the Vault secrets path is the mount. The rest
-        # is the path in Vault to the secrets, which we will also use for the
-        # policy name.
-        _, vault_path = environment_config.vault_path_prefix.split("/", 1)
-        policy_name = f"{vault_path}/write"
+    def _audit_read_approle(
+        self, vault_client: VaultClient, config: EnvironmentConfig
+    ) -> str | None:
+        """Audit a read approle for any errors.
+
+        Parameters
+        ----------
+        vault_client
+            Vault client.
+        config
+            Phalanx configuration for the relevant environment.
+
+        Returns
+        -------
+        str or None
+            Human-readable report of any errors, or `None` if no errors were
+            found.
+        """
+        approle = vault_client.get_approle(config.vault_read_approle)
+        if not approle:
+            return f"No read AppRole ({config.vault_read_approle})\n"
+
+        expected_policies = {config.vault_read_policy}
+        errors = self._audit_policies(approle.policies, expected_policies)
+        template = self._templates.get_template("vault-read-policy.tmpl")
+        expected = template.render({"path": config.vault_path})
+        policy = vault_client.get_policy(config.vault_read_policy)
+        if policy != expected:
+            name = config.vault_read_policy
+            errors.append(f"Policy {name} doesn't have expected contents")
+
+        if errors:
+            items = "\n• ".join(errors)
+            name = config.vault_read_approle
+            return f"Problems with read AppRole ({name}):\n• " + items + "\n"
+        else:
+            return None
+
+    def _audit_write_token(
+        self, vault_client: VaultClient, config: EnvironmentConfig
+    ) -> str | None:
+        """Audit a write token for any errors.
+
+        Parameters
+        ----------
+        vault_client
+            Vault client.
+        config
+            Phalanx configuration for the relevant environment.
+
+        Returns
+        -------
+        str or None
+            Human-readable report of any errors, or `None` if no errors were
+            found.
+        """
+        tokens = self._find_write_tokens(vault_client, config)
+        if not tokens:
+            return f"No write token ({config.vault_write_token})\n"
+        report = ""
+        if len(tokens) > 1:
+            report = "Multiple write tokens found\n"
 
         template = self._templates.get_template("vault-write-policy.tmpl")
-        policy = template.render({"path": vault_path})
-        vault_client.create_policy(policy_name, policy)
-        return vault_client.create_token([policy_name], lifetime)
+        expected = template.render({"path": config.vault_path})
+        policy = vault_client.get_policy(config.vault_write_policy)
+
+        now = current_datetime()
+        policies = {config.vault_write_policy}
+        for token in tokens:
+            errors = []
+            if token.expires < now:
+                expiration = format_datetime_for_logging(token.expires)
+                errors.append(f"Token expired at {expiration}")
+            elif token.expires < now + VAULT_WRITE_TOKEN_WARNING_LIFETIME:
+                expiration = format_datetime_for_logging(token.expires)
+                errors.append(f"Token will expire at {expiration}")
+            errors.extend(self._audit_policies(token.policies, policies))
+            if policy != expected:
+                name = config.vault_write_policy
+                errors.append(f"Policy {name} doesn't have expected contents")
+
+            if errors:
+                items = "\n• ".join(errors)
+                summary = f"Problems with write token ({token.display_name})"
+                report += f"{summary}:\n• " + items + "\n"
+
+        return report
+
+    def _audit_policies(
+        self, policies: list[str], expected: set[str]
+    ) -> list[str]:
+        """Audit policies against an expected set.
+
+        Parameters
+        ----------
+        policies
+            Policies attached to an AppRole or token.
+        expected
+            Expected set of policies, without ``default``.
+
+        Returns
+        -------
+        list of str
+            Any errors found, or the empty list if none were found.
+        """
+        found = set(policies)
+        errors = [f"Missing policy {p}" for p in expected if p not in found]
+        found -= expected | {"default"}
+        errors.extend([f"Unexpected policy {p}" for p in found])
+        return errors
+
+    def _find_write_tokens(
+        self, vault_client: VaultClient, config: EnvironmentConfig
+    ) -> list[VaultTokenMetadata]:
+        """Find the write token for a given environment.
+
+        The write token is located by iterating through all token accessors
+        and finding all tokens whose display name match the expected display
+        name of the write token for that environment.
+
+        Parameters
+        ----------
+        vault_client
+            Vault client.
+        config
+            Phalanx configuration for the environment.
+
+        Returns
+        -------
+        list of VaultTokenMetadata
+            List of tokens with the appropriate write policy.
+        """
+        accessors = vault_client.list_token_accessors()
+        tokens = []
+        for accessor in accessors:
+            token = vault_client.get_token(accessor)
+            if token and token.display_name == config.vault_write_token:
+                tokens.append(token)
+        return tokens

--- a/tests/cli/vault_test.py
+++ b/tests/cli/vault_test.py
@@ -2,15 +2,121 @@
 
 from __future__ import annotations
 
+import re
+from datetime import datetime, timedelta
+
 import jinja2
 import yaml
 from click.testing import CliRunner
+from safir.datetime import current_datetime
 
 from phalanx.cli import main
+from phalanx.constants import VAULT_WRITE_TOKEN_LIFETIME
 from phalanx.factory import Factory
 from phalanx.models.vault import VaultAppRole, VaultToken
 
+from ..support.data import read_output_data
 from ..support.vault import MockVaultClient
+
+
+def test_audit(factory: Factory, mock_vault: MockVaultClient) -> None:
+    config_storage = factory.create_config_storage()
+    environment = config_storage.load_environment_config("idfdev")
+    _, vault_path = environment.vault_path_prefix.split("/", 1)
+    _, role_name = vault_path.rsplit("/", 1)
+
+    runner = CliRunner()
+
+    # Nothing has been created, so audit will report both missing.
+    result = runner.invoke(
+        main, ["vault", "audit", "idfdev"], catch_exceptions=False
+    )
+    assert result.exit_code == 1
+    assert result.output == read_output_data("idfdev", "audit-both-missing")
+
+    # Create an AppRole with the wrong policy and the wrong list of policies.
+    mock_vault.create_or_update_policy(f"{vault_path}/read", "blah blah blah")
+    mock_vault.create_or_update_approle(
+        role_name, token_policies=["something"], token_type="service"
+    )
+    result = runner.invoke(
+        main, ["vault", "audit", "idfdev"], catch_exceptions=False
+    )
+    assert result.exit_code == 1
+    assert result.output == read_output_data("idfdev", "audit-approle-policy")
+
+    # Use the Phalanx Vault service to recreate the AppRole, which should fix
+    # all of the problems, and then add an extra policy.
+    vault_service = factory.create_vault_service()
+    vault_service.create_read_approle("idfdev")
+    mock_vault.create_or_update_approle(
+        role_name,
+        token_policies=[f"{vault_path}/read", "extra"],
+        token_type="service",
+    )
+    result = runner.invoke(
+        main, ["vault", "audit", "idfdev"], catch_exceptions=False
+    )
+    assert result.exit_code == 1
+    assert result.output == read_output_data("idfdev", "audit-approle-extra")
+
+    # Fix the AppRole again, and create a write token with the wrong policies
+    # and a write policy with the wrong contents.
+    vault_service.create_read_approle("idfdev")
+    r = mock_vault.create(
+        display_name=role_name,
+        policies=["something"],
+        ttl=VAULT_WRITE_TOKEN_LIFETIME,
+    )
+    accessor = r["auth"]["accessor"]
+    mock_vault.create_or_update_policy(f"{vault_path}/write", "blah blah blah")
+    result = runner.invoke(
+        main, ["vault", "audit", "idfdev"], catch_exceptions=False
+    )
+    assert result.exit_code == 1
+    assert result.output == read_output_data("idfdev", "audit-token-policy")
+
+    # Create a new token that expires in six days and use that to fix the
+    # policy. The old token should still exist and produce the same warnings,
+    # except for the incorrect write policy, and there should be a new warning
+    # about the token expiring within seven days. We have to do some munging
+    # here of the output since the date and time will vary.
+    vault_service.create_write_token("idfdev", "6d")
+    result = runner.invoke(
+        main, ["vault", "audit", "idfdev"], catch_exceptions=False
+    )
+    assert result.exit_code == 1
+    output = re.sub(r"[\d-]{10} [\d:]{8}", "<timestamp>", result.output)
+    assert output == read_output_data("idfdev", "audit-token-multiple")
+
+    # Delete the manually-created token and make a new one that is already
+    # expired.
+    mock_vault.revoke_accessor(accessor)
+    r = mock_vault.create(
+        display_name=role_name,
+        policies=[f"{vault_path}/write"],
+        ttl=VAULT_WRITE_TOKEN_LIFETIME,
+        create_expired_token=True,
+    )
+    result = runner.invoke(
+        main, ["vault", "audit", "idfdev"], catch_exceptions=False
+    )
+    assert result.exit_code == 1
+    output = re.sub(r"[\d-]{10} [\d:]{8}", "<timestamp>", result.output)
+    assert output == read_output_data("idfdev", "audit-token-expired")
+
+
+def test_audit_clean(factory: Factory, mock_vault: MockVaultClient) -> None:
+    vault_service = factory.create_vault_service()
+    vault_service.create_read_approle("idfdev")
+    vault_service.create_write_token("idfdev", VAULT_WRITE_TOKEN_LIFETIME)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["vault", "audit", "idfdev"], catch_exceptions=False
+    )
+    assert result.exit_code == 0
+    assert result.output == ""
 
 
 def test_create_read_approle(
@@ -19,7 +125,7 @@ def test_create_read_approle(
     templates: jinja2.Environment,
 ) -> None:
     config_storage = factory.create_config_storage()
-    environment = config_storage.load_environment("idfdev")
+    environment = config_storage.load_environment_config("idfdev")
     _, vault_path = environment.vault_path_prefix.split("/", 1)
 
     runner = CliRunner()
@@ -51,8 +157,14 @@ def test_create_write_token(
     templates: jinja2.Environment,
 ) -> None:
     config_storage = factory.create_config_storage()
-    environment = config_storage.load_environment("idfdev")
+    environment = config_storage.load_environment_config("idfdev")
     _, vault_path = environment.vault_path_prefix.split("/", 1)
+    if "/" in vault_path:
+        _, display_name = vault_path.rsplit("/", 1)
+    else:
+        display_name = vault_path
+    lifetime = timedelta(days=int(VAULT_WRITE_TOKEN_LIFETIME[:-1]))
+    expires = current_datetime() + lifetime
 
     runner = CliRunner()
     result = runner.invoke(
@@ -60,8 +172,13 @@ def test_create_write_token(
     )
     assert result.exit_code == 0
     token = VaultToken.parse_obj(yaml.safe_load(result.output))
+    assert token.display_name == display_name
+    assert expires - timedelta(seconds=5) <= token.expires <= expires
     assert token.policies == [f"{vault_path}/write"]
-    assert token.token in {t.token for t in mock_vault.vault_tokens}
+    token_metadata = mock_vault.lookup_accessor(token.accessor)
+    assert token_metadata["data"]["display_name"] == token.display_name
+    expire_time = token_metadata["data"]["expire_time"]
+    assert datetime.fromisoformat(expire_time) == token.expires
 
     # Check the write policy against the proper expansion of the template.
     r = mock_vault.read_policy(token.policies[0])

--- a/tests/data/output/idfdev/audit-approle-extra
+++ b/tests/data/output/idfdev/audit-approle-extra
@@ -1,0 +1,3 @@
+Problems with read AppRole (data-dev.lsst.cloud):
+• Unexpected policy extra
+No write token (data-dev.lsst.cloud)

--- a/tests/data/output/idfdev/audit-approle-policy
+++ b/tests/data/output/idfdev/audit-approle-policy
@@ -1,0 +1,5 @@
+Problems with read AppRole (data-dev.lsst.cloud):
+• Missing policy phalanx/data-dev.lsst.cloud/read
+• Unexpected policy something
+• Policy phalanx/data-dev.lsst.cloud/read doesn't have expected contents
+No write token (data-dev.lsst.cloud)

--- a/tests/data/output/idfdev/audit-both-missing
+++ b/tests/data/output/idfdev/audit-both-missing
@@ -1,0 +1,2 @@
+No read AppRole (data-dev.lsst.cloud)
+No write token (data-dev.lsst.cloud)

--- a/tests/data/output/idfdev/audit-token-expired
+++ b/tests/data/output/idfdev/audit-token-expired
@@ -1,0 +1,5 @@
+Multiple write tokens found
+Problems with write token (data-dev.lsst.cloud):
+• Token will expire at <timestamp>
+Problems with write token (data-dev.lsst.cloud):
+• Token expired at <timestamp>

--- a/tests/data/output/idfdev/audit-token-multiple
+++ b/tests/data/output/idfdev/audit-token-multiple
@@ -1,0 +1,6 @@
+Multiple write tokens found
+Problems with write token (data-dev.lsst.cloud):
+• Missing policy phalanx/data-dev.lsst.cloud/write
+• Unexpected policy something
+Problems with write token (data-dev.lsst.cloud):
+• Token will expire at <timestamp>

--- a/tests/data/output/idfdev/audit-token-policy
+++ b/tests/data/output/idfdev/audit-token-policy
@@ -1,0 +1,4 @@
+Problems with write token (data-dev.lsst.cloud):
+• Missing policy phalanx/data-dev.lsst.cloud/write
+• Unexpected policy something
+• Policy phalanx/data-dev.lsst.cloud/write doesn't have expected contents

--- a/tests/support/vault.py
+++ b/tests/support/vault.py
@@ -26,13 +26,7 @@ __all__ = [
 
 
 class MockVaultClient:
-    """Mock Vault client for testing.
-
-    Attributes
-    ----------
-    tokens
-       All tokens that have been created.
-    """
+    """Mock Vault client for testing."""
 
     def __init__(self) -> None:
         # All APIs are currently collapsed into one object rather than using


### PR DESCRIPTION
Add a command to check the authentication credentials for a given environment (both the read AppRole and the write token) and report any problems found. Add a display name to write tokens so that they can be more easily found among all of the other accessors.