### PR TITLE
DM-40343: Minor Phalanx configuration cleanup

### DIFF
--- a/applications/gafaelfawr/values-ccin2p3.yaml
+++ b/applications/gafaelfawr/values-ccin2p3.yaml
@@ -38,10 +38,9 @@ config:
     - "mainetti"
 
   groupMapping:
-    "admin:token": "lsst"
-    "user:token": "lsst"
-    "exec:admin": "lsst"
-    "read:all":
+    "admin:token":
+      - "lsst"
+    "exec:admin":
       - "lsst"
     "exec:internal-tools":
       - "lsst"
@@ -49,9 +48,11 @@ config:
       - "lsst"
     "exec:portal":
       - "lsst"
-    "read:tap":
+    "read:all":
       - "lsst"
     "read:image":
+      - "lsst"
+    "read:tap":
       - "lsst"
 
   # Allow access by GitHub team.

--- a/docs/applications/argo-cd/index.rst
+++ b/docs/applications/argo-cd/index.rst
@@ -9,7 +9,6 @@ It is itself a set of Kubernetes resources and running pods managed with Helm_.
 
 .. jinja:: argocd
    :file: applications/_summary.rst.jinja
-   :debug:
 
 Guides
 ======

--- a/environments/values-usdfdev.yaml
+++ b/environments/values-usdfdev.yaml
@@ -42,8 +42,6 @@ nublado2:
   enabled: true
 obsloctap:
   enabled: true
-obstap:
-  enabled: true
 ook:
   enabled: false
 plot-navigator:


### PR DESCRIPTION
Fix several issues found while reworking the Phalanx documentation generation.

- Fix Gafaelfawr `config.groupMapping` for CC-IN2P3, which in some cases set the group list to a string rather than a list
- Remove a stray setting enabling the now-nonexistent obstap service for USDF dev
- Disable debugging for Argo CD application summary templating