### PR TITLE
DM-40501: Add 1Password support for static secrets

### DIFF
--- a/docs/developers/define-secrets.rst
+++ b/docs/developers/define-secrets.rst
@@ -158,8 +158,8 @@ See the `vault-secrets-operator documentation <https://github.com/ricoberger/vau
 
 .. _dev-add-onepassword:
 
-Create static secrets in 1Password
-==================================
+Create static secrets in 1Password (current)
+============================================
 
 .. note::
 
@@ -260,6 +260,60 @@ To sync multiple environments at once:
 .. code-block:: sh
 
    ./update_all_secrets.sh
+
+Create static secrets in 1Password (new)
+========================================
+
+.. note::
+
+   This section only applies to Phalanx environments run by SQuaRE that have been converted to the new 1Password setup that is currently under development.
+
+For SQuaRE-run Phalanx environments, static secrets for applications are stored in a 1Password vault before being automatically synced to the Vault service.
+Such secrets are things for external cloud services where we don't automatically provision accounts and password.
+When we manually create such a secret, we store it in 1Password.
+
+This step may have to be done for you by a Phalanx environment administrator depending on how permissions in Vault and any underlying secrets store are handled for your environment.
+
+.. note::
+
+   This document only covers creating a 1Password-backed secret for the first time for an application.
+   If you want to update a secret, either by adding new 1Password secrets or by changing their secret values, you should follow the instructions in :doc:`/developers/update-a-onepassword-secret`.
+
+.. warning::
+
+   This is the new process for storing secrets in 1Password that is currently under development.
+   Most environments should continue to use the instrutions in :ref:`dev-add-onepassword`.
+
+1. Open the 1Password vault
+---------------------------
+
+In one password, access the **LSST IT** 1Password team and open the vault for the environment to which you're adding a secret.
+If your application will be deployed in multiple environments, you will need to repeat this process for each environment.
+
+The name of the 1Password vault for a given environment is configured in the ``onepassword.vaultTitle`` key in the :file:`values-{environment}.yaml` file in :file:`environments` for that environment.
+
+2. Create the new item
+----------------------
+
+Each application should have one entry in the 1Password vault.
+Each field in that entry is one Phalanx secret for that application.
+The value of the field is the value of the secret.
+
+For a new application, create a new 1Password item of type :guilabel:`Server`.
+Delete all of the pre-defined fields.
+
+Then, create a field for each static secret for that application, and set the value to the value of that secret in that environemnt.
+The field names should match the secret keys for the application.
+Change the field type to password so that the value isn't displayed any time someone opens the 1Password entry.
+
+Do not use sections.
+Phalanx requires all of the secret entries be top-level fields outside of any section.
+
+3. Sync 1Password items into Vault
+----------------------------------
+
+To sync the new 1Password items into Vault, follow the instructions in :doc:`/admin/sync-secrets`.
+This must be done using a Phalanx configuration that includes your new application and the secret configuration for it that you created above.
 
 Next steps
 ==========

--- a/docs/developers/update-a-onepassword-secret.rst
+++ b/docs/developers/update-a-onepassword-secret.rst
@@ -19,6 +19,13 @@ So, if you want to make any changes to a ``VaultSecret``'s data, you'll need to:
 2. Run the `installer/update_secrets.sh <https://github.com/lsst-sqre/phalanx/blob/main/installer/update_secrets.sh>`__ script, as described in :ref:`dev-add-onepassword`.
 3. Wait a few minutes for automatic reconciliation
 
+.. note::
+
+   In the future, you will be able to run :command:`phalanx secrets sync` instead of :command:`installer/update_secrets.sh` to update the secrets in Vault.
+   This support is currently being developed.
+
+These steps may have to be done for you by a Phalanx environment administrator depending on how permissions in Vault and any underlying secrets store are handled for your environment.
+
 Forcing reconciliation
 ======================
 

--- a/docs/documenteer.toml
+++ b/docs/documenteer.toml
@@ -27,6 +27,7 @@ nitpick_ignore = [
     # whole undocumented package because I've caught documentation bugs by
     # having Sphinx complain about a new symbol.
     ["py:class", "pydantic.main.BaseModel"],
+    ["py:class", "pydantic.networks.AnyHttpUrl"],
     ["py:class", "pydantic.types.SecretStr"],
     ["py:class", "pydantic.utils.Representation"],
 ]

--- a/docs/extras/schemas/environment.json
+++ b/docs/extras/schemas/environment.json
@@ -11,6 +11,9 @@
       "title": "Fqdn",
       "type": "string"
     },
+    "onepassword": {
+      "$ref": "#/definitions/OnepasswordConfig"
+    },
     "vaultUrl": {
       "title": "Vaulturl",
       "type": "string"
@@ -51,5 +54,29 @@
     "applications"
   ],
   "additionalProperties": false,
-  "$id": "https://phalanx.lsst.io/schemas/environment.json"
+  "$id": "https://phalanx.lsst.io/schemas/environment.json",
+  "definitions": {
+    "OnepasswordConfig": {
+      "title": "OnepasswordConfig",
+      "description": "Configuration for 1Password static secrets source.",
+      "type": "object",
+      "properties": {
+        "connectUrl": {
+          "title": "Connecturl",
+          "minLength": 1,
+          "maxLength": 65536,
+          "format": "uri",
+          "type": "string"
+        },
+        "vaultTitle": {
+          "title": "Vaulttitle",
+          "type": "string"
+        }
+      },
+      "required": [
+        "connectUrl",
+        "vaultTitle"
+      ]
+    }
+  }
 }

--- a/docs/internals/api.rst
+++ b/docs/internals/api.rst
@@ -58,6 +58,9 @@ This API is only intended for use within the Phalanx code itself.
 .. automodapi:: phalanx.storage.helm
    :include-all-objects:
 
+.. automodapi:: phalanx.storage.onepassword
+   :include-all-objects:
+
 .. automodapi:: phalanx.storage.vault
    :include-all-objects:
 

--- a/environments/values-idfdev.yaml
+++ b/environments/values-idfdev.yaml
@@ -1,6 +1,9 @@
 butlerRepositoryIndex: "s3://butler-us-central1-repo-locations/data-dev-repos.yaml"
 fqdn: data-dev.lsst.cloud
 name: idfdev
+onepassword:
+  connectUrl: "https://roundtable-dev.lsst.cloud/1password/idfdev"
+  vaultTitle: "RSP data-dev.lsst.cloud"
 vaultUrl: "https://vault.lsst.codes"
 vaultPathPrefix: secret/k8s_operator/data-dev.lsst.cloud
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -777,7 +777,9 @@ pytest-cov==4.1.0 \
 python-dateutil==2.8.2 \
     --hash=sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86 \
     --hash=sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9
-    # via matplotlib
+    # via
+    #   -c requirements/main.txt
+    #   matplotlib
 pyyaml==6.0.1 \
     --hash=sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5 \
     --hash=sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc \
@@ -865,6 +867,7 @@ six==1.16.0 \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
     # via
+    #   -c requirements/main.txt
     #   latexcodec
     #   pybtex
     #   python-dateutil

--- a/requirements/main.in
+++ b/requirements/main.in
@@ -12,5 +12,6 @@ cryptography
 GitPython
 hvac
 jinja2
+onepasswordconnectsdk
 PyYAML
 safir

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -311,6 +311,10 @@ markupsafe==2.1.3 \
     --hash=sha256:e4dd52d80b8c83fdce44e12478ad2e85c64ea965e75d66dbeafb0a3e77308fcc \
     --hash=sha256:fec21693218efe39aa7f8599346e90c705afa52c5b31ae019b2e57e8f6542bb2
     # via jinja2
+onepasswordconnectsdk==1.3.0 \
+    --hash=sha256:a7a771d7a3d2e3e6a132095becb5c9fdbebc4f3e11a2bc3054c9a24857cc344f \
+    --hash=sha256:c741e978b47c3c691b779fc2d1d860075fed666ce5e4e28712102f39b3dd17a7
+    # via -r requirements/main.in
 pycparser==2.21 \
     --hash=sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9 \
     --hash=sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206
@@ -363,6 +367,10 @@ pyjwt[crypto]==2.8.0 \
     --hash=sha256:57e28d156e3d5c10088e0c68abb90bfac3df82b40a71bd0daa20c65ccd5c23de \
     --hash=sha256:59127c392cc44c2da5bb3192169a91f429924e17aff6534d70fdc02ab3e04320
     # via gidgethub
+python-dateutil==2.8.2 \
+    --hash=sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86 \
+    --hash=sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9
+    # via onepasswordconnectsdk
 pyyaml==6.0.1 \
     --hash=sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5 \
     --hash=sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc \
@@ -418,11 +426,19 @@ pyyaml==6.0.1 \
 requests==2.31.0 \
     --hash=sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f \
     --hash=sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1
-    # via hvac
+    # via
+    #   hvac
+    #   onepasswordconnectsdk
 safir==4.3.1 \
     --hash=sha256:6d1fcb7aba10e02fd456076d29e38aaa8699574f52b0fc2f326a9ee3958b41ea \
     --hash=sha256:da473520785428ae3b9da80406403054d46c089a34d0beceeb88c4cb78925cd3
     # via -r requirements/main.in
+six==1.16.0 \
+    --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
+    --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
+    # via
+    #   onepasswordconnectsdk
+    #   python-dateutil
 smmap==5.0.0 \
     --hash=sha256:2aba19d6a040e78d8b09de5c57e96207b09ed71d8e55ce0959eeee6c8e190d94 \
     --hash=sha256:c840e62059cd3be204b0c9c9f74be2c09d5648eddd4580d9314c3ecde0b30936

--- a/src/phalanx/cli.py
+++ b/src/phalanx/cli.py
@@ -27,6 +27,7 @@ __all__ = [
     "secrets",
     "secrets_audit",
     "secrets_list",
+    "secrets_onepassword_secrets",
     "secrets_schema",
     "secrets_static_template",
     "secrets_vault_secrets",
@@ -274,6 +275,35 @@ def secrets_list(environment: str, *, config: Path | None) -> None:
     secrets = secrets_service.list_secrets(environment)
     for secret in secrets:
         print(secret.application, secret.key)
+
+
+@secrets.command("onepassword-secrets")
+@click.argument("environment")
+@click.argument("output", type=click.Path(path_type=Path))
+@click.option(
+    "-c",
+    "--config",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Path to root of Phalanx configuration.",
+)
+def secrets_onepassword_secrets(
+    environment: str, output: Path, *, config: Path | None
+) -> None:
+    """Write the 1Password secrets for the given environment.
+
+    One JSON file per application with secrets will be created in the output
+    directory, containing the secrets for that application. If the value of a
+    secret is not known, it will be written as null.
+
+    The environment variable OP_CONNECT_TOKEN must be set to the 1Password
+    Connect token for the given environment.
+    """
+    if not config:
+        config = _find_config()
+    factory = Factory(config)
+    secrets_service = factory.create_secrets_service()
+    secrets_service.save_onepassword_secrets(environment, output)
 
 
 @secrets.command("schema")

--- a/src/phalanx/exceptions.py
+++ b/src/phalanx/exceptions.py
@@ -116,6 +116,10 @@ class InvalidSecretConfigError(Exception):
         super().__init__(msg)
 
 
+class NoOnepasswordConfigError(Exception):
+    """Environment does not use 1Password."""
+
+
 class NoOnepasswordCredentialsError(Exception):
     """1Password is configured, but no credentials were supplied."""
 

--- a/src/phalanx/exceptions.py
+++ b/src/phalanx/exceptions.py
@@ -13,6 +13,7 @@ __all__ = [
     "InvalidApplicationConfigError",
     "InvalidEnvironmentConfigError",
     "InvalidSecretConfigError",
+    "NoOnepasswordCredentialsError",
     "UnknownEnvironmentError",
     "UnresolvedSecretsError",
     "VaultNotFoundError",
@@ -112,6 +113,14 @@ class InvalidSecretConfigError(Exception):
     def __init__(self, application: str, key: str, error: str) -> None:
         name = f"{application}/{key}"
         msg = f"Invalid configuration for secret {name}: {error}"
+        super().__init__(msg)
+
+
+class NoOnepasswordCredentialsError(Exception):
+    """1Password is configured, but no credentials were supplied."""
+
+    def __init__(self) -> None:
+        msg = "No 1Password Connect credentials (OP_CONNECT_TOKEN) set"
         super().__init__(msg)
 
 

--- a/src/phalanx/factory.py
+++ b/src/phalanx/factory.py
@@ -9,6 +9,7 @@ from .services.secrets import SecretsService
 from .services.vault import VaultService
 from .storage.config import ConfigStorage
 from .storage.helm import HelmStorage
+from .storage.onepassword import OnepasswordStorage
 from .storage.vault import VaultStorage
 
 __all__ = ["Factory"]
@@ -57,8 +58,11 @@ class Factory:
             Service for manipulating secrets.
         """
         config_storage = self.create_config_storage()
+        onepassword_storage = OnepasswordStorage()
         vault_storage = VaultStorage()
-        return SecretsService(config_storage, vault_storage)
+        return SecretsService(
+            config_storage, onepassword_storage, vault_storage
+        )
 
     def create_vault_service(self) -> VaultService:
         """Create service for managing Vault tokens and policies.

--- a/src/phalanx/models/applications.py
+++ b/src/phalanx/models/applications.py
@@ -126,3 +126,11 @@ class ApplicationInstance(BaseModel):
                 return False
             values = values[key]
         return bool(values)
+
+    def all_static_secrets(self) -> list[Secret]:
+        """Return all static secrets for this instance of the application."""
+        return [
+            s
+            for s in self.secrets
+            if not (s.copy_rules or s.generate or s.value)
+        ]

--- a/src/phalanx/models/environments.py
+++ b/src/phalanx/models/environments.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import ClassVar
 
-from pydantic import BaseModel, Extra
+from pydantic import AnyHttpUrl, BaseModel, Extra, validator
 from safir.pydantic import CamelCaseModel
 
 from .applications import Application, ApplicationInstance
@@ -20,8 +20,19 @@ __all__ = [
     "GafaelfawrGitHubTeam",
     "GafaelfawrScope",
     "IdentityProvider",
+    "OnepasswordConfig",
     "PhalanxConfig",
 ]
+
+
+class OnepasswordConfig(CamelCaseModel):
+    """Configuration for 1Password static secrets source."""
+
+    connect_url: AnyHttpUrl
+    """URL to the 1Password Connect API server."""
+
+    vault_title: str
+    """Title of the 1Password vault from which to retrieve secrets."""
 
 
 class EnvironmentBaseConfig(CamelCaseModel):
@@ -33,11 +44,24 @@ class EnvironmentBaseConfig(CamelCaseModel):
     fqdn: str
     """Fully-qualified domain name."""
 
+    onepassword: OnepasswordConfig | None = None
+    """Configuration for using 1Password as a static secrets source."""
+
     vault_url: str
     """URL of Vault server."""
 
     vault_path_prefix: str
     """Prefix of Vault paths, including the Kv2 mount point."""
+
+    @validator("onepassword", pre=True)
+    def _validate_onepassword(cls, v: dict[str, str]) -> dict[str, str] | None:
+        if not v:
+            return v
+        if not isinstance(v, dict):
+            raise TypeError("onepassword is not a dictionary")
+        if v["connectUrl"] == "":
+            return None
+        return v
 
     @property
     def vault_path(self) -> str:

--- a/src/phalanx/models/secrets.py
+++ b/src/phalanx/models/secrets.py
@@ -242,9 +242,8 @@ class Secret(SecretConfig):
 class ResolvedSecret(BaseModel):
     """A secret that has been resolved for a given application instance.
 
-    Secret resolution means that the configuration has been translated into
-    either a secret value or knowledge that the secret is a static secret that
-    must come from elsewhere.
+    Secret resolution means that the configuration has been translated into a
+    secret value.
     """
 
     key: str

--- a/src/phalanx/services/secrets.py
+++ b/src/phalanx/services/secrets.py
@@ -19,6 +19,7 @@ from ..models.secrets import (
     StaticSecrets,
 )
 from ..storage.config import ConfigStorage
+from ..storage.onepassword import OnepasswordStorage
 from ..storage.vault import VaultClient, VaultStorage
 from ..yaml import YAMLFoldedString
 
@@ -32,14 +33,20 @@ class SecretsService:
     ----------
     config_storage
         Storage object for the Phalanx configuration.
+    onepassword_storage
+        Storage object for 1Password.
     vault_storage
         Storage object for Vault.
     """
 
     def __init__(
-        self, config_storage: ConfigStorage, vault_storage: VaultStorage
+        self,
+        config_storage: ConfigStorage,
+        onepassword_storage: OnepasswordStorage,
+        vault_storage: VaultStorage,
     ) -> None:
         self._config = config_storage
+        self._onepassword = onepassword_storage
         self._vault = vault_storage
 
     def audit(
@@ -62,6 +69,8 @@ class SecretsService:
             Audit report as a text document.
         """
         environment = self._config.load_environment(env_name)
+        if not static_secrets:
+            static_secrets = self._get_onepassword_secrets(environment)
         vault_client = self._vault.get_vault_client(environment)
 
         # Retrieve all the current secrets from Vault and resolve all of the
@@ -123,12 +132,11 @@ class SecretsService:
         dict
             YAML template the user can fill out, as a string.
         """
-        secrets = self.list_secrets(env_name)
+        environment = self._config.load_environment(env_name)
         template: defaultdict[str, dict[str, dict[str, str | None]]]
         template = defaultdict(dict)
-        for secret in secrets:
-            static = not (secret.copy_rules or secret.generate or secret.value)
-            if static:
+        for application in environment.all_applications():
+            for secret in application.all_static_secrets():
                 template[secret.application][secret.key] = {
                     "description": YAMLFoldedString(secret.description),
                     "value": None,
@@ -207,6 +215,8 @@ class SecretsService:
             Whether to delete unknown Vault secrets.
         """
         environment = self._config.load_environment(env_name)
+        if not static_secrets:
+            static_secrets = self._get_onepassword_secrets(environment)
         vault_client = self._vault.get_vault_client(environment)
         secrets = environment.all_secrets()
         vault_secrets = vault_client.get_environment_secrets()
@@ -274,6 +284,38 @@ class SecretsService:
                 vault_client.store_application_secret(application, values)
                 for key in sorted(to_delete):
                     print("Deleted Vault secret for", application, key)
+
+    def _get_onepassword_secrets(
+        self, environment: Environment
+    ) -> StaticSecrets | None:
+        """Get static secrets for an environment from 1Password.
+
+        Parameters
+        ----------
+        environment
+            Environment for which to get static secrets.
+
+        Returns
+        -------
+        dict of StaticSecret or None
+            Static secrets for this environment retrieved from 1Password, or
+            `None` if this environment doesn't use 1Password.
+
+        Raises
+        ------
+        NoOnepasswordCredentialsError
+            Raised if the environment uses 1Password but no 1Password
+            credentials were available in the environment.
+        """
+        if not environment.onepassword:
+            return None
+        onepassword = self._onepassword.get_onepassword_client(environment)
+        query = {}
+        for application in environment.all_applications():
+            query[application.name] = [
+                s.key for s in application.all_static_secrets()
+            ]
+        return onepassword.get_secrets(query)
 
     def _resolve_secrets(
         self,

--- a/src/phalanx/storage/onepassword.py
+++ b/src/phalanx/storage/onepassword.py
@@ -1,0 +1,122 @@
+"""Retrieve secrets stored in 1Password via 1Password Connect."""
+
+from __future__ import annotations
+
+import os
+from collections import defaultdict
+
+from onepasswordconnectsdk import load_dict, new_client
+from onepasswordconnectsdk.client import FailedToRetrieveItemException
+
+from ..exceptions import NoOnepasswordCredentialsError
+from ..models.environments import EnvironmentBaseConfig
+from ..models.secrets import StaticSecret, StaticSecrets
+
+__all__ = ["OnepasswordClient", "OnepasswordStorage"]
+
+
+class OnepasswordClient:
+    """Retrieve secrets stored in 1Password via 1Password Connect.
+
+    This client is specific to a particular Phalanx environment. It is created
+    using the metadata of a Phalanx environment by `OnepasswordStorage`.
+
+    The 1Password Connect authentication token is taken from the
+    ``OP_CONNECT_TOKEN`` environment variable, which must be set.
+
+    Parameters
+    ----------
+    url
+        URL of the 1Password Connect server.
+    vault_title
+        Title of vault within that 1Password Connect server from which to
+        retrieve secrets.
+    """
+
+    def __init__(self, url: str, vault_title: str) -> None:
+        token = os.getenv("OP_CONNECT_TOKEN")
+        if not token:
+            raise NoOnepasswordCredentialsError
+        self._onepassword = new_client(url, token)
+        self._vault_id = self._onepassword.get_vault_by_title(vault_title).id
+
+    def get_secrets(self, query: dict[str, list[str]]) -> StaticSecrets:
+        """Get static secrets for an environment from 1Password.
+
+        Parameters
+        ----------
+        query
+            Query for secrets in the form of a dictionary of applications to
+            lists of secret keys for that application that should be
+            retrieved.
+
+        Returns
+        -------
+        dict of dict
+            Retrieved static secrets as a dictionary of applications to secret
+            keys to `~phalanx.models.secrets.StaticSecret` objects.
+        """
+        request: dict[tuple[str, str], dict[str, str]] = {}
+        extra = []
+        for application, secrets in query.items():
+            for secret in secrets:
+                if "." in secret:
+                    extra.append((application, secret))
+                else:
+                    request[(application, secret)] = {
+                        "opitem": application,
+                        "opfield": f".{secret}",
+                        "opvault": self._vault_id,
+                    }
+        response = load_dict(self._onepassword, request)
+        result: StaticSecrets = defaultdict(dict)
+        for key, value in response.items():
+            application, secret = key
+            result[application][secret] = StaticSecret(value=value)
+
+        # Separately handle the secret field names that contain periods, since
+        # that conflicts with the syntax used by load_dict.
+        for application, secret in extra:
+            item = self._onepassword.get_item(application, self._vault_id)
+            found = False
+            for field in item.fields:
+                if field.label == secret:
+                    static_secret = StaticSecret(value=field.value)
+                    result[application][secret] = static_secret
+                    found = True
+                    break
+            if not found:
+                msg = f"Item {application} has no field {secret}"
+                raise FailedToRetrieveItemException(msg)
+
+        return result
+
+
+class OnepasswordStorage:
+    """Create 1Password Connect clients for specific environments."""
+
+    def get_onepassword_client(
+        self, env: EnvironmentBaseConfig
+    ) -> OnepasswordClient:
+        """Return a 1Password client configured for the given environment.
+
+        Parameters
+        ----------
+        env
+            Phalanx environment.
+
+        Returns
+        -------
+        OnepasswordClient
+            1Password Connect client configured for that environment.
+
+        Raises
+        ------
+        ValueError
+            Raised if this environment is not configured to use 1Password.
+        """
+        if not env.onepassword:
+            raise ValueError(f"{env.name} does not use 1Password")
+        return OnepasswordClient(
+            str(env.onepassword.connect_url), env.onepassword.vault_title
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ import pytest
 from phalanx.factory import Factory
 
 from .support.data import phalanx_test_path
+from .support.onepassword import MockOnepasswordClient, patch_onepassword
 from .support.vault import MockVaultClient, patch_vault
 
 
@@ -17,6 +18,12 @@ from .support.vault import MockVaultClient, patch_vault
 def factory() -> Factory:
     """Create a factory pointing at the test data."""
     return Factory(phalanx_test_path())
+
+
+@pytest.fixture
+def mock_onepassword() -> Iterator[MockOnepasswordClient]:
+    """Mock out the 1Password Connect client API."""
+    yield from patch_onepassword()
 
 
 @pytest.fixture

--- a/tests/data/input/environments/values-minikube.yaml
+++ b/tests/data/input/environments/values-minikube.yaml
@@ -1,5 +1,8 @@
 name: minikube
 fqdn: minikube.lsst.cloud
+onepassword:
+  connectUrl: https://roundtable-dev.lsst.cloud/1password/minikube/
+  vaultTitle: "RSP minikube.lsst.codes"
 vaultUrl: https://vault.lsst.codes/
 vaultPathPrefix: secret/phalanx/minikube
 

--- a/tests/data/input/environments/values.yaml
+++ b/tests/data/input/environments/values.yaml
@@ -8,6 +8,15 @@ name: ""
 # @default -- None, must be set
 fqdn: ""
 
+onepassword:
+  # -- URL to the 1Password server for this environment, if 1Password is used
+  # for static secrets.
+  # @default -- Do not use 1Password.
+  connectUrl: ""
+
+  # -- Title of the 1Password vault to use for static secrets.
+  vaultTitle: ""
+
 # -- URL of Vault server for this environment
 # @default -- None, must be set
 vaultUrl: ""

--- a/tests/data/input/onepassword/minikube.yaml
+++ b/tests/data/input/onepassword/minikube.yaml
@@ -1,0 +1,7 @@
+argocd:
+  "dex.clientSecret": some-dex-secret
+gafaelfawr:
+  github-client-secret: some-github-secret
+mobu:
+  ALERT_HOOK: https://example.com/alert-hook
+  app-alert-webhook: https://example.com/app-hook

--- a/tests/data/input/vault/minikube/unknown.json
+++ b/tests/data/input/vault/minikube/unknown.json
@@ -1,0 +1,3 @@
+{
+  "some-secret": "secret-for-unknown-application"
+}

--- a/tests/data/output/minikube/sync-output
+++ b/tests/data/output/minikube/sync-output
@@ -1,0 +1,4 @@
+Created Vault secret for argocd
+Created Vault secret for gafaelfawr
+Created Vault secret for mobu
+Created Vault secret for postgres

--- a/tests/data/output/minikube/values-after-add.yaml
+++ b/tests/data/output/minikube/values-after-add.yaml
@@ -8,6 +8,15 @@ name: ""
 # @default -- None, must be set
 fqdn: ""
 
+onepassword:
+  # -- URL to the 1Password server for this environment, if 1Password is used
+  # for static secrets.
+  # @default -- Do not use 1Password.
+  connectUrl: ""
+
+  # -- Title of the 1Password vault to use for static secrets.
+  vaultTitle: ""
+
 # -- URL of Vault server for this environment
 # @default -- None, must be set
 vaultUrl: ""

--- a/tests/support/onepassword.py
+++ b/tests/support/onepassword.py
@@ -1,0 +1,131 @@
+"""Mock 1Password Connect API for testing."""
+
+from __future__ import annotations
+
+import os
+import uuid
+from collections.abc import Iterator
+from unittest.mock import patch
+
+import yaml
+from onepasswordconnectsdk.client import (
+    FailedToRetrieveItemException,
+    FailedToRetrieveVaultException,
+)
+from onepasswordconnectsdk.models import Field, Item, Vault
+
+from .data import phalanx_test_path
+
+__all__ = [
+    "MockOnepasswordClient",
+    "patch_onepassword",
+]
+
+
+class MockOnepasswordClient:
+    """Mock 1Password Connect client for testing."""
+
+    def __init__(self) -> None:
+        self._data: dict[str, dict[str, Item]] = {}
+        self._uuids: dict[str, str] = {}
+
+    def load_test_data(self, vault: str, environment: str) -> None:
+        """Load 1Password test data for the given environment.
+
+        This method is not part of the 1Password Connect API. It is intended
+        for use by the test suite to set up a test.
+
+        Parameters
+        ----------
+        vault
+            Name of the 1Password vault.
+        environment
+            Name of the environment for which to load 1Password test data.
+        """
+        data_path = phalanx_test_path() / "onepassword" / f"{environment}.yaml"
+        with data_path.open() as fh:
+            data = yaml.safe_load(fh)
+            self._data[vault] = {}
+            for title, values in data.items():
+                fields = [Field(label=k, value=v) for k, v in values.items()]
+                self._data[vault][title] = Item(title=title, fields=fields)
+
+    def get_item(self, title: str, vault_id: str) -> Item:
+        """Get an item from a 1Password vault.
+
+        Parameters
+        ----------
+        title
+            Title of the item.
+        vault_id
+            UUID of the vault.
+
+        Returns
+        -------
+        Item
+            Corresponding item.
+
+        Raises
+        ------
+        FailedToRetrieveItemException
+            Raised if the item was not found.
+        """
+        try:
+            vault = self._uuids[vault_id]
+            return self._data[vault][title]
+        except KeyError:
+            msg = f"Item {title} does not exist"
+            raise FailedToRetrieveItemException(msg) from None
+
+    def get_vault_by_title(self, title: str) -> Vault:
+        """Get vault metadata by title.
+
+        There are more fields normally, but we only care about the ``id``
+        field. Populate this on the fly with a generated UUID the first time
+        we're asked for a vault by name, provided that we have data for that
+        vault name.
+
+        Parameters
+        ----------
+        title
+            Title of the vault.
+
+        Returns
+        -------
+        Vault
+            Partially-filled-out vault model.
+
+        Raises
+        ------
+        FailedToRetrieveVaultException
+            Raised if we have no data for this vault title.
+        """
+        if title not in self._data:
+            msg = f"Vault {title} does not exist"
+            raise FailedToRetrieveVaultException(msg) from None
+        assert title in self._data
+        for vault_id, name in self._uuids.items():
+            if name == title:
+                return Vault(id=vault_id, name=name)
+        vault_id = str(uuid.uuid4())
+        self._uuids[vault_id] = title
+        return Vault(id=vault_id, name=title)
+
+
+def patch_onepassword() -> Iterator[MockOnepasswordClient]:
+    """Replace the onepasswordconnectsdk client with a mock class.
+
+    Yields
+    ------
+    MockOnepasswordClient
+        Mock onepasswordconnectsdk client.
+    """
+    mock = MockOnepasswordClient()
+    with patch("phalanx.storage.onepassword.new_client", return_value=mock):
+        old = os.getenv("OP_CONNECT_TOKEN")
+        os.environ["OP_CONNECT_TOKEN"] = "some-token"
+        yield mock
+        if old:
+            os.environ["OP_CONNECT_TOKEN"] = old
+        else:
+            del os.environ["OP_CONNECT_TOKEN"]


### PR DESCRIPTION
Add new configuration options for environments that allow specifying a 1Password Connect server and Vault title. If those options are set for an environment, use that, via onepasswordconnectsdk, to retrieve static secrets provided that a separate static secrets YAML file was not given.

The layout used for 1Password is to have one 1Password item per application, with one field (without section nesting) for each secret.