### PR TITLE
Remove quotes from write:sasquatch description

### DIFF
--- a/applications/gafaelfawr/values.yaml
+++ b/applications/gafaelfawr/values.yaml
@@ -271,7 +271,7 @@ config:
     "read:tap": >-
       Execute SELECT queries in the TAP interface on project datasets
     "write:sasquatch": >-
-      "Write access to the Sasquatch telemetry service"
+      Write access to the Sasquatch telemetry service
     "user:token": >-
       Can create and modify user tokens
 


### PR DESCRIPTION
The scope description for write:sasquatch had spurious additional quotes because it was quoted two ways in YAML. Remove the surrounding double quotes.