### PR TITLE
DM-40790: Template the Argo CD secret

### DIFF
--- a/applications/argocd/templates/vault-secrets.yaml
+++ b/applications/argocd/templates/vault-secrets.yaml
@@ -4,6 +4,15 @@ metadata:
   name: argocd-secret
 spec:
   path: "{{ .Values.global.vaultSecretsPath }}/argocd"
+  templates:
+    "admin.password": >-
+      {% index .Secrets "admin.password" %}
+    "admin.passwordMtime": >-
+      {% index .Secrets "admin.passwordMtime" %}
+    "dex.clientSecret": >-
+      {% index .Secrets "dex.clientSecret" %}
+    "server.secretkey": >-
+      {% index .Secrets "server.secretkey" %}
   type: Opaque
 ---
 apiVersion: ricoberger.de/v1alpha1


### PR DESCRIPTION
Now that we're including the clear-text admin password in the Vault Argo CD secret, template the Argo CD Kubernetes secret to exclude that key, since we don't want to write the Argo CD password into Kubernetes.