### PR TITLE
Fix some documentation link issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ init:
 # level of shell trickery after failed commands.
 .PHONY: linkcheck
 linkcheck:
+	rm -rf docs/internals/api/
 	sphinx-build --keep-going -n -W -T -b linkcheck docs	\
 	    docs/_build/linkcheck				\
 	    || (cat docs/_build/linkcheck/output.txt; exit 1)

--- a/applications/rubintv/Chart.yaml
+++ b/applications/rubintv/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
 name: rubintv
 version: 1.0.0
-description: real-time display front end
+description: Real-time display front end
 sources:
-  - https://github.com/lsst-sqre/rubin-tv
+  - https://github.com/lsst-sqre/rubintv
 appVersion: 0.1.0
 dependencies:
   - name: redis

--- a/applications/rubintv/README.md
+++ b/applications/rubintv/README.md
@@ -1,10 +1,10 @@
 # rubintv
 
-real-time display front end
+Real-time display front end
 
 ## Source Code
 
-* <https://github.com/lsst-sqre/rubin-tv>
+* <https://github.com/lsst-sqre/rubintv>
 
 ## Values
 

--- a/docs/admin/installation.rst
+++ b/docs/admin/installation.rst
@@ -44,6 +44,9 @@ To create a new Phalanx environment, take the following steps:
    - :px-app-bootstrap:`portal`
    - :px-app-bootstrap:`squareone`
 
+#. Add the URL of your new environment to :file:`docs/documenteer.toml` under ``phinx.linkcheck.ignore``.
+   The Argo CD URL of your environment will be unreachable, so you need to tell Sphinx valid link checking to ignore it.
+
 #. Generate the secrets for the new environment and store them in Vault with `installer/update_secrets.sh <https://github.com/lsst-sqre/phalanx/blob/main/installer/update_secrets.sh>`__.
    You will need the write key for the Vault enclave you are using for this environment.
    If you are using 1Password as a source of secrets, you will also need the access token for the 1Password Connect server.

--- a/docs/applications/rubintv/index.rst
+++ b/docs/applications/rubintv/index.rst
@@ -1,26 +1,24 @@
 .. px-app:: rubintv
 
-##########################################
-rubintv — real-time display front end
-##########################################
+#####################################
+rubintv — Real-time display front end
+#####################################
 
-RubinTV is a display front end for various real-time activities on the
-project.  It is primarily to support and display summit activities, but
-also serves data from other sites (currently the Tucson Test Stand and
-the clean room camera testing activities at SLAC).
+RubinTV is a display front end for various real-time activities on the project.
+It is primarily to support and display summit activities, but also serves data from other sites (currently the Tucson Test Stand and the clean room camera testing activities at SLAC).
 
 At the summit, the real-time activities currently include:
-* AuxTel observing
-* ComCam testing
-* All sky camera observations
-* StarTracker data taking on the TMA
-* TMA testing activities
 
-The Rapid Analysis Framework performes realtime analysis on data from
-these sources, rendering the outputs destined for RubinTV as pngs/jpegs,
-mp4s, and JSON files, which are put in S3 buckets at the summit and at
-USDF.  The RubinTV frontend then monitors these buckets and serves these
-files to users.
+.. rst-class:: compact
+
+- AuxTel observing
+- ComCam testing
+- All sky camera observations
+- StarTracker data taking on the TMA
+- TMA testing activities
+
+The Rapid Analysis Framework performes realtime analysis on data from these sources, rendering the outputs destined for RubinTV as PNGs, JPEGs, MP4s, and JSON files, which are put in S3 buckets at the summit and at USDF.
+The RubinTV frontend then monitors these buckets and serves these files to users.
 
 .. jinja:: rubintv
    :file: applications/_summary.rst.jinja

--- a/docs/documenteer.toml
+++ b/docs/documenteer.toml
@@ -57,6 +57,7 @@ ignore = [
     '^https://rsp.lsst.ac.uk',
     '^https://roundtable-dev.lsst.cloud',
     '^https://roundtable.lsst.cloud',
+    '^https://usdf-prompt-processing-dev.slac.stanford.edu',
     '^https://usdf-rsp.slac.stanford.edu',
     '^https://usdf-rsp-dev.slac.stanford.edu',
     '^https://usdf-tel-rsp.slac.stanford.edu',


### PR DESCRIPTION
- Delete automodsumm files before doing a link check
- Update the RubinTV URL and fix the application page style
- Add the new prompt-processing environment to the ignore list
- Document that you need to update the ignore list when adding new environments