### PR TITLE
DM-40790: Add a command to copy Vault secrets

### DIFF
--- a/src/phalanx/storage/vault.py
+++ b/src/phalanx/storage/vault.py
@@ -336,17 +336,24 @@ class VaultClient:
 class VaultStorage:
     """Create Vault clients for specific environments."""
 
-    def get_vault_client(self, env: EnvironmentBaseConfig) -> VaultClient:
+    def get_vault_client(
+        self, env: EnvironmentBaseConfig, path_prefix: str | None = None
+    ) -> VaultClient:
         """Return a Vault client configured for the given environment.
 
         Parameters
         ----------
         env
             Phalanx environment.
+        path_prefix
+            Path prefix within Vault for application secrets. If given, this
+            overrides the path prefix in the environment configuration.
 
         Returns
         -------
         VaultClient
             Vault client configured to manage secrets for that environment.
         """
-        return VaultClient(env.vault_url, env.vault_path_prefix)
+        if not path_prefix:
+            path_prefix = env.vault_path_prefix
+        return VaultClient(env.vault_url, path_prefix)

--- a/tests/data/input/environments/values-idfdev.yaml
+++ b/tests/data/input/environments/values-idfdev.yaml
@@ -1,7 +1,7 @@
 name: idfdev
 fqdn: data-dev.lsst.cloud
 vaultUrl: https://vault.lsst.codes/
-vaultPathPrefix: secret/phalanx/data-dev.lsst.cloud
+vaultPathPrefix: secret/phalanx/idfdev
 
 applications:
   mobu: true

--- a/tests/data/output/idfdev/audit-approle-extra
+++ b/tests/data/output/idfdev/audit-approle-extra
@@ -1,3 +1,3 @@
-Problems with read AppRole (data-dev.lsst.cloud):
+Problems with read AppRole (idfdev):
 • Unexpected policy extra
-No write token (data-dev.lsst.cloud)
+No write token (idfdev)

--- a/tests/data/output/idfdev/audit-approle-policy
+++ b/tests/data/output/idfdev/audit-approle-policy
@@ -1,5 +1,5 @@
-Problems with read AppRole (data-dev.lsst.cloud):
-• Missing policy phalanx/data-dev.lsst.cloud/read
+Problems with read AppRole (idfdev):
+• Missing policy phalanx/idfdev/read
 • Unexpected policy something
-• Policy phalanx/data-dev.lsst.cloud/read doesn't have expected contents
-No write token (data-dev.lsst.cloud)
+• Policy phalanx/idfdev/read doesn't have expected contents
+No write token (idfdev)

--- a/tests/data/output/idfdev/audit-both-missing
+++ b/tests/data/output/idfdev/audit-both-missing
@@ -1,2 +1,2 @@
-No read AppRole (data-dev.lsst.cloud)
-No write token (data-dev.lsst.cloud)
+No read AppRole (idfdev)
+No write token (idfdev)

--- a/tests/data/output/idfdev/audit-token-expired
+++ b/tests/data/output/idfdev/audit-token-expired
@@ -1,5 +1,5 @@
 Multiple write tokens found
-Problems with write token (data-dev.lsst.cloud):
+Problems with write token (idfdev):
 • Token will expire at <timestamp>
-Problems with write token (data-dev.lsst.cloud):
+Problems with write token (idfdev):
 • Token expired at <timestamp>

--- a/tests/data/output/idfdev/audit-token-policy
+++ b/tests/data/output/idfdev/audit-token-policy
@@ -1,4 +1,4 @@
-Problems with write token (data-dev.lsst.cloud):
-• Missing policy phalanx/data-dev.lsst.cloud/write
+Problems with write token (idfdev):
+• Missing policy phalanx/idfdev/write
 • Unexpected policy something
-• Policy phalanx/data-dev.lsst.cloud/write doesn't have expected contents
+• Policy phalanx/idfdev/write doesn't have expected contents


### PR DESCRIPTION
Add phalanx vault copy-secrets, which copies all application secrets under the specified path into the Vault area for the specified environment, overwriting any existing secrets. This is primarily intended as a migration tool to move our existing secrets to the new Vault paths with the new access control model and active management.
