### PR TITLE
Update the Vault URL for the roe environment

### DIFF
--- a/environments/values-roe.yaml
+++ b/environments/values-roe.yaml
@@ -1,6 +1,6 @@
 name: roe
 fqdn: rsp.lsst.ac.uk
-vaultUrl: "https://vault.lsst.codes"
+vaultUrl: "https://vault.lsst.ac.uk"
 vaultPathPrefix: secret/k8s_operator/roe
 
 applications:


### PR DESCRIPTION
Move from "https://vault.lsst.codes" to locally (UK) managed one: "https://vault.lsst.ac.uk"
