### PR TITLE
Reduce inxfluxdb-source PV to 1TB at base

### DIFF
--- a/applications/sasquatch/values-base.yaml
+++ b/applications/sasquatch/values-base.yaml
@@ -64,7 +64,7 @@ source-influxdb:
   enabled: true
   persistence:
     storageClass: rook-ceph-block
-    size: 10Ti
+    size: 1Ti
   ingress:
     enabled: true
     hostname: base-lsp.lsst.codes

--- a/applications/sasquatch/values-summit.yaml
+++ b/applications/sasquatch/values-summit.yaml
@@ -41,6 +41,15 @@ influxdb2:
     enabled: true
     hostname: summit-lsp.lsst.codes
 
+source-influxdb:
+  enabled: true
+  persistence:
+    storageClass: rook-ceph-block
+    size: 1Ti
+  ingress:
+    enabled: true
+    hostname: summit-lsp.lsst.codes
+
 kafka-connect-manager:
   influxdbSink:
     # Based on the kafka producers configuration for the Summit


### PR DESCRIPTION
This PR temporarily creates 1TB PVs at the base and summit for Ceph write performance tests.