### PR TITLE
DM-40343: Detect location of the Phalanx configuration

### DIFF
--- a/src/phalanx/factory.py
+++ b/src/phalanx/factory.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from .services.secrets import SecretsService
 from .services.vault import VaultService
 from .storage.config import ConfigStorage
@@ -11,7 +13,16 @@ __all__ = ["Factory"]
 
 
 class Factory:
-    """Factory to create Phalanx components."""
+    """Factory to create Phalanx components.
+
+    Parameters
+    ----------
+    path
+        Path to the root of the Phalanx configuration tree.
+    """
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
 
     def create_config_storage(self) -> ConfigStorage:
         """Create storage layer for the Phalanx configuration.
@@ -21,7 +32,7 @@ class Factory:
         ConfigStorage
             Storage service for loading the Phalanx configuration.
         """
-        return ConfigStorage()
+        return ConfigStorage(self._path)
 
     def create_secrets_service(self) -> SecretsService:
         """Create service for manipulating Phalanx secrets.

--- a/src/phalanx/storage/config.py
+++ b/src/phalanx/storage/config.py
@@ -45,10 +45,16 @@ def _merge_overrides(
 
 
 class ConfigStorage:
-    """Analyze Phalanx configuration and convert it to models."""
+    """Analyze Phalanx configuration and convert it to models.
 
-    def __init__(self) -> None:
-        self._path = Path.cwd()
+    Parameters
+    ----------
+    path
+        Root path to Phalanx configuration.
+    """
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
 
     def load_environment(self, environment_name: str) -> Environment:
         """Load the configuration of a Phalanx environment from disk.
@@ -104,7 +110,7 @@ class ConfigStorage:
             Raised if the named environment has no configuration.
         """
         values_name = f"values-{environment_name}.yaml"
-        values_path = Path.cwd() / "environments" / values_name
+        values_path = self._path / "environments" / values_name
         if not values_path.exists():
             raise UnknownEnvironmentError(environment_name)
         with values_path.open() as fh:
@@ -169,7 +175,7 @@ class ConfigStorage:
         Application
             Application data.
         """
-        base_path = Path.cwd() / "applications" / name
+        base_path = self._path / "applications" / name
 
         # Load main values file.
         values_path = base_path / "values.yaml"

--- a/tests/cli/secrets_test.py
+++ b/tests/cli/secrets_test.py
@@ -8,14 +8,13 @@ from datetime import datetime, timedelta
 from pathlib import Path
 
 import bcrypt
-from click.testing import CliRunner
 from cryptography.fernet import Fernet
 from safir.datetime import current_datetime
 
-from phalanx.cli import main
 from phalanx.factory import Factory
 from phalanx.models.gafaelfawr import Token
 
+from ..support.cli import run_cli
 from ..support.data import (
     phalanx_test_path,
     read_input_static_secrets,
@@ -50,28 +49,21 @@ def test_audit(factory: Factory, mock_vault: MockVaultClient) -> None:
     mock_vault.load_test_data(environment.vault_path_prefix, "idfdev")
 
     secrets_path = input_path / "secrets" / "idfdev.yaml"
-    runner = CliRunner()
-    result = runner.invoke(
-        main,
-        ["secrets", "audit", "--secrets", str(secrets_path), "idfdev"],
-        catch_exceptions=False,
+    result = run_cli(
+        "secrets", "audit", "--secrets", str(secrets_path), "idfdev"
     )
     assert result.exit_code == 0
     assert result.output == read_output_data("idfdev", "secrets-audit")
 
 
-def test_list(factory: Factory) -> None:
-    runner = CliRunner()
-    result = runner.invoke(
-        main, ["secrets", "list", "idfdev"], catch_exceptions=False
-    )
+def test_list() -> None:
+    result = run_cli("secrets", "list", "idfdev")
     assert result.exit_code == 0
     assert result.output == read_output_data("idfdev", "secrets-list")
 
 
 def test_schema() -> None:
-    runner = CliRunner()
-    result = runner.invoke(main, ["secrets", "schema"], catch_exceptions=False)
+    result = run_cli("secrets", "schema", needs_config=False)
     assert result.exit_code == 0
     current = (
         Path(__file__).parent.parent.parent
@@ -83,11 +75,8 @@ def test_schema() -> None:
     assert result.output == current.read_text()
 
 
-def test_static_template(factory: Factory) -> None:
-    runner = CliRunner()
-    result = runner.invoke(
-        main, ["secrets", "static-template", "idfdev"], catch_exceptions=False
-    )
+def test_static_template() -> None:
+    result = run_cli("secrets", "static-template", "idfdev")
     assert result.exit_code == 0
     assert result.output == read_output_data("idfdev", "static-secrets.yaml")
 
@@ -100,11 +89,8 @@ def test_sync(factory: Factory, mock_vault: MockVaultClient) -> None:
     mock_vault.load_test_data(environment.vault_path_prefix, "idfdev")
     _, base_vault_path = environment.vault_path_prefix.split("/", 1)
 
-    runner = CliRunner()
-    result = runner.invoke(
-        main,
-        ["secrets", "sync", "--secrets", str(secrets_path), "idfdev"],
-        catch_exceptions=False,
+    result = run_cli(
+        "secrets", "sync", "--secrets", str(secrets_path), "idfdev"
     )
     assert result.exit_code == 0
     assert result.output == read_output_data("idfdev", "sync-output")
@@ -134,11 +120,7 @@ def test_sync(factory: Factory, mock_vault: MockVaultClient) -> None:
     # Gafaelfawr Vault secret key is deleted. This also tests that if the
     # static secrets are already in Vault, there's no need to provide a source
     # for static secrets and the Phalanx CLI will silently cope.
-    result = runner.invoke(
-        main,
-        ["secrets", "sync", "--delete", "idfdev"],
-        catch_exceptions=False,
-    )
+    result = run_cli("secrets", "sync", "--delete", "idfdev")
     assert result.exit_code == 0
     assert result.output == read_output_data("idfdev", "sync-delete-output")
     after = _get_app_secret(mock_vault, f"{base_vault_path}/gafaelfawr")
@@ -159,18 +141,13 @@ def test_sync_regenerate(
     _, base_vault_path = environment.vault_path_prefix.split("/", 1)
     before = _get_app_secret(mock_vault, f"{base_vault_path}/gafaelfawr")
 
-    runner = CliRunner()
-    result = runner.invoke(
-        main,
-        [
-            "secrets",
-            "sync",
-            "--secrets",
-            str(secrets_path),
-            "--regenerate",
-            "idfdev",
-        ],
-        catch_exceptions=False,
+    result = run_cli(
+        "secrets",
+        "sync",
+        "--secrets",
+        str(secrets_path),
+        "--regenerate",
+        "idfdev",
     )
     assert result.exit_code == 0
     expected = read_output_data("idfdev", "sync-regenerate-output")
@@ -213,12 +190,7 @@ def test_vault_secrets(
     environment = config_storage.load_environment("idfdev")
     mock_vault.load_test_data(environment.vault_path_prefix, "idfdev")
 
-    runner = CliRunner()
-    result = runner.invoke(
-        main,
-        ["secrets", "vault-secrets", "idfdev", str(tmp_path)],
-        catch_exceptions=False,
-    )
+    result = run_cli("secrets", "vault-secrets", "idfdev", str(tmp_path))
     assert result.exit_code == 0
     assert result.output == ""
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-import os
 from collections.abc import Iterator
-from pathlib import Path
 
 import jinja2
 import pytest
@@ -16,13 +14,9 @@ from .support.vault import MockVaultClient, patch_vault
 
 
 @pytest.fixture
-def factory() -> Iterator[Factory]:
-    """Change directories to the test data directory and return a factory."""
-    input_path = phalanx_test_path()
-    cwd = Path.cwd()
-    os.chdir(str(input_path))
-    yield Factory()
-    os.chdir(str(cwd))
+def factory() -> Factory:
+    """Create a factory pointing at the test data."""
+    return Factory(phalanx_test_path())
 
 
 @pytest.fixture

--- a/tests/support/cli.py
+++ b/tests/support/cli.py
@@ -1,0 +1,31 @@
+"""Helper functions for running command-line tests."""
+
+from __future__ import annotations
+
+from click.testing import CliRunner, Result
+
+from phalanx.cli import main
+
+from .data import phalanx_test_path
+
+__all__ = ["run_cli"]
+
+
+def run_cli(*command: str, needs_config: bool = True) -> Result:
+    """Run the given command in the Click testing harness.
+
+    The command will always be run with exception catching disabled.
+
+    Parameters
+    ----------
+    *command
+        Command to run.
+    needs_config
+        Whether to add the ``--config`` flag pointing to the test data to the
+        end of the command.
+    """
+    args = list(command)
+    if needs_config:
+        args.extend(["--config", str(phalanx_test_path())])
+    runner = CliRunner()
+    return runner.invoke(main, args, catch_exceptions=False)


### PR DESCRIPTION
Add a flag to every phalanx CLI command that uses the Phalanx configuration specifying its location, and default to searching upwards from the current directory to find the top of the configuration tree (by looking for the applications and environments directories).

Add a wrapper function around Click command-line testing for the test suite that adds the path to the test configuration directory and flips the default for catching exceptions to False.