### PR TITLE
Decrease influxdb resources at idfdev

### DIFF
--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -34,6 +34,14 @@ influxdb2:
   ingress:
     enabled: true
     hostname: data-dev.lsst.cloud
+  resources:
+    requests:
+      memory: 16Gi
+      cpu: 2
+    limits:
+      memory: 16Gi
+      cpu: 2
+
 
 telegraf-kafka-consumer:
   enabled: true


### PR DESCRIPTION
- idfdev cluster does not have enough resources for the default influxdb resources configuration