### PR TITLE
DM-40865: Update to Times Square 0.9.2

### DIFF
--- a/applications/times-square/Chart.yaml
+++ b/applications/times-square/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 type: application
 
 # The default version tag of the times-square docker image
-appVersion: "0.9.1"
+appVersion: "0.9.2"
 
 dependencies:
   - name: redis


### PR DESCRIPTION
Deploys https://github.com/lsst-sqre/times-square/releases/tag/0.9.2