### PR TITLE
[DM-40888] Expose Schema Registry API in Sasquatch

### DIFF
--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -320,6 +320,9 @@ Rubin Observatory's telemetry service.
 | strimzi-kafka.mirrormaker2.sourceConnect.enabled | bool | `false` | Whether to deploy another Connect cluster for topics replicated from the source cluster. Requires the sourceRegistry enabled. |
 | strimzi-kafka.mirrormaker2.sourceRegistry.enabled | bool | `false` | Whether to deploy another Schema Registry for the schemas replicated from the source cluster. |
 | strimzi-kafka.mirrormaker2.sourceRegistry.schemaTopic | string | `"source.registry-schemas"` | Name of the topic Schema Registry topic replicated from the source cluster |
+| strimzi-kafka.registry.ingress.annotations | object | `{}` | Annotations that will be added to the Ingress resource. |
+| strimzi-kafka.registry.ingress.enabled | bool | `false` | Whether to enable ingress for the Schema Registry. |
+| strimzi-kafka.registry.ingress.hostname | string | `""` | Hostname for the Schema Registry. |
 | strimzi-kafka.registry.schemaTopic | string | `"registry-schemas"` | Name of the topic used by the Schema Registry |
 | strimzi-kafka.superusers | list | `["kafka-admin"]` | A list of usernames for users who should have global admin permissions. These users will be created, along with their credentials. |
 | strimzi-kafka.users.kafdrop.enabled | bool | `true` | Enable user Kafdrop (deployed by parent Sasquatch chart). |

--- a/applications/sasquatch/charts/strimzi-kafka/README.md
+++ b/applications/sasquatch/charts/strimzi-kafka/README.md
@@ -39,6 +39,9 @@ A subchart to deploy Strimzi Kafka components for Sasquatch.
 | mirrormaker2.sourceConnect.enabled | bool | `false` | Whether to deploy another Connect cluster for topics replicated from the source cluster. Requires the sourceRegistry enabled. |
 | mirrormaker2.sourceRegistry.enabled | bool | `false` | Whether to deploy another Schema Registry for the schemas replicated from the source cluster. |
 | mirrormaker2.sourceRegistry.schemaTopic | string | `"source.registry-schemas"` | Name of the topic Schema Registry topic replicated from the source cluster |
+| registry.ingress.annotations | object | `{}` | Annotations that will be added to the Ingress resource. |
+| registry.ingress.enabled | bool | `false` | Whether to enable ingress for the Schema Registry. |
+| registry.ingress.hostname | string | `""` | Hostname for the Schema Registry. |
 | registry.schemaTopic | string | `"registry-schemas"` | Name of the topic used by the Schema Registry |
 | superusers | list | `["kafka-admin"]` | A list of usernames for users who should have global admin permissions. These users will be created, along with their credentials. |
 | users.kafdrop.enabled | bool | `true` | Enable user Kafdrop (deployed by parent Sasquatch chart). |

--- a/applications/sasquatch/charts/strimzi-kafka/templates/schema-registry-ingress.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/schema-registry-ingress.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.registry.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: sasquatch-schema-registry
+  labels:
+    name: sasquatch-schema-registry
+  annotations:
+    {{- with .Values.registry.ingress.annotations }}
+    {{ toYaml . | indent 4 }}
+    {{- end }}
+spec:
+  ingressClassName: "nginx"
+  rules:
+    - host: {{ .Values.registry.ingress.hostname | quote }}
+      http:
+        paths:
+          - path: {{ .Values.registry.ingress.path }}
+            pathType: Prefix
+            backend:
+              service:
+                name: sasquatch-schema-registry
+                port:
+                  number: 8081
+{{- end }}

--- a/applications/sasquatch/charts/strimzi-kafka/values.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/values.yaml
@@ -122,6 +122,13 @@ connect:
   replicas: 3
 
 registry:
+  ingress:
+    # -- Whether to enable ingress for the Schema Registry.
+    enabled: false
+    # -- Hostname for the Schema Registry.
+    hostname: ""
+    # -- Annotations that will be added to the Ingress resource.
+    annotations: {}
   # -- Name of the topic used by the Schema Registry
   schemaTopic: registry-schemas
 

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -16,6 +16,13 @@ strimzi-kafka:
   users:
     replicator:
       enabled: true
+  registry:
+    ingress:
+      enabled: true
+      annotations:
+        nginx.ingress.kubernetes.io/rewrite-target: /$2
+      hostname: data-dev.lsst.cloud
+      path: /schema-registry(/|$)(.*)
 
 influxdb:
   ingress:

--- a/applications/sasquatch/values-tucson-teststand.yaml
+++ b/applications/sasquatch/values-tucson-teststand.yaml
@@ -18,6 +18,13 @@ strimzi-kafka:
   zookeeper:
     storage:
       storageClassName: rook-ceph-block
+  registry:
+    ingress:
+      enabled: true
+      annotations:
+        nginx.ingress.kubernetes.io/rewrite-target: /$2
+      hostname: tucson-teststand.lsst.codes
+      path: /schema-registry(/|$)(.*)
 
 influxdb:
   persistence:


### PR DESCRIPTION
Add ingress configuration to give external access to the SR API it  can be used in the TTS. 
Authentication will be implemented later.