### PR TITLE
DM-40343: Add API and schema documentation

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,3 +1,4 @@
 /_build
 /_static/*.png
+/internals/api/
 .venv

--- a/docs/_templates/autosummary_core/exception.rst
+++ b/docs/_templates/autosummary_core/exception.rst
@@ -1,0 +1,15 @@
+{% if referencefile %}
+.. include:: {{ referencefile }}
+{% endif %}
+
+{{ objname }}
+{{ underline }}
+
+.. currentmodule:: {{ module }}
+
+.. autoexception:: {{ objname }}
+   :members:
+   :show-inheritance:
+   {% if noindex -%}
+   :noindex:
+   {%- endif %}

--- a/docs/_templates/autosummary_core/pydantic_model.rst
+++ b/docs/_templates/autosummary_core/pydantic_model.rst
@@ -1,0 +1,11 @@
+{% if referencefile %}
+.. include:: {{ referencefile }}
+{% endif %}
+
+{{ objname }}
+{{ underline }}
+
+.. currentmodule:: {{ module }}
+
+.. auto{{ objtype }}:: {{ objname }}
+   :inherited-members: BaseModel

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,6 +11,7 @@ from phalanx.docs.jinja import build_jinja_contexts
 
 exclude_patterns.extend(
     [
+        "_templates/**",
         "environments/_summary.rst.jinja",
         "applications/_summary.rst.jinja",
     ]

--- a/docs/documenteer.toml
+++ b/docs/documenteer.toml
@@ -7,13 +7,39 @@ github_default_branch = "main"
 version = "Current"
 
 [sphinx]
-rst_epilog_file = "_rst_epilog.rst"
+disable_primary_sidebars = [
+  "internals/api",
+]
 extensions = [
   "sphinx_click",
   "sphinx_diagrams",
   "sphinx_jinja",
+  "sphinxcontrib.autodoc_pydantic",
   "phalanx.docs.crossref",
 ]
+nitpicky = true
+nitpick_ignore = [
+    # Ignore missing cross-references for modules that don't provide
+    # intersphinx.  The documentation itself should use double-quotes instead
+    # of single-quotes to not generate a reference, but automatic references
+    # are generated from the type signatures and can't be avoided.  These are
+    # intentionally listed specifically because I've caught documentation bugs
+    # by having Sphinx complain about a new symbol.
+    ["py:class", "pydantic.main.BaseModel"],
+    ["py:class", "pydantic.types.SecretStr"],
+    ["py:class", "pydantic.utils.Representation"],
+]
+nitpick_ignore_regex = [
+    # Bug in Sphinx
+    ["py:obj", "SecretGenerateType\\..*"],
+]
+python_api_dir = "internals/api"
+rst_epilog_file = "_rst_epilog.rst"
+
+[sphinx.intersphinx.projects]
+python = "https://docs.python.org/3/"
+safir = "https://safir.lsst.io/"
+sphinx = "https://www.sphinx-doc.org/en/master/"
 
 [sphinx.linkcheck]
 ignore = [

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,6 +22,7 @@ Phalanx is on GitHub at https://github.com/lsst-sqre/phalanx.
    admin/index
    applications/index
    environments/index
+   internals/index
 
 .. grid:: 3
 

--- a/docs/internals/api.rst
+++ b/docs/internals/api.rst
@@ -1,0 +1,56 @@
+####################
+Phalanx internal API
+####################
+
+These pages document the Phalanx internal API, which may be of interest when extending the Phalanx command-line tool or documentation build infrastructure.
+
+Phalanx does not provide a library or Python module for external use.
+This API is only intended for use within the Phalanx code itself.
+
+.. automodapi:: phalanx
+   :include-all-objects:
+
+.. automodapi:: phalanx.constants
+   :include-all-objects:
+
+.. automodapi:: phalanx.docs.crossref
+   :include-all-objects:
+
+.. automodapi:: phalanx.docs.jinja
+   :include-all-objects:
+
+.. automodapi:: phalanx.exceptions
+   :include-all-objects:
+
+.. automodapi:: phalanx.factory
+   :include-all-objects:
+
+.. automodapi:: phalanx.models.applications
+   :include-all-objects:
+
+.. automodapi:: phalanx.models.environments
+   :include-all-objects:
+
+.. automodapi:: phalanx.models.gafaelfawr
+   :include-all-objects:
+
+.. automodapi:: phalanx.models.secrets
+   :include-all-objects:
+
+.. automodapi:: phalanx.models.vault
+   :include-all-objects:
+
+.. automodapi:: phalanx.services.secrets
+   :include-all-objects:
+
+.. automodapi:: phalanx.services.vault
+   :include-all-objects:
+
+.. automodapi:: phalanx.storage.config
+   :include-all-objects:
+
+.. automodapi:: phalanx.storage.vault
+   :include-all-objects:
+
+.. automodapi:: phalanx.yaml
+   :include-all-objects:

--- a/docs/internals/index.rst
+++ b/docs/internals/index.rst
@@ -1,0 +1,12 @@
+#########
+Internals
+#########
+
+This documentation of the internal implementation details of Phalanx is intended primarily for people doing development on the Phalanx infrastructure itself, as opposed to a Phalanx :doc:`application </developers/index>` or :doc:`environment </admin/index>`.
+Most users of Phalanx and administrators of Phalanx environments do not need to know this information.
+
+.. toctree::
+   :caption: Reference
+
+   json-schema
+   api

--- a/docs/internals/json-schema.rst
+++ b/docs/internals/json-schema.rst
@@ -1,0 +1,20 @@
+###########
+JSON schema
+###########
+
+Some of the YAML configuration files used by Phalanx have published JSON schemas, generated from their Pydantic_ models.
+
+.. _Pydantic: https://docs.pydantic.dev/latest/
+
+These schemas are used by the check-jsonschema_ pre-commit hook to validate changes to those files before commit.
+If the underlying model changes, the schema will be detected as out-of-date by the Phalanx test suite.
+A schema for the current model can be generated with the appropriate Phalanx command-line invocation, as documented below.
+
+.. _check-jsonschema: https://check-jsonschema.readthedocs.io/en/latest/
+
+.. list-table::
+
+   * - Schema
+     - Command
+   * - `secrets.yaml files </schemas/secrets.json>`__
+     - :command:`phalanx secrets schema`

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -17,6 +17,7 @@ ruff
 types-PyYAML
 
 # Documentation
+autodoc_pydantic
 documenteer[guide]>=0.7.0,<1
 pydantic<2
 sphinx-click

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,6 +8,10 @@ alabaster==0.7.13 \
     --hash=sha256:1ee19aca801bbabb5ba3f5f258e4422dfa86f82f3e9cefb0859b283cdd7f62a3 \
     --hash=sha256:a27a4a084d5e690e16e01e03ad2b2e552c61a65469419b907243193de1a84ae2
     # via sphinx
+autodoc-pydantic==1.9.0 \
+    --hash=sha256:0f35f8051abe77b5ae16d8a1084c47a5871435e2ca9060e36c838d063c03cc89 \
+    --hash=sha256:cbf7ec2f27f913629bd38f9944fa6c4a86541c3cadba4a6fa9d2079e500223d8
+    # via -r requirements/dev.in
 babel==2.12.1 \
     --hash=sha256:b4246fb7677d3b98f501a39d43396d3cafdc8eadb045f4a31be01863f655c610 \
     --hash=sha256:cc2d99999cd01d44420ae725a21c9e3711b3aadc7976d6147f622d8581963455
@@ -707,6 +711,7 @@ pydantic==1.10.12 \
     # via
     #   -c requirements/main.txt
     #   -r requirements/dev.in
+    #   autodoc-pydantic
     #   documenteer
 pydata-sphinx-theme==0.12.0 \
     --hash=sha256:7a07c3ac1fb1cfbb5f7d1e147a9500fb120e329d610e0fa2caac4a645141bdd9 \
@@ -835,6 +840,7 @@ sphinx==6.2.1 \
     --hash=sha256:6d56a34697bb749ffa0152feafc4b19836c755d90a7c59b72bc7dfd371b9cc6b \
     --hash=sha256:97787ff1fa3256a3eef9eda523a63dbf299f7b47e053cfcf684a1c2a8380c912
     # via
+    #   autodoc-pydantic
     #   documenteer
     #   myst-parser
     #   pydata-sphinx-theme

--- a/src/phalanx/models/secrets.py
+++ b/src/phalanx/models/secrets.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel, Extra, Field, SecretStr, validator
 
 from .gafaelfawr import Token
 
+# Including StaticSecrets in __all__ triggers a Sphinx automodsumm bug.
 __all__ = [
     "ConditionalMixin",
     "ConditionalSecretConfig",
@@ -32,7 +33,6 @@ __all__ = [
     "SimpleSecretGenerateRules",
     "SourceSecretGenerateRules",
     "StaticSecret",
-    "StaticSecrets",
 ]
 
 

--- a/src/phalanx/storage/vault.py
+++ b/src/phalanx/storage/vault.py
@@ -148,7 +148,7 @@ class VaultClient:
 
         Returns
         -------
-        dict of pydantic.SecretStr
+        dict of pydantic.types.SecretStr
             Mapping from secret key to its secret from Vault.
 
         Raises

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,10 @@ deps =
 
 [testenv:docs]
 description = Build documentation (HTML) with Sphinx.
+allowlist_externals =
+    rm
 commands =
+    rm -rf docs/internals/api/
     sphinx-build --keep-going -n -W -T -b html -d {envtmpdir}/doctrees docs docs/_build/html
 
 [testenv:docs-linkcheck]


### PR DESCRIPTION
Add an internals page that is available only via the top bar from the pull-down menu, since most people will never need to see it. Document the JSON schemas there (currently only one for secrets.yaml but more will come later) and add internal API documentation.

This is of arguable usefulness, but sometimes it can be nice to browse the API documentation when working on new code, and it has the nice benefit of checking all of the docstrings more thoroughly than a linter does.