### PR TITLE
DM-40790: Add --as-secret flag to create-read-approle

### DIFF
--- a/src/phalanx/cli.py
+++ b/src/phalanx/cli.py
@@ -475,6 +475,16 @@ def vault_audit(environment: str, *, config: Path | None) -> None:
 @vault.command("create-read-approle")
 @click.argument("environment")
 @click.option(
+    "--as-secret",
+    type=str,
+    default=None,
+    help=(
+        "Output the credentials as a Kubernetes Secret for"
+        " vault-secrets-operator, with the provided name, suitable for passing"
+        " to kubectl apply."
+    ),
+)
+@click.option(
     "-c",
     "--config",
     type=click.Path(path_type=Path),
@@ -482,7 +492,7 @@ def vault_audit(environment: str, *, config: Path | None) -> None:
     help="Path to root of Phalanx configuration.",
 )
 def vault_create_read_approle(
-    environment: str, *, config: Path | None
+    environment: str, as_secret: str | None, *, config: Path | None
 ) -> None:
     """Create a new Vault read AppRole.
 
@@ -499,7 +509,10 @@ def vault_create_read_approle(
     factory = Factory(config)
     vault_service = factory.create_vault_service()
     vault_approle = vault_service.create_read_approle(environment)
-    sys.stdout.write(vault_approle.to_yaml())
+    if as_secret:
+        sys.stdout.write(vault_approle.to_kubernetes_secret(as_secret))
+    else:
+        sys.stdout.write(vault_approle.to_yaml())
 
 
 @vault.command("create-write-token")

--- a/src/phalanx/constants.py
+++ b/src/phalanx/constants.py
@@ -11,6 +11,7 @@ from datetime import timedelta
 __all__ = [
     "HELM_DOCLINK_ANNOTATION",
     "PULL_SECRET_DESCRIPTION",
+    "VAULT_SECRET_TEMPLATE",
     "VAULT_WRITE_TOKEN_LIFETIME",
     "VAULT_WRITE_TOKEN_WARNING_LIFETIME",
 ]
@@ -25,6 +26,19 @@ PULL_SECRET_DESCRIPTION = (
     " credentials for that registry."
 )
 """Description to put in the static secrets YAML file for ``pull-secret``."""
+
+VAULT_SECRET_TEMPLATE = """\
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {name}
+  namespace: vault-secrets-operator
+data:
+  VAULT_ROLE_ID: {role_id}
+  VAULT_SECRET_ID: {secret_id}
+type: Opaque
+"""
+"""Template for a ``Secret`` containing AppRole credentials."""
 
 VAULT_WRITE_TOKEN_LIFETIME = "3650d"
 """Default lifetime to set for Vault write tokens."""

--- a/src/phalanx/models/vault.py
+++ b/src/phalanx/models/vault.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+from base64 import b64encode
 from datetime import datetime
 
 import yaml
 from pydantic import BaseModel
+
+from ..constants import VAULT_SECRET_TEMPLATE
 
 __all__ = [
     "VaultAppRole",
@@ -33,6 +36,27 @@ class VaultAppRole(VaultAppRoleMetadata):
 
     secret_id_accessor: str
     """Accessor for the AppRole authentication credentials."""
+
+    def to_kubernetes_secret(self, name: str) -> str:
+        """Format the data as a secret for vault-secrets-operator.
+
+        Parameters
+        ----------
+        name
+            Name of the secret to create.
+
+        Returns
+        -------
+        str
+            YAML creating a Kubernetes ``Secret`` resource for
+            vault-secrets-operator_, suitable for passing to :command:`kubectl
+            apply`.
+        """
+        role_id = b64encode(self.role_id.encode()).decode()
+        secret_id = b64encode(self.secret_id.encode()).decode()
+        return VAULT_SECRET_TEMPLATE.format(
+            name=name, role_id=role_id, secret_id=secret_id
+        )
 
     def to_yaml(self) -> str:
         """Format the data in YAML."""


### PR DESCRIPTION
Support outputting the credentials for the read Vault AppRole as a Vault Secret resource suitable for vault-secrets-operator.