### PR TITLE
Extend ts-salkafka user access control to groups

### DIFF
--- a/applications/sasquatch/charts/strimzi-kafka/templates/users.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/users.yaml
@@ -18,6 +18,11 @@ spec:
     type: simple
     acls:
       - resource:
+          type: group
+          name: "*"
+          patternType: literal
+        operation: All
+      - resource:
           type: topic
           name: "lsst.sal"
           patternType: prefix


### PR DESCRIPTION
In salobj, the ts-salkafka user also needs authorization to perform operations on kafka groups.