### PR TITLE
DM-40343: Only process specific directories with helm-docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,10 +27,16 @@ repos:
     hooks:
       - id: helm-docs
         args:
-          - --chart-search-root=.
-          # The `./` makes it relative to the chart-search-root set above
-          - --template-files=./helm-docs.md.gotmpl
+          - --chart-search-root=environments
+          - --chart-search-root=applications
+          # The `../` makes it relative to the chart-search-root set above
+          - --template-files=../helm-docs.md.gotmpl
           - --document-dependency-values=true
+      - id: helm-docs
+        args:
+          - --chart-search-root=environments
+          # The `../` makes it relative to the chart-search-root set above
+          - --template-files=../helm-docs.md.gotmpl
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.0.280


### PR DESCRIPTION
Change the helm-docs pre-commit hook to only process the environments nad applications directories. This avoids generating unwanted README.md files in other directories that look like they may contain a Helm chart, such as input data for the test suite.