### PR TITLE
DM-40343: Fix InvalidEnvironmentConfigError error

### DIFF
--- a/src/phalanx/exceptions.py
+++ b/src/phalanx/exceptions.py
@@ -27,7 +27,7 @@ class InvalidEnvironmentConfigError(Exception):
     """
 
     def __init__(self, name: str, error: str) -> None:
-        msg = "Invalid configuration for environment {name}: {error}"
+        msg = f"Invalid configuration for environment {name}: {error}"
         super().__init__(msg)
 
 


### PR DESCRIPTION
The f-string formatting the error message accidentally omitted the f prefix and thus wasn't formatted.