### PR TITLE
DM-40889: Fix a bunch of small documentation issues

### DIFF
--- a/docs/admin/migrating-secrets.rst
+++ b/docs/admin/migrating-secrets.rst
@@ -2,7 +2,7 @@
 Migrating to the new secrets management system
 ##############################################
 
-We introduced a new command-line-driven secrets management system for Phalanx environments in September of 2021.
+We introduced a new command-line-driven secrets management system for Phalanx environments in September of 2023.
 This page documents how to migrate to the new system from the older scripts in :file:`installer`.
 
 These instructions assume that, if you are using 1Password for static secrets, you have already set up a 1Password vault and corresponding :px-app:`1Password Connect server <onepassword-connect-dev>` for this environment, but that vault may be empty.

--- a/docs/admin/troubleshooting.rst
+++ b/docs/admin/troubleshooting.rst
@@ -40,17 +40,6 @@ If more than 50 images are cached, images may go missing from that list even tho
 If this doesn't work, another possibility is that there is a node that cachemachine thinks is available for JupyterLab images but which is not eligible for its ``DaemonSet``.
 This would be a bug in cachemachine, which should ignore cordoned nodes, but it's possible there is a new iteration of node state or a new rule for where ``DaemonSets`` are allowed to run that it does not know about.
 
-Spawner menu shows empty parentheses after recommended rather than image tag
-============================================================================
-
-**Symptoms:** When a user goes to the spawner page for the Notebook Aspect, the "recommended" image is followed by empty parentheses rather than by a description of which image "recommended" refers to.
-
-**Cause:** Cachemachine is responsible for generating the menu used for spawning new JupyterLab instances, as above.
-In order for it to know which image corresponds to the ``recommended`` tag, it has to also pull that image under its specific tag name so that it sees that tag and ``recommended`` have the same hash.
-However, it only pulls a certain number of recent weeklies (generally three), so if the weekly tagged with ``recommended`` is older than that, it won't know which weekly it corresponds to and won't be able to fill in those details.
-
-**Solution**: :ref:`prepull-recommended`
-
 Spawning a notebook fails with a pending error
 ==============================================
 

--- a/docs/applications/cachemachine/bootstrap.rst
+++ b/docs/applications/cachemachine/bootstrap.rst
@@ -36,4 +36,3 @@ For other deployments that use the normal Rubin Notebook Aspect images, a reason
        }
 
 This prepulls the latest release, the latest two weeklies, and the latest three dailies, as well as the image tagged ``recommended``.
-However, also see :ref:`prepull-recommended` for information on how to ensure cachemachine knows the correct tag and description for the recommended image.

--- a/docs/developers/add-application.rst
+++ b/docs/developers/add-application.rst
@@ -29,7 +29,7 @@ Configure other Phalanx applications
 If the application needs to listen on hostnames other than the normal cluster-wide hostname, you will need to configure :px-app:`cert-manager` so that it can generate a TLS certificate for that hostname.
 See :doc:`/applications/cert-manager/add-new-hostname` for more details.
 
-If your application exposes Prometheus endpoints, you will want to configure these in the `telegraf application's prometheus_config <https://github.com/lsst-sqre/phalanx/blob/main/applications/telegraf/values.yaml#L36>`__.
+If your application exposes Prometheus endpoints, you will want to configure these in the `telegraf application's prometheus_config <https://github.com/lsst-sqre/phalanx/blob/main/applications/telegraf/values.yaml>`__.
 
 Enable the application for some environment
 ===========================================

--- a/docs/developers/create-an-application.rst
+++ b/docs/developers/create-an-application.rst
@@ -17,7 +17,7 @@ The easiest way to start a new FastAPI_ application written in Python and intend
 On the LSSTC Slack, send the message ``create project`` to ``@sqrbot-jr``.
 Select ``FastAPI application (Safir)`` from the list of project types.
 This will create a new GitHub repository with the basic framework of a FastAPI_ application that will work well inside the Rubin Science Platform.
-The template uses Safir_ to simplify and regularize many parts of your FastAPI_ application, from logger to database handling.
+The template uses Safir_ to simplify and regularize many parts of your FastAPI_ application, from logging to database handling.
 
 Any Python application destined for the RSP must regularly update its dependencies to pick up any security fixes and make new releases with those updated dependencies.
 If you use the template as described above, GitHub Actions CI will warn you when application dependencies are out of date.
@@ -41,6 +41,7 @@ If you use the FastAPI application template, a ``Dockerfile`` is be created as p
 
 If you use ``ghcr.io`` as your repository (which is the FastAPI template default) you can use GitHub's built-in ``GITHUB_TOKEN`` to push new images.
 You don't need to create an additional secret in GitHub Actions.
+
 If you are using Docker Hub you must create two secrets in your new GitHub repository, ``DOCKER_USERNAME`` and ``DOCKER_TOKEN``.
 ``DOCKER_USERNAME`` should be set to the Docker Hub username of the account that will be pushing the new Docker images.
 ``DOCKER_TOKEN`` should be set to a secret authentication token for that account.

--- a/docs/documenteer.toml
+++ b/docs/documenteer.toml
@@ -34,6 +34,7 @@ nitpick_ignore = [
 nitpick_ignore_regex = [
     # Bug in Sphinx
     ["py:obj", "SecretGenerateType\\..*"],
+    ["py:obj", ".*all fields"],
 ]
 python_api_dir = "internals/api"
 rst_epilog_file = "_rst_epilog.rst"

--- a/src/phalanx/models/vault.py
+++ b/src/phalanx/models/vault.py
@@ -48,9 +48,8 @@ class VaultAppRole(VaultAppRoleMetadata):
         Returns
         -------
         str
-            YAML creating a Kubernetes ``Secret`` resource for
-            vault-secrets-operator_, suitable for passing to :command:`kubectl
-            apply`.
+            YAML creating a Kubernetes ``Secret`` resource for `Vault Secrets
+            Operator`_, suitable for passing to :command:`kubectl apply`.
         """
         role_id = b64encode(self.role_id.encode()).decode()
         secret_id = b64encode(self.secret_id.encode()).decode()


### PR DESCRIPTION
- Fix date of new secrets management system
- Do not link directly to a `values.yaml` line number
- Improve the wording of the Safir pointer
- Ignore a bogus cross-reference due to a Sphinx bug
- Fix the link to Vault Secrets Operator documentation
- Remove references to prepulling recommended