### PR TITLE
Improve monitoring docs page

### DIFF
--- a/docs/applications/giftless/index.rst
+++ b/docs/applications/giftless/index.rst
@@ -1,7 +1,7 @@
 .. px-app:: giftless
 
 #########################
-Giftless — Git LFS server
+giftless — Git LFS server
 #########################
 
 Giftless, a Git LFS server provided by Datopian, is the Rubin Observatory provider of Git LFS services.

--- a/docs/applications/monitoring/index.rst
+++ b/docs/applications/monitoring/index.rst
@@ -1,11 +1,11 @@
 .. px-app:: monitoring
 
-########################
-Monitoring Chronograf UI
-########################
+#####################################
+monitoring — Chronograf monitoring UI
+#####################################
 
-Monitoring is an implementation of the Chronograf UI for monitoring the
-health and resource usage of Phalanx applications.
+Monitoring is an implementation of the Chronograf UI for monitoring the health and resource usage of Phalanx applications.
+It runs on the Roundtable environment and provides access to the data sent by the :px-app:`telegraf` and :px-app:`telegraf-ds` applications running in individual RSP instances.
 
 .. jinja:: monitoring
    :file: applications/_summary.rst.jinja


### PR DESCRIPTION
Fix the title of the monitoring application documentation page and add some additional explanation of what it does. Include links to the telegraf and telegraf-ds applications.