### PR TITLE
Change Strimzi loglevel to INFO

### DIFF
--- a/applications/strimzi/values-base.yaml
+++ b/applications/strimzi/values-base.yaml
@@ -6,4 +6,4 @@ strimzi-kafka-operator:
       memory: "512Mi"
   watchNamespaces:
     - "sasquatch"
-  logLevel: "DEBUG"
+  logLevel: "INFO"

--- a/applications/strimzi/values-idfdev.yaml
+++ b/applications/strimzi/values-idfdev.yaml
@@ -6,4 +6,4 @@ strimzi-kafka-operator:
       memory: "512Mi"
   watchNamespaces:
     - "sasquatch"
-  logLevel: "DEBUG"
+  logLevel: "INFO"

--- a/applications/strimzi/values-idfint.yaml
+++ b/applications/strimzi/values-idfint.yaml
@@ -7,4 +7,4 @@ strimzi-kafka-operator:
   watchNamespaces:
     - "sasquatch"
     - "alert-stream-broker"
-  logLevel: "DEBUG"
+  logLevel: "INFO"

--- a/applications/strimzi/values-minikube.yaml
+++ b/applications/strimzi/values-minikube.yaml
@@ -1,4 +1,4 @@
 strimzi-kafka-operator:
   watchNamespaces:
     - "sasquatch"
-  logLevel: "DEBUG"
+  logLevel: "INFO"

--- a/applications/strimzi/values-tucson-teststand.yaml
+++ b/applications/strimzi/values-tucson-teststand.yaml
@@ -6,4 +6,4 @@ strimzi-kafka-operator:
       memory: "512Mi"
   watchNamespaces:
     - "sasquatch"
-  logLevel: "DEBUG"
+  logLevel: "INFO"

--- a/applications/strimzi/values-usdfdev.yaml
+++ b/applications/strimzi/values-usdfdev.yaml
@@ -6,4 +6,4 @@ strimzi-kafka-operator:
       memory: "512Mi"
   watchNamespaces:
     - "sasquatch"
-  logLevel: "DEBUG"
+  logLevel: "INFO"


### PR DESCRIPTION
- Strimzi loglevel was set to DEBUG in some environments, but logs are too chatty.