### PR TITLE
DM-36772: Migrate PostgreSQL credentials to mounted file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,6 +39,11 @@ repos:
           - --chart-search-root=environments
           # The `../` makes it relative to the chart-search-root set above
           - --template-files=../helm-docs.md.gotmpl
+      - id: helm-docs
+        args:
+          - --chart-search-root=charts
+          # The `../` makes it relative to the chart-search-root set above
+          - --template-files=../helm-docs.md.gotmpl
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.0.289

--- a/applications/prompt-proto-service-hsc/Chart.yaml
+++ b/applications/prompt-proto-service-hsc/Chart.yaml
@@ -1,8 +1,16 @@
 apiVersion: v2
 name: prompt-proto-service-hsc
 version: 1.0.0
-description: Deployment for prompt proto service for HSC images
+description: Prompt Proto Service is an event driven service for processing camera images.  The service runs on knative. This deployment handles HSC images.
+home: https://github.com/lsst-dm/prompt_prototype/blob/main/doc/playbook.rst
+sources:
+  - https://github.com/lsst-dm/prompt_prototype
+annotations:
+  phalanx.lsst.io/docs: |
+    - id: "DMTN-219"
+      title: "Proposal and Prototype for Prompt Processing"
+      url: "https://dmtn-219.lsst.io/"
 dependencies:
-- name: prompt-proto-service
-  version: 1.0.0
-  repository: "file://../../charts/prompt-proto-service"
+  - name: prompt-proto-service
+    version: 1.0.0
+    repository: "file://../../charts/prompt-proto-service"

--- a/applications/prompt-proto-service-hsc/README.md
+++ b/applications/prompt-proto-service-hsc/README.md
@@ -13,11 +13,11 @@ Prompt Proto Service is an event driven service for processing camera images.  T
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | prompt-proto-service.additionalVolumeMounts | list | `[]` | Kubernetes YAML configs for extra container volume(s). Any volumes required by other config options are automatically handled by the Helm chart. |
-| prompt-proto-service.apdb.db | string | `"lsst-devl"` | PostgreSQL database name for the APDB |
-| prompt-proto-service.apdb.ip | string | None, must be set | IP address or hostname and port of the APDB |
+| prompt-proto-service.apdb.db | string | `"lsst-devl"` | PostgreSQL database name for the APDB (deprecated for apdb.url) |
+| prompt-proto-service.apdb.ip | string | None, must be set | IP address or hostname and port of the APDB (deprecated for apdb.url) |
 | prompt-proto-service.apdb.namespace | string | `"pp_apdb"` | Database namespace for the APDB |
 | prompt-proto-service.apdb.url | string | None, must be set | URL to the APDB, in any form recognized by SQLAlchemy |
-| prompt-proto-service.apdb.user | string | `"rubin"` | Database user for the APDB |
+| prompt-proto-service.apdb.user | string | `"rubin"` | Database user for the APDB (deprecated for apdb.url) |
 | prompt-proto-service.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
 | prompt-proto-service.image.repository | string | `"ghcr.io/lsst-dm/prompt-proto-service"` | Image to use in the PP deployment |
 | prompt-proto-service.image.tag | string | `"latest"` | Overrides the image tag whose default is the chart appVersion. |
@@ -36,9 +36,9 @@ Prompt Proto Service is an event driven service for processing camera images.  T
 | prompt-proto-service.logLevel | string | log prompt_prototype at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
 | prompt-proto-service.podAnnotations | object | See the `values.yaml` file. | Annotations for the prompt-proto-service pod |
 | prompt-proto-service.registry.centralRepoFile | bool | `false` | If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted. |
-| prompt-proto-service.registry.db | string | None, must be set | PostgreSQL database name for the Butler registry database |
-| prompt-proto-service.registry.ip | string | None, must be set | IP address or hostname and port of the Butler registry database |
-| prompt-proto-service.registry.user | string | None, must be set | Database user for the Butler registry database |
+| prompt-proto-service.registry.db | string | None, must be set | PostgreSQL database name for the Butler registry database (deprecated) |
+| prompt-proto-service.registry.ip | string | None, must be set | IP address or hostname and port of the Butler registry database (deprecated) |
+| prompt-proto-service.registry.user | string | None, must be set | Database user for the Butler registry database (deprecated) |
 | prompt-proto-service.s3.auth_env | bool | `true` | If set, get S3 credentials from this application's Vault secret. |
 | prompt-proto-service.s3.disableBucketValidation | string | `"0"` | Set this to disable validation of S3 bucket names, allowing Ceph multi-tenant colon-separated names to be used. |
 | prompt-proto-service.s3.endpointUrl | string | None, must be set | S3 endpoint containing `imageBucket` |

--- a/applications/prompt-proto-service-hsc/README.md
+++ b/applications/prompt-proto-service-hsc/README.md
@@ -18,7 +18,7 @@ Deployment for prompt proto service for HSC images
 | prompt-proto-service.imageNotifications.topic | string | `""` |  |
 | prompt-proto-service.instrument.calibRepo | string | `""` |  |
 | prompt-proto-service.instrument.name | string | `"HSC"` |  |
-| prompt-proto-service.instrument.pipelines | string | `"(survey=\"SURVEY\")=[${PROMPT_PROTOTYPE_DIR}/pipelines/${RUBIN_INSTRUMENT}/ApPipe.yaml]"` |  |
+| prompt-proto-service.instrument.pipelines | string | `""` |  |
 | prompt-proto-service.instrument.skymap | string | `"hsc_rings_v1"` |  |
 | prompt-proto-service.knative.ephemeralStorageLimit | string | `"20Gi"` |  |
 | prompt-proto-service.knative.ephemeralStorageRequest | string | `"20Gi"` |  |

--- a/applications/prompt-proto-service-hsc/README.md
+++ b/applications/prompt-proto-service-hsc/README.md
@@ -6,30 +6,33 @@ Deployment for prompt proto service for HSC images
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| prompt-proto-service.apdb.db | string | `"lsst-devl"` |  |
-| prompt-proto-service.apdb.ip | string | `""` |  |
-| prompt-proto-service.apdb.namespace | string | `"pp_apdb"` |  |
-| prompt-proto-service.apdb.user | string | `"rubin"` |  |
-| prompt-proto-service.image.pullPolicy | string | `"IfNotPresent"` |  |
-| prompt-proto-service.image.repository | string | `"ghcr.io/lsst-dm/prompt-proto-service"` |  |
-| prompt-proto-service.image.tag | string | `"latest"` |  |
-| prompt-proto-service.imageNotifications.imageTimeout | string | `"120"` |  |
-| prompt-proto-service.imageNotifications.kafkaClusterAddress | string | `""` |  |
-| prompt-proto-service.imageNotifications.topic | string | `""` |  |
-| prompt-proto-service.instrument.calibRepo | string | `""` |  |
-| prompt-proto-service.instrument.name | string | `"HSC"` |  |
-| prompt-proto-service.instrument.pipelines | string | `""` |  |
-| prompt-proto-service.instrument.skymap | string | `"hsc_rings_v1"` |  |
-| prompt-proto-service.knative.ephemeralStorageLimit | string | `"20Gi"` |  |
-| prompt-proto-service.knative.ephemeralStorageRequest | string | `"20Gi"` |  |
-| prompt-proto-service.knative.idleTimeout | int | `900` |  |
-| prompt-proto-service.knative.responseStartTimeout | int | `900` |  |
-| prompt-proto-service.knative.timeout | int | `900` |  |
-| prompt-proto-service.podAnnotations | object | `{"autoscaling.knative.dev/max-scale":"100","autoscaling.knative.dev/min-scale":"3","autoscaling.knative.dev/target-burst-capacity":"-1","autoscaling.knative.dev/target-utilization-percentage":"60","revision":"1"}` | Annotations for the prompt-proto-service pod |
-| prompt-proto-service.registry.db | string | `""` |  |
-| prompt-proto-service.registry.ip | string | `""` |  |
-| prompt-proto-service.registry.user | string | `""` |  |
-| prompt-proto-service.s3.auth_env | bool | `true` |  |
-| prompt-proto-service.s3.disableBucketValidation | string | `"0"` |  |
-| prompt-proto-service.s3.endpointUrl | string | `""` |  |
-| prompt-proto-service.s3.imageBucket | string | `""` |  |
+| prompt-proto-service.additionalVolumeMounts | list | `[]` | Kubernetes YAML configs for extra container volume(s). Any volumes required by other config options are automatically handled by the Helm chart. |
+| prompt-proto-service.apdb.db | string | `"lsst-devl"` | PostgreSQL database name for the APDB |
+| prompt-proto-service.apdb.ip | string | None, must be set | IP address or hostname and port of the APDB |
+| prompt-proto-service.apdb.namespace | string | `"pp_apdb"` | Database namespace for the APDB |
+| prompt-proto-service.apdb.user | string | `"rubin"` | Database user for the APDB |
+| prompt-proto-service.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
+| prompt-proto-service.image.repository | string | `"ghcr.io/lsst-dm/prompt-proto-service"` | Image to use in the PP deployment |
+| prompt-proto-service.image.tag | string | `"latest"` | Overrides the image tag whose default is the chart appVersion. |
+| prompt-proto-service.imageNotifications.imageTimeout | string | `"120"` | Timeout to wait after expected script completion for raw image arrival (seconds). |
+| prompt-proto-service.imageNotifications.kafkaClusterAddress | string | None, must be set | Hostname and port of the Kafka provider |
+| prompt-proto-service.imageNotifications.topic | string | None, must be set | Topic where raw image arrival notifications appear |
+| prompt-proto-service.instrument.calibRepo | string | None, must be set | URI to the shared repo used for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself. |
+| prompt-proto-service.instrument.name | string | `"HSC"` | The "short" name of the instrument |
+| prompt-proto-service.instrument.pipelines | string | None, must be set | Machine-readable string describing which pipeline(s) should be run for which visits. Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_prototype/blob/main/python/activator/config.py) for examples. |
+| prompt-proto-service.instrument.skymap | string | `"hsc_rings_v1"` | Skymap to use with the instrument |
+| prompt-proto-service.knative.ephemeralStorageLimit | string | `"20Gi"` | The maximum storage space allowed for each container (mostly local Butler). |
+| prompt-proto-service.knative.ephemeralStorageRequest | string | `"20Gi"` | The storage space reserved for each container (mostly local Butler). |
+| prompt-proto-service.knative.idleTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service (seconds). |
+| prompt-proto-service.knative.responseStartTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service after initial submission (seconds). |
+| prompt-proto-service.knative.timeout | int | `900` | Maximum time that a container can respond to a next_visit request (seconds). |
+| prompt-proto-service.logLevel | string | log prompt_prototype at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
+| prompt-proto-service.podAnnotations | object | See the `values.yaml` file. | Annotations for the prompt-proto-service pod |
+| prompt-proto-service.registry.centralRepoFile | bool | `false` | If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted. |
+| prompt-proto-service.registry.db | string | None, must be set | PostgreSQL database name for the Butler registry database |
+| prompt-proto-service.registry.ip | string | None, must be set | IP address or hostname and port of the Butler registry database |
+| prompt-proto-service.registry.user | string | None, must be set | Database user for the Butler registry database |
+| prompt-proto-service.s3.auth_env | bool | `true` | If set, get S3 credentials from this application's Vault secret. |
+| prompt-proto-service.s3.disableBucketValidation | string | `"0"` | Set this to disable validation of S3 bucket names, allowing Ceph multi-tenant colon-separated names to be used. |
+| prompt-proto-service.s3.endpointUrl | string | None, must be set | S3 endpoint containing `imageBucket` |
+| prompt-proto-service.s3.imageBucket | string | None, must be set | Bucket containing the incoming raw images |

--- a/applications/prompt-proto-service-hsc/README.md
+++ b/applications/prompt-proto-service-hsc/README.md
@@ -16,6 +16,7 @@ Prompt Proto Service is an event driven service for processing camera images.  T
 | prompt-proto-service.apdb.db | string | `"lsst-devl"` | PostgreSQL database name for the APDB |
 | prompt-proto-service.apdb.ip | string | None, must be set | IP address or hostname and port of the APDB |
 | prompt-proto-service.apdb.namespace | string | `"pp_apdb"` | Database namespace for the APDB |
+| prompt-proto-service.apdb.url | string | None, must be set | URL to the APDB, in any form recognized by SQLAlchemy |
 | prompt-proto-service.apdb.user | string | `"rubin"` | Database user for the APDB |
 | prompt-proto-service.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
 | prompt-proto-service.image.repository | string | `"ghcr.io/lsst-dm/prompt-proto-service"` | Image to use in the PP deployment |

--- a/applications/prompt-proto-service-hsc/README.md
+++ b/applications/prompt-proto-service-hsc/README.md
@@ -1,6 +1,12 @@
 # prompt-proto-service-hsc
 
-Deployment for prompt proto service for HSC images
+Prompt Proto Service is an event driven service for processing camera images.  The service runs on knative. This deployment handles HSC images.
+
+**Homepage:** <https://github.com/lsst-dm/prompt_prototype/blob/main/doc/playbook.rst>
+
+## Source Code
+
+* <https://github.com/lsst-dm/prompt_prototype>
 
 ## Values
 

--- a/applications/prompt-proto-service-hsc/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-hsc/values-usdfdev-prompt-processing.yaml
@@ -24,6 +24,7 @@ prompt-proto-service:
     topic: rubin-prompt-processing
 
   apdb:
+    url: postgresql://rubin@usdf-prompt-processing-dev.slac.stanford.edu:5432/lsst-devl
     ip: usdf-prompt-processing-dev.slac.stanford.edu:5432
 
   registry:

--- a/applications/prompt-proto-service-hsc/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-hsc/values-usdfdev-prompt-processing.yaml
@@ -11,6 +11,7 @@ prompt-proto-service:
     tag: latest
 
   instrument:
+    pipelines: (survey="SURVEY")=[${PROMPT_PROTOTYPE_DIR}/pipelines/${RUBIN_INSTRUMENT}/ApPipe.yaml]
     calibRepo: s3://rubin:rubin-pp-users/central_repo/
 
   s3:

--- a/applications/prompt-proto-service-hsc/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-hsc/values-usdfdev-prompt-processing.yaml
@@ -11,7 +11,7 @@ prompt-proto-service:
     tag: latest
 
   instrument:
-    pipelines: (survey="SURVEY")=[${PROMPT_PROTOTYPE_DIR}/pipelines/${RUBIN_INSTRUMENT}/ApPipe.yaml]
+    pipelines: (survey="SURVEY")=[${PROMPT_PROTOTYPE_DIR}/pipelines/HSC/ApPipe.yaml]
     calibRepo: s3://rubin:rubin-pp-users/central_repo/
 
   s3:

--- a/applications/prompt-proto-service-hsc/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-hsc/values-usdfdev-prompt-processing.yaml
@@ -25,9 +25,9 @@ prompt-proto-service:
 
   apdb:
     url: postgresql://rubin@usdf-prompt-processing-dev.slac.stanford.edu:5432/lsst-devl
-    ip: usdf-prompt-processing-dev.slac.stanford.edu:5432
+    ip: usdf-prompt-processing-dev.slac.stanford.edu:5432  # TODO: remove on DM-40839
 
-  registry:
+  registry:  # TODO: remove on DM-40839
     ip: usdf-prompt-processing-dev.slac.stanford.edu:5432
     db: ppcentralbutler
     user: pp

--- a/applications/prompt-proto-service-hsc/values.yaml
+++ b/applications/prompt-proto-service-hsc/values.yaml
@@ -1,6 +1,7 @@
 prompt-proto-service:
 
   # -- Annotations for the prompt-proto-service pod
+  # @default -- See the `values.yaml` file.
   podAnnotations:
     autoscaling.knative.dev/min-scale: "3"
     autoscaling.knative.dev/max-scale: "100"
@@ -10,42 +11,90 @@ prompt-proto-service:
     revision: "1"
 
   image:
+    # -- Image to use in the PP deployment
     repository: ghcr.io/lsst-dm/prompt-proto-service
+    # -- Pull policy for the PP image
+    # @default -- `IfNotPresent` in prod, `Always` in dev
     pullPolicy: IfNotPresent
-    # Overrides the image tag whose default is the chart appVersion.
+    # -- Overrides the image tag whose default is the chart appVersion.
     tag: latest
 
   instrument:
+    # -- The "short" name of the instrument
     name: HSC
+    # -- Machine-readable string describing which pipeline(s) should be run for which visits.
+    # Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_prototype/blob/main/python/activator/config.py) for examples.
+    # @default -- None, must be set
     pipelines: ""
+    # -- Skymap to use with the instrument
     skymap: hsc_rings_v1
+    # -- URI to the shared repo used for calibrations, templates, and pipeline outputs.
+    # If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself.
+    # @default -- None, must be set
     calibRepo: ""
 
   s3:
+    # -- Bucket containing the incoming raw images
+    # @default -- None, must be set
     imageBucket: ""
+    # -- S3 endpoint containing `imageBucket`
+    # @default -- None, must be set
     endpointUrl: ""
+    # -- If set, get S3 credentials from this application's Vault secret.
     auth_env: true
+    # -- Set this to disable validation of S3 bucket names, allowing Ceph multi-tenant colon-separated names to be used.
     disableBucketValidation: '0'
 
   imageNotifications:
+    # -- Hostname and port of the Kafka provider
+    # @default -- None, must be set
     kafkaClusterAddress: ""
+    # -- Topic where raw image arrival notifications appear
+    # @default -- None, must be set
     topic: ""
+    # -- Timeout to wait after expected script completion for raw image arrival (seconds).
     imageTimeout: '120'
 
   apdb:
+    # -- IP address or hostname and port of the APDB
+    # @default -- None, must be set
     ip: ""
+    # -- PostgreSQL database name for the APDB
     db: lsst-devl
+    # -- Database user for the APDB
     user: rubin
+    # -- Database namespace for the APDB
     namespace: pp_apdb
 
   registry:
+    # -- IP address or hostname and port of the Butler registry database
+    # @default -- None, must be set
     ip: ""
+    # -- PostgreSQL database name for the Butler registry database
+    # @default -- None, must be set
     db: ""
+    # -- Database user for the Butler registry database
+    # @default -- None, must be set
     user: ""
+    # -- If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted.
+    centralRepoFile: false
+
+  # -- Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level).
+  # @default -- log prompt_prototype at DEBUG, other LSST code at INFO, and third-party code at WARNING.
+  logLevel: ""
 
   knative:
+    # -- The storage space reserved for each container (mostly local Butler).
     ephemeralStorageRequest: "20Gi"
+    # -- The maximum storage space allowed for each container (mostly local Butler).
     ephemeralStorageLimit: "20Gi"
+    # -- Maximum time that a container can respond to a next_visit request (seconds).
     timeout: 900
+    # -- Maximum time that a container can send nothing to the fanout service (seconds).
     idleTimeout: 900
+    # -- Maximum time that a container can send nothing to the fanout service after initial submission (seconds).
     responseStartTimeout: 900
+
+  # -- Kubernetes YAML configs for extra container volume(s).
+  # Any volumes required by other config options are automatically handled by the Helm chart.
+  additionalVolumeMounts: []

--- a/applications/prompt-proto-service-hsc/values.yaml
+++ b/applications/prompt-proto-service-hsc/values.yaml
@@ -17,7 +17,7 @@ prompt-proto-service:
 
   instrument:
     name: HSC
-    pipelines: (survey="SURVEY")=[${PROMPT_PROTOTYPE_DIR}/pipelines/${RUBIN_INSTRUMENT}/ApPipe.yaml]
+    pipelines: ""
     skymap: hsc_rings_v1
     calibRepo: ""
 

--- a/applications/prompt-proto-service-hsc/values.yaml
+++ b/applications/prompt-proto-service-hsc/values.yaml
@@ -59,26 +59,26 @@ prompt-proto-service:
     # -- URL to the APDB, in any form recognized by SQLAlchemy
     # @default -- None, must be set
     url: ""
-    # -- IP address or hostname and port of the APDB
+    # -- IP address or hostname and port of the APDB (deprecated for apdb.url)
     # @default -- None, must be set
-    ip: ""
-    # -- PostgreSQL database name for the APDB
-    db: lsst-devl
-    # -- Database user for the APDB
-    user: rubin
+    ip: ""  # TODO: remove on DM-40839
+    # -- PostgreSQL database name for the APDB (deprecated for apdb.url)
+    db: lsst-devl  # TODO: remove on DM-40839
+    # -- Database user for the APDB (deprecated for apdb.url)
+    user: rubin  # TODO: remove on DM-40839
     # -- Database namespace for the APDB
     namespace: pp_apdb
 
   registry:
-    # -- IP address or hostname and port of the Butler registry database
+    # -- IP address or hostname and port of the Butler registry database (deprecated)
     # @default -- None, must be set
-    ip: ""
-    # -- PostgreSQL database name for the Butler registry database
+    ip: ""  # TODO: remove on DM-40839
+    # -- PostgreSQL database name for the Butler registry database (deprecated)
     # @default -- None, must be set
-    db: ""
-    # -- Database user for the Butler registry database
+    db: ""  # TODO: remove on DM-40839
+    # -- Database user for the Butler registry database (deprecated)
     # @default -- None, must be set
-    user: ""
+    user: ""  # TODO: remove on DM-40839
     # -- If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted.
     centralRepoFile: false
 

--- a/applications/prompt-proto-service-hsc/values.yaml
+++ b/applications/prompt-proto-service-hsc/values.yaml
@@ -56,6 +56,9 @@ prompt-proto-service:
     imageTimeout: '120'
 
   apdb:
+    # -- URL to the APDB, in any form recognized by SQLAlchemy
+    # @default -- None, must be set
+    url: ""
     # -- IP address or hostname and port of the APDB
     # @default -- None, must be set
     ip: ""

--- a/applications/prompt-proto-service-latiss/Chart.yaml
+++ b/applications/prompt-proto-service-latiss/Chart.yaml
@@ -1,8 +1,16 @@
 apiVersion: v2
 name: prompt-proto-service-latiss
 version: 1.0.0
-description: Deployment for prompt proto service for LATISS images
+description: Prompt Proto Service is an event driven service for processing camera images.  The service runs on knative. This deployment handles LATISS images.
+home: https://github.com/lsst-dm/prompt_prototype/blob/main/doc/playbook.rst
+sources:
+  - https://github.com/lsst-dm/prompt_prototype
+annotations:
+  phalanx.lsst.io/docs: |
+    - id: "DMTN-219"
+      title: "Proposal and Prototype for Prompt Processing"
+      url: "https://dmtn-219.lsst.io/"
 dependencies:
-- name: prompt-proto-service
-  version: 1.0.0
-  repository: "file://../../charts/prompt-proto-service"
+  - name: prompt-proto-service
+    version: 1.0.0
+    repository: "file://../../charts/prompt-proto-service"

--- a/applications/prompt-proto-service-latiss/README.md
+++ b/applications/prompt-proto-service-latiss/README.md
@@ -6,32 +6,33 @@ Deployment for prompt proto service for LATISS images
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| prompt-proto-service.apdb.db | string | `"lsst-devl"` |  |
-| prompt-proto-service.apdb.ip | string | `""` |  |
-| prompt-proto-service.apdb.namespace | string | `"pp_apdb"` |  |
-| prompt-proto-service.apdb.user | string | `"rubin"` |  |
-| prompt-proto-service.image.pullPolicy | string | `"IfNotPresent"` |  |
-| prompt-proto-service.image.repository | string | `"ghcr.io/lsst-dm/prompt-proto-service"` |  |
-| prompt-proto-service.image.tag | string | `"latest"` |  |
-| prompt-proto-service.imageNotifications.imageTimeout | string | `"120"` |  |
-| prompt-proto-service.imageNotifications.kafkaClusterAddress | string | `""` |  |
-| prompt-proto-service.imageNotifications.topic | string | `""` |  |
-| prompt-proto-service.instrument.calibRepo | string | `"s3://rubin-summit-users/"` |  |
-| prompt-proto-service.instrument.name | string | `"LATISS"` |  |
-| prompt-proto-service.instrument.pipelines | string | `""` |  |
-| prompt-proto-service.instrument.skymap | string | `"latiss_v1"` |  |
-| prompt-proto-service.knative.ephemeralStorageLimit | string | `"20Gi"` |  |
-| prompt-proto-service.knative.ephemeralStorageRequest | string | `"20Gi"` |  |
-| prompt-proto-service.knative.idleTimeout | int | `900` |  |
-| prompt-proto-service.knative.responseStartTimeout | int | `900` |  |
-| prompt-proto-service.knative.timeout | int | `900` |  |
-| prompt-proto-service.logLevel | string | `""` |  |
-| prompt-proto-service.podAnnotations | object | `{"autoscaling.knative.dev/max-scale":"100","autoscaling.knative.dev/min-scale":"3","autoscaling.knative.dev/target-burst-capacity":"-1","autoscaling.knative.dev/target-utilization-percentage":"60","revision":"1"}` | Annotations for the prompt-proto-service pod |
-| prompt-proto-service.registry.centralRepoFile | bool | `false` |  |
-| prompt-proto-service.registry.db | string | `"lsstdb1"` |  |
-| prompt-proto-service.registry.ip | string | `""` |  |
-| prompt-proto-service.registry.user | string | `"rubin"` |  |
-| prompt-proto-service.s3.auth_env | bool | `true` |  |
-| prompt-proto-service.s3.disableBucketValidation | string | `"0"` |  |
+| prompt-proto-service.additionalVolumeMounts | list | `[]` | Kubernetes YAML configs for extra container volume(s). Any volumes required by other config options are automatically handled by the Helm chart. |
+| prompt-proto-service.apdb.db | string | `"lsst-devl"` | PostgreSQL database name for the APDB |
+| prompt-proto-service.apdb.ip | string | None, must be set | IP address or hostname and port of the APDB |
+| prompt-proto-service.apdb.namespace | string | `"pp_apdb"` | Database namespace for the APDB |
+| prompt-proto-service.apdb.user | string | `"rubin"` | Database user for the APDB |
+| prompt-proto-service.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
+| prompt-proto-service.image.repository | string | `"ghcr.io/lsst-dm/prompt-proto-service"` | Image to use in the PP deployment |
+| prompt-proto-service.image.tag | string | `"latest"` | Overrides the image tag whose default is the chart appVersion. |
+| prompt-proto-service.imageNotifications.imageTimeout | string | `"120"` | Timeout to wait after expected script completion for raw image arrival (seconds). |
+| prompt-proto-service.imageNotifications.kafkaClusterAddress | string | None, must be set | Hostname and port of the Kafka provider |
+| prompt-proto-service.imageNotifications.topic | string | None, must be set | Topic where raw image arrival notifications appear |
+| prompt-proto-service.instrument.calibRepo | string | None, must be set | URI to the shared repo used for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself. |
+| prompt-proto-service.instrument.name | string | `"LATISS"` | The "short" name of the instrument |
+| prompt-proto-service.instrument.pipelines | string | None, must be set | Machine-readable string describing which pipeline(s) should be run for which visits. Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_prototype/blob/main/python/activator/config.py) for examples. |
+| prompt-proto-service.instrument.skymap | string | `"latiss_v1"` | Skymap to use with the instrument |
+| prompt-proto-service.knative.ephemeralStorageLimit | string | `"20Gi"` | The maximum storage space allowed for each container (mostly local Butler). |
+| prompt-proto-service.knative.ephemeralStorageRequest | string | `"20Gi"` | The storage space reserved for each container (mostly local Butler). |
+| prompt-proto-service.knative.idleTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service (seconds). |
+| prompt-proto-service.knative.responseStartTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service after initial submission (seconds). |
+| prompt-proto-service.knative.timeout | int | `900` | Maximum time that a container can respond to a next_visit request (seconds). |
+| prompt-proto-service.logLevel | string | log prompt_prototype at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
+| prompt-proto-service.podAnnotations | object | See the `values.yaml` file. | Annotations for the prompt-proto-service pod |
+| prompt-proto-service.registry.centralRepoFile | bool | `false` | If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted. |
+| prompt-proto-service.registry.db | string | None, must be set | PostgreSQL database name for the Butler registry database |
+| prompt-proto-service.registry.ip | string | None, must be set | IP address or hostname and port of the Butler registry database |
+| prompt-proto-service.registry.user | string | None, must be set | Database user for the Butler registry database |
+| prompt-proto-service.s3.auth_env | bool | `true` | If set, get S3 credentials from this application's Vault secret. |
+| prompt-proto-service.s3.disableBucketValidation | string | `"0"` | Set this to disable validation of S3 bucket names, allowing Ceph multi-tenant colon-separated names to be used. |
 | prompt-proto-service.s3.endpointUrl | string | `""` |  |
-| prompt-proto-service.s3.imageBucket | string | `""` |  |
+| prompt-proto-service.s3.imageBucket | string | None, must be set | Bucket containing the incoming raw images |

--- a/applications/prompt-proto-service-latiss/README.md
+++ b/applications/prompt-proto-service-latiss/README.md
@@ -13,11 +13,11 @@ Prompt Proto Service is an event driven service for processing camera images.  T
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | prompt-proto-service.additionalVolumeMounts | list | `[]` | Kubernetes YAML configs for extra container volume(s). Any volumes required by other config options are automatically handled by the Helm chart. |
-| prompt-proto-service.apdb.db | string | `"lsst-devl"` | PostgreSQL database name for the APDB |
-| prompt-proto-service.apdb.ip | string | None, must be set | IP address or hostname and port of the APDB |
+| prompt-proto-service.apdb.db | string | `"lsst-devl"` | PostgreSQL database name for the APDB (deprecated for apdb.url) |
+| prompt-proto-service.apdb.ip | string | None, must be set | IP address or hostname and port of the APDB (deprecated for apdb.url) |
 | prompt-proto-service.apdb.namespace | string | `"pp_apdb"` | Database namespace for the APDB |
 | prompt-proto-service.apdb.url | string | None, must be set | URL to the APDB, in any form recognized by SQLAlchemy |
-| prompt-proto-service.apdb.user | string | `"rubin"` | Database user for the APDB |
+| prompt-proto-service.apdb.user | string | `"rubin"` | Database user for the APDB (deprecated for apdb.url) |
 | prompt-proto-service.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
 | prompt-proto-service.image.repository | string | `"ghcr.io/lsst-dm/prompt-proto-service"` | Image to use in the PP deployment |
 | prompt-proto-service.image.tag | string | `"latest"` | Overrides the image tag whose default is the chart appVersion. |
@@ -36,9 +36,9 @@ Prompt Proto Service is an event driven service for processing camera images.  T
 | prompt-proto-service.logLevel | string | log prompt_prototype at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
 | prompt-proto-service.podAnnotations | object | See the `values.yaml` file. | Annotations for the prompt-proto-service pod |
 | prompt-proto-service.registry.centralRepoFile | bool | `false` | If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted. |
-| prompt-proto-service.registry.db | string | None, must be set | PostgreSQL database name for the Butler registry database |
-| prompt-proto-service.registry.ip | string | None, must be set | IP address or hostname and port of the Butler registry database |
-| prompt-proto-service.registry.user | string | None, must be set | Database user for the Butler registry database |
+| prompt-proto-service.registry.db | string | None, must be set | PostgreSQL database name for the Butler registry database (deprecated) |
+| prompt-proto-service.registry.ip | string | None, must be set | IP address or hostname and port of the Butler registry database (deprecated) |
+| prompt-proto-service.registry.user | string | None, must be set | Database user for the Butler registry database (deprecated) |
 | prompt-proto-service.s3.auth_env | bool | `true` | If set, get S3 credentials from this application's Vault secret. |
 | prompt-proto-service.s3.disableBucketValidation | string | `"0"` | Set this to disable validation of S3 bucket names, allowing Ceph multi-tenant colon-separated names to be used. |
 | prompt-proto-service.s3.endpointUrl | string | `""` |  |

--- a/applications/prompt-proto-service-latiss/README.md
+++ b/applications/prompt-proto-service-latiss/README.md
@@ -16,6 +16,7 @@ Prompt Proto Service is an event driven service for processing camera images.  T
 | prompt-proto-service.apdb.db | string | `"lsst-devl"` | PostgreSQL database name for the APDB |
 | prompt-proto-service.apdb.ip | string | None, must be set | IP address or hostname and port of the APDB |
 | prompt-proto-service.apdb.namespace | string | `"pp_apdb"` | Database namespace for the APDB |
+| prompt-proto-service.apdb.url | string | None, must be set | URL to the APDB, in any form recognized by SQLAlchemy |
 | prompt-proto-service.apdb.user | string | `"rubin"` | Database user for the APDB |
 | prompt-proto-service.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
 | prompt-proto-service.image.repository | string | `"ghcr.io/lsst-dm/prompt-proto-service"` | Image to use in the PP deployment |

--- a/applications/prompt-proto-service-latiss/README.md
+++ b/applications/prompt-proto-service-latiss/README.md
@@ -1,6 +1,12 @@
 # prompt-proto-service-latiss
 
-Deployment for prompt proto service for LATISS images
+Prompt Proto Service is an event driven service for processing camera images.  The service runs on knative. This deployment handles LATISS images.
+
+**Homepage:** <https://github.com/lsst-dm/prompt_prototype/blob/main/doc/playbook.rst>
+
+## Source Code
+
+* <https://github.com/lsst-dm/prompt_prototype>
 
 ## Values
 

--- a/applications/prompt-proto-service-latiss/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfdev-prompt-processing.yaml
@@ -22,6 +22,7 @@ prompt-proto-service:
     topic: rubin-prompt-processing
 
   apdb:
+    url: postgresql://rubin@usdf-prompt-processing-dev.slac.stanford.edu/lsst-devl
     ip: usdf-prompt-processing-dev.slac.stanford.edu:5432
 
   registry:

--- a/applications/prompt-proto-service-latiss/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfdev-prompt-processing.yaml
@@ -23,9 +23,9 @@ prompt-proto-service:
 
   apdb:
     url: postgresql://rubin@usdf-prompt-processing-dev.slac.stanford.edu/lsst-devl
-    ip: usdf-prompt-processing-dev.slac.stanford.edu:5432
+    ip: usdf-prompt-processing-dev.slac.stanford.edu:5432  # TODO: remove on DM-40839
 
-  registry:
+  registry:  # TODO: remove on DM-40839
     ip: usdf-butler.slac.stanford.edu:5432
 
   fullnameOverride: "prompt-proto-service-latiss"

--- a/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
@@ -12,12 +12,12 @@ prompt-proto-service:
 
   instrument:
     pipelines: >-
-      (survey="AUXTEL_PHOTO_IMAGING")=[${PROMPT_PROTOTYPE_DIR}/pipelines/${RUBIN_INSTRUMENT}/ApPipe.yaml,
-      ${PROMPT_PROTOTYPE_DIR}/pipelines/${RUBIN_INSTRUMENT}/SingleFrame.yaml,
-      ${PROMPT_PROTOTYPE_DIR}/pipelines/${RUBIN_INSTRUMENT}/Isr.yaml]
-      (survey="AUXTEL_DRP_IMAGING")=[${PROMPT_PROTOTYPE_DIR}/pipelines/${RUBIN_INSTRUMENT}/ApPipe.yaml,
-      ${PROMPT_PROTOTYPE_DIR}/pipelines/${RUBIN_INSTRUMENT}/SingleFrame.yaml,
-      ${PROMPT_PROTOTYPE_DIR}/pipelines/${RUBIN_INSTRUMENT}/Isr.yaml]
+      (survey="AUXTEL_PHOTO_IMAGING")=[${PROMPT_PROTOTYPE_DIR}/pipelines/LATISS/ApPipe.yaml,
+      ${PROMPT_PROTOTYPE_DIR}/pipelines/LATISS/SingleFrame.yaml,
+      ${PROMPT_PROTOTYPE_DIR}/pipelines/LATISS/Isr.yaml]
+      (survey="AUXTEL_DRP_IMAGING")=[${PROMPT_PROTOTYPE_DIR}/pipelines/LATISS/ApPipe.yaml,
+      ${PROMPT_PROTOTYPE_DIR}/pipelines/LATISS/SingleFrame.yaml,
+      ${PROMPT_PROTOTYPE_DIR}/pipelines/LATISS/Isr.yaml]
       (survey="spec")=[] (survey="spec_with_rotation")=[] (survey="spec_bright")=[] (survey="spec_bright_with_rotation")=[] (survey="spec_pole")=[] (survey="spec_pole_with_rotation")=[] (survey="")=[]
     calibRepo: /app/butler
 

--- a/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
@@ -30,6 +30,7 @@ prompt-proto-service:
     topic: rubin-prompt-processing-prod
 
   apdb:
+    url: postgresql://rubin@usdf-prompt-processing.slac.stanford.edu:5432/lsst-devl
     ip: usdf-prompt-processing.slac.stanford.edu:5432
 
   registry:

--- a/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
@@ -31,10 +31,10 @@ prompt-proto-service:
 
   apdb:
     url: postgresql://rubin@usdf-prompt-processing.slac.stanford.edu:5432/lsst-devl
-    ip: usdf-prompt-processing.slac.stanford.edu:5432
+    ip: usdf-prompt-processing.slac.stanford.edu:5432  # TODO: remove on DM-40839
 
   registry:
-    ip: usdf-butler.slac.stanford.edu:5432
+    ip: usdf-butler.slac.stanford.edu:5432  # TODO: remove on DM-40839
     centralRepoFile: true
 
   logLevel: lsst.resources=DEBUG

--- a/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
@@ -43,7 +43,3 @@ prompt-proto-service:
     ephemeralStorageLimit: "50Gi"
 
   fullnameOverride: "prompt-proto-service-latiss"
-
-  additionalVolumeMounts:
-    - mountPath: /app/butler/
-      name: central-repo-file

--- a/applications/prompt-proto-service-latiss/values.yaml
+++ b/applications/prompt-proto-service-latiss/values.yaml
@@ -59,26 +59,26 @@ prompt-proto-service:
     # -- URL to the APDB, in any form recognized by SQLAlchemy
     # @default -- None, must be set
     url: ""
-    # -- IP address or hostname and port of the APDB
+    # -- IP address or hostname and port of the APDB (deprecated for apdb.url)
     # @default -- None, must be set
-    ip: ""
-    # -- PostgreSQL database name for the APDB
-    db: lsst-devl
-    # -- Database user for the APDB
-    user: rubin
+    ip: ""  # TODO: remove on DM-40839
+    # -- PostgreSQL database name for the APDB (deprecated for apdb.url)
+    db: lsst-devl  # TODO: remove on DM-40839
+    # -- Database user for the APDB (deprecated for apdb.url)
+    user: rubin  # TODO: remove on DM-40839
     # -- Database namespace for the APDB
     namespace: pp_apdb
 
   registry:
-    # -- IP address or hostname and port of the Butler registry database
+    # -- IP address or hostname and port of the Butler registry database (deprecated)
     # @default -- None, must be set
-    ip: ""
-    # -- PostgreSQL database name for the Butler registry database
+    ip: ""  # TODO: remove on DM-40839
+    # -- PostgreSQL database name for the Butler registry database (deprecated)
     # @default -- None, must be set
-    db: lsstdb1
-    # -- Database user for the Butler registry database
+    db: lsstdb1  # TODO: remove on DM-40839
+    # -- Database user for the Butler registry database (deprecated)
     # @default -- None, must be set
-    user: rubin
+    user: rubin  # TODO: remove on DM-40839
     # -- If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted.
     centralRepoFile: false
 

--- a/applications/prompt-proto-service-latiss/values.yaml
+++ b/applications/prompt-proto-service-latiss/values.yaml
@@ -56,6 +56,9 @@ prompt-proto-service:
     imageTimeout: '120'
 
   apdb:
+    # -- URL to the APDB, in any form recognized by SQLAlchemy
+    # @default -- None, must be set
+    url: ""
     # -- IP address or hostname and port of the APDB
     # @default -- None, must be set
     ip: ""

--- a/applications/prompt-proto-service-latiss/values.yaml
+++ b/applications/prompt-proto-service-latiss/values.yaml
@@ -1,6 +1,7 @@
 prompt-proto-service:
 
   # -- Annotations for the prompt-proto-service pod
+  # @default -- See the `values.yaml` file.
   podAnnotations:
     autoscaling.knative.dev/min-scale: "3"
     autoscaling.knative.dev/max-scale: "100"
@@ -11,45 +12,89 @@ prompt-proto-service:
 
 
   image:
+    # -- Image to use in the PP deployment
     repository: ghcr.io/lsst-dm/prompt-proto-service
+    # -- Pull policy for the PP image
+    # @default -- `IfNotPresent` in prod, `Always` in dev
     pullPolicy: IfNotPresent
-    # Overrides the image tag whose default is the chart appVersion.
+    # -- Overrides the image tag whose default is the chart appVersion.
     tag: latest
 
   instrument:
+    # -- The "short" name of the instrument
     name: LATISS
+    # -- Machine-readable string describing which pipeline(s) should be run for which visits.
+    # Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_prototype/blob/main/python/activator/config.py) for examples.
+    # @default -- None, must be set
     pipelines: ""
+    # -- Skymap to use with the instrument
     skymap: latiss_v1
+    # -- URI to the shared repo used for calibrations, templates, and pipeline outputs.
+    # If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself.
+    # @default -- None, must be set
     calibRepo: s3://rubin-summit-users/
 
   s3:
+    # -- Bucket containing the incoming raw images
+    # @default -- None, must be set
     imageBucket: ""
+    # @default -- None, must be set
     endpointUrl: ""
+    # -- If set, get S3 credentials from this application's Vault secret.
     auth_env: true
+    # -- Set this to disable validation of S3 bucket names, allowing Ceph multi-tenant colon-separated names to be used.
     disableBucketValidation: '0'
 
   imageNotifications:
+    # -- Hostname and port of the Kafka provider
+    # @default -- None, must be set
     kafkaClusterAddress: ""
+    # -- Topic where raw image arrival notifications appear
+    # @default -- None, must be set
     topic: ""
+    # -- Timeout to wait after expected script completion for raw image arrival (seconds).
     imageTimeout: '120'
 
   apdb:
+    # -- IP address or hostname and port of the APDB
+    # @default -- None, must be set
     ip: ""
+    # -- PostgreSQL database name for the APDB
     db: lsst-devl
+    # -- Database user for the APDB
     user: rubin
+    # -- Database namespace for the APDB
     namespace: pp_apdb
 
   registry:
+    # -- IP address or hostname and port of the Butler registry database
+    # @default -- None, must be set
     ip: ""
+    # -- PostgreSQL database name for the Butler registry database
+    # @default -- None, must be set
     db: lsstdb1
+    # -- Database user for the Butler registry database
+    # @default -- None, must be set
     user: rubin
+    # -- If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted.
     centralRepoFile: false
 
+  # -- Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level).
+  # @default -- log prompt_prototype at DEBUG, other LSST code at INFO, and third-party code at WARNING.
   logLevel: ""
 
   knative:
+    # -- The storage space reserved for each container (mostly local Butler).
     ephemeralStorageRequest: "20Gi"
+    # -- The maximum storage space allowed for each container (mostly local Butler).
     ephemeralStorageLimit: "20Gi"
+    # -- Maximum time that a container can respond to a next_visit request (seconds).
     timeout: 900
+    # -- Maximum time that a container can send nothing to the fanout service (seconds).
     idleTimeout: 900
+    # -- Maximum time that a container can send nothing to the fanout service after initial submission (seconds).
     responseStartTimeout: 900
+
+  # -- Kubernetes YAML configs for extra container volume(s).
+  # Any volumes required by other config options are automatically handled by the Helm chart.
+  additionalVolumeMounts: []

--- a/applications/prompt-proto-service-lsstcam/Chart.yaml
+++ b/applications/prompt-proto-service-lsstcam/Chart.yaml
@@ -1,8 +1,16 @@
 apiVersion: v2
 name: prompt-proto-service-lsstcam
 version: 1.0.0
-description: Deployment for prompt proto service for LSSTCam images
+description: Prompt Proto Service is an event driven service for processing camera images.  The service runs on knative. This deployment handles LSSTCam images.
+home: https://github.com/lsst-dm/prompt_prototype/blob/main/doc/playbook.rst
+sources:
+  - https://github.com/lsst-dm/prompt_prototype
+annotations:
+  phalanx.lsst.io/docs: |
+    - id: "DMTN-219"
+      title: "Proposal and Prototype for Prompt Processing"
+      url: "https://dmtn-219.lsst.io/"
 dependencies:
-- name: prompt-proto-service
-  version: 1.0.0
-  repository: "file://../../charts/prompt-proto-service"
+  - name: prompt-proto-service
+    version: 1.0.0
+    repository: "file://../../charts/prompt-proto-service"

--- a/applications/prompt-proto-service-lsstcam/README.md
+++ b/applications/prompt-proto-service-lsstcam/README.md
@@ -13,11 +13,11 @@ Prompt Proto Service is an event driven service for processing camera images.  T
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | prompt-proto-service.additionalVolumeMounts | list | `[]` | Kubernetes YAML configs for extra container volume(s). Any volumes required by other config options are automatically handled by the Helm chart. |
-| prompt-proto-service.apdb.db | string | `"lsst-devl"` | PostgreSQL database name for the APDB |
-| prompt-proto-service.apdb.ip | string | None, must be set | IP address or hostname and port of the APDB |
+| prompt-proto-service.apdb.db | string | `"lsst-devl"` | PostgreSQL database name for the APDB (deprecated for apdb.url) |
+| prompt-proto-service.apdb.ip | string | None, must be set | IP address or hostname and port of the APDB (deprecated for apdb.url) |
 | prompt-proto-service.apdb.namespace | string | `"pp_apdb"` | Database namespace for the APDB |
 | prompt-proto-service.apdb.url | string | None, must be set | URL to the APDB, in any form recognized by SQLAlchemy |
-| prompt-proto-service.apdb.user | string | `"rubin"` | Database user for the APDB |
+| prompt-proto-service.apdb.user | string | `"rubin"` | Database user for the APDB (deprecated for apdb.url) |
 | prompt-proto-service.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
 | prompt-proto-service.image.repository | string | `"ghcr.io/lsst-dm/prompt-proto-service"` | Image to use in the PP deployment |
 | prompt-proto-service.image.tag | string | `"latest"` | Overrides the image tag whose default is the chart appVersion. |
@@ -36,9 +36,9 @@ Prompt Proto Service is an event driven service for processing camera images.  T
 | prompt-proto-service.logLevel | string | log prompt_prototype at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
 | prompt-proto-service.podAnnotations | object | See the `values.yaml` file. | Annotations for the prompt-proto-service pod |
 | prompt-proto-service.registry.centralRepoFile | bool | `false` | If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted. |
-| prompt-proto-service.registry.db | string | None, must be set | PostgreSQL database name for the Butler registry database |
-| prompt-proto-service.registry.ip | string | None, must be set | IP address or hostname and port of the Butler registry database |
-| prompt-proto-service.registry.user | string | None, must be set | Database user for the Butler registry database |
+| prompt-proto-service.registry.db | string | None, must be set | PostgreSQL database name for the Butler registry database (deprecated) |
+| prompt-proto-service.registry.ip | string | None, must be set | IP address or hostname and port of the Butler registry database (deprecated) |
+| prompt-proto-service.registry.user | string | None, must be set | Database user for the Butler registry database (deprecated) |
 | prompt-proto-service.s3.auth_env | bool | `true` | If set, get S3 credentials from this application's Vault secret. |
 | prompt-proto-service.s3.disableBucketValidation | string | `"0"` | Set this to disable validation of S3 bucket names, allowing Ceph multi-tenant colon-separated names to be used. |
 | prompt-proto-service.s3.endpointUrl | string | None, must be set | S3 endpoint containing `imageBucket` |

--- a/applications/prompt-proto-service-lsstcam/README.md
+++ b/applications/prompt-proto-service-lsstcam/README.md
@@ -1,6 +1,12 @@
 # prompt-proto-service-lsstcam
 
-Deployment for prompt proto service for LSSTCam images
+Prompt Proto Service is an event driven service for processing camera images.  The service runs on knative. This deployment handles LSSTCam images.
+
+**Homepage:** <https://github.com/lsst-dm/prompt_prototype/blob/main/doc/playbook.rst>
+
+## Source Code
+
+* <https://github.com/lsst-dm/prompt_prototype>
 
 ## Values
 

--- a/applications/prompt-proto-service-lsstcam/README.md
+++ b/applications/prompt-proto-service-lsstcam/README.md
@@ -6,31 +6,33 @@ Deployment for prompt proto service for LSSTCam images
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| prompt-proto-service.apdb.db | string | `"lsst-devl"` |  |
-| prompt-proto-service.apdb.ip | string | `""` |  |
-| prompt-proto-service.apdb.namespace | string | `"pp_apdb"` |  |
-| prompt-proto-service.apdb.user | string | `"rubin"` |  |
-| prompt-proto-service.image.pullPolicy | string | `"IfNotPresent"` |  |
-| prompt-proto-service.image.repository | string | `"ghcr.io/lsst-dm/prompt-proto-service"` |  |
-| prompt-proto-service.image.tag | string | `"latest"` |  |
-| prompt-proto-service.imageNotifications.imageTimeout | string | `"120"` |  |
-| prompt-proto-service.imageNotifications.kafkaClusterAddress | string | `""` |  |
-| prompt-proto-service.imageNotifications.topic | string | `""` |  |
-| prompt-proto-service.instrument.calibRepo | string | `""` |  |
-| prompt-proto-service.instrument.name | string | `""` |  |
-| prompt-proto-service.instrument.pipelines | string | `""` |  |
-| prompt-proto-service.instrument.skymap | string | `""` |  |
-| prompt-proto-service.knative.ephemeralStorageLimit | string | `"20Gi"` |  |
-| prompt-proto-service.knative.ephemeralStorageRequest | string | `"20Gi"` |  |
-| prompt-proto-service.knative.idleTimeout | int | `900` |  |
-| prompt-proto-service.knative.responseStartTimeout | int | `900` |  |
-| prompt-proto-service.knative.timeout | int | `900` |  |
-| prompt-proto-service.podAnnotations | object | `{"autoscaling.knative.dev/max-scale":"600","autoscaling.knative.dev/min-scale":"10","autoscaling.knative.dev/target-burst-capacity":"-1","autoscaling.knative.dev/target-utilization-percentage":"60","revision":"1"}` | Annotations for the prompt-proto-service pod |
-| prompt-proto-service.registry.db | string | `"lsstdb1"` |  |
-| prompt-proto-service.registry.ip | string | `""` |  |
-| prompt-proto-service.registry.user | string | `"rubin"` |  |
-| prompt-proto-service.s3.auth_env | bool | `true` |  |
-| prompt-proto-service.s3.disableBucketValidation | string | `"0"` |  |
-| prompt-proto-service.s3.endpointUrl | string | `""` |  |
-| prompt-proto-service.s3.imageBucket | string | `""` |  |
-| prompt-proto-service.vaultSecretsPath | string | `""` |  |
+| prompt-proto-service.additionalVolumeMounts | list | `[]` | Kubernetes YAML configs for extra container volume(s). Any volumes required by other config options are automatically handled by the Helm chart. |
+| prompt-proto-service.apdb.db | string | `"lsst-devl"` | PostgreSQL database name for the APDB |
+| prompt-proto-service.apdb.ip | string | None, must be set | IP address or hostname and port of the APDB |
+| prompt-proto-service.apdb.namespace | string | `"pp_apdb"` | Database namespace for the APDB |
+| prompt-proto-service.apdb.user | string | `"rubin"` | Database user for the APDB |
+| prompt-proto-service.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
+| prompt-proto-service.image.repository | string | `"ghcr.io/lsst-dm/prompt-proto-service"` | Image to use in the PP deployment |
+| prompt-proto-service.image.tag | string | `"latest"` | Overrides the image tag whose default is the chart appVersion. |
+| prompt-proto-service.imageNotifications.imageTimeout | string | `"120"` | Timeout to wait after expected script completion for raw image arrival (seconds). |
+| prompt-proto-service.imageNotifications.kafkaClusterAddress | string | None, must be set | Hostname and port of the Kafka provider |
+| prompt-proto-service.imageNotifications.topic | string | None, must be set | Topic where raw image arrival notifications appear |
+| prompt-proto-service.instrument.calibRepo | string | None, must be set | URI to the shared repo used for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself. |
+| prompt-proto-service.instrument.name | string | `""` | The "short" name of the instrument |
+| prompt-proto-service.instrument.pipelines | string | None, must be set | Machine-readable string describing which pipeline(s) should be run for which visits. Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_prototype/blob/main/python/activator/config.py) for examples. |
+| prompt-proto-service.instrument.skymap | string | `""` | Skymap to use with the instrument |
+| prompt-proto-service.knative.ephemeralStorageLimit | string | `"20Gi"` | The maximum storage space allowed for each container (mostly local Butler). |
+| prompt-proto-service.knative.ephemeralStorageRequest | string | `"20Gi"` | The storage space reserved for each container (mostly local Butler). |
+| prompt-proto-service.knative.idleTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service (seconds). |
+| prompt-proto-service.knative.responseStartTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service after initial submission (seconds). |
+| prompt-proto-service.knative.timeout | int | `900` | Maximum time that a container can respond to a next_visit request (seconds). |
+| prompt-proto-service.logLevel | string | log prompt_prototype at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
+| prompt-proto-service.podAnnotations | object | See the `values.yaml` file. | Annotations for the prompt-proto-service pod |
+| prompt-proto-service.registry.centralRepoFile | bool | `false` | If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted. |
+| prompt-proto-service.registry.db | string | None, must be set | PostgreSQL database name for the Butler registry database |
+| prompt-proto-service.registry.ip | string | None, must be set | IP address or hostname and port of the Butler registry database |
+| prompt-proto-service.registry.user | string | None, must be set | Database user for the Butler registry database |
+| prompt-proto-service.s3.auth_env | bool | `true` | If set, get S3 credentials from this application's Vault secret. |
+| prompt-proto-service.s3.disableBucketValidation | string | `"0"` | Set this to disable validation of S3 bucket names, allowing Ceph multi-tenant colon-separated names to be used. |
+| prompt-proto-service.s3.endpointUrl | string | None, must be set | S3 endpoint containing `imageBucket` |
+| prompt-proto-service.s3.imageBucket | string | None, must be set | Bucket containing the incoming raw images |

--- a/applications/prompt-proto-service-lsstcam/README.md
+++ b/applications/prompt-proto-service-lsstcam/README.md
@@ -16,6 +16,7 @@ Prompt Proto Service is an event driven service for processing camera images.  T
 | prompt-proto-service.apdb.db | string | `"lsst-devl"` | PostgreSQL database name for the APDB |
 | prompt-proto-service.apdb.ip | string | None, must be set | IP address or hostname and port of the APDB |
 | prompt-proto-service.apdb.namespace | string | `"pp_apdb"` | Database namespace for the APDB |
+| prompt-proto-service.apdb.url | string | None, must be set | URL to the APDB, in any form recognized by SQLAlchemy |
 | prompt-proto-service.apdb.user | string | `"rubin"` | Database user for the APDB |
 | prompt-proto-service.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
 | prompt-proto-service.image.repository | string | `"ghcr.io/lsst-dm/prompt-proto-service"` | Image to use in the PP deployment |

--- a/applications/prompt-proto-service-lsstcam/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcam/values-usdfdev-prompt-processing.yaml
@@ -23,6 +23,7 @@ prompt-proto-service:
     topic: rubin-prompt-processing
 
   apdb:
+    url: postgresql://rubin@usdf-prompt-processing-dev.slac.stanford.edu:5432/lsst-devl
     ip: usdf-prompt-processing-dev.slac.stanford.edu:5432
 
   registry:

--- a/applications/prompt-proto-service-lsstcam/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcam/values-usdfdev-prompt-processing.yaml
@@ -24,9 +24,9 @@ prompt-proto-service:
 
   apdb:
     url: postgresql://rubin@usdf-prompt-processing-dev.slac.stanford.edu:5432/lsst-devl
-    ip: usdf-prompt-processing-dev.slac.stanford.edu:5432
+    ip: usdf-prompt-processing-dev.slac.stanford.edu:5432  # TODO: remove on DM-40839
 
-  registry:
+  registry:  # TODO: remove on DM-40839
     ip: usdf-butler.slac.stanford.edu:5432
 
   fullnameOverride: "prompt-proto-service-lsstcam"

--- a/applications/prompt-proto-service-lsstcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcam/values.yaml
@@ -59,26 +59,26 @@ prompt-proto-service:
     # -- URL to the APDB, in any form recognized by SQLAlchemy
     # @default -- None, must be set
     url: ""
-    # -- IP address or hostname and port of the APDB
+    # -- IP address or hostname and port of the APDB (deprecated for apdb.url)
     # @default -- None, must be set
-    ip: ""
-    # -- PostgreSQL database name for the APDB
-    db: lsst-devl
-    # -- Database user for the APDB
-    user: rubin
+    ip: ""  # TODO: remove on DM-40839
+    # -- PostgreSQL database name for the APDB (deprecated for apdb.url)
+    db: lsst-devl  # TODO: remove on DM-40839
+    # -- Database user for the APDB (deprecated for apdb.url)
+    user: rubin  # TODO: remove on DM-40839
     # -- Database namespace for the APDB
     namespace: pp_apdb
 
   registry:
-    # -- IP address or hostname and port of the Butler registry database
+    # -- IP address or hostname and port of the Butler registry database (deprecated)
     # @default -- None, must be set
-    ip: ""
-    # -- PostgreSQL database name for the Butler registry database
+    ip: ""  # TODO: remove on DM-40839
+    # -- PostgreSQL database name for the Butler registry database (deprecated)
     # @default -- None, must be set
-    db: lsstdb1
-    # -- Database user for the Butler registry database
+    db: lsstdb1  # TODO: remove on DM-40839
+    # -- Database user for the Butler registry database (deprecated)
     # @default -- None, must be set
-    user: rubin
+    user: rubin  # TODO: remove on DM-40839
     # -- If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted.
     centralRepoFile: false
 

--- a/applications/prompt-proto-service-lsstcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcam/values.yaml
@@ -1,6 +1,7 @@
 prompt-proto-service:
 
   # -- Annotations for the prompt-proto-service pod
+  # @default -- See the `values.yaml` file.
   podAnnotations:
     autoscaling.knative.dev/min-scale: "10"
     autoscaling.knative.dev/max-scale: "600"
@@ -10,44 +11,90 @@ prompt-proto-service:
     revision: "1"
 
   image:
+    # -- Image to use in the PP deployment
     repository: ghcr.io/lsst-dm/prompt-proto-service
+    # -- Pull policy for the PP image
+    # @default -- `IfNotPresent` in prod, `Always` in dev
     pullPolicy: IfNotPresent
-    # Overrides the image tag whose default is the chart appVersion.
+    # -- Overrides the image tag whose default is the chart appVersion.
     tag: latest
 
   instrument:
+    # -- The "short" name of the instrument
     name: ""
+    # -- Machine-readable string describing which pipeline(s) should be run for which visits.
+    # Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_prototype/blob/main/python/activator/config.py) for examples.
+    # @default -- None, must be set
     pipelines: ""
+    # -- Skymap to use with the instrument
     skymap: ""
+    # -- URI to the shared repo used for calibrations, templates, and pipeline outputs.
+    # If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself.
+    # @default -- None, must be set
     calibRepo: ""
 
   s3:
+    # -- Bucket containing the incoming raw images
+    # @default -- None, must be set
     imageBucket: ""
+    # -- S3 endpoint containing `imageBucket`
+    # @default -- None, must be set
     endpointUrl: ""
+    # -- If set, get S3 credentials from this application's Vault secret.
     auth_env: true
+    # -- Set this to disable validation of S3 bucket names, allowing Ceph multi-tenant colon-separated names to be used.
     disableBucketValidation: '0'
 
   imageNotifications:
+    # -- Hostname and port of the Kafka provider
+    # @default -- None, must be set
     kafkaClusterAddress: ""
+    # -- Topic where raw image arrival notifications appear
+    # @default -- None, must be set
     topic: ""
+    # -- Timeout to wait after expected script completion for raw image arrival (seconds).
     imageTimeout: '120'
 
   apdb:
+    # -- IP address or hostname and port of the APDB
+    # @default -- None, must be set
     ip: ""
+    # -- PostgreSQL database name for the APDB
     db: lsst-devl
+    # -- Database user for the APDB
     user: rubin
+    # -- Database namespace for the APDB
     namespace: pp_apdb
 
   registry:
+    # -- IP address or hostname and port of the Butler registry database
+    # @default -- None, must be set
     ip: ""
+    # -- PostgreSQL database name for the Butler registry database
+    # @default -- None, must be set
     db: lsstdb1
+    # -- Database user for the Butler registry database
+    # @default -- None, must be set
     user: rubin
+    # -- If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted.
+    centralRepoFile: false
+
+  # -- Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level).
+  # @default -- log prompt_prototype at DEBUG, other LSST code at INFO, and third-party code at WARNING.
+  logLevel: ""
 
   knative:
+    # -- The storage space reserved for each container (mostly local Butler).
     ephemeralStorageRequest: "20Gi"
+    # -- The maximum storage space allowed for each container (mostly local Butler).
     ephemeralStorageLimit: "20Gi"
+    # -- Maximum time that a container can respond to a next_visit request (seconds).
     timeout: 900
+    # -- Maximum time that a container can send nothing to the fanout service (seconds).
     idleTimeout: 900
+    # -- Maximum time that a container can send nothing to the fanout service after initial submission (seconds).
     responseStartTimeout: 900
 
-  vaultSecretsPath: ""
+  # -- Kubernetes YAML configs for extra container volume(s).
+  # Any volumes required by other config options are automatically handled by the Helm chart.
+  additionalVolumeMounts: []

--- a/applications/prompt-proto-service-lsstcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcam/values.yaml
@@ -56,6 +56,9 @@ prompt-proto-service:
     imageTimeout: '120'
 
   apdb:
+    # -- URL to the APDB, in any form recognized by SQLAlchemy
+    # @default -- None, must be set
+    url: ""
     # -- IP address or hostname and port of the APDB
     # @default -- None, must be set
     ip: ""

--- a/applications/prompt-proto-service-lsstcomcam/Chart.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/Chart.yaml
@@ -1,8 +1,16 @@
 apiVersion: v2
 name: prompt-proto-service-lsstcomcam
 version: 1.0.0
-description: Deployment for prompt proto service for LSSTComCam images
+description: Prompt Proto Service is an event driven service for processing camera images.  The service runs on knative. This deployment handles LSSTComCam images.
+home: https://github.com/lsst-dm/prompt_prototype/blob/main/doc/playbook.rst
+sources:
+  - https://github.com/lsst-dm/prompt_prototype
+annotations:
+  phalanx.lsst.io/docs: |
+    - id: "DMTN-219"
+      title: "Proposal and Prototype for Prompt Processing"
+      url: "https://dmtn-219.lsst.io/"
 dependencies:
-- name: prompt-proto-service
-  version: 1.0.0
-  repository: "file://../../charts/prompt-proto-service"
+  - name: prompt-proto-service
+    version: 1.0.0
+    repository: "file://../../charts/prompt-proto-service"

--- a/applications/prompt-proto-service-lsstcomcam/README.md
+++ b/applications/prompt-proto-service-lsstcomcam/README.md
@@ -12,11 +12,11 @@ Prompt Proto Service is an event driven service for processing camera images.  T
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| prompt-proto-service.apdb.db | string | `"lsst-devl"` | PostgreSQL database name for the APDB |
-| prompt-proto-service.apdb.ip | string | None, must be set | IP address or hostname and port of the APDB |
+| prompt-proto-service.apdb.db | string | `"lsst-devl"` | PostgreSQL database name for the APDB (deprecated for apdb.url) |
+| prompt-proto-service.apdb.ip | string | None, must be set | IP address or hostname and port of the APDB (deprecated for apdb.url) |
 | prompt-proto-service.apdb.namespace | string | `"pp_apdb"` | Database namespace for the APDB |
 | prompt-proto-service.apdb.url | string | None, must be set | URL to the APDB, in any form recognized by SQLAlchemy |
-| prompt-proto-service.apdb.user | string | `"rubin"` | Database user for the APDB |
+| prompt-proto-service.apdb.user | string | `"rubin"` | Database user for the APDB (deprecated for apdb.url) |
 | prompt-proto-service.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
 | prompt-proto-service.image.repository | string | `"ghcr.io/lsst-dm/prompt-proto-service"` | Image to use in the PP deployment |
 | prompt-proto-service.image.tag | string | `"latest"` | Overrides the image tag whose default is the chart appVersion. |
@@ -35,9 +35,9 @@ Prompt Proto Service is an event driven service for processing camera images.  T
 | prompt-proto-service.logLevel | string | log prompt_prototype at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
 | prompt-proto-service.podAnnotations | object | See the `values.yaml` file. | Annotations for the prompt-proto-service pod |
 | prompt-proto-service.registry.centralRepoFile | bool | `false` | If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted. |
-| prompt-proto-service.registry.db | string | None, must be set | PostgreSQL database name for the Butler registry database |
-| prompt-proto-service.registry.ip | string | None, must be set | IP address or hostname and port of the Butler registry database |
-| prompt-proto-service.registry.user | string | None, must be set | Database user for the Butler registry database |
+| prompt-proto-service.registry.db | string | None, must be set | PostgreSQL database name for the Butler registry database (deprecated) |
+| prompt-proto-service.registry.ip | string | None, must be set | IP address or hostname and port of the Butler registry database (deprecated) |
+| prompt-proto-service.registry.user | string | None, must be set | Database user for the Butler registry database (deprecated) |
 | prompt-proto-service.s3.auth_env | bool | `true` | If set, get S3 credentials from this application's Vault secret. |
 | prompt-proto-service.s3.disableBucketValidation | string | `"0"` | Set this to disable validation of S3 bucket names, allowing Ceph multi-tenant colon-separated names to be used. |
 | prompt-proto-service.s3.endpointUrl | string | None, must be set | S3 endpoint containing `imageBucket` |

--- a/applications/prompt-proto-service-lsstcomcam/README.md
+++ b/applications/prompt-proto-service-lsstcomcam/README.md
@@ -1,6 +1,12 @@
 # prompt-proto-service-lsstcomcam
 
-Deployment for prompt proto service for LSSTComCam images
+Prompt Proto Service is an event driven service for processing camera images.  The service runs on knative. This deployment handles LSSTComCam images.
+
+**Homepage:** <https://github.com/lsst-dm/prompt_prototype/blob/main/doc/playbook.rst>
+
+## Source Code
+
+* <https://github.com/lsst-dm/prompt_prototype>
 
 ## Values
 

--- a/applications/prompt-proto-service-lsstcomcam/README.md
+++ b/applications/prompt-proto-service-lsstcomcam/README.md
@@ -6,31 +6,32 @@ Deployment for prompt proto service for LSSTComCam images
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| prompt-proto-service.apdb.db | string | `"lsst-devl"` |  |
-| prompt-proto-service.apdb.ip | string | `""` |  |
-| prompt-proto-service.apdb.namespace | string | `"pp_apdb"` |  |
-| prompt-proto-service.apdb.user | string | `"rubin"` |  |
-| prompt-proto-service.image.pullPolicy | string | `"IfNotPresent"` |  |
-| prompt-proto-service.image.repository | string | `"ghcr.io/lsst-dm/prompt-proto-service"` |  |
-| prompt-proto-service.image.tag | string | `"latest"` |  |
-| prompt-proto-service.imageNotifications.imageTimeout | string | `"120"` |  |
-| prompt-proto-service.imageNotifications.kafkaClusterAddress | string | `""` |  |
-| prompt-proto-service.imageNotifications.topic | string | `""` |  |
-| prompt-proto-service.instrument.calibRepo | string | `""` |  |
-| prompt-proto-service.instrument.name | string | `""` |  |
-| prompt-proto-service.instrument.pipelines | string | `""` |  |
-| prompt-proto-service.instrument.skymap | string | `""` |  |
-| prompt-proto-service.knative.ephemeralStorageLimit | string | `"20Gi"` |  |
-| prompt-proto-service.knative.ephemeralStorageRequest | string | `"20Gi"` |  |
-| prompt-proto-service.knative.idleTimeout | int | `900` |  |
-| prompt-proto-service.knative.responseStartTimeout | int | `900` |  |
-| prompt-proto-service.knative.timeout | int | `900` |  |
-| prompt-proto-service.podAnnotations | object | `{"autoscaling.knative.dev/max-scale":"30","autoscaling.knative.dev/min-scale":"3","autoscaling.knative.dev/target-burst-capacity":"-1","autoscaling.knative.dev/target-utilization-percentage":"60","revision":"1"}` | Annotations for the prompt-proto-service pod |
-| prompt-proto-service.registry.db | string | `"lsstdb1"` |  |
-| prompt-proto-service.registry.ip | string | `""` |  |
-| prompt-proto-service.registry.user | string | `"rubin"` |  |
-| prompt-proto-service.s3.auth_env | bool | `true` |  |
-| prompt-proto-service.s3.disableBucketValidation | string | `"0"` |  |
-| prompt-proto-service.s3.endpointUrl | string | `""` |  |
-| prompt-proto-service.s3.imageBucket | string | `""` |  |
-| prompt-proto-service.vaultSecretsPath | string | `"secret/rubin/usdf-prompt-processing-dev/prompt-proto-service-lsstcomcam"` |  |
+| prompt-proto-service.apdb.db | string | `"lsst-devl"` | PostgreSQL database name for the APDB |
+| prompt-proto-service.apdb.ip | string | None, must be set | IP address or hostname and port of the APDB |
+| prompt-proto-service.apdb.namespace | string | `"pp_apdb"` | Database namespace for the APDB |
+| prompt-proto-service.apdb.user | string | `"rubin"` | Database user for the APDB |
+| prompt-proto-service.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
+| prompt-proto-service.image.repository | string | `"ghcr.io/lsst-dm/prompt-proto-service"` | Image to use in the PP deployment |
+| prompt-proto-service.image.tag | string | `"latest"` | Overrides the image tag whose default is the chart appVersion. |
+| prompt-proto-service.imageNotifications.imageTimeout | string | `"120"` | Timeout to wait after expected script completion for raw image arrival (seconds). |
+| prompt-proto-service.imageNotifications.kafkaClusterAddress | string | None, must be set | Hostname and port of the Kafka provider |
+| prompt-proto-service.imageNotifications.topic | string | None, must be set | Topic where raw image arrival notifications appear |
+| prompt-proto-service.instrument.calibRepo | string | None, must be set | URI to the shared repo used for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself. |
+| prompt-proto-service.instrument.name | string | `""` | The "short" name of the instrument |
+| prompt-proto-service.instrument.pipelines | string | None, must be set | Machine-readable string describing which pipeline(s) should be run for which visits. Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_prototype/blob/main/python/activator/config.py) for examples. |
+| prompt-proto-service.instrument.skymap | string | `""` | Skymap to use with the instrument |
+| prompt-proto-service.knative.ephemeralStorageLimit | string | `"20Gi"` | The maximum storage space allowed for each container (mostly local Butler). |
+| prompt-proto-service.knative.ephemeralStorageRequest | string | `"20Gi"` | The storage space reserved for each container (mostly local Butler). |
+| prompt-proto-service.knative.idleTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service (seconds). |
+| prompt-proto-service.knative.responseStartTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service after initial submission (seconds). |
+| prompt-proto-service.knative.timeout | int | `900` | Maximum time that a container can respond to a next_visit request (seconds). |
+| prompt-proto-service.logLevel | string | log prompt_prototype at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
+| prompt-proto-service.podAnnotations | object | See the `values.yaml` file. | Annotations for the prompt-proto-service pod |
+| prompt-proto-service.registry.centralRepoFile | bool | `false` | If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted. |
+| prompt-proto-service.registry.db | string | None, must be set | PostgreSQL database name for the Butler registry database |
+| prompt-proto-service.registry.ip | string | None, must be set | IP address or hostname and port of the Butler registry database |
+| prompt-proto-service.registry.user | string | None, must be set | Database user for the Butler registry database |
+| prompt-proto-service.s3.auth_env | bool | `true` | If set, get S3 credentials from this application's Vault secret. |
+| prompt-proto-service.s3.disableBucketValidation | string | `"0"` | Set this to disable validation of S3 bucket names, allowing Ceph multi-tenant colon-separated names to be used. |
+| prompt-proto-service.s3.endpointUrl | string | None, must be set | S3 endpoint containing `imageBucket` |
+| prompt-proto-service.s3.imageBucket | string | None, must be set | Bucket containing the incoming raw images |

--- a/applications/prompt-proto-service-lsstcomcam/README.md
+++ b/applications/prompt-proto-service-lsstcomcam/README.md
@@ -15,6 +15,7 @@ Prompt Proto Service is an event driven service for processing camera images.  T
 | prompt-proto-service.apdb.db | string | `"lsst-devl"` | PostgreSQL database name for the APDB |
 | prompt-proto-service.apdb.ip | string | None, must be set | IP address or hostname and port of the APDB |
 | prompt-proto-service.apdb.namespace | string | `"pp_apdb"` | Database namespace for the APDB |
+| prompt-proto-service.apdb.url | string | None, must be set | URL to the APDB, in any form recognized by SQLAlchemy |
 | prompt-proto-service.apdb.user | string | `"rubin"` | Database user for the APDB |
 | prompt-proto-service.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
 | prompt-proto-service.image.repository | string | `"ghcr.io/lsst-dm/prompt-proto-service"` | Image to use in the PP deployment |

--- a/applications/prompt-proto-service-lsstcomcam/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/values-usdfdev-prompt-processing.yaml
@@ -24,9 +24,9 @@ prompt-proto-service:
 
   apdb:
     url: postgresql://rubin@usdf-prompt-processing-dev.slac.stanford.edu:5432/lsst-devl
-    ip: usdf-prompt-processing-dev.slac.stanford.edu:5432
+    ip: usdf-prompt-processing-dev.slac.stanford.edu:5432  # TODO: remove on DM-40839
 
-  registry:
+  registry:  # TODO: remove on DM-40839
     ip: usdf-butler.slac.stanford.edu:5432
 
   fullnameOverride: "prompt-proto-service-lsstcomcam"

--- a/applications/prompt-proto-service-lsstcomcam/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/values-usdfdev-prompt-processing.yaml
@@ -23,6 +23,7 @@ prompt-proto-service:
     topic: rubin-prompt-processing
 
   apdb:
+    url: postgresql://rubin@usdf-prompt-processing-dev.slac.stanford.edu:5432/lsst-devl
     ip: usdf-prompt-processing-dev.slac.stanford.edu:5432
 
   registry:

--- a/applications/prompt-proto-service-lsstcomcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/values.yaml
@@ -59,26 +59,26 @@ prompt-proto-service:
     # -- URL to the APDB, in any form recognized by SQLAlchemy
     # @default -- None, must be set
     url: ""
-    # -- IP address or hostname and port of the APDB
+    # -- IP address or hostname and port of the APDB (deprecated for apdb.url)
     # @default -- None, must be set
-    ip: ""
-    # -- PostgreSQL database name for the APDB
-    db: lsst-devl
-    # -- Database user for the APDB
-    user: rubin
+    ip: ""  # TODO: remove on DM-40839
+    # -- PostgreSQL database name for the APDB (deprecated for apdb.url)
+    db: lsst-devl  # TODO: remove on DM-40839
+    # -- Database user for the APDB (deprecated for apdb.url)
+    user: rubin  # TODO: remove on DM-40839
     # -- Database namespace for the APDB
     namespace: pp_apdb
 
   registry:
-    # -- IP address or hostname and port of the Butler registry database
+    # -- IP address or hostname and port of the Butler registry database (deprecated)
     # @default -- None, must be set
-    ip: ""
-    # -- PostgreSQL database name for the Butler registry database
+    ip: ""  # TODO: remove on DM-40839
+    # -- PostgreSQL database name for the Butler registry database (deprecated)
     # @default -- None, must be set
-    db: lsstdb1
-    # -- Database user for the Butler registry database
+    db: lsstdb1  # TODO: remove on DM-40839
+    # -- Database user for the Butler registry database (deprecated)
     # @default -- None, must be set
-    user: rubin
+    user: rubin  # TODO: remove on DM-40839
     # -- If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted.
     centralRepoFile: false
 

--- a/applications/prompt-proto-service-lsstcomcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/values.yaml
@@ -1,6 +1,7 @@
 prompt-proto-service:
 
   # -- Annotations for the prompt-proto-service pod
+  # @default -- See the `values.yaml` file.
   podAnnotations:
     autoscaling.knative.dev/min-scale: "3"
     autoscaling.knative.dev/max-scale: "30"
@@ -10,44 +11,86 @@ prompt-proto-service:
     revision: "1"
 
   image:
+    # -- Image to use in the PP deployment
     repository: ghcr.io/lsst-dm/prompt-proto-service
+    # -- Pull policy for the PP image
+    # @default -- `IfNotPresent` in prod, `Always` in dev
     pullPolicy: IfNotPresent
-    # Overrides the image tag whose default is the chart appVersion.
+    # -- Overrides the image tag whose default is the chart appVersion.
     tag: latest
 
   instrument:
+    # -- The "short" name of the instrument
     name: ""
+    # -- Machine-readable string describing which pipeline(s) should be run for which visits.
+    # Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_prototype/blob/main/python/activator/config.py) for examples.
+    # @default -- None, must be set
     pipelines: ""
+    # -- Skymap to use with the instrument
     skymap: ""
+    # -- URI to the shared repo used for calibrations, templates, and pipeline outputs.
+    # If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself.
+    # @default -- None, must be set
     calibRepo: ""
 
   s3:
+    # -- Bucket containing the incoming raw images
+    # @default -- None, must be set
     imageBucket: ""
+    # -- S3 endpoint containing `imageBucket`
+    # @default -- None, must be set
     endpointUrl: ""
+    # -- If set, get S3 credentials from this application's Vault secret.
     auth_env: true
+    # -- Set this to disable validation of S3 bucket names, allowing Ceph multi-tenant colon-separated names to be used.
     disableBucketValidation: '0'
 
   imageNotifications:
+    # -- Hostname and port of the Kafka provider
+    # @default -- None, must be set
     kafkaClusterAddress: ""
+    # -- Topic where raw image arrival notifications appear
+    # @default -- None, must be set
     topic: ""
+    # -- Timeout to wait after expected script completion for raw image arrival (seconds).
     imageTimeout: '120'
 
   apdb:
+    # -- IP address or hostname and port of the APDB
+    # @default -- None, must be set
     ip: ""
+    # -- PostgreSQL database name for the APDB
     db: lsst-devl
+    # -- Database user for the APDB
     user: rubin
+    # -- Database namespace for the APDB
     namespace: pp_apdb
 
   registry:
+    # -- IP address or hostname and port of the Butler registry database
+    # @default -- None, must be set
     ip: ""
+    # -- PostgreSQL database name for the Butler registry database
+    # @default -- None, must be set
     db: lsstdb1
+    # -- Database user for the Butler registry database
+    # @default -- None, must be set
     user: rubin
+    # -- If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted.
+    centralRepoFile: false
+
+  # -- Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level).
+  # @default -- log prompt_prototype at DEBUG, other LSST code at INFO, and third-party code at WARNING.
+  logLevel: ""
 
   knative:
+    # -- The storage space reserved for each container (mostly local Butler).
     ephemeralStorageRequest: "20Gi"
+    # -- The maximum storage space allowed for each container (mostly local Butler).
     ephemeralStorageLimit: "20Gi"
+    # -- Maximum time that a container can respond to a next_visit request (seconds).
     timeout: 900
+    # -- Maximum time that a container can send nothing to the fanout service (seconds).
     idleTimeout: 900
+    # -- Maximum time that a container can send nothing to the fanout service after initial submission (seconds).
     responseStartTimeout: 900
-
-  vaultSecretsPath: "secret/rubin/usdf-prompt-processing-dev/prompt-proto-service-lsstcomcam"

--- a/applications/prompt-proto-service-lsstcomcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/values.yaml
@@ -56,6 +56,9 @@ prompt-proto-service:
     imageTimeout: '120'
 
   apdb:
+    # -- URL to the APDB, in any form recognized by SQLAlchemy
+    # @default -- None, must be set
+    url: ""
     # -- IP address or hostname and port of the APDB
     # @default -- None, must be set
     ip: ""

--- a/charts/prompt-proto-service/Chart.yaml
+++ b/charts/prompt-proto-service/Chart.yaml
@@ -4,6 +4,11 @@ version: 1.0.0
 appVersion: "0.1.0"
 description: Prompt Proto Service is an event driven service for processing camera images.  The service runs on knative.
 type: application
-home: https://prompt-proto-service.lsst.io/
+home: https://github.com/lsst-dm/prompt_prototype/blob/main/doc/playbook.rst
 sources:
   - https://github.com/lsst-dm/prompt_prototype
+annotations:
+  phalanx.lsst.io/docs: |
+    - id: "DMTN-219"
+      title: "Proposal and Prototype for Prompt Processing"
+      url: "https://dmtn-219.lsst.io/"

--- a/charts/prompt-proto-service/README.md
+++ b/charts/prompt-proto-service/README.md
@@ -17,6 +17,7 @@ Prompt Proto Service is an event driven service for processing camera images.  T
 | apdb.db | string | `""` | PostgreSQL database name for the APDB |
 | apdb.ip | string | None, must be set | IP address or hostname and port of the APDB |
 | apdb.namespace | string | `""` | Database namespace for the APDB |
+| apdb.url | string | None, must be set | URL to the APDB, in any form recognized by SQLAlchemy |
 | apdb.user | string | `""` | Database user for the APDB |
 | containerConcurrency | int | `1` |  |
 | fullnameOverride | string | `"prompt-proto-service"` | Override the full name for resources (includes the release name) |

--- a/charts/prompt-proto-service/README.md
+++ b/charts/prompt-proto-service/README.md
@@ -12,37 +12,40 @@ Prompt Proto Service is an event driven service for processing camera images.  T
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| additionalVolumeMounts | list | `[]` |  |
+| additionalVolumeMounts | list | `[]` | Kubernetes YAML configs for extra container volume(s). Any volumes required by other config options are automatically handled by the Helm chart. |
 | affinity | object | `{}` |  |
-| apdb.db | string | `""` |  |
-| apdb.ip | string | `""` |  |
-| apdb.namespace | string | `""` |  |
-| apdb.user | string | `""` |  |
+| apdb.db | string | `""` | PostgreSQL database name for the APDB |
+| apdb.ip | string | None, must be set | IP address or hostname and port of the APDB |
+| apdb.namespace | string | `""` | Database namespace for the APDB |
+| apdb.user | string | `""` | Database user for the APDB |
 | containerConcurrency | int | `1` |  |
 | fullnameOverride | string | `"prompt-proto-service"` | Override the full name for resources (includes the release name) |
-| image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"ghcr.io/lsst-dm/prompt-proto-service"` |  |
-| image.tag | string | `"latest"` |  |
-| imageNotifications.imageTimeout | string | `"120"` |  |
-| imageNotifications.kafkaClusterAddress | string | `""` |  |
-| imageNotifications.topic | string | `""` |  |
+| image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
+| image.repository | string | `"ghcr.io/lsst-dm/prompt-proto-service"` | Image to use in the PP deployment |
+| image.tag | string | `"latest"` | Overrides the image tag whose default is the chart appVersion. |
+| imageNotifications.imageTimeout | string | `"120"` | Timeout to wait after expected script completion for raw image arrival (seconds). |
+| imageNotifications.kafkaClusterAddress | string | None, must be set | Hostname and port of the Kafka provider |
+| imageNotifications.topic | string | None, must be set | Topic where raw image arrival notifications appear |
 | imagePullSecrets | list | `[]` |  |
-| instrument.calibRepo | string | `""` |  |
-| instrument.name | string | `""` |  |
-| instrument.pipelines | string | `""` |  |
-| instrument.skymap | string | `""` |  |
-| knative.ephemeralStorageLimit | string | `"20Gi"` |  |
-| knative.ephemeralStorageRequest | string | `"8Gi"` |  |
-| knative.timeout | int | `900` |  |
+| instrument.calibRepo | string | None, must be set | URI to the shared repo used for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself. |
+| instrument.name | string | None, must be set | The "short" name of the instrument |
+| instrument.pipelines | string | None, must be set | Machine-readable string describing which pipeline(s) should be run for which visits. Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_prototype/blob/main/python/activator/config.py) for examples. |
+| instrument.skymap | string | `""` | Skymap to use with the instrument |
+| knative.ephemeralStorageLimit | string | `"20Gi"` | The maximum storage space allowed for each container (mostly local Butler). |
+| knative.ephemeralStorageRequest | string | `"20Gi"` | The storage space reserved for each container (mostly local Butler). |
+| knative.idleTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service (seconds). |
+| knative.responseStartTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service after initial submission (seconds). |
+| knative.timeout | int | `900` | Maximum time that a container can respond to a next_visit request (seconds). |
+| logLevel | string | log prompt_prototype at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
 | nameOverride | string | `""` | Override the base name for resources |
-| namespace | string | `"prompt-proto-service"` |  |
 | nodeSelector | object | `{}` |  |
-| podAnnotations | object | `{"autoscaling.knative.dev/max-scale":"10","autoscaling.knative.dev/min-scale":"1","autoscaling.knative.dev/target-utilization-percentage":"80","revision":"1"}` | Annotations for the prompt-proto-service pod |
-| registry.db | string | `"lsstdb1"` |  |
-| registry.ip | string | `"usdf-butler.slac.stanford.edu:5432"` |  |
-| registry.user | string | `"rubin"` |  |
-| s3.auth_env | bool | `true` |  |
-| s3.endpointUrl | string | `""` |  |
-| s3.imageBucket | string | `""` |  |
+| podAnnotations | object | See the `values.yaml` file. | Annotations for the prompt-proto-service pod |
+| registry.centralRepoFile | bool | `false` | If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted. |
+| registry.db | string | None, must be set | PostgreSQL database name for the Butler registry database |
+| registry.ip | string | None, must be set | IP address or hostname and port of the Butler registry database |
+| registry.user | string | None, must be set | Database user for the Butler registry database |
+| s3.auth_env | bool | `true` | If set, get S3 credentials from this application's Vault secret. |
+| s3.disableBucketValidation | string | `"0"` | Set this to disable validation of S3 bucket names, allowing Ceph multi-tenant colon-separated names to be used. |
+| s3.endpointUrl | string | None, must be set | S3 endpoint containing `imageBucket` |
+| s3.imageBucket | string | None, must be set | Bucket containing the incoming raw images |
 | tolerations | list | `[]` |  |
-| vaultSecretsPath | string | `""` |  |

--- a/charts/prompt-proto-service/README.md
+++ b/charts/prompt-proto-service/README.md
@@ -2,7 +2,7 @@
 
 Prompt Proto Service is an event driven service for processing camera images.  The service runs on knative.
 
-**Homepage:** <https://prompt-proto-service.lsst.io/>
+**Homepage:** <https://github.com/lsst-dm/prompt_prototype/blob/main/doc/playbook.rst>
 
 ## Source Code
 

--- a/charts/prompt-proto-service/README.md
+++ b/charts/prompt-proto-service/README.md
@@ -14,11 +14,11 @@ Prompt Proto Service is an event driven service for processing camera images.  T
 |-----|------|---------|-------------|
 | additionalVolumeMounts | list | `[]` | Kubernetes YAML configs for extra container volume(s). Any volumes required by other config options are automatically handled by the Helm chart. |
 | affinity | object | `{}` |  |
-| apdb.db | string | `""` | PostgreSQL database name for the APDB |
-| apdb.ip | string | None, must be set | IP address or hostname and port of the APDB |
+| apdb.db | string | `""` | PostgreSQL database name for the APDB (deprecated for apdb.url) |
+| apdb.ip | string | None, must be set | IP address or hostname and port of the APDB (deprecated for apdb.url) |
 | apdb.namespace | string | `""` | Database namespace for the APDB |
 | apdb.url | string | None, must be set | URL to the APDB, in any form recognized by SQLAlchemy |
-| apdb.user | string | `""` | Database user for the APDB |
+| apdb.user | string | `""` | Database user for the APDB (deprecated for apdb.url) |
 | containerConcurrency | int | `1` |  |
 | fullnameOverride | string | `"prompt-proto-service"` | Override the full name for resources (includes the release name) |
 | image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
@@ -42,9 +42,9 @@ Prompt Proto Service is an event driven service for processing camera images.  T
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | See the `values.yaml` file. | Annotations for the prompt-proto-service pod |
 | registry.centralRepoFile | bool | `false` | If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted. |
-| registry.db | string | None, must be set | PostgreSQL database name for the Butler registry database |
-| registry.ip | string | None, must be set | IP address or hostname and port of the Butler registry database |
-| registry.user | string | None, must be set | Database user for the Butler registry database |
+| registry.db | string | None, must be set | PostgreSQL database name for the Butler registry database (deprecated) |
+| registry.ip | string | None, must be set | IP address or hostname and port of the Butler registry database (deprecated) |
+| registry.user | string | None, must be set | Database user for the Butler registry database (deprecated) |
 | s3.auth_env | bool | `true` | If set, get S3 credentials from this application's Vault secret. |
 | s3.disableBucketValidation | string | `"0"` | Set this to disable validation of S3 bucket names, allowing Ceph multi-tenant colon-separated names to be used. |
 | s3.endpointUrl | string | None, must be set | S3 endpoint containing `imageBucket` |

--- a/charts/prompt-proto-service/templates/prompt-proto-service.yaml
+++ b/charts/prompt-proto-service/templates/prompt-proto-service.yaml
@@ -83,6 +83,8 @@ spec:
         - name: AWS_SHARED_CREDENTIALS_FILE
           value: /app/s3/credentials
         {{- end }}
+        - name: PGPASSFILE
+          value: /app/pgsql/.pgpass
         - name: LOCAL_REPOS
           value: "/tmp-butler"
         - name: SERVICE_LOG_LEVELS
@@ -90,6 +92,9 @@ spec:
         volumeMounts:
         - mountPath: /tmp-butler
           name: ephemeral
+        - mountPath: /app/pgsql
+          name: pgpass-credentials-file
+          readOnly: true
         {{- if .Values.s3.cred_file_auth }}
         - mountPath: /app/s3/
           name: s3-credentials-file
@@ -114,6 +119,13 @@ spec:
       - name: ephemeral
         emptyDir:
           sizeLimit: {{ .Values.knative.ephemeralStorageLimit }}
+      - name: pgpass-credentials-file
+        secret:
+          secretName: {{ template "prompt-proto-service.fullname" . }}-secret
+          items:
+          - key: pgpass_file
+            path: .pgpass
+          defaultMode: 0400  # PostgreSQL refuses to read group- or world-readable files
       {{- if .Values.s3.cred_file_auth }}
       - name: s3-credentials-file
         secret:

--- a/charts/prompt-proto-service/templates/prompt-proto-service.yaml
+++ b/charts/prompt-proto-service/templates/prompt-proto-service.yaml
@@ -47,8 +47,6 @@ spec:
           value: {{ .Values.instrument.pipelines }}
         - name: SKYMAP
           value: {{ .Values.instrument.skymap }}
-        - name: PUBSUB_VERIFICATION_TOKEN
-          value: rubin-prompt-proto-main
         - name: IMAGE_BUCKET
           value: {{ .Values.s3.imageBucket }}
         - name: BUCKET_TOPIC

--- a/charts/prompt-proto-service/templates/prompt-proto-service.yaml
+++ b/charts/prompt-proto-service/templates/prompt-proto-service.yaml
@@ -98,9 +98,9 @@ spec:
         - mountPath: {{ .Values.instrument.calibRepo }}
           name: central-repo-file
         {{- end }}
-          {{- with .Values.additionalVolumeMounts }}
-          {{- toYaml . | nindent 8 }}
-          {{- end }}
+        {{- with .Values.additionalVolumeMounts }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         readinessProbe:
           successThreshold: 1
           tcpSocket:

--- a/charts/prompt-proto-service/templates/prompt-proto-service.yaml
+++ b/charts/prompt-proto-service/templates/prompt-proto-service.yaml
@@ -68,6 +68,8 @@ spec:
           value: {{ .Values.apdb.db }}
         - name: USER_APDB
           value: {{ .Values.apdb.user }}
+        - name: URL_APDB
+          value: {{ .Values.apdb.url }}
         - name: NAMESPACE_APDB
           value: {{ .Values.apdb.namespace }}
         - name: IP_REGISTRY

--- a/charts/prompt-proto-service/templates/prompt-proto-service.yaml
+++ b/charts/prompt-proto-service/templates/prompt-proto-service.yaml
@@ -61,32 +61,32 @@ spec:
           value: {{ .Values.instrument.calibRepo }}
         - name: LSST_DISABLE_BUCKET_VALIDATION
           value: {{ .Values.s3.disableBucketValidation | quote }}
-        - name: IP_APDB
+        - name: IP_APDB  # TODO: remove on DM-40839
           # Need explicit port for make_pgpass.py
           value: {{ .Values.apdb.ip }}
-        - name: DB_APDB
+        - name: DB_APDB  # TODO: remove on DM-40839
           value: {{ .Values.apdb.db }}
-        - name: USER_APDB
+        - name: USER_APDB  # TODO: remove on DM-40839
           value: {{ .Values.apdb.user }}
         - name: URL_APDB
           value: {{ .Values.apdb.url }}
         - name: NAMESPACE_APDB
           value: {{ .Values.apdb.namespace }}
-        - name: IP_REGISTRY
+        - name: IP_REGISTRY  # TODO: remove on DM-40839
           # Need explicit port for make_pgpass.py
           value: {{ .Values.registry.ip }}
-        - name: DB_REGISTRY
+        - name: DB_REGISTRY  # TODO: remove on DM-40839
           value: {{ .Values.registry.db }}
-        - name: USER_REGISTRY
+        - name: USER_REGISTRY  # TODO: remove on DM-40839
           value: {{ .Values.registry.user }}
         - name: KAFKA_CLUSTER
           value: {{ .Values.imageNotifications.kafkaClusterAddress }}
-        - name: PSQL_REGISTRY_PASS
+        - name: PSQL_REGISTRY_PASS  # TODO: remove on DM-40839
           valueFrom:
             secretKeyRef:
               name: {{ template "prompt-proto-service.fullname" . }}-secret
               key: registry_password
-        - name: PSQL_APDB_PASS
+        - name: PSQL_APDB_PASS  # TODO: remove on DM-40839
           valueFrom:
             secretKeyRef:
               name: {{ template "prompt-proto-service.fullname" . }}-secret

--- a/charts/prompt-proto-service/templates/prompt-proto-service.yaml
+++ b/charts/prompt-proto-service/templates/prompt-proto-service.yaml
@@ -90,6 +90,14 @@ spec:
         volumeMounts:
         - mountPath: /tmp-butler
           name: ephemeral
+        {{- if .Values.s3.cred_file_auth }}
+        - mountPath: /app/s3/
+          name: s3-credentials-file
+        {{- end }}
+        {{- if .Values.registry.centralRepoFile }}
+        - mountPath: {{ .Values.instrument.calibRepo }}
+          name: central-repo-file
+        {{- end }}
           {{- with .Values.additionalVolumeMounts }}
           {{- toYaml . | nindent 8 }}
           {{- end }}

--- a/charts/prompt-proto-service/templates/prompt-proto-service.yaml
+++ b/charts/prompt-proto-service/templates/prompt-proto-service.yaml
@@ -12,6 +12,30 @@ spec:
       {{- end }}
     spec:
       containerConcurrency: {{ .Values.containerConcurrency }}
+      initContainers:
+      - name: init-copy-pgpass
+        # Make a copy of the read-only secret so we can change owner
+        image: busybox
+        command: ["sh", "-c", "cp -L /app/pg-mount/.pgpass /app/pgsql/"]
+        volumeMounts:
+        - mountPath: /app/pg-mount
+          name: pgpass-mount
+          readOnly: true
+        - mountPath: /app/pgsql
+          name: pgpass-credentials-file
+      - name: init-chown-pgpass
+        image: busybox
+        command: ["sh", "-c", "chown 1000:1000 /app/pgsql/.pgpass"]  # lsst account created by main image
+        volumeMounts:
+        - mountPath: /app/pgsql
+          name: pgpass-credentials-file
+      - name: init-chmod-pgpass
+        image: busybox
+        # PostgreSQL refuses to read group- or world-readable files
+        command: ["sh", "-c", "chmod u=r,go-rwx /app/pgsql/.pgpass"]
+        volumeMounts:
+        - mountPath: /app/pgsql
+          name: pgpass-credentials-file
       containers:
       - image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
@@ -119,13 +143,17 @@ spec:
       - name: ephemeral
         emptyDir:
           sizeLimit: {{ .Values.knative.ephemeralStorageLimit }}
-      - name: pgpass-credentials-file
+      - name: pgpass-mount
+        # Temporary mount for .pgpass; cannot be read directly because it's owned by root
         secret:
           secretName: {{ template "prompt-proto-service.fullname" . }}-secret
           items:
           - key: pgpass_file
             path: .pgpass
-          defaultMode: 0400  # PostgreSQL refuses to read group- or world-readable files
+          defaultMode: 0400  # Minimal permissions, as extra protection
+      - name: pgpass-credentials-file
+        emptyDir:
+          sizeLimit: 10Ki  # Just a text file!
       {{- if .Values.s3.cred_file_auth }}
       - name: s3-credentials-file
         secret:

--- a/charts/prompt-proto-service/values.yaml
+++ b/charts/prompt-proto-service/values.yaml
@@ -58,6 +58,9 @@ imageNotifications:
   imageTimeout: '120'
 
 apdb:
+  # -- URL to the APDB, in any form recognized by SQLAlchemy
+  # @default -- None, must be set
+  url: ""
   # -- IP address or hostname and port of the APDB
   # @default -- None, must be set
   ip: ""

--- a/charts/prompt-proto-service/values.yaml
+++ b/charts/prompt-proto-service/values.yaml
@@ -61,26 +61,26 @@ apdb:
   # -- URL to the APDB, in any form recognized by SQLAlchemy
   # @default -- None, must be set
   url: ""
-  # -- IP address or hostname and port of the APDB
+  # -- IP address or hostname and port of the APDB (deprecated for apdb.url)
   # @default -- None, must be set
-  ip: ""
-  # -- PostgreSQL database name for the APDB
-  db: ""
-  # -- Database user for the APDB
-  user: ""
+  ip: ""  # TODO: remove on DM-40839
+  # -- PostgreSQL database name for the APDB (deprecated for apdb.url)
+  db: ""  # TODO: remove on DM-40839
+  # -- Database user for the APDB (deprecated for apdb.url)
+  user: ""  # TODO: remove on DM-40839
   # -- Database namespace for the APDB
   namespace: ""
 
 registry:
-  # -- IP address or hostname and port of the Butler registry database
+  # -- IP address or hostname and port of the Butler registry database (deprecated)
   # @default -- None, must be set
-  ip: ""
-  # -- PostgreSQL database name for the Butler registry database
+  ip: ""  # TODO: remove on DM-40839
+  # -- PostgreSQL database name for the Butler registry database (deprecated)
   # @default -- None, must be set
-  db: ""
-  # -- Database user for the Butler registry database
+  db: ""  # TODO: remove on DM-40839
+  # -- Database user for the Butler registry database (deprecated)
   # @default -- None, must be set
-  user: ""
+  user: ""  # TODO: remove on DM-40839
   # -- If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted.
   centralRepoFile: false
 

--- a/charts/prompt-proto-service/values.yaml
+++ b/charts/prompt-proto-service/values.yaml
@@ -3,6 +3,7 @@
 # Declare variables to be passed into your templates.
 
 # -- Annotations for the prompt-proto-service pod
+# @default -- See the `values.yaml` file.
 podAnnotations:
   autoscaling.knative.dev/min-scale: "1"
   autoscaling.knative.dev/max-scale: "10"
@@ -11,46 +12,89 @@ podAnnotations:
   revision: "1"
 
 image:
+  # -- Image to use in the PP deployment
   repository: ghcr.io/lsst-dm/prompt-proto-service
+  # -- Pull policy for the PP image
+  # @default -- `IfNotPresent` in prod, `Always` in dev
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
+  # -- Overrides the image tag whose default is the chart appVersion.
   tag: latest
 
 instrument:
+  # -- The "short" name of the instrument
+  # @default -- None, must be set
   name: ""
+  # -- Machine-readable string describing which pipeline(s) should be run for which visits.
+  # Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_prototype/blob/main/python/activator/config.py) for examples.
+  # @default -- None, must be set
   pipelines: ""
+  # -- Skymap to use with the instrument
   skymap: ""
+  # -- URI to the shared repo used for calibrations, templates, and pipeline outputs.
+  # If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself.
+  # @default -- None, must be set
   calibRepo: ""
 
 s3:
+  # -- Bucket containing the incoming raw images
+  # @default -- None, must be set
   imageBucket: ""
+  # -- S3 endpoint containing `imageBucket`
+  # @default -- None, must be set
   endpointUrl: ""
+  # -- If set, get S3 credentials from this application's Vault secret.
   auth_env: true
+  # -- Set this to disable validation of S3 bucket names, allowing Ceph multi-tenant colon-separated names to be used.
+  disableBucketValidation: '0'
 
 imageNotifications:
+  # -- Hostname and port of the Kafka provider
+  # @default -- None, must be set
   kafkaClusterAddress: ""
+  # -- Topic where raw image arrival notifications appear
+  # @default -- None, must be set
   topic: ""
+  # -- Timeout to wait after expected script completion for raw image arrival (seconds).
   imageTimeout: '120'
 
 apdb:
+  # -- IP address or hostname and port of the APDB
+  # @default -- None, must be set
   ip: ""
+  # -- PostgreSQL database name for the APDB
   db: ""
+  # -- Database user for the APDB
   user: ""
+  # -- Database namespace for the APDB
   namespace: ""
 
 registry:
+  # -- IP address or hostname and port of the Butler registry database
+  # @default -- None, must be set
   ip: ""
+  # -- PostgreSQL database name for the Butler registry database
+  # @default -- None, must be set
   db: ""
+  # -- Database user for the Butler registry database
+  # @default -- None, must be set
   user: ""
+  # -- If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted.
   centralRepoFile: false
 
+# -- Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level).
+# @default -- log prompt_prototype at DEBUG, other LSST code at INFO, and third-party code at WARNING.
 logLevel: ""
 
 knative:
+    # -- The storage space reserved for each container (mostly local Butler).
   ephemeralStorageRequest: "20Gi"
+    # -- The maximum storage space allowed for each container (mostly local Butler).
   ephemeralStorageLimit: "20Gi"
+    # -- Maximum time that a container can respond to a next_visit request (seconds).
   timeout: 900
+    # -- Maximum time that a container can send nothing to the fanout service (seconds).
   idleTimeout: 900
+    # -- Maximum time that a container can send nothing to the fanout service after initial submission (seconds).
   responseStartTimeout: 900
 
 # -- Override the base name for resources
@@ -59,8 +103,11 @@ nameOverride: ""
 # -- Override the full name for resources (includes the release name)
 fullnameOverride: "prompt-proto-service"
 
+# The number of Knative requests that can be handled simultaneously by one container
 containerConcurrency: 1
 
+# -- Kubernetes YAML configs for extra container volume(s).
+# Any volumes required by other config options are automatically handled by the Helm chart.
 additionalVolumeMounts: []
 
 imagePullSecrets: []

--- a/docs/about/local-environment-setup.rst
+++ b/docs/about/local-environment-setup.rst
@@ -66,6 +66,7 @@ See the `helm-docs installation guide <https://github.com/norwoodj/helm-docs#ins
    However, this (unlike the installation methods documented in the installation guide) will require that you have Go installed locally.
 
 If you don't want to (or don't have access to) install helm-docs globally on your system, you can put the binary in the :file:`bin` directory of the virtual environment you created in :ref:`about-venv`.
+To see which binary is most appropriate for a Linux system, run ``uname -a``.
 
 Install helm
 ============


### PR DESCRIPTION
This PR does some refactoring and documentation cleanup of the `prompt-proto-service-*` applications, then rewrites its handling of PostreSQL credentials to mount them as a file instead of through environment variables. This change (with the corresponding code in lsst-dm/prompt_prototype#83) will greatly simplify `prompt-proto-service` configuration in the future.