### PR TITLE
[DM-40723] Disable repairer connectors at USDF

### DIFF
--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -39,69 +39,69 @@ kafka-connect-manager:
     connectors:
       auxtel:
         enabled: true
-        repairerConnector: true
+        repairerConnector: false
         topicsRegex: ".*ATAOS|.*ATDome|.*ATDomeTrajectory|.*ATHexapod|.*ATPneumatics|.*ATPtg|.*ATMCS"
       maintel:
         enabled: true
-        repairerConnector: true
+        repairerConnector: false
         topicsRegex: ".*MTAOS|.*MTDome|.*MTDomeTrajectory|.*MTPtg"
       mtmount:
         enabled: true
-        repairerConnector: true
+        repairerConnector: false
         topicsRegex: ".*MTMount"
         tasksMax: "8"
       comcam:
         enabled: true
-        repairerConnector: true
+        repairerConnector: false
         topicsRegex: ".*CCCamera|.*CCHeaderService|.*CCOODS"
       eas:
         enabled: true
-        repairerConnector: true
+        repairerConnector: false
         topicsRegex: ".*DIMM|.*DSM|.*ESS|.*HVAC|.*WeatherForecast"
       latiss:
         enabled: true
-        repairerConnector: true
+        repairerConnector: false
         topicsRegex: ".*ATCamera|.*ATHeaderService|.*ATOODS|.*ATSpectrograph"
       m1m3:
         enabled: true
-        repairerConnector: true
+        repairerConnector: false
         topicsRegex: ".*MTM1M3"
         tasksMax: "8"
       m2:
         enabled: true
-        repairerConnector: true
+        repairerConnector: false
         topicsRegex: ".*MTHexapod|.*MTM2|.*MTRotator"
       obssys:
         enabled: true
-        repairerConnector: true
+        repairerConnector: false
         topicsRegex: ".*Scheduler|.*Script|.*ScriptQueue|.*Watcher"
       ocps:
         enabled: true
-        repairerConnector: true
+        repairerConnector: false
         topicsRegex: ".*OCPS"
       test:
         enabled: true
-        repairerConnector: true
+        repairerConnector: false
         topicsRegex: "lsst.sal.Test"
       pmd:
         enabled: true
-        repairerConnector: true
+        repairerConnector: false
         topicsRegex: ".*PMD"
       calsys:
         enabled: true
-        repairerConnector: true
+        repairerConnector: false
         topicsRegex: ".*ATMonochromator|.*ATWhiteLight|.*CBP|.*Electrometer|.*FiberSpectrograph|.*LinearStage|.*TunableLaser"
       mtaircompressor:
         enabled: true
-        repairerConnector: true
+        repairerConnector: false
         topicsRegex: ".*MTAirCompressor"
       genericcamera:
         enabled: true
-        repairerConnector: true
+        repairerConnector: false
         topicsRegex: ".*GCHeaderService|.*GenericCamera"
       gis:
         enabled: true
-        repairerConnector: true
+        repairerConnector: false
         topicsRegex: ".*GIS"
       mtvms:
         enabled: true
@@ -109,7 +109,7 @@ kafka-connect-manager:
         topicsRegex: ".*MTVMS"
       lasertracker:
         enabled: true
-        repairerConnector: true
+        repairerConnector: false
         topicsRegex: ".*LaserTracker"
 
 kafdrop:


### PR DESCRIPTION
We confirmed that the repairer connectors are affected similarly by the data corruption errors seen at usdf, and thus there's no need for them to be running since they don't help to mitigate the problem.