### PR TITLE
DM-40448: Add schema checking for environments

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,9 @@ repos:
       - id: check-jsonschema
         files: "^applications/.*/secrets(-[^./-]+)?\\.yaml"
         args: ["--schemafile", "docs/extras/schemas/secrets.json"]
+      - id: check-jsonschema
+        files: "^environments/values(-[^./-]+)?\\.yaml"
+        args: ["--schemafile", "docs/extras/schemas/environment.json"]
       - id: check-metaschema
         files: "^docs/extras/schemas/.*\\.json"
 

--- a/docs/extras/schemas/environment.json
+++ b/docs/extras/schemas/environment.json
@@ -1,0 +1,55 @@
+{
+  "title": "EnvironmentConfig",
+  "description": "Configuration for a Phalanx environment.\n\nThis is a model for the :file:`values-{environment}.yaml` files for each\nenvironment and is also used to validate those files. For the complete\nconfiguration for an environment, initialize this model with the merger of\n:file:`values.yaml` and :file:`values-{environment}.yaml`.",
+  "type": "object",
+  "properties": {
+    "name": {
+      "title": "Name",
+      "type": "string"
+    },
+    "fqdn": {
+      "title": "Fqdn",
+      "type": "string"
+    },
+    "vaultUrl": {
+      "title": "Vaulturl",
+      "type": "string"
+    },
+    "vaultPathPrefix": {
+      "title": "Vaultpathprefix",
+      "type": "string"
+    },
+    "applications": {
+      "title": "Applications",
+      "type": "object",
+      "additionalProperties": {
+        "type": "boolean"
+      }
+    },
+    "butlerRepositoryIndex": {
+      "title": "Butlerrepositoryindex",
+      "type": "string"
+    },
+    "onepasswordUuid": {
+      "title": "Onepassworduuid",
+      "type": "string"
+    },
+    "repoUrl": {
+      "title": "Repourl",
+      "type": "string"
+    },
+    "targetRevision": {
+      "title": "Targetrevision",
+      "type": "string"
+    }
+  },
+  "required": [
+    "name",
+    "fqdn",
+    "vaultUrl",
+    "vaultPathPrefix",
+    "applications"
+  ],
+  "additionalProperties": false,
+  "$id": "https://phalanx.lsst.io/schemas/environment.json"
+}

--- a/docs/internals/json-schema.rst
+++ b/docs/internals/json-schema.rst
@@ -16,5 +16,7 @@ A schema for the current model can be generated with the appropriate Phalanx com
 
    * - Schema
      - Command
+   * - `environment values files </schemas/environment.json>`__
+     - :command:`phalanx environment schema`
    * - `secrets.yaml files </schemas/secrets.json>`__
      - :command:`phalanx secrets schema`

--- a/src/phalanx/cli.py
+++ b/src/phalanx/cli.py
@@ -13,15 +13,22 @@ from pydantic.tools import schema_of
 
 from .constants import VAULT_WRITE_TOKEN_LIFETIME
 from .factory import Factory
+from .models.environments import EnvironmentConfig
 from .models.secrets import ConditionalSecretConfig, StaticSecret
 
 __all__ = [
     "help",
+    "main",
+    "environment",
+    "environment_schema",
+    "secrets",
     "secrets_audit",
     "secrets_list",
     "secrets_schema",
     "secrets_static_template",
     "secrets_vault_secrets",
+    "vault",
+    "vault_audit",
     "vault_create_read_approle",
     "vault_create_write_token",
 ]
@@ -124,6 +131,37 @@ def help(ctx: click.Context, topic: str | None, subtopic: str | None) -> None:
     # Fall through to the error case of no subcommand found.
     msg = f"Unknown help topic {topic} {subtopic}"
     raise click.UsageError(msg, ctx)
+
+
+@main.group()
+def environment() -> None:
+    """Commands for Phalanx environment configuration."""
+
+
+@environment.command("schema")
+@click.option(
+    "-o",
+    "--output",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Path to which to write schema.",
+)
+def environment_schema(*, output: Path | None) -> None:
+    """Generate schema for environment configuration.
+
+    The output is a JSON schema for the values-<environment>.yaml file for a
+    Phalanx environment. If the ``--output`` flag is not given, the schema is
+    printed to standard output.
+
+    Users normally don't need to run this command. It is used to update the
+    schema file in the Phalanx repository, which is used by a pre-commit hook
+    to validate environment configuration files before committing them.
+    """
+    json_schema = EnvironmentConfig.schema_json(indent=2)
+    if output:
+        output.write_text(json_schema)
+    else:
+        sys.stdout.write(json_schema)
 
 
 @main.group()

--- a/src/phalanx/models/environments.py
+++ b/src/phalanx/models/environments.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 from enum import Enum
+from typing import ClassVar
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Extra
 from safir.pydantic import CamelCaseModel
 
 from .applications import Application, ApplicationInstance
@@ -30,10 +31,10 @@ class EnvironmentBaseConfig(CamelCaseModel):
     """Name of the environment."""
 
     fqdn: str
-    """Fully-qualified domain name of the environment."""
+    """Fully-qualified domain name."""
 
     vault_url: str
-    """URL of Vault server for this environment."""
+    """URL of Vault server."""
 
     vault_path_prefix: str
     """Prefix of Vault paths, including the Kv2 mount point."""
@@ -87,6 +88,40 @@ class EnvironmentConfig(EnvironmentBaseConfig):
 
     applications: dict[str, bool]
     """List of applications and whether they are enabled."""
+
+    butler_repository_index: str | None = None
+    """URL to Butler repository index."""
+
+    onepassword_uuid: str | None = None
+    """UUID of 1Password item in which to find Vault tokens.
+
+    This is used only by the old installer and will be removed once the new
+    secrets management and 1Password integration is deployed everywhere.
+    """
+
+    repo_url: str | None = None
+    """URL of the Git repository holding Argo CD configuration.
+
+    This is required in the merged values file that includes environment
+    overrides, but the environment override file doesn't need to set it, so
+    it's marked as optional for schema checking purposes to allow the override
+    file to be schema-checked independently.
+    """
+
+    target_revision: str | None = None
+    """Branch of the Git repository holding Argo CD configuration.
+
+    This is required in the merged values file that includes environment
+    overrides, but the environment override file doesn't need to set it, so
+    it's marked as optional for schema checking purposes to allow the override
+    file to be schema-checked independently.
+    """
+
+    class Config:
+        extra = Extra.forbid
+        schema_extra: ClassVar[dict[str, str]] = {
+            "$id": "https://phalanx.lsst.io/schemas/environment.json"
+        }
 
     @property
     def enabled_applications(self) -> list[str]:

--- a/tests/cli/environment_test.py
+++ b/tests/cli/environment_test.py
@@ -1,0 +1,20 @@
+"""Tests for the environment command-line subcommand."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..support.cli import run_cli
+
+
+def test_schema() -> None:
+    result = run_cli("environment", "schema", needs_config=False)
+    assert result.exit_code == 0
+    current = (
+        Path(__file__).parent.parent.parent
+        / "docs"
+        / "extras"
+        / "schemas"
+        / "environment.json"
+    )
+    assert result.output == current.read_text()

--- a/tests/docs/parse_test.py
+++ b/tests/docs/parse_test.py
@@ -1,0 +1,18 @@
+"""Tests ensuring that the Phalanx configuration can be parsed."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from phalanx.docs.jinja import build_jinja_contexts
+
+
+def test_parse() -> None:
+    """Ensure the Phalanx configuration can be parsed into doc models."""
+    cwd = Path.cwd()
+    os.chdir(str(Path(__file__).parent.parent.parent / "docs"))
+    try:
+        build_jinja_contexts()
+    finally:
+        os.chdir(str(cwd))


### PR DESCRIPTION
Now that we can fully model the schema for the values files for environments, add a command to generate that schema, store the current version in the schema directory, and enable schema checking for those files.

Add a Python test that parses the full Phalanx configuration as if we were about to generate documentation. This is redundant with actually generating documentation, but the Python test suite is much faster to run, so this catches problems earlier when iterating.