### PR TITLE
Give admins admin:jupyterhub scope

### DIFF
--- a/applications/gafaelfawr/values-idfint.yaml
+++ b/applications/gafaelfawr/values-idfint.yaml
@@ -40,6 +40,8 @@ config:
 
   # Allow access by GitHub team.
   groupMapping:
+    "admin:jupyterlab":
+      - "g_admins"
     "admin:provision":
       - "g_admins"
     "exec:admin":

--- a/applications/gafaelfawr/values-idfprod.yaml
+++ b/applications/gafaelfawr/values-idfprod.yaml
@@ -34,6 +34,8 @@ config:
         memory: 16
 
   groupMapping:
+    "admin:jupyterlab":
+      - "g_admins"
     "admin:provision":
       - "g_admins"
     "exec:admin":


### PR DESCRIPTION
On IDF int and IDF prod, give admins admin:jupyterhub scope so that they can ask the Nublado lab controller about the status of labs.