### PR TITLE
DM-40567: Bump version of Gafaelfawr

### DIFF
--- a/applications/gafaelfawr/Chart.yaml
+++ b/applications/gafaelfawr/Chart.yaml
@@ -5,7 +5,7 @@ description: Authentication and identity system
 home: https://gafaelfawr.lsst.io/
 sources:
   - https://github.com/lsst-sqre/gafaelfawr
-appVersion: 9.3.0
+appVersion: 9.3.1
 
 dependencies:
   - name: redis


### PR DESCRIPTION
Pick up the Gafaelfawr 9.3.1 release, which has some improvements to error handling.