### PR TITLE
DM-40790: Regenerate documentation if src changes

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -41,6 +41,7 @@ jobs:
               - "applications/*/values.yaml"
               - "applications/gafaelfawr/values-*.yaml"
               - "environments/values-*.yaml"
+              - "src/phalanx/**"
 
       - name: Install graphviz
         if: steps.filter.outputs.docs == 'true'


### PR DESCRIPTION
Now that we're generating API and (more importantly) CLI documentation from src/phalanx, regenerate documentation if files under those paths change.