### PR TITLE
DM-23487: Delete all other AppRole SecretIDs and write tokens on creation

### DIFF
--- a/src/phalanx/services/vault.py
+++ b/src/phalanx/services/vault.py
@@ -88,6 +88,9 @@ class VaultService:
         template = self._templates.get_template("vault-read-policy.tmpl")
         policy = template.render({"path": config.vault_path})
         vault_client.create_policy(config.vault_read_policy, policy)
+        approle = vault_client.get_approle(config.vault_read_approle)
+        if approle:
+            vault_client.revoke_approle_secret_ids(config.vault_read_approle)
         return vault_client.create_approle(
             config.vault_read_approle, [config.vault_read_policy]
         )

--- a/src/phalanx/storage/vault.py
+++ b/src/phalanx/storage/vault.py
@@ -277,6 +277,18 @@ class VaultClient:
         r = self._vault.auth.token.list_accessors()
         return r["data"]["keys"]
 
+    def revoke_approle_secret_ids(self, name: str) -> None:
+        """Revoke all existing SecretIDs for a Vault AppRole.
+
+        Parameters
+        ----------
+        name
+            Name of the AppRole.
+        """
+        r = self._vault.auth.approle.list_secret_id_accessors(name)
+        for accessor in r["data"]["keys"]:
+            self._vault.auth.approle.destroy_secret_id_accessor(name, accessor)
+
     def revoke_token(self, accessor: str) -> None:
         """Revoke a token by accessor.
 

--- a/src/phalanx/storage/vault.py
+++ b/src/phalanx/storage/vault.py
@@ -254,6 +254,11 @@ class VaultClient:
         -------
         list of str
             Names of available application secrets.
+
+        Raises
+        ------
+        VaultNotFoundError
+            Raised if the path for application secrets does not exist.
         """
         try:
             r = self._vault.secrets.kv.list_secrets(self._path)
@@ -271,6 +276,16 @@ class VaultClient:
         """
         r = self._vault.auth.token.list_accessors()
         return r["data"]["keys"]
+
+    def revoke_token(self, accessor: str) -> None:
+        """Revoke a token by accessor.
+
+        Parameters
+        ----------
+        accessor
+            Accessor of token.
+        """
+        self._vault.auth.token.revoke_accessor(accessor)
 
     def store_application_secret(
         self, application: str, values: dict[str, SecretStr]

--- a/tests/cli/vault_test.py
+++ b/tests/cli/vault_test.py
@@ -63,12 +63,11 @@ def test_audit(factory: Factory, mock_vault: MockVaultClient) -> None:
     # Fix the AppRole again, and create a write token with the wrong policies
     # and a write policy with the wrong contents.
     vault_service.create_read_approle("idfdev")
-    r = mock_vault.create(
+    mock_vault.create(
         display_name=role_name,
         policies=["something"],
         ttl=VAULT_WRITE_TOKEN_LIFETIME,
     )
-    r["auth"]["accessor"]
     mock_vault.create_or_update_policy(f"{vault_path}/write", "blah blah blah")
     result = runner.invoke(
         main, ["vault", "audit", "idfdev"], catch_exceptions=False

--- a/tests/data/output/idfdev/audit-token-multiple
+++ b/tests/data/output/idfdev/audit-token-multiple
@@ -1,6 +1,0 @@
-Multiple write tokens found
-Problems with write token (data-dev.lsst.cloud):
-• Missing policy phalanx/data-dev.lsst.cloud/write
-• Unexpected policy something
-Problems with write token (data-dev.lsst.cloud):
-• Token will expire at <timestamp>


### PR DESCRIPTION
When creating a new Vault AppRole or write token for an environment, search for any existing AppRole SecretIDs or write tokens and delete them. This more aggressive credential management approach maintains an invariant of only having one active AppRole SecretID and write token at a time, better for both conceptual simplicity and security, and means most problems with an AppRole or write token configuration can be fully resolved by creating a new one.