### PR TITLE
DM-40256: Support secret sync with no static secrets source

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,6 @@ ignore = [
     "FBT003",  # positional booleans are normal for Pydantic field defaults
     "G004",    # forbidding logging f-strings is appealing, but not our style
     "PD011",   # false positive with non-NumPY code that uses .values
-    "PLR0911", # way too strict of a function complexity constraint
     "PLR0913", # factory pattern uses constructors with many arguments
     "PLR2004", # too aggressive about magic values
     "RET505",  # disagree that omitting else always makes code more readable

--- a/tests/cli/secrets_test.py
+++ b/tests/cli/secrets_test.py
@@ -131,17 +131,12 @@ def test_sync(factory: Factory, mock_vault: MockVaultClient) -> None:
     assert postgres["nublado3_password"] == nublado["hub_db_password"]
 
     # Now sync again with --delete. The only change should be that the stray
-    # Gafaelfawr Vault secret key is deleted.
+    # Gafaelfawr Vault secret key is deleted. This also tests that if the
+    # static secrets are already in Vault, there's no need to provide a source
+    # for static secrets and the Phalanx CLI will silently cope.
     result = runner.invoke(
         main,
-        [
-            "secrets",
-            "sync",
-            "--delete",
-            "--secrets",
-            str(secrets_path),
-            "idfdev",
-        ],
+        ["secrets", "sync", "--delete", "idfdev"],
         catch_exceptions=False,
     )
     assert result.exit_code == 0


### PR DESCRIPTION
If no static secret source was provided but all of the required static secrets are already in Vault, successfully sync and retain the secrets in Vault. This is required to support the USDF environments, where static secrets are maintained directly in Vault, and in general will be more convenient since it will mean that 1Password secrets don't have to be provided when one is just syncing new generated secrets.