### PR TITLE
[DM-40761] Datalinker 1.6.2 for hosting 2MASS HiPS

### DIFF
--- a/applications/datalinker/Chart.yaml
+++ b/applications/datalinker/Chart.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 description: IVOA DataLink-based service and data discovery
 sources:
   - https://github.com/lsst-sqre/datalinker
-appVersion: 1.6.1
+appVersion: 1.6.2
 annotations:
   phalanx.lsst.io/docs: |
     - id: "DMTN-238"


### PR DESCRIPTION
This will add the 2MASS HiPS tiles into the static list of paths in the bucket to scrape to make a list.