### PR TITLE
DM-40790: Rename secrets vault-secrets to vault export-secrets

### DIFF
--- a/src/phalanx/services/secrets.py
+++ b/src/phalanx/services/secrets.py
@@ -2,10 +2,8 @@
 
 from __future__ import annotations
 
-import json
 from base64 import b64decode
 from collections import defaultdict
-from pathlib import Path
 
 import yaml
 from pydantic import SecretStr
@@ -178,35 +176,6 @@ class SecretsService:
         """
         environment = self._config.load_environment(env_name)
         return environment.all_secrets()
-
-    def save_vault_secrets(self, env_name: str, path: Path) -> None:
-        """Generate JSON files of the Vault secrets for an environment.
-
-        One file per application with secrets will be written to the provided
-        path. Each file will be named after the application with ``.json``
-        appended, and will contain the secret values for that application.
-        Secrets that are required but have no known value will be written as
-        null.
-
-        Parameters
-        ----------
-        env_name
-            Name of the environment.
-        path
-            Output path.
-        """
-        environment = self._config.load_environment(env_name)
-        vault_client = self._vault.get_vault_client(environment)
-        vault_secrets = vault_client.get_environment_secrets()
-        for app_name, values in vault_secrets.items():
-            app_secrets: dict[str, str | None] = {}
-            for key, secret in values.items():
-                if secret:
-                    app_secrets[key] = secret.get_secret_value()
-                else:
-                    app_secrets[key] = None
-            with (path / f"{app_name}.json").open("w") as fh:
-                json.dump(app_secrets, fh, indent=2)
 
     def sync(
         self,

--- a/tests/cli/secrets_test.py
+++ b/tests/cli/secrets_test.py
@@ -19,7 +19,6 @@ from phalanx.models.gafaelfawr import Token
 
 from ..support.cli import run_cli
 from ..support.data import (
-    assert_json_dirs_match,
     phalanx_test_path,
     read_input_static_secrets,
     read_output_data,
@@ -275,19 +274,3 @@ def test_sync_regenerate(
     mtime = datetime.fromisoformat(argocd["admin.passwordMtime"])
     now = current_datetime()
     assert now - timedelta(seconds=5) <= mtime <= now
-
-
-def test_vault_secrets(
-    factory: Factory, tmp_path: Path, mock_vault: MockVaultClient
-) -> None:
-    input_path = phalanx_test_path()
-    vault_input_path = input_path / "vault" / "idfdev"
-    config_storage = factory.create_config_storage()
-    environment = config_storage.load_environment("idfdev")
-    mock_vault.load_test_data(environment.vault_path_prefix, "idfdev")
-
-    result = run_cli("secrets", "vault-secrets", "idfdev", str(tmp_path))
-    assert result.exit_code == 0
-    assert result.output == ""
-
-    assert_json_dirs_match(tmp_path, vault_input_path)

--- a/tests/cli/vault_test.py
+++ b/tests/cli/vault_test.py
@@ -108,7 +108,7 @@ def test_copy_secrets(
     result = run_cli("vault", "copy-secrets", "idfdev", old_path)
     assert result.exit_code == 0
     assert result.output == ""
-    result = run_cli("secrets", "vault-secrets", "idfdev", str(tmp_path))
+    result = run_cli("vault", "export-secrets", "idfdev", str(tmp_path))
     assert result.exit_code == 0
     assert result.output == ""
 
@@ -199,3 +199,19 @@ def test_create_write_token(
     template = templates.get_template("vault-write-policy.hcl.jinja")
     expected_policy = template.render({"path": vault_path})
     assert seen_policy == expected_policy
+
+
+def test_export_secrets(
+    factory: Factory, tmp_path: Path, mock_vault: MockVaultClient
+) -> None:
+    input_path = phalanx_test_path()
+    vault_input_path = input_path / "vault" / "idfdev"
+    config_storage = factory.create_config_storage()
+    environment = config_storage.load_environment("idfdev")
+    mock_vault.load_test_data(environment.vault_path_prefix, "idfdev")
+
+    result = run_cli("vault", "export-secrets", "idfdev", str(tmp_path))
+    assert result.exit_code == 0
+    assert result.output == ""
+
+    assert_json_dirs_match(tmp_path, vault_input_path)


### PR DESCRIPTION
Now that there are a bunch of other vault commands, it makes more sense to move this command, which operates only on Vault, into the vault command list.