### PR TITLE
DM-40502: Add onepassword-connect-dev application

### DIFF
--- a/applications/onepassword-connect-dev/.helmignore
+++ b/applications/onepassword-connect-dev/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/applications/onepassword-connect-dev/Chart.yaml
+++ b/applications/onepassword-connect-dev/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+description: 1Password API server (dev)
+name: onepassword-connect-dev
+type: application
+version: 1.0.0
+
+dependencies:
+  - name: connect
+    version: 1.14.0
+    repository: https://1password.github.io/connect-helm-charts/
+    alias: idfdev
+
+annotations:
+  phalanx.lsst.io/docs: |
+    - id: "SQR-079"
+      title: "Secrets management for Phalanx"
+      url: "https://sqr-079.lsst.io/"

--- a/applications/onepassword-connect-dev/README.md
+++ b/applications/onepassword-connect-dev/README.md
@@ -1,0 +1,15 @@
+# onepassword-connect-dev
+
+1Password API server (dev)
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
+| global.host | string | Set by Argo CD | Host name for ingress |
+| global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
+| idfdev.connect.applicationName | string | `"connect-idfdev"` | Name of the Kubernetes Deployment |
+| idfdev.connect.credentialsKey | string | `"op-session"` | Name of key inside secret containing 1Password credentials |
+| idfdev.connect.credentialsName | string | `"idfdev-secret"` | Name of secret containing the 1Password credentials |
+| idfdev.connect.serviceType | string | `"ClusterIP"` | Type of service to create |

--- a/applications/onepassword-connect-dev/secrets.yaml
+++ b/applications/onepassword-connect-dev/secrets.yaml
@@ -1,0 +1,5 @@
+idfdev:
+  description: >-
+    Credentials used by the 1Password Connect API server to access the vault
+    for the IDF dev (data-dev.lsst.cloud) environment. This secret can be
+    changed at any time.

--- a/applications/onepassword-connect-dev/templates/_helpers.tpl
+++ b/applications/onepassword-connect-dev/templates/_helpers.tpl
@@ -1,0 +1,26 @@
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "onepassword-connect-dev.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "onepassword-connect-dev.labels" -}}
+helm.sh/chart: {{ include "onepassword-connect-dev.chart" . }}
+{{ include "onepassword-connect-dev.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "onepassword-connect-dev.selectorLabels" -}}
+app.kubernetes.io/name: "onepassword-connect-dev"
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/applications/onepassword-connect-dev/templates/idfdev-ingress.yaml
+++ b/applications/onepassword-connect-dev/templates/idfdev-ingress.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Values.idfdev.connect.applicationName | quote }}
+  labels:
+    {{- include "onepassword-connect-dev.labels" . | nindent 4 }}
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: "/$1"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/use-regex: "true"
+spec:
+  ingressClassName: "nginx"
+  rules:
+    - host: {{ required "global.host must be set" .Values.global.host | quote }}
+      http:
+        paths:
+          - path: "/1password/idfdev/(.*)"
+            pathType: "ImplementationSpecific"
+            backend:
+              service:
+                name: {{ .Values.idfdev.connect.applicationName | quote }}
+                port:
+                  name: "connect-api"

--- a/applications/onepassword-connect-dev/templates/idfdev-vault-secrets.yaml
+++ b/applications/onepassword-connect-dev/templates/idfdev-vault-secrets.yaml
@@ -1,0 +1,11 @@
+apiVersion: ricoberger.de/v1alpha1
+kind: VaultSecret
+metadata:
+  name: "idfdev-secret"
+  labels:
+    {{- include "onepassword-connect-dev.labels" . | nindent 4 }}
+spec:
+  path: "{{ .Values.global.vaultSecretsPath }}/onepassword-connect-dev"
+  type: "Opaque"
+  templates:
+    op-session: "{% .Secrets.idfdev %}"

--- a/applications/onepassword-connect-dev/values.yaml
+++ b/applications/onepassword-connect-dev/values.yaml
@@ -1,0 +1,32 @@
+# Default values for onepassword-connect-dev.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+idfdev:
+  connect:
+    # -- Name of the Kubernetes Deployment
+    applicationName: "connect-idfdev"
+
+    # -- Name of secret containing the 1Password credentials
+    credentialsName: "idfdev-secret"
+
+    # -- Name of key inside secret containing 1Password credentials
+    credentialsKey: "op-session"
+
+    # -- Type of service to create
+    serviceType: "ClusterIP"
+
+# The following will be set by parameters injected by Argo CD and should not
+# be set in the individual environment values files.
+global:
+  # -- Base URL for the environment
+  # @default -- Set by Argo CD
+  baseUrl: ""
+
+  # -- Host name for ingress
+  # @default -- Set by Argo CD
+  host: ""
+
+  # -- Base path for Vault secrets
+  # @default -- Set by Argo CD
+  vaultSecretsPath: ""

--- a/docs/applications/index.rst
+++ b/docs/applications/index.rst
@@ -68,6 +68,7 @@ To learn how to develop applications for Phalanx, see the :doc:`/developers/inde
    giftless/index
    kubernetes-replicator/index
    monitoring/index
+   onepassword-connect-dev/index
    ook/index
    squarebot/index
 

--- a/docs/applications/onepassword-connect-dev/index.rst
+++ b/docs/applications/onepassword-connect-dev/index.rst
@@ -1,0 +1,27 @@
+.. px-app:: onepassword-connect-dev
+
+####################################################
+onepassword-connect-dev - 1Password API server (dev)
+####################################################
+
+1Password Connect provides API access to a 1Password vault.
+It is used to provide the API for Phalanx integration with 1Password as a source of static secrets.
+
+Each instance of the upstream 1Password Connect chart provides an API server for a single 1Password vault.
+We want to use one vault per SQuaRE-managed Phalanx environment to ensure isolation of secrets between environments.
+The Phalanx onepassword-connect applications therefore instantiate the upstream chart multiple times, one for each vault we are providing access to.
+
+Unfortunately, because dependencies and their aliases can't be conditional on :file:`values.yaml` settings, that means the set of 1Password Connect servers deployed on roundtable-dev have to be a separate application from the ones deployed on roundtable.
+This application is the roundtable-dev set of 1Password Connect API servers.
+These provide access to the vaults for development and test environments.
+
+.. jinja:: onepassword-connect-dev
+   :file: applications/_summary.rst.jinja
+
+Guides
+======
+
+.. toctree::
+   :maxdepth: 1
+
+   values

--- a/docs/applications/onepassword-connect-dev/values.md
+++ b/docs/applications/onepassword-connect-dev/values.md
@@ -1,0 +1,12 @@
+```{px-app-values} onepassword-connect-dev
+```
+
+# onepassword-connect-dev Helm values reference
+
+Helm values reference table for the {px-app}`onepassword-connect-dev` application.
+
+```{include} ../../../applications/onepassword-connect-dev/README.md
+---
+start-after: "## Values"
+---
+```

--- a/environments/README.md
+++ b/environments/README.md
@@ -26,6 +26,7 @@
 | applications.nublado | bool | `false` | Enable the nublado application (v3 of the Notebook Aspect) |
 | applications.nublado2 | bool | `false` | Enable the nublado2 application (v2 of the Notebook Aspect, now deprecated). This should not be used for new environments. |
 | applications.obsloctap | bool | `false` | Enable the obsloctap application |
+| applications.onepassword-connect-dev | bool | `false` | Enable the onepassword-connect-dev application |
 | applications.ook | bool | `false` | Enable the ook application |
 | applications.plot-navigator | bool | `false` | Enable the plot-navigator application |
 | applications.portal | bool | `false` | Enable the portal application |

--- a/environments/templates/onepassword-connect-dev-application.yaml
+++ b/environments/templates/onepassword-connect-dev-application.yaml
@@ -1,0 +1,34 @@
+{{- if (index .Values "applications" "onepassword-connect-dev") -}}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "onepassword-connect-dev"
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: "onepassword-connect-dev"
+  namespace: "argocd"
+  finalizers:
+    - "resources-finalizer.argocd.argoproj.io"
+spec:
+  destination:
+    namespace: "onepassword-connect-dev"
+    server: "https://kubernetes.default.svc"
+  project: "default"
+  source:
+    path: "applications/onepassword-connect-dev"
+    repoURL: {{ .Values.repoUrl | quote }}
+    targetRevision: {{ .Values.targetRevision | quote }}
+    helm:
+      parameters:
+        - name: "global.host"
+          value: {{ .Values.fqdn | quote }}
+        - name: "global.baseUrl"
+          value: "https://{{ .Values.fqdn }}"
+        - name: "global.vaultSecretsPath"
+          value: {{ .Values.vaultPathPrefix | quote }}
+      valueFiles:
+        - "values.yaml"
+        - "values-{{ .Values.name }}.yaml"
+{{- end -}}

--- a/environments/values-roundtable-dev.yaml
+++ b/environments/values-roundtable-dev.yaml
@@ -7,6 +7,7 @@ applications:
   giftless: true
   kubernetes-replicator: true
   monitoring: true
+  onepassword-connect-dev: true
   ook: true
   sasquatch: true
   squarebot: true

--- a/environments/values.yaml
+++ b/environments/values.yaml
@@ -100,6 +100,9 @@ applications:
   # deprecated). This should not be used for new environments.
   nublado2: false
 
+  # -- Enable the onepassword-connect-dev application
+  onepassword-connect-dev: false
+
   # -- Enable the ook application
   ook: false
 


### PR DESCRIPTION
This application will create the 1Password Connect API servers for all development and test 1Password vaults for SQuaRE-run Phalanx environments.

Because we need to create a separate subchart per 1Password vault and dependencies with aliases can't be templated using values.yaml, unfortunately we'll need to create two Phalanx applications, one that collects the API servers for the development and test vaults and runs on roundtable-dev, and one that collects the API servers for the production vaults and runs on roundtable. This is the one for development and test servers, starting with just IDF dev.