### PR TITLE
DM-40501: Support encoding secrets in 1Password

### DIFF
--- a/applications/nublado/secrets-idfdev.yaml
+++ b/applications/nublado/secrets-idfdev.yaml
@@ -2,6 +2,8 @@
   description: >-
     Google Cloud Storage credentials to the Butler data store, formatted using
     AWS syntax for use with boto.
+  onepassword:
+    encoded: true
 "butler-gcs-idf-creds.json":
   description: >-
     Google Cloud Storage credentials to the Butler data store in the native
@@ -13,3 +15,5 @@
 "postgres-credentials.txt":
   description: >-
     PostgreSQL credentials in its pgpass format for the Butler database.
+  onepassword:
+    encoded: true

--- a/docs/developers/define-secrets.rst
+++ b/docs/developers/define-secrets.rst
@@ -323,6 +323,13 @@ Phalanx requires all of the secret entries be top-level fields outside of any se
 
 Newlines will be converted to spaces when pasting the secret value.
 If newlines need to be preserved, be sure to mark the secret with ``onepassword.encoded`` set to ``true`` in :file:`secrets.yaml`, and then encode the secret in base64 before pasting it into 1Password.
+To encode the secret, save it to a file with the correct newlines, and then use a command such as:
+
+.. prompt:: bash
+
+   base64 -w0 < /path/to/secret; echo ''
+
+This will generate a base64-encoded version of the secret on one line, suitable for cutting and pasting into the 1Password field.
 
 3. Sync 1Password items into Vault
 ----------------------------------

--- a/docs/developers/define-secrets.rst
+++ b/docs/developers/define-secrets.rst
@@ -36,6 +36,11 @@ This is done with the ``copy`` directive.
 Secrets may be conditional on specific Helm chart settings by using ``if``; in this case, the secret doesn't need to exist unless that Helm setting is true.
 It's also possible for the generate or copy rules to be conditional, meaning that the secret is only generated or copied if some condition is set, and otherwise may be a static secret.
 
+Secrets that contain newlines cannot be stored in 1Password as-is, since 1Password field values don't support newlines.
+Mark these secrets by setting ``onepassword.encoded`` to ``true``, since they will be stored in 1Password with an additional layer of base64 encoding.
+(You do not need to do this with GCE service account credentials.
+Although their normal form contains newlines, they are encoded in JSON, so the newlines are not significant and may be stripped.)
+
 For a full specification of the contents of this file, see :doc:`secrets-spec`.
 
 Examples
@@ -99,7 +104,7 @@ This is the Gafaelfawr database password, which is a static secret when using an
        if: config.internalDatabase
        type: password
 
-Finally, here is an example of a secret that is copied from another application.
+Here is an example of a secret that is copied from another application.
 This is the matching definition of the Gafaelfawr database password in the in-cluster PostgreSQL server, which is copied from the Gafaelfawr application if Gafaelfawr is using the in-cluster database.
 
 .. code-block:: yaml
@@ -111,6 +116,17 @@ This is the matching definition of the Gafaelfawr database password in the in-cl
      copy:
        application: gafaelfawr
        key: database-password
+
+Finally, here is an example of a static secret that needs an additional layer of base64 encoding when stored in 1Password because its value contains newlines:
+
+.. code-block:: yaml
+   :caption: applications/nublado/secrets-idfdev.yaml
+
+   "postgres-credentials.txt":
+     description: >-
+       PostgreSQL credentials in its pgpass format for the Butler database.
+     onepassword:
+       encoded: true
 
 .. _secret-definition-legacy:
 
@@ -304,6 +320,9 @@ Change the field type to password so that the value isn't displayed any time som
 
 Do not use sections.
 Phalanx requires all of the secret entries be top-level fields outside of any section.
+
+Newlines will be converted to spaces when pasting the secret value.
+If newlines need to be preserved, be sure to mark the secret with ``onepassword.encoded`` set to ``true`` in :file:`secrets.yaml`, and then encode the secret in base64 before pasting it into 1Password.
 
 3. Sync 1Password items into Vault
 ----------------------------------

--- a/docs/developers/secrets-spec.rst
+++ b/docs/developers/secrets-spec.rst
@@ -69,4 +69,11 @@ The specification of the secret has the following keys:
 
     ``value`` must not be set if either ``copy`` or ``generate`` are set and either do not have an ``if`` condition or have a true ``if`` condition.
 
+``onepassword`` (object, optional)
+    Configuration describing how the secret is stored in 1Password in the cases where it is a static secret and 1Password is used as the static secrets store.
+
+    ``encoded`` (bool, optional, default: false)
+        If set to true, the secret stored in 1Password has an extra layer of base64-encoding that must be removed when retrieving the secret.
+        This is used for secrets that contain embedded newlines that must be preserved, since 1Password doesn't support newlines in field values.
+
 These files will be syntax-checked against a YAML schema in CI tests for the Phalanx repository.

--- a/docs/extras/schemas/secrets.json
+++ b/docs/extras/schemas/secrets.json
@@ -85,6 +85,18 @@
         "source"
       ]
     },
+    "SecretOnepasswordConfig": {
+      "title": "SecretOnepasswordConfig",
+      "description": "Configuration for how a static secret is stored in 1Password.",
+      "type": "object",
+      "properties": {
+        "encoded": {
+          "title": "Encoded",
+          "default": false,
+          "type": "boolean"
+        }
+      }
+    },
     "ConditionalSecretConfig": {
       "title": "ConditionalSecretConfig",
       "description": "Possibly conditional specification for an application secret.",
@@ -116,6 +128,17 @@
             },
             {
               "$ref": "#/definitions/ConditionalSourceSecretGenerateRules"
+            }
+          ]
+        },
+        "onepassword": {
+          "title": "Onepassword",
+          "default": {
+            "encoded": false
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/SecretOnepasswordConfig"
             }
           ]
         },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,20 @@ init_typed = true
 warn_required_dynamic_aliases = true
 warn_untyped_fields = true
 
+[tool.pytest.ini_options]
+# The python_files setting is not for test detection (pytest will pick up any
+# test files named *_test.py without this setting) but to enable special
+# assert processing in any non-test supporting files under tests. We
+# conventionally put test support functions under tests.support and may
+# sometimes use assert in test fixtures in conftest.py, and pytest only
+# enables magical assert processing (showing a full diff on assert failures
+# with complex data structures rather than only the assert message) in files
+# listed in python_files.
+python_files = [
+    "tests/*.py",
+    "tests/*/*.py"
+]
+
 # The rule used with Ruff configuration is to disable every lint that has
 # legitimate exceptions that are not dodgy code, rather than cluttering code
 # with noqa markers. This is therefore a reiatively relaxed configuration that

--- a/src/phalanx/models/applications.py
+++ b/src/phalanx/models/applications.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from .secrets import ConditionalSecretConfig, Secret
 
@@ -98,8 +98,21 @@ class ApplicationInstance(BaseModel):
     values: dict[str, Any]
     """Merged Helm values for the application in this environment."""
 
-    secrets: list[Secret] = []
-    """Secrets required for this application in this environment."""
+    secrets: dict[str, Secret] = Field(
+        {},
+        title="Required secrets",
+        description=(
+            "Secrets required for this application in this environment."
+        ),
+    )
+
+    def all_static_secrets(self) -> list[Secret]:
+        """Return all static secrets for this instance of the application."""
+        return [
+            s
+            for s in self.secrets.values()
+            if not (s.copy_rules or s.generate or s.value)
+        ]
 
     def is_values_setting_true(self, setting: str) -> bool:
         """Determine whether a given Helm values setting is true.
@@ -126,11 +139,3 @@ class ApplicationInstance(BaseModel):
                 return False
             values = values[key]
         return bool(values)
-
-    def all_static_secrets(self) -> list[Secret]:
-        """Return all static secrets for this instance of the application."""
-        return [
-            s
-            for s in self.secrets
-            if not (s.copy_rules or s.generate or s.value)
-        ]

--- a/src/phalanx/models/environments.py
+++ b/src/phalanx/models/environments.py
@@ -168,9 +168,9 @@ class Environment(EnvironmentBaseConfig):
 
     def all_secrets(self) -> list[Secret]:
         """Return all secrets regardless of application."""
-        secrets = []
+        secrets: list[Secret] = []
         for application in self.all_applications():
-            secrets.extend(application.secrets)
+            secrets.extend(application.secrets.values())
         return secrets
 
 

--- a/src/phalanx/models/secrets.py
+++ b/src/phalanx/models/secrets.py
@@ -30,6 +30,7 @@ __all__ = [
     "SecretCopyRules",
     "SecretGenerateRules",
     "SecretGenerateType",
+    "SecretOnepasswordConfig",
     "SimpleSecretGenerateRules",
     "SourceSecretGenerateRules",
     "StaticSecret",
@@ -164,6 +165,19 @@ ConditionalSecretGenerateRules = (
 )
 
 
+class SecretOnepasswordConfig(BaseModel):
+    """Configuration for how a static secret is stored in 1Password."""
+
+    encoded: bool = False
+    """Whether the 1Password copy of the secret is encoded in base64.
+
+    1Password doesn't support newlines in secrets, so secrets that contain
+    significant newlines have to be encoded when storing them in 1Password.
+    This flag indicates that this has been done, and therefore when retrieving
+    the secret from 1Password, its base64-encoding must be undone.
+    """
+
+
 class SecretConfig(BaseModel):
     """Specification for an application secret."""
 
@@ -178,6 +192,9 @@ class SecretConfig(BaseModel):
 
     generate: SecretGenerateRules | None = None
     """Rules for how the secret should be generated."""
+
+    onepassword: SecretOnepasswordConfig = SecretOnepasswordConfig()
+    """Configuration for how the secret is stored in 1Password."""
 
     value: SecretStr | None = None
     """Secret value."""

--- a/src/phalanx/storage/config.py
+++ b/src/phalanx/storage/config.py
@@ -670,12 +670,13 @@ class ConfigStorage:
                 description=config.description,
                 copy_rules=copy,
                 generate=generate,
+                onepassword=config.onepassword,
                 value=config.value,
             )
             required_secrets.append(secret)
 
         # Add the secrets to the new instance and return it.
-        instance.secrets = sorted(
-            required_secrets, key=lambda s: (s.application, s.key)
-        )
+        instance.secrets = {
+            s.key: s for s in sorted(required_secrets, key=lambda s: s.key)
+        }
         return instance

--- a/tests/data/input/applications/mobu/secrets.yaml
+++ b/tests/data/input/applications/mobu/secrets.yaml
@@ -9,3 +9,5 @@ app-alert-webhook:
 ALERT_HOOK:
   description: >-
     Slack web hook to which mobu should report failures and daily status.
+  onepassword:
+    encoded: true

--- a/tests/data/input/onepassword/minikube.yaml
+++ b/tests/data/input/onepassword/minikube.yaml
@@ -3,5 +3,5 @@ argocd:
 gafaelfawr:
   github-client-secret: some-github-secret
 mobu:
-  ALERT_HOOK: https://example.com/alert-hook
+  ALERT_HOOK: aHR0cHM6Ly9leGFtcGxlLmNvbS9hbGVydC1ob29r
   app-alert-webhook: https://example.com/app-hook

--- a/tests/data/output/minikube/onepassword/argocd.json
+++ b/tests/data/output/minikube/onepassword/argocd.json
@@ -1,0 +1,3 @@
+{
+  "dex.clientSecret": "some-dex-secret"
+}

--- a/tests/data/output/minikube/onepassword/gafaelfawr.json
+++ b/tests/data/output/minikube/onepassword/gafaelfawr.json
@@ -1,0 +1,3 @@
+{
+  "github-client-secret": "some-github-secret"
+}

--- a/tests/data/output/minikube/onepassword/mobu.json
+++ b/tests/data/output/minikube/onepassword/mobu.json
@@ -1,0 +1,4 @@
+{
+  "ALERT_HOOK": "https://example.com/alert-hook",
+  "app-alert-webhook": "https://example.com/app-hook"
+}

--- a/tests/support/data.py
+++ b/tests/support/data.py
@@ -9,11 +9,44 @@ from typing import Any
 import yaml
 
 __all__ = [
+    "assert_json_dirs_match",
+    "output_path",
     "phalanx_test_path",
     "read_input_static_secrets",
     "read_output_data",
     "read_output_json",
 ]
+
+
+def assert_json_dirs_match(left: Path, right: Path) -> None:
+    """Assert that two directories full of JSON files match.
+
+    Parameters
+    ----------
+    left
+        One tree of JSON files.
+    right
+        Another tree of JSON files.
+    """
+    left_files = {p.name for p in left.iterdir()}
+    right_files = {p.name for p in right.iterdir()}
+    assert left_files == right_files
+    for left_path in left.iterdir():
+        with left_path.open() as fh:
+            left_json = json.load(fh)
+        with (right / left_path.name).open() as fh:
+            assert left_json == json.load(fh)
+
+
+def output_path() -> Path:
+    """Return path to Phalanx test output.
+
+    Returns
+    -------
+    Path
+        Path to test output data.
+    """
+    return Path(__file__).parent.parent / "data" / "output"
 
 
 def phalanx_test_path() -> Path:
@@ -22,7 +55,7 @@ def phalanx_test_path() -> Path:
     Returns
     -------
     Path
-        Path to test input data.  The directory will contain test data in the
+        Path to test input data. The directory will contain test data in the
         layout of a Phalanx repository to test information gathering and
         analysis.
     """
@@ -67,8 +100,7 @@ def read_output_data(environment: str, filename: str) -> str:
     str
         Contents of the file.
     """
-    base_path = Path(__file__).parent.parent / "data" / "output"
-    return (base_path / environment / filename).read_text()
+    return (output_path() / environment / filename).read_text()
 
 
 def read_output_json(environment: str, filename: str) -> Any:
@@ -87,8 +119,7 @@ def read_output_json(environment: str, filename: str) -> Any:
     Any
         Contents of the file.
     """
-    base_path = Path(__file__).parent.parent / "data" / "output"
-    data = (base_path / environment / (filename + ".json")).read_text()
+    data = (output_path() / environment / (filename + ".json")).read_text()
     return json.loads(data)
 
 
@@ -109,6 +140,5 @@ def write_output_json(environment: str, filename: str, data: Any) -> None:
     data
         Data to write.
     """
-    base_path = Path(__file__).parent.parent / "data" / "output"
-    with (base_path / environment / (filename + ".json")).open("w") as f:
+    with (output_path() / environment / (filename + ".json")).open("w") as f:
         json.dump(data, f, indent=2)


### PR DESCRIPTION
Some of our secrets contain significant newlines, such as the AWS credentials and pgpass file for Butler. 1Password unfortunately does not allow embedded newlines in fields. The official solution to this problem is to use files, but files can no longer be attached to Server items and instead need to be separate Document items, which breaks our entire 1Password layout.

Instead, support encoding the secret in base64 when storing it in 1Password and decoding it when retrieving it. This should allow arbitrary values at the cost of some complexity and having to explicitly tag which secrets are encoded in base64.