### PR TITLE
Revert version of Portal

### DIFF
--- a/applications/portal/Chart.yaml
+++ b/applications/portal/Chart.yaml
@@ -5,7 +5,7 @@ description: Rubin Science Platform Portal Aspect
 sources:
   - https://github.com/lsst/suit
   - https://github.com/Caltech-IPAC/firefly
-appVersion: "suit-2023.2.1"
+appVersion: "suit-2023.1.5"
 
 dependencies:
   - name: redis


### PR DESCRIPTION
The new Portal release broke the plugin to integrate with the Notebook Aspect.