### PR TITLE
DM-40495: Show a summary of errors from linkcheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ help:
 	@echo "Make targets for Phalanx:"
 	@echo "make clean - Remove generated files"
 	@echo "make init - Set up dev environment (install pre-commit hooks)"
+	@echo "make linkcheck - Check for broken links in documentation"
 	@echo "make update - Update pinned dependencies and run make init"
 	@echo "make update-deps - Update pinned dependencies"
 
@@ -18,6 +19,16 @@ init:
 	rm -rf .tox
 	pip install --upgrade pre-commit tox
 	pre-commit install
+
+# This is defined as a Makefile target instead of only a tox command because
+# if the command fails we want to cat output.txt, which contains the
+# actually useful linkcheck output. tox unfortunately doesn't support this
+# level of shell trickery after failed commands.
+.PHONY: linkcheck
+linkcheck:
+	sphinx-build --keep-going -n -W -T -b linkcheck docs	\
+	    docs/_build/linkcheck				\
+	    || (cat docs/_build/linkcheck/output.txt; exit 1)
 
 .PHONY: update
 update: update-deps init

--- a/tox.ini
+++ b/tox.ini
@@ -18,8 +18,10 @@ commands =
 
 [testenv:docs-linkcheck]
 description = Check links in the documentation.
+allowlist_externals =
+    make
 commands =
-    sphinx-build --keep-going -n -W -T -b linkcheck -d {envtmpdir}/doctrees docs docs/_build/linkcheck
+    make linkcheck
 
 [testenv:coverage-report]
 description = Compile coverage from each test run.


### PR DESCRIPTION
Sphinx's linkcheck command doesn't summarize errors on failure, but it does write them to a file named output.txt. Move link checking into a Makefile target so that we can use shell trickery to display those errors if link checking fails.