### PR TITLE
DM-40448: Fix blank line in telegraf-ds configuration

### DIFF
--- a/applications/telegraf-ds/templates/configmap.yaml
+++ b/applications/telegraf-ds/templates/configmap.yaml
@@ -29,10 +29,11 @@ data:
         resource_include = [ "pods" ]
         insecure_skip_verify = true
         namespace = ""
-  {{ range $app := splitList "@" .Values.global.enabledServices }}
+  {{- range $app := splitList "@" .Values.global.enabledServices }}
     {{- if $app }}
       {{- $bucket := replace "-" "_" $app }}
       {{- $namespace := replace "_" "-" $app }}
+
       [[outputs.influxdb_v2]]
         urls = ["https://monitoring.lsst.codes"]
         token = "$INFLUX_TOKEN"


### PR DESCRIPTION
The changes to adjust for the new format of the enabled applications field omitted blank lines between output definitions. Add that blank line back in.