### PR TITLE
DM-40501: Ignore another Argo CD URL pattern

### DIFF
--- a/docs/documenteer.toml
+++ b/docs/documenteer.toml
@@ -55,6 +55,7 @@ ignore = [
     '^https://data-int.lsst.cloud',
     '^https://data.lsst.cloud',
     '^https://data-dev.lsst.eu',
+    '^https://k8s.slac.stanford.edu',
     '^https://rsp.lsst.ac.uk',
     '^https://roundtable-dev.lsst.cloud',
     '^https://roundtable.lsst.cloud',


### PR DESCRIPTION
The prompt-processing environment is using k8s.slac.stanford.edu for its Argo CD URL. Phalanx doesn't handle this correctly yet, but we can at least ignore the broken link errors.