### PR TITLE
Allow snippet annotations in ingress-nginx

### DIFF
--- a/applications/ingress-nginx/README.md
+++ b/applications/ingress-nginx/README.md
@@ -13,12 +13,13 @@ Ingress controller
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
+| ingress-nginx.controller.allowSnippetAnnotations | bool | `true` | Allow Ingress resources to add NGINX configuration snippets. This is required by Gafaelfawr. |
 | ingress-nginx.controller.config.compute-full-forwarded-for | string | `"true"` | Put the complete path in `X-Forwarded-For`, not just the last hop, so that the client IP will be exposed to Gafaelfawr |
 | ingress-nginx.controller.config.proxy-body-size | string | `"100m"` | Maximum size of the client request body (needs to be large enough to allow table uploads) |
 | ingress-nginx.controller.config.server-snippet | string | See `values.yaml` | Add additional per-server configuration used by Gafaelfawr to report errors from the authorization layer |
-| ingress-nginx.controller.config.ssl-redirect | string | `"true"` | Redirect all non-SSL access to SSL. |
+| ingress-nginx.controller.config.ssl-redirect | string | `"true"` | Redirect all non-SSL access to SSL |
 | ingress-nginx.controller.config.use-forwarded-headers | string | `"true"` | Enable the `X-Forwarded-For` processing |
 | ingress-nginx.controller.metrics.enabled | bool | `true` | Enable metrics reporting via Prometheus |
 | ingress-nginx.controller.podLabels | object | See `values.yaml` | Add labels used by `NetworkPolicy` objects to restrict access to the ingress and thus ensure that auth subrequest handlers run |
 | ingress-nginx.controller.service.externalTrafficPolicy | string | `"Local"` | Force traffic routing policy to Local so that the external IP in `X-Forwarded-For` will be correct |
-| vaultCertificate.enabled | bool | `false` | Whether to store ingress TLS certificate via vault-secrets-operator.  Typically "squareone" owns it instead in an RSP. |
+| vaultCertificate.enabled | bool | `false` | Whether to store ingress TLS certificate via vault-secrets-operator. Typically the `squareone` application owns it instead in an RSP. |

--- a/applications/ingress-nginx/values.yaml
+++ b/applications/ingress-nginx/values.yaml
@@ -2,6 +2,10 @@
 # https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml
 ingress-nginx:
   controller:
+    # -- Allow Ingress resources to add NGINX configuration snippets. This
+    # is required by Gafaelfawr.
+    allowSnippetAnnotations: true
+
     config:
       # -- Put the complete path in `X-Forwarded-For`, not just the last hop,
       # so that the client IP will be exposed to Gafaelfawr
@@ -11,7 +15,7 @@ ingress-nginx:
       # to allow table uploads)
       proxy-body-size: "100m"
 
-      # -- Redirect all non-SSL access to SSL.
+      # -- Redirect all non-SSL access to SSL
       ssl-redirect: "true"
 
       # -- Enable the `X-Forwarded-For` processing
@@ -36,6 +40,10 @@ ingress-nginx:
           return 403;
         }
 
+    metrics:
+      # -- Enable metrics reporting via Prometheus
+      enabled: true
+
     service:
       # -- Force traffic routing policy to Local so that the external IP in
       # `X-Forwarded-For` will be correct
@@ -48,14 +56,9 @@ ingress-nginx:
       gafaelfawr.lsst.io/ingress: "true"
       hub.jupyter.org/network-access-proxy-http: "true"
 
-    metrics:
-      # -- Enable metrics reporting via Prometheus
-      enabled: true
-
 vaultCertificate:
-  # -- Whether to store ingress TLS certificate via
-  # vault-secrets-operator.  Typically "squareone" owns it instead in an
-  # RSP.
+  # -- Whether to store ingress TLS certificate via vault-secrets-operator.
+  # Typically the `squareone` application owns it instead in an RSP.
   enabled: false
 
 # The following will be set by parameters injected by Argo CD and should not


### PR DESCRIPTION
This now defaults to false, but Gafaelfawr support requires it.