### PR TITLE
Set auto.offset.reset to consume latest offsets

### DIFF
--- a/applications/sasquatch/charts/strimzi-kafka/templates/connect.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/connect.yaml
@@ -36,6 +36,8 @@ spec:
     value.converter.schemas.enable: true
     value.converter.schema.registry.url: http://sasquatch-schema-registry.sasquatch:8081
     request.timeout.ms: 120000
+    auto.offset.reset: latest
+    consumer.auto.offset.reset: latest
   resources:
     requests:
       cpu: "2"


### PR DESCRIPTION
This change was required to recover Kafka from Ceph filling up on September 14th. It was applied to the Summit the same day, and will be reverted during the next Summit maintenance window. Do not merge this PR.