### PR TITLE
[DM-40761] Add 2MASS color to the list of HiPS sets

### DIFF
--- a/applications/portal/templates/deployment.yaml
+++ b/applications/portal/templates/deployment.yaml
@@ -106,7 +106,8 @@ spec:
                               "temp://lsst/dp02_dc2/hips/images/band_r",
                               "temp://lsst/dp02_dc2/hips/images/band_i",
                               "temp://lsst/dp02_dc2/hips/images/band_z",
-                              "temp://lsst/dp02_dc2/hips/images/band_y"
+                              "temp://lsst/dp02_dc2/hips/images/band_y",
+                              "ivo://CDS/P/2MASS/color"
                           ],
                           "label": "Rubin Featured MOC"
                       }


### PR DESCRIPTION
This will tell the portal to put it in the list of selectable HiPS sets.  It should alread have its properties file as part of the list file.