### PR TITLE
[DM-40662] Fix Kapacitor alerts crosstalk at base

### DIFF
--- a/applications/sasquatch/Chart.yaml
+++ b/applications/sasquatch/Chart.yaml
@@ -42,6 +42,11 @@ dependencies:
     version: 1.2.6
     repository: https://helm.influxdata.com/
   - name: kapacitor
+    alias: source-kapacitor
+    condition: source-kapacitor.enabled
+    version: 1.4.7
+    repository: https://helm.influxdata.com/
+  - name: kapacitor
     condition: kapacitor.enabled
     version: 1.4.7
     repository: https://helm.influxdata.com/

--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -98,6 +98,16 @@ Rubin Observatory's telemetry service.
 | source-influxdb.resources.requests.memory | string | `"96Gi"` |  |
 | source-influxdb.setDefaultUser | object | `{"enabled":true,"user":{"existingSecret":"sasquatch"}}` | Default InfluxDB user, use influxb-user and influxdb-password keys from secret. |
 | source-kafka-connect-manager | object | `{"enabled":false,"env":{"kafkaConnectUrl":"http://sasquatch-source-connect-api.sasquatch:8083"}}` | Override source-kafka-connect-manager configuration. |
+| source-kapacitor.enabled | bool | `false` | Enable Kapacitor. |
+| source-kapacitor.envVars | object | `{"KAPACITOR_SLACK_ENABLED":true}` | Kapacitor environment variables. |
+| source-kapacitor.existingSecret | string | `"sasquatch"` | InfluxDB credentials, use influxdb-user and influxdb-password keys from secret. |
+| source-kapacitor.image | object | `{"repository":"kapacitor","tag":"1.6.6"}` | Kapacitor image tag. |
+| source-kapacitor.influxURL | string | `"http://sasquatch-influxdb-staging.sasquatch:8086"` | InfluxDB connection URL. |
+| source-kapacitor.persistence | object | `{"enabled":true,"size":"100Gi"}` | Chronograf data persistence configuration. |
+| source-kapacitor.resources.limits.cpu | int | `4` |  |
+| source-kapacitor.resources.limits.memory | string | `"16Gi"` |  |
+| source-kapacitor.resources.requests.cpu | int | `1` |  |
+| source-kapacitor.resources.requests.memory | string | `"1Gi"` |  |
 | squareEvents.enabled | bool | `false` | Enable the Square Events subchart with topic and user configurations. |
 | strimzi-kafka | object | `{}` | Override strimzi-kafka configuration. |
 | strimzi-registry-operator | object | `{"clusterName":"sasquatch","clusterNamespace":"sasquatch","operatorNamespace":"sasquatch"}` | strimzi-registry-operator configuration. |

--- a/applications/sasquatch/values-base.yaml
+++ b/applications/sasquatch/values-base.yaml
@@ -253,6 +253,11 @@ chronograf:
     PUBLIC_URL: https://base-lsp.lsst.codes
     STATUS_FEED_URL: https://raw.githubusercontent.com/lsst-sqre/rsp_broadcast/main/jsonfeeds/base.json
 
+source-kapacitor:
+  enabled: true
+  persistence:
+    storageClass: rook-ceph-block
+
 kapacitor:
   persistence:
     storageClass: rook-ceph-block

--- a/applications/sasquatch/values.yaml
+++ b/applications/sasquatch/values.yaml
@@ -300,6 +300,32 @@ chronograf:
       memory: 64Gi
       cpu: 4
 
+source-kapacitor:
+  # -- Enable Kapacitor.
+  enabled: false
+  # -- Kapacitor image tag.
+  image:
+    repository: kapacitor
+    tag: 1.6.6
+  # -- Chronograf data persistence configuration.
+  persistence:
+    enabled: true
+    size: 100Gi
+  # -- InfluxDB connection URL.
+  influxURL: http://sasquatch-influxdb-staging.sasquatch:8086
+  # -- InfluxDB credentials, use influxdb-user and influxdb-password keys from secret.
+  existingSecret: sasquatch
+  # -- Kapacitor environment variables.
+  envVars:
+    KAPACITOR_SLACK_ENABLED: true
+  resources:
+    requests:
+      memory: 1Gi
+      cpu: 1
+    limits:
+      memory: 16Gi
+      cpu: 4
+
 kapacitor:
   # -- Enable Kapacitor.
   enabled: true


### PR DESCRIPTION
Deploy a second instance of Kapacitor and point it to its corresponding InfluxDB instance.
Enable it at base.