### PR TITLE
DM-40790: Remove stub for Argo CD SSO for argo-workflows

### DIFF
--- a/applications/argo-workflows/templates/vault-secrets.yaml
+++ b/applications/argo-workflows/templates/vault-secrets.yaml
@@ -1,7 +1,0 @@
-apiVersion: ricoberger.de/v1alpha1
-kind: VaultSecret
-metadata:
-  name: argo-sso-secret
-spec:
-  path: "{{ .Values.global.vaultSecretsPath }}/argo-sso"
-  type: Opaque

--- a/applications/argocd/templates/vault-secrets.yaml
+++ b/applications/argocd/templates/vault-secrets.yaml
@@ -5,11 +5,3 @@ metadata:
 spec:
   path: "{{ .Values.global.vaultSecretsPath }}/argocd"
   type: Opaque
----
-apiVersion: ricoberger.de/v1alpha1
-kind: VaultSecret
-metadata:
-  name: argo-sso-secret
-spec:
-  path: "{{ .Values.global.vaultSecretsPath }}/argo-sso"
-  type: Opaque

--- a/applications/argocd/values-idfdev.yaml
+++ b/applications/argocd/values-idfdev.yaml
@@ -1,18 +1,4 @@
 argo-cd:
-  # Some time we may want to play with this more, but currently we're
-  # just using GafaelfawrIngress to protect Argo Workflows and requiring
-  # 'exec:admin' scope.  It is theoretically possible to piggyback
-  # Workflows off of Dex SSO, but how to actually hook up the RBAC is
-  # going to need a lot of experimentation, creating service tokens, etc.
-
-  #dex:
-  #  env:
-  #    - name: ARGO_WORKFLOWS_SSO_CLIENT_SECRET
-  #      valueFrom:
-  #        secretKeyRef:
-  #          name: argo-sso-secret
-  #          key: client-secret
-
   server:
     ingress:
       hosts:
@@ -33,15 +19,6 @@ argo-cd:
               hostedDomains:
                 - lsst.cloud
               redirectURI: https://data-dev.lsst.cloud/argo-cd/api/dex/callback
-
-        # Again, change this if we want to use SSO
-
-        # staticClients:
-        #   - id: argo-workflows-sso
-        #     name: Argo Workflow
-        #     redirectURIs:
-        #       - https://data-dev-workflows.lsst.cloud/oauth2/callback
-        #     secretEnv: ARGO_WORKFLOWS_SSO_CLIENT_SECRET
 
     rbacConfig:
       policy.csv: |


### PR DESCRIPTION
There were stub secrets to allow argo-workflows to do SSO to Argo CD, but we never got that working. Remove those stub secrets and the Argo CD configuration, since they aren't being ported to the new secret management system.