### PR TITLE
DM-40495: Remove link to IDF prod cachemachine setup

### DIFF
--- a/docs/applications/cachemachine/bootstrap.rst
+++ b/docs/applications/cachemachine/bootstrap.rst
@@ -9,7 +9,6 @@ As part of bootstrapping a new environment, you will want to configure it to pre
 
 For deployments on Google Kubernetes Engine, you will want to use Google Artifact Repository (GAR) as the source of images.
 See :doc:`gar` for basic information and instructions on how to configure workload identity.
-A good starting point for the cachemachine configuration is the `configuration from the IDF environment <https://github.com/lsst-sqre/phalanx/blob/main/applications/cachemachine/values-idfprod.yaml>`__, which sets up GAR as the image source and prepulls a reasonable number of images.
 
 For Telescope and Site deployments that need special images and image cycle configuration, start from the `summit configuration <https://github.com/lsst-sqre/phalanx/blob/main/applications/cachemachine/values-summit.yaml>`__.
 Consult with Telescope and Site to determine the correct recommended tag and cycle number.


### PR DESCRIPTION
The cachemachine documentation included a link to the IDF prod cachemachine configuration, but we no longer use cachemachine on IDF prod. Remove that sentence.