### PR TITLE
turn on LE for rw endpoint

### DIFF
--- a/applications/giftless/templates/ingress.yaml
+++ b/applications/giftless/templates/ingress.yaml
@@ -56,7 +56,7 @@ template:
     tls:
       - hosts:
         - {{ .Values.ingress.hostname.readwrite | quote }}
-        secretName: tls
+        secretName: tls-rw
     rules:
       - host: {{ .Values.ingress.hostname.readwrite | quote }}
         http:


### PR DESCRIPTION
Turns out we can't share the secret between the two ingresses.