### PR TITLE
DM-40790: Fix secrets tool issues found during IDF dev testing

### DIFF
--- a/src/phalanx/cli.py
+++ b/src/phalanx/cli.py
@@ -457,7 +457,7 @@ def vault_audit(environment: str, *, config: Path | None) -> None:
 def vault_copy_secrets(
     environment: str, old_prefix: str, *, config: Path | None
 ) -> None:
-    """Copy secrets for an environment from another Vault path prefix.
+    """Copy secrets from another Vault path prefix.
 
     Copy secrets for an environment from another Vault path prefix in the same
     Vault server, overwriting any secrets that already exist with the same

--- a/src/phalanx/exceptions.py
+++ b/src/phalanx/exceptions.py
@@ -138,9 +138,8 @@ class UnresolvedSecretsError(Exception):
     """
 
     def __init__(self, secrets: Iterable[Secret]) -> None:
-        names = [f"{u.application}/{u.key}" for u in secrets]
-        names_str = ", ".join(names)
-        msg = f"Some secrets could not be resolved: {names_str}"
+        self.secrets = [f"{u.application}/{u.key}" for u in secrets]
+        msg = f'Some secrets could not be resolved: {", ".join(self.secrets)}'
         super().__init__(msg)
 
 

--- a/src/phalanx/models/environments.py
+++ b/src/phalanx/models/environments.py
@@ -100,9 +100,10 @@ class EnvironmentBaseConfig(CamelCaseModel):
         """Display name of the Vault write token for this environment.
 
         Unlike AppRole names, this could include a slash, but use the same
-        name as the AppRole for consistency and simplicity.
+        base name as the AppRole for consistency and simplicity. Vault always
+        prepends ``token-``, which we strip off when creating the token.
         """
-        return self.vault_read_approle
+        return f"token-{self.vault_read_approle}"
 
     @property
     def vault_read_policy(self) -> str:

--- a/src/phalanx/models/vault.py
+++ b/src/phalanx/models/vault.py
@@ -72,8 +72,8 @@ class VaultTokenMetadata(BaseModel):
     accessor: str
     """Accessor for the token, used to get metadata or revoke it."""
 
-    expires: datetime
-    """When the token expires."""
+    expires: datetime | None
+    """When the token expires, if it does."""
 
     policies: list[str]
     """Policies applied to this token."""

--- a/src/phalanx/services/secrets.py
+++ b/src/phalanx/services/secrets.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from base64 import b64decode
 from collections import defaultdict
+from dataclasses import dataclass, field
 
 import yaml
 from pydantic import SecretStr
@@ -23,7 +24,38 @@ from ..storage.onepassword import OnepasswordStorage
 from ..storage.vault import VaultClient, VaultStorage
 from ..yaml import YAMLFoldedString
 
-__all__ = ["SecretsService"]
+__all__ = [
+    "SecretsAuditReport",
+    "SecretsService",
+]
+
+
+@dataclass
+class SecretsAuditReport:
+    """Results of auditing secrets against the contents of Vault."""
+
+    missing: list[str] = field(default_factory=list)
+    """Secrets missing from Vault."""
+
+    mismatch: list[str] = field(default_factory=list)
+    """Secrets that are incorrect in Vault."""
+
+    unknown: list[str] = field(default_factory=list)
+    """Unexpected secrets in Vault."""
+
+    def to_text(self) -> str:
+        """Format as a textual report for output."""
+        report = ""
+        if self.missing:
+            secrets = "\n• ".join(sorted(self.missing))
+            report += "Missing secrets:\n• " + secrets + "\n"
+        if self.mismatch:
+            secrets = "\n• ".join(sorted(self.mismatch))
+            report += "Incorrect secrets:\n• " + secrets + "\n"
+        if self.unknown:
+            secrets = "\n• ".join(sorted(self.unknown))
+            report += "Unknown secrets in Vault:\n• " + secrets + "\n"
+        return report
 
 
 class SecretsService:
@@ -72,6 +104,7 @@ class SecretsService:
         if not static_secrets:
             static_secrets = self._get_onepassword_secrets(environment)
         vault_client = self._vault.get_vault_client(environment)
+        pull_secret = static_secrets.pull_secret if static_secrets else None
 
         # Retrieve all the current secrets from Vault and resolve all of the
         # secrets.
@@ -88,29 +121,12 @@ class SecretsService:
             return "Unresolved secrets:\n• " + "\n• ".join(e.secrets) + "\n"
 
         # Compare the resolved secrets to the Vault data.
-        missing = []
-        mismatch = []
-        unknown = []
-        for app_name, values in resolved.applications.items():
-            for key, secret in values.items():
-                if key not in vault_secrets.get(app_name, {}):
-                    missing.append(f"{app_name} {key}")
-                    continue
-                if secret != vault_secrets[app_name][key]:
-                    mismatch.append(f"{app_name} {key}")
-                del vault_secrets[app_name][key]
-        unknown = [f"{a} {k}" for a, lv in vault_secrets.items() for k in lv]
+        report = self._audit_secrets(resolved, vault_secrets, pull_secret)
 
         # Generate the textual report.
-        report = ""
-        if missing:
-            report += "Missing secrets:\n• " + "\n• ".join(missing) + "\n"
-        if mismatch:
-            report += "Incorrect secrets:\n• " + "\n• ".join(mismatch) + "\n"
-        if unknown:
-            unknown_str = "\n• ".join(unknown)
-            report += "Unknown secrets in Vault:\n• " + unknown_str + "\n"
-        return report
+        return report.to_text()
+
+        # Generate the textual report.
 
     def generate_static_template(self, env_name: str) -> str:
         """Generate a template for providing static secrets.
@@ -236,6 +252,62 @@ class SecretsService:
                 resolved,
                 has_pull_secret=resolved.pull_secret is not None,
             )
+
+    def _audit_secrets(
+        self,
+        resolved: ResolvedSecrets,
+        vault_secrets: dict[str, dict[str, SecretStr]],
+        pull_secret: PullSecret | None,
+    ) -> SecretsAuditReport:
+        """Compare resolved secrets with the contents of Vault.
+
+        Parameters
+        ----------
+        resolved
+            Resolved secrets for an environment.
+        vault_secrets
+            Vault secrets for that environment.
+        pull_secret
+            Pull secret for the environment, if one is needed.
+
+        Returns
+        -------
+        SecretsAuditReport
+            Audit report.
+        """
+        missing = []
+        mismatch = []
+        for app_name, values in resolved.applications.items():
+            for key, secret in values.items():
+                if key not in vault_secrets.get(app_name, {}):
+                    missing.append(f"{app_name} {key}")
+                    continue
+                if secret != vault_secrets[app_name][key]:
+                    mismatch.append(f"{app_name} {key}")
+                del vault_secrets[app_name][key]
+        unknown = [
+            f"{a} {k}"
+            for a, lv in vault_secrets.items()
+            for k in lv
+            if a != "pull-secret"
+        ]
+
+        # The pull-secret has to be handled separately.
+        if pull_secret:
+            if "pull-secret" in vault_secrets:
+                value = SecretStr(pull_secret.to_dockerconfigjson())
+                expected = {".dockerconfigjson": value}
+                if expected != vault_secrets["pull-secret"]:
+                    mismatch.append("pull-secret")
+            else:
+                missing.append("pull-secret")
+        elif "pull-secret" in vault_secrets:
+            unknown.append("pull-secret")
+
+        # Return the report.
+        return SecretsAuditReport(
+            missing=missing, mismatch=mismatch, unknown=unknown
+        )
 
     def _clean_vault_secrets(
         self,

--- a/src/phalanx/services/secrets.py
+++ b/src/phalanx/services/secrets.py
@@ -77,12 +77,15 @@ class SecretsService:
         # secrets.
         secrets = environment.all_secrets()
         vault_secrets = vault_client.get_environment_secrets()
-        resolved = self._resolve_secrets(
-            secrets=secrets,
-            environment=environment,
-            vault_secrets=vault_secrets,
-            static_secrets=static_secrets,
-        )
+        try:
+            resolved = self._resolve_secrets(
+                secrets=secrets,
+                environment=environment,
+                vault_secrets=vault_secrets,
+                static_secrets=static_secrets,
+            )
+        except UnresolvedSecretsError as e:
+            return "Unresolved secrets:\n• " + "\n• ".join(e.secrets) + "\n"
 
         # Compare the resolved secrets to the Vault data.
         missing = []

--- a/src/phalanx/services/vault.py
+++ b/src/phalanx/services/vault.py
@@ -263,7 +263,9 @@ class VaultService:
         policies = {config.vault_write_policy}
         for token in tokens:
             errors = []
-            if token.expires < now:
+            if not token.expires:
+                errors.append("Token expiration missing")
+            elif token.expires < now:
                 expiration = format_datetime_for_logging(token.expires)
                 errors.append(f"Token expired at {expiration}")
             elif token.expires < now + VAULT_WRITE_TOKEN_WARNING_LIFETIME:

--- a/src/phalanx/storage/vault.py
+++ b/src/phalanx/storage/vault.py
@@ -99,7 +99,9 @@ class VaultClient:
         Parameters
         ----------
         display_name
-            Display name of the token.
+            Display name of the token. This must begin with ``token-``, which
+            is stripped off when creating the token since it will be added by
+            Vault.
         policies
             Policies to assign to that token.
         lifetime
@@ -110,6 +112,7 @@ class VaultClient:
         VaultToken
             Newly-created Vault token.
         """
+        display_name = display_name.removeprefix("token-")
         token = self._vault.auth.token.create(
             display_name=display_name, policies=policies, ttl=lifetime
         )

--- a/tests/cli/vault_test.py
+++ b/tests/cli/vault_test.py
@@ -176,9 +176,9 @@ def test_create_write_token(
     environment = config_storage.load_environment_config("idfdev")
     _, vault_path = environment.vault_path_prefix.split("/", 1)
     if "/" in vault_path:
-        _, display_name = vault_path.rsplit("/", 1)
+        display_name = "token-" + vault_path.rsplit("/", 1)[1]
     else:
-        display_name = vault_path
+        display_name = "token-" + vault_path
     lifetime = timedelta(days=int(VAULT_WRITE_TOKEN_LIFETIME[:-1]))
 
     result = run_cli("vault", "create-write-token", "idfdev")

--- a/tests/data/output/idfdev/audit-approle-extra
+++ b/tests/data/output/idfdev/audit-approle-extra
@@ -1,3 +1,3 @@
 Problems with read AppRole (idfdev):
 • Unexpected policy extra
-No write token (idfdev)
+No write token (token-idfdev)

--- a/tests/data/output/idfdev/audit-approle-policy
+++ b/tests/data/output/idfdev/audit-approle-policy
@@ -2,4 +2,4 @@ Problems with read AppRole (idfdev):
 • Missing policy phalanx/idfdev/read
 • Unexpected policy something
 • Policy phalanx/idfdev/read doesn't have expected contents
-No write token (idfdev)
+No write token (token-idfdev)

--- a/tests/data/output/idfdev/audit-both-missing
+++ b/tests/data/output/idfdev/audit-both-missing
@@ -1,2 +1,2 @@
 No read AppRole (idfdev)
-No write token (idfdev)
+No write token (token-idfdev)

--- a/tests/data/output/idfdev/audit-token-expired
+++ b/tests/data/output/idfdev/audit-token-expired
@@ -1,5 +1,5 @@
 Multiple write tokens found
-Problems with write token (idfdev):
+Problems with write token (token-idfdev):
 • Token will expire at <timestamp>
-Problems with write token (idfdev):
+Problems with write token (token-idfdev):
 • Token expired at <timestamp>

--- a/tests/data/output/idfdev/audit-token-policy
+++ b/tests/data/output/idfdev/audit-token-policy
@@ -1,4 +1,4 @@
-Problems with write token (idfdev):
+Problems with write token (token-idfdev):
 • Missing policy phalanx/idfdev/write
 • Unexpected policy something
 • Policy phalanx/idfdev/write doesn't have expected contents

--- a/tests/support/vault.py
+++ b/tests/support/vault.py
@@ -81,7 +81,8 @@ class MockVaultClient:
         Parameters
         ----------
         display_name
-            Display name of the token.
+            Display name of the token. Simulate the (weird) behavior of Vault
+            and add ``token-`` to the start of this name.
         policies
             Policies to set for the token.
         ttl
@@ -97,7 +98,7 @@ class MockVaultClient:
         else:
             expires = current_datetime() + timedelta(days=int(ttl[:-1]))
         token = VaultToken(
-            display_name=display_name,
+            display_name=f"token-{display_name}",
             token=f"s.{os.urandom(16).hex()}",
             accessor=os.urandom(16).hex(),
             policies=policies,


### PR DESCRIPTION
- Shorten help summary for vault copy-secrets so it isn't truncated
- Allow token expiration to be null when reporting a newly-created token
- Add `token-` to write token display names since Vault forces that prefix
- Improve secrets audit output for unresolved secrets
- Audit pull-secret as well when auditing secrets