### PR TITLE
DM-40343: Change key for environment name to name

### DIFF
--- a/docs/developers/add-application.rst
+++ b/docs/developers/add-application.rst
@@ -140,7 +140,7 @@ This is done by creating an Argo CD ``Application`` that manages your applicatio
                 value: {{ .Values.vaultPathPrefix | quote }}
             valueFiles:
               - "values.yaml"
-              - 'values-{{ .Values.environment }}.yaml"
+              - "values-{{ .Values.name }}.yaml"
       {{- end -}}
 
    Replace every instance of ``<name>`` with the name of your application.

--- a/environments/README.md
+++ b/environments/README.md
@@ -10,7 +10,6 @@
 | cachemachine.enabled | bool | `false` |  |
 | cert-manager.enabled | bool | `false` |  |
 | datalinker.enabled | bool | `false` |  |
-| environment | string | None, must be set | Name of the environment |
 | exposurelog.enabled | bool | `false` |  |
 | fqdn | string | None, must be set | Fully-qualified domain name where the environment is running |
 | gafaelfawr.enabled | bool | `false` |  |
@@ -23,6 +22,7 @@
 | mobu.enabled | bool | `false` |  |
 | moneypenny.enabled | bool | `false` |  |
 | monitoring.enabled | bool | `false` |  |
+| name | string | None, must be set | Name of the environment |
 | narrativelog.enabled | bool | `false` |  |
 | noteburst.enabled | bool | `false` |  |
 | nublado.enabled | bool | `false` |  |

--- a/environments/templates/alert-stream-broker-application.yaml
+++ b/environments/templates/alert-stream-broker-application.yaml
@@ -23,5 +23,5 @@ spec:
     helm:
       valueFiles:
         - "values.yaml"
-        - "values-{{ .Values.environment }}.yaml"
+        - "values-{{ .Values.name }}.yaml"
 {{- end -}}

--- a/environments/templates/argo-workflows-application.yaml
+++ b/environments/templates/argo-workflows-application.yaml
@@ -30,5 +30,5 @@ spec:
           value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
-        - "values-{{ .Values.environment }}.yaml"
+        - "values-{{ .Values.name }}.yaml"
 {{- end -}}

--- a/environments/templates/argocd-application.yaml
+++ b/environments/templates/argocd-application.yaml
@@ -20,4 +20,4 @@ spec:
           value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
-        - "values-{{ .Values.environment }}.yaml"
+        - "values-{{ .Values.name }}.yaml"

--- a/environments/templates/cachemachine-application.yaml
+++ b/environments/templates/cachemachine-application.yaml
@@ -30,5 +30,5 @@ spec:
           value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
-        - "values-{{ .Values.environment }}.yaml"
+        - "values-{{ .Values.name }}.yaml"
 {{- end -}}

--- a/environments/templates/cert-manager-application.yaml
+++ b/environments/templates/cert-manager-application.yaml
@@ -26,7 +26,7 @@ spec:
           value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
-        - "values-{{ .Values.environment }}.yaml"
+        - "values-{{ .Values.name }}.yaml"
   ignoreDifferences:
     - group: "admissionregistration.k8s.io"
       kind: "MutatingWebhookConfiguration"

--- a/environments/templates/datalinker-application.yaml
+++ b/environments/templates/datalinker-application.yaml
@@ -32,5 +32,5 @@ spec:
           value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
-        - "values-{{ .Values.environment }}.yaml"
+        - "values-{{ .Values.name }}.yaml"
 {{- end -}}

--- a/environments/templates/exposurelog-application.yaml
+++ b/environments/templates/exposurelog-application.yaml
@@ -30,5 +30,5 @@ spec:
           value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
-        - "values-{{ .Values.environment }}.yaml"
+        - "values-{{ .Values.name }}.yaml"
 {{- end -}}

--- a/environments/templates/gafaelfawr-application.yaml
+++ b/environments/templates/gafaelfawr-application.yaml
@@ -30,5 +30,5 @@ spec:
           value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
-        - "values-{{ .Values.environment }}.yaml"
+        - "values-{{ .Values.name }}.yaml"
 {{- end -}}

--- a/environments/templates/giftless-application.yaml
+++ b/environments/templates/giftless-application.yaml
@@ -30,5 +30,5 @@ spec:
           value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
-        - "values-{{ .Values.environment }}.yaml"
+        - "values-{{ .Values.name }}.yaml"
 {{- end -}}

--- a/environments/templates/hips-application.yaml
+++ b/environments/templates/hips-application.yaml
@@ -28,5 +28,5 @@ spec:
           value: "https://{{ .Values.fqdn }}"
       valueFiles:
         - "values.yaml"
-        - "values-{{ .Values.environment }}.yaml"
+        - "values-{{ .Values.name }}.yaml"
 {{- end -}}

--- a/environments/templates/ingress-nginx-application.yaml
+++ b/environments/templates/ingress-nginx-application.yaml
@@ -26,5 +26,5 @@ spec:
           value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
-        - "values-{{ .Values.environment }}.yaml"
+        - "values-{{ .Values.name }}.yaml"
 {{- end -}}

--- a/environments/templates/kubernetes-replicator-application.yaml
+++ b/environments/templates/kubernetes-replicator-application.yaml
@@ -30,5 +30,5 @@ spec:
           value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
-        - "values-{{ .Values.environment }}.yaml"
+        - "values-{{ .Values.name }}.yaml"
 {{- end -}}

--- a/environments/templates/linters-application.yaml
+++ b/environments/templates/linters-application.yaml
@@ -30,5 +30,5 @@ spec:
           value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
-        - "values-{{ .Values.environment }}.yaml"
+        - "values-{{ .Values.name }}.yaml"
 {{- end -}}

--- a/environments/templates/livetap-application.yaml
+++ b/environments/templates/livetap-application.yaml
@@ -30,5 +30,5 @@ spec:
           value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
-        - "values-{{ .Values.environment }}.yaml"
+        - "values-{{ .Values.name }}.yaml"
 {{- end -}}

--- a/environments/templates/mobu-application.yaml
+++ b/environments/templates/mobu-application.yaml
@@ -30,5 +30,5 @@ spec:
           value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
-        - "values-{{ .Values.environment }}.yaml"
+        - "values-{{ .Values.name }}.yaml"
 {{- end -}}

--- a/environments/templates/moneypenny-application.yaml
+++ b/environments/templates/moneypenny-application.yaml
@@ -30,5 +30,5 @@ spec:
           value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
-        - "values-{{ .Values.environment }}.yaml"
+        - "values-{{ .Values.name }}.yaml"
 {{- end -}}

--- a/environments/templates/monitoring-application.yaml
+++ b/environments/templates/monitoring-application.yaml
@@ -30,5 +30,5 @@ spec:
           value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
-        - "values-{{ .Values.environment }}.yaml"
+        - "values-{{ .Values.name }}.yaml"
 {{- end -}}

--- a/environments/templates/narrativelog-application.yaml
+++ b/environments/templates/narrativelog-application.yaml
@@ -30,5 +30,5 @@ spec:
           value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
-        - "values-{{ .Values.environment }}.yaml"
+        - "values-{{ .Values.name }}.yaml"
 {{- end -}}

--- a/environments/templates/noteburst-application.yaml
+++ b/environments/templates/noteburst-application.yaml
@@ -28,5 +28,5 @@ spec:
           value: "https://{{ .Values.fqdn }}"
       valueFiles:
         - "values.yaml"
-        - "values-{{ .Values.environment }}.yaml"
+        - "values-{{ .Values.name }}.yaml"
 {{- end -}}

--- a/environments/templates/nublado-application.yaml
+++ b/environments/templates/nublado-application.yaml
@@ -30,7 +30,7 @@ spec:
           value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
-        - "values-{{ .Values.environment }}.yaml"
+        - "values-{{ .Values.name }}.yaml"
   ignoreDifferences:
     - kind: "Secret"
       jsonPointers:

--- a/environments/templates/nublado2-application.yaml
+++ b/environments/templates/nublado2-application.yaml
@@ -23,7 +23,7 @@ spec:
     helm:
       valueFiles:
         - "values.yaml"
-        - "values-{{ .Values.environment }}.yaml"
+        - "values-{{ .Values.name }}.yaml"
       parameters:
         - name: "global.vaultSecretsPath"
           value: {{ .Values.vaultPathPrefix | quote }}

--- a/environments/templates/obsloctap-application.yaml
+++ b/environments/templates/obsloctap-application.yaml
@@ -30,5 +30,5 @@ spec:
           value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
-        - "values-{{ .Values.environment }}.yaml"
+        - "values-{{ .Values.name }}.yaml"
 {{- end -}}

--- a/environments/templates/ook-application.yaml
+++ b/environments/templates/ook-application.yaml
@@ -30,5 +30,5 @@ spec:
           value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
-        - "values-{{ .Values.environment }}.yaml"
+        - "values-{{ .Values.name }}.yaml"
 {{- end -}}

--- a/environments/templates/plot-navigator-application.yaml
+++ b/environments/templates/plot-navigator-application.yaml
@@ -30,5 +30,5 @@ spec:
           value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
-        - "values-{{ .Values.environment }}.yaml"
+        - "values-{{ .Values.name }}.yaml"
 {{- end -}}

--- a/environments/templates/portal-application.yaml
+++ b/environments/templates/portal-application.yaml
@@ -30,5 +30,5 @@ spec:
           value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
-        - "values-{{ .Values.environment }}.yaml"
+        - "values-{{ .Values.name }}.yaml"
 {{- end -}}

--- a/environments/templates/postgres-application.yaml
+++ b/environments/templates/postgres-application.yaml
@@ -26,5 +26,5 @@ spec:
           value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
-        - "values-{{ .Values.environment }}.yaml"
+        - "values-{{ .Values.name }}.yaml"
 {{- end -}}

--- a/environments/templates/production-tools-application.yaml
+++ b/environments/templates/production-tools-application.yaml
@@ -30,5 +30,5 @@ spec:
           value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
-        - "values-{{ .Values.environment }}.yaml"
+        - "values-{{ .Values.name }}.yaml"
 {{- end -}}

--- a/environments/templates/sasquatch-application.yaml
+++ b/environments/templates/sasquatch-application.yaml
@@ -30,5 +30,5 @@ spec:
           value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
-        - "values-{{ .Values.environment }}.yaml"
+        - "values-{{ .Values.name }}.yaml"
 {{- end -}}

--- a/environments/templates/semaphore-application.yaml
+++ b/environments/templates/semaphore-application.yaml
@@ -30,5 +30,5 @@ spec:
           value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
-        - "values-{{ .Values.environment }}.yaml"
+        - "values-{{ .Values.name }}.yaml"
 {{- end -}}

--- a/environments/templates/sherlock-application.yaml
+++ b/environments/templates/sherlock-application.yaml
@@ -30,5 +30,5 @@ spec:
           value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
-        - "values-{{ .Values.environment }}.yaml"
+        - "values-{{ .Values.name }}.yaml"
 {{- end -}}

--- a/environments/templates/sqlproxy-cross-project-application.yaml
+++ b/environments/templates/sqlproxy-cross-project-application.yaml
@@ -23,5 +23,5 @@ spec:
     helm:
       valueFiles:
         - "values.yaml"
-        - "values-{{ .Values.environment }}.yaml"
+        - "values-{{ .Values.name }}.yaml"
 {{- end -}}

--- a/environments/templates/squarebot-application.yaml
+++ b/environments/templates/squarebot-application.yaml
@@ -30,5 +30,5 @@ spec:
           value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
-        - "values-{{ .Values.environment }}.yaml"
+        - "values-{{ .Values.name }}.yaml"
 {{- end -}}

--- a/environments/templates/squareone-application.yaml
+++ b/environments/templates/squareone-application.yaml
@@ -30,5 +30,5 @@ spec:
           value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
-        - "values-{{ .Values.environment }}.yaml"
+        - "values-{{ .Values.name }}.yaml"
 {{- end -}}

--- a/environments/templates/ssotap-application.yaml
+++ b/environments/templates/ssotap-application.yaml
@@ -30,5 +30,5 @@ spec:
           value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
-        - "values-{{ .Values.environment }}.yaml"
+        - "values-{{ .Values.name }}.yaml"
 {{- end -}}

--- a/environments/templates/strimzi-access-operator-application.yaml
+++ b/environments/templates/strimzi-access-operator-application.yaml
@@ -23,5 +23,5 @@ spec:
     helm:
       valueFiles:
         - "values.yaml"
-        - "values-{{ .Values.environment }}.yaml"
+        - "values-{{ .Values.name }}.yaml"
 {{- end -}}

--- a/environments/templates/strimzi-application.yaml
+++ b/environments/templates/strimzi-application.yaml
@@ -22,5 +22,5 @@ spec:
     targetRevision: {{ .Values.targetRevision | quote }}
     helm:
       valueFiles:
-        - "values-{{ .Values.environment }}.yaml"
+        - "values-{{ .Values.name }}.yaml"
 {{- end -}}

--- a/environments/templates/tap-application.yaml
+++ b/environments/templates/tap-application.yaml
@@ -30,5 +30,5 @@ spec:
           value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
-        - "values-{{ .Values.environment }}.yaml"
+        - "values-{{ .Values.name }}.yaml"
 {{- end -}}

--- a/environments/templates/tap-schema-application.yaml
+++ b/environments/templates/tap-schema-application.yaml
@@ -26,5 +26,5 @@ spec:
           value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
-        - "values-{{ .Values.environment }}.yaml"
+        - "values-{{ .Values.name }}.yaml"
 {{- end -}}

--- a/environments/templates/telegraf-application.yaml
+++ b/environments/templates/telegraf-application.yaml
@@ -30,5 +30,5 @@ spec:
           value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
-        - "values-{{ .Values.environment }}.yaml"
+        - "values-{{ .Values.name }}.yaml"
 {{- end -}}

--- a/environments/templates/telegraf-ds-application.yaml
+++ b/environments/templates/telegraf-ds-application.yaml
@@ -30,5 +30,5 @@ spec:
           value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
-        - "values-{{ .Values.environment }}.yaml"
+        - "values-{{ .Values.name }}.yaml"
 {{- end -}}

--- a/environments/templates/times-square-application.yaml
+++ b/environments/templates/times-square-application.yaml
@@ -30,5 +30,5 @@ spec:
           value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
-        - "values-{{ .Values.environment }}.yaml"
+        - "values-{{ .Values.name }}.yaml"
 {{- end -}}

--- a/environments/templates/vault-secrets-operator-application.yaml
+++ b/environments/templates/vault-secrets-operator-application.yaml
@@ -26,5 +26,5 @@ spec:
           value: {{ .Values.vaultUrl | quote }}
       valueFiles:
         - "values.yaml"
-        - "values-{{ .Values.environment }}.yaml"
+        - "values-{{ .Values.name }}.yaml"
 {{- end -}}

--- a/environments/templates/vo-cutouts-application.yaml
+++ b/environments/templates/vo-cutouts-application.yaml
@@ -32,5 +32,5 @@ spec:
           value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:
         - "values.yaml"
-        - "values-{{ .Values.environment }}.yaml"
+        - "values-{{ .Values.name }}.yaml"
 {{- end -}}

--- a/environments/values-base.yaml
+++ b/environments/values-base.yaml
@@ -1,4 +1,4 @@
-environment: base
+name: base
 fqdn: base-lsp.lsst.codes
 vaultUrl: "https://vault.lsst.codes"
 vaultPathPrefix: secret/k8s_operator/base-lsp.lsst.codes

--- a/environments/values-ccin2p3.yaml
+++ b/environments/values-ccin2p3.yaml
@@ -1,4 +1,4 @@
-environment: ccin2p3
+name: ccin2p3
 fqdn: data-dev.lsst.eu
 vaultUrl: "https://vault.lsst.codes"
 vaultPathPrefix: secret/k8s_operator/rsp-cc

--- a/environments/values-idfdev.yaml
+++ b/environments/values-idfdev.yaml
@@ -1,6 +1,6 @@
 butlerRepositoryIndex: "s3://butler-us-central1-repo-locations/data-dev-repos.yaml"
-environment: idfdev
 fqdn: data-dev.lsst.cloud
+name: idfdev
 vaultUrl: "https://vault.lsst.codes"
 vaultPathPrefix: secret/k8s_operator/data-dev.lsst.cloud
 

--- a/environments/values-idfint.yaml
+++ b/environments/values-idfint.yaml
@@ -1,6 +1,6 @@
 butlerRepositoryIndex: "s3://butler-us-central1-repo-locations/data-int-repos.yaml"
-environment: idfint
 fqdn: data-int.lsst.cloud
+name: idfint
 vaultUrl: "https://vault.lsst.codes"
 vaultPathPrefix: secret/k8s_operator/data-int.lsst.cloud
 

--- a/environments/values-idfprod.yaml
+++ b/environments/values-idfprod.yaml
@@ -1,6 +1,6 @@
 butlerRepositoryIndex: "s3://butler-us-central1-repo-locations/data-repos.yaml"
-environment: idfprod
 fqdn: data.lsst.cloud
+name: idfprod
 vaultUrl: "https://vault.lsst.codes"
 vaultPathPrefix: secret/k8s_operator/data.lsst.cloud
 

--- a/environments/values-minikube.yaml
+++ b/environments/values-minikube.yaml
@@ -1,4 +1,4 @@
-environment: minikube
+name: minikube
 fqdn: minikube.lsst.codes
 vaultUrl: "https://vault.lsst.codes"
 vaultPathPrefix: secret/k8s_operator/minikube.lsst.codes

--- a/environments/values-roe.yaml
+++ b/environments/values-roe.yaml
@@ -1,4 +1,4 @@
-environment: roe
+name: roe
 fqdn: rsp.lsst.ac.uk
 vaultUrl: "https://vault.lsst.codes"
 vaultPathPrefix: secret/k8s_operator/roe

--- a/environments/values-roundtable-dev.yaml
+++ b/environments/values-roundtable-dev.yaml
@@ -1,4 +1,4 @@
-environment: roundtable-dev
+name: roundtable-dev
 fqdn: roundtable-dev.lsst.cloud
 vaultUrl: "https://vault.lsst.codes"
 vaultPathPrefix: secret/k8s_operator/roundtable-dev.lsst.cloud

--- a/environments/values-roundtable-prod.yaml
+++ b/environments/values-roundtable-prod.yaml
@@ -1,4 +1,4 @@
-environment: roundtable-prod
+name: roundtable-prod
 fqdn: roundtable.lsst.cloud
 vaultUrl: "https://vault.lsst.codes"
 vaultPathPrefix: secret/k8s_operator/roundtable.lsst.cloud

--- a/environments/values-summit.yaml
+++ b/environments/values-summit.yaml
@@ -1,4 +1,4 @@
-environment: summit
+name: summit
 fqdn: summit-lsp.lsst.codes
 vaultUrl: "https://vault.lsst.codes"
 vaultPathPrefix: secret/k8s_operator/summit-lsp.lsst.codes

--- a/environments/values-tucson-teststand.yaml
+++ b/environments/values-tucson-teststand.yaml
@@ -1,4 +1,4 @@
-environment: tucson-teststand
+name: tucson-teststand
 fqdn: tucson-teststand.lsst.codes
 vaultUrl: "https://vault.lsst.codes"
 vaultPathPrefix: secret/k8s_operator/tucson-teststand.lsst.codes

--- a/environments/values-usdf-tel-rsp.yaml
+++ b/environments/values-usdf-tel-rsp.yaml
@@ -1,4 +1,4 @@
-environment: usdf-tel-rsp
+name: usdf-tel-rsp
 fqdn: usdf-tel-rsp.slac.stanford.edu
 vaultUrl: "https://vault.slac.stanford.edu"
 vaultPathPrefix: secret/rubin/usdf-tel-rsp

--- a/environments/values-usdfdev.yaml
+++ b/environments/values-usdfdev.yaml
@@ -1,6 +1,6 @@
 butlerRepositoryIndex: "s3://rubin-summit-users/data-repos.yaml"
-environment: usdfdev
 fqdn: usdf-rsp-dev.slac.stanford.edu
+name: usdfdev
 vaultUrl: "https://vault.slac.stanford.edu"
 vaultPathPrefix: secret/rubin/usdf-rsp-dev
 

--- a/environments/values-usdfprod.yaml
+++ b/environments/values-usdfprod.yaml
@@ -1,6 +1,6 @@
 butlerRepositoryIndex: "s3://rubin-summit-users/data-repos.yaml"
-environment: usdfprod
 fqdn: usdf-rsp.slac.stanford.edu
+name: usdfprod
 vaultUrl: "https://vault.slac.stanford.edu"
 vaultPathPrefix: secret/rubin/usdf-rsp
 

--- a/environments/values.yaml
+++ b/environments/values.yaml
@@ -6,7 +6,7 @@ butlerRepositoryIndex: ""
 
 # -- Name of the environment
 # @default -- None, must be set
-environment: ""
+name: ""
 
 # -- Fully-qualified domain name where the environment is running
 # @default -- None, must be set

--- a/src/phalanx/docs/models.py
+++ b/src/phalanx/docs/models.py
@@ -310,7 +310,7 @@ class Environment:
     ) -> Environment:
         """Load an environment by inspecting the Phalanx repository."""
         # Extract name from dir/values-envname.yaml
-        name = values["environment"]
+        name = values["name"]
 
         # Get Application instances active in this environment
         apps: list[Application] = []
@@ -366,7 +366,7 @@ class Phalanx:
             if not env_values_path.is_file():
                 continue
             values = yaml.safe_load(env_values_path.read_text())
-            name = values["environment"]
+            name = values["name"]
             env_values[name] = values
 
         # Gather applications

--- a/src/phalanx/models/environments.py
+++ b/src/phalanx/models/environments.py
@@ -67,7 +67,7 @@ class EnvironmentConfig(EnvironmentVaultConfig):
     This is a partial model for the environment :file:`values.yaml` file.
     """
 
-    environment: str
+    name: str
     """Name of the environment."""
 
     applications: list[str] = Field(

--- a/src/phalanx/storage/config.py
+++ b/src/phalanx/storage/config.py
@@ -75,7 +75,7 @@ class ConfigStorage:
             for a in applications
         }
         return Environment(
-            name=config.environment,
+            name=config.name,
             vault_url=config.vault_url,
             vault_path_prefix=config.vault_path_prefix,
             applications=instances,

--- a/tests/data/input/environments/values-idfdev.yaml
+++ b/tests/data/input/environments/values-idfdev.yaml
@@ -1,4 +1,4 @@
-environment: idfdev
+name: idfdev
 fqdn: data-dev.lsst.cloud
 vaultUrl: https://vault.lsst.codes/
 vaultPathPrefix: secret/phalanx/data-dev.lsst.cloud

--- a/tests/data/input/environments/values.yaml
+++ b/tests/data/input/environments/values.yaml
@@ -2,7 +2,7 @@
 
 # -- Name of the environment
 # @default -- None, must be set
-environment: ""
+name: ""
 
 # -- Fully-qualified domain name where the environment is running
 # @default -- None, must be set


### PR DESCRIPTION
Previously, the per-environment values files used environment as the key for the environment name. Since we want the configuration models to match the schema of the files on disk, but constantly using environment.environment in the Python code is annoying, rename the key to name.