### PR TITLE
DM-36772: Remove vault path overrides for prompt-proto-service.

### DIFF
--- a/applications/prompt-proto-service-latiss/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfdev-prompt-processing.yaml
@@ -29,5 +29,3 @@ prompt-proto-service:
     ip: usdf-butler.slac.stanford.edu:5432
 
   fullnameOverride: "prompt-proto-service-latiss"
-
-  vaultSecretsPath: "secret/rubin/usdf-prompt-processing-dev/prompt-proto-service-latiss"

--- a/applications/prompt-proto-service-lsstcam/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcam/values-usdfdev-prompt-processing.yaml
@@ -30,5 +30,3 @@ prompt-proto-service:
     ip: usdf-butler.slac.stanford.edu:5432
 
   fullnameOverride: "prompt-proto-service-lsstcam"
-
-  vaultSecretsPath: "secret/rubin/usdf-prompt-processing-dev/prompt-proto-service-lsstcam"

--- a/applications/prompt-proto-service-lsstcomcam/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/values-usdfdev-prompt-processing.yaml
@@ -30,5 +30,3 @@ prompt-proto-service:
     ip: usdf-butler.slac.stanford.edu:5432
 
   fullnameOverride: "prompt-proto-service-lsstcomcam"
-
-  vaultSecretsPath: "secret/rubin/usdf-prompt-processing-dev/prompt-proto-service-lsstcomcam"


### PR DESCRIPTION
This PR removes unwanted `vaultSecretsPath` overrides (see #2520) that should have been cleaned up on #2538.