### PR TITLE
[DM-40741] Enable MM2 auto-restart feature

### DIFF
--- a/applications/sasquatch/charts/strimzi-kafka/templates/mirrormaker2.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/mirrormaker2.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   version: {{ .Values.kafka.version | quote }}
   replicas: 1
+  autoRestart:
+    enabled: true
   # In the unidirectional (active/passive) replication scenario
   # it is recommended to deploy MirrorMaker2 on the target (passive) cluster.
   connectCluster: "target"


### PR DESCRIPTION
- When enabled, the Strimzi Cluster Operator watches the connector and its tasks for failures and if in case of failures it automatically restarts them.