### PR TITLE
DM-40889: Improve installation instructions

### DIFF
--- a/docs/about/local-environment-setup.rst
+++ b/docs/about/local-environment-setup.rst
@@ -49,6 +49,8 @@ From the ``phalanx`` directory, initialize your environment:
 
 This step populates your virtual environment with Phalanx's dependencies, installs tox_ (used for testing and other build steps), and installs pre-commit_ (used to check and sometimes reformat your changes before committing them).
 
+.. _about-helm-docs:
+
 Install helm-docs
 =================
 
@@ -56,6 +58,8 @@ Install helm-docs
 You therefore must have it installed on your PATH.
 
 See the `helm-docs installation guide <https://github.com/norwoodj/helm-docs#installation>`__ for details.
+Also, not mentioned on that page, you can download a binary release from the `releases page <https://github.com/norwoodj/helm-docs/releases>`__.
+To see which binary is most appropriate for a Linux system, run ``uname -m``.
 
 .. warning::
 
@@ -64,9 +68,11 @@ See the `helm-docs installation guide <https://github.com/norwoodj/helm-docs#ins
 
    The best (but possibly not the most convenient) way to make certain you have the same version is to run the same :command:`go install` command that GitHub Actions uses.
    However, this (unlike the installation methods documented in the installation guide) will require that you have Go installed locally.
+   Alternately, find the binary release matching the desired version in the releases page and download that version.
 
 If you don't want to (or don't have access to) install helm-docs globally on your system, you can put the binary in the :file:`bin` directory of the virtual environment you created in :ref:`about-venv`.
-To see which binary is most appropriate for a Linux system, run ``uname -a``.
+
+.. _about-helm:
 
 Install helm
 ============

--- a/docs/admin/requirements.rst
+++ b/docs/admin/requirements.rst
@@ -41,15 +41,10 @@ See :doc:`hostnames` for more information.
 Management tooling
 ==================
 
-Installing Phalanx requires the following tools be available:
+First, follow the instructions in :doc:`/about/local-environment-setup`.
+This setup is also required to install or maintain a Phalanx environment.
 
-- Python 3.11 or later.
-  Phalanx expects users of its tooling to use a Python virtual environment (like venv_ or virtualenvwrapper_) and install Python packages with :command:`pip`.
-  Its prerequisite Python modules will be installed as part of setting up a development environment and do not need to be separately installed on the system.
-  See :doc:`/about/local-environment-setup` for details on how to set up a local environment suitable for running Phalanx tooling.
-
-- Helm v3 or later.
-  (See the `Helm installation instructions <https://helm.sh/docs/intro/install/>`__.)
+For installing an environment, you will also need the following tools:
 
 - Argo CD's command-line tool.
   It may be necessary to update this regularly to match the version of Argo CD that Phalanx, since Argo CD tends to break backward compatibility for its command-line API.


### PR DESCRIPTION
Be more explicit about how to find the right version of helm-docs. Point to the general local development environment setup instructions in the admin pages rather than repeating the same requirements.