### PR TITLE
DM-40790: Adjust datalinker secrets for new approach

### DIFF
--- a/applications/datalinker/README.md
+++ b/applications/datalinker/README.md
@@ -17,6 +17,7 @@ IVOA DataLink-based service and data discovery
 | autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU utilization of datalinker deployment pods |
 | config.pgUser | string | `"rubin"` | User to use from the PGPASSFILE rubin is the default |
 | config.s3EndpointUrl | string | `"https://storage.googleapis.com"` | S3 Endpoint URL |
+| config.separateSecrets | bool | `false` | Whether to use the new secrets management scheme |
 | config.storageBackend | string | `"GCS"` | Storage backend to use: either GCS or S3 GCS is the default |
 | config.tapMetadataUrl | string | `"https://github.com/lsst/sdm_schemas/releases/download/1.2.0/datalink-columns.zip"` | URL containing TAP schema metadata used to construct queries |
 | fullnameOverride | string | `""` | Override the full name for resources (includes the release name) |

--- a/applications/datalinker/secrets-idfdev.yaml
+++ b/applications/datalinker/secrets-idfdev.yaml
@@ -1,0 +1,20 @@
+aws-credentials:
+  description: >-
+    Google Cloud Storage credentials to the Butler data store, formatted using
+    AWS syntax for use with boto.
+  copy:
+    application: nublado
+    key: "aws-credentials.ini"
+google-credentials:
+  description: >-
+    Google Cloud Storage credentials to the Butler data store in the native
+    Google syntax, containing the private asymmetric key.
+  copy:
+    application: nublado
+    key: "butler-gcs-idf-creds.json"
+postgres-credentials:
+  description: >-
+    PostgreSQL credentials in its pgpass format for the Butler database.
+  copy:
+    application: nublado
+    key: "postgres-credentials.txt"

--- a/applications/datalinker/templates/deployment.yaml
+++ b/applications/datalinker/templates/deployment.yaml
@@ -85,7 +85,7 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
-            - name: "butler-secret"
+            - name: "secrets"
               mountPath: "/etc/butler/secrets"
             - name: "tmp"
               mountPath: "/tmp"
@@ -102,8 +102,8 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
-        - name: "butler-secret"
+        - name: "secrets"
           secret:
-            secretName: {{ template "datalinker.fullname" . }}-butler-secret
+            secretName: {{ template "datalinker.fullname" . }}
         - name: "tmp"
           emptyDir: {}

--- a/applications/datalinker/templates/vault-secrets.yaml
+++ b/applications/datalinker/templates/vault-secrets.yaml
@@ -1,9 +1,13 @@
 apiVersion: ricoberger.de/v1alpha1
 kind: VaultSecret
 metadata:
-  name: {{ template "datalinker.fullname" . }}-butler-secret
+  name: {{ template "datalinker.fullname" . }}
   labels:
     {{- include "datalinker.labels" . | nindent 4 }}
 spec:
+{{- if .Values.config.separateSecrets }}
+  path: "{{ .Values.global.vaultSecretsPath }}/datalinker"
+{{- else }}
   path: "{{ .Values.global.vaultSecretsPath }}/butler-secret"
+{{- end }}
   type: Opaque

--- a/applications/datalinker/values-idfdev.yaml
+++ b/applications/datalinker/values-idfdev.yaml
@@ -1,0 +1,2 @@
+config:
+  separateSecrets: true

--- a/applications/datalinker/values.yaml
+++ b/applications/datalinker/values.yaml
@@ -54,6 +54,9 @@ config:
   # -- S3 Endpoint URL
   s3EndpointUrl: "https://storage.googleapis.com"
 
+  # -- Whether to use the new secrets management scheme
+  separateSecrets: false
+
 # -- Annotations for the datalinker deployment pod
 podAnnotations: {}
 


### PR DESCRIPTION
Datalinker was installing a copy of the Butler secret. Switch to copying the secrets from nublado instead. This isn't correct on environments without secrets, so it will require some additional work.