### PR TITLE
DM-40537: Support disabling Gafaelfawr

### DIFF
--- a/src/phalanx/models/environments.py
+++ b/src/phalanx/models/environments.py
@@ -156,6 +156,7 @@ class IdentityProvider(Enum):
     CILOGON = "CILogon"
     GITHUB = "GitHub"
     OIDC = "OpenID Connect"
+    NONE = "None"
 
 
 class GafaelfawrGitHubTeam(BaseModel):

--- a/tests/data/input/applications/argocd/values-usdfdev-prompt-processing.yaml
+++ b/tests/data/input/applications/argocd/values-usdfdev-prompt-processing.yaml
@@ -1,0 +1,78 @@
+argo-cd:
+  configs:
+
+    params:
+      # -- Base href for `index.html` when running under a reverse proxy
+      server.basehref: "/"
+
+  server:
+    ingress:
+      enabled: true
+      hosts:
+        - "k8s.slac.stanford.edu"
+      annotations:
+        nginx.ingress.kubernetes.io/rewrite-target: "/$2"
+      paths:
+        - /usdf-prompt-processing-dev/argo-cd(/|$)(.*)
+    extraArgs:
+      - "--basehref=/usdf-prompt-processing-dev/argo-cd"
+      - "--insecure=true"
+
+    env:
+      - name: HTTP_PROXY
+        value: http://squid.slac.stanford.edu:3128
+      - name: HTTPS_PROXY
+        value: http://squid.slac.stanford.edu:3128
+      - name: NO_PROXY
+        value: 127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.cluster.local,argocd-repo-server
+
+    config:
+      url: "https://k8s.slac.stanford.edu/usdf-prompt-processing-dev/argo-cd"
+      oidc.config: |
+        name: SLAC
+        issuer: https://dex.slac.stanford.edu
+        clientID: $oidc.clientId
+        clientSecret: $oidc.clientSecret
+        # Optional set of OIDC scopes to request. If omitted, defaults to: ["openid", "profile", "email", "groups"]
+        requestedScopes: ["openid", "profile", "email", "groups"]
+        # Optional set of OIDC claims to request on the ID token.
+        requestedIDTokenClaims: {"groups": {"essential": true}}
+    rbacConfig:
+      policy.csv: |
+        g, ytl@slac.stanford.edu, role:admin
+        g, ppascual@slac.stanford.edu, role:admin
+        g, pav@slac.stanford.edu, role:admin
+        g, reinking@slac.stanford.edu, role:admin
+        g, dspeck@slac.stanford.edu, role:admin
+      scopes: "[email]"
+
+    helm.repositories: |
+      - url: https://lsst-sqre.github.io/charts/
+        name: lsst-sqre
+      - url: https://charts.helm.sh/stable
+        name: stable
+    repoServer:
+
+  env:
+    - name: HTTP_PROXY
+      value: http://sdfproxy.sdf.slac.stanford.edu:3128
+    - name: HTTPS_PROXY
+      value: http://sdfproxy.sdf.slac.stanford.edu:3128
+    - name: NO_PROXY
+      value: 127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.cluster.local,argocd-repo-server
+
+controller:
+
+  env:
+    - name: HTTP_PROXY
+      value: http://sdfproxy.sdf.slac.stanford.edu:3128
+    - name: HTTPS_PROXY
+      value: http://sdfproxy.sdf.slac.stanford.edu:3128
+    - name: NO_PROXY
+      value: 127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.cluster.local,argocd-repo-server
+
+  configs:
+    secret:
+      createSecret: false
+
+vaultSecretsPath: "secret/rubin/usdf-prompt-processing-dev/"

--- a/tests/data/input/environments/values-usdfdev-prompt-processing.yaml
+++ b/tests/data/input/environments/values-usdfdev-prompt-processing.yaml
@@ -1,0 +1,9 @@
+name: usdfdev-prompt-processing
+fqdn: usdf-prompt-processing-dev.slac.stanford.edu
+vaultUrl: "https://vault.slac.stanford.edu"
+vaultPathPrefix: secret/rubin/usdf-prompt-processing-dev
+
+applications:
+  cert-manager: false
+  gafaelfawr: false
+  ingress-nginx: false


### PR DESCRIPTION
When generating the documentation, support environments that have Gafaelfawr disabled. We may have Phalanx environments that only run backend processes without any user interface, in which case Gafaelfawr is unnecessary.