### PR TITLE
DM-40889: Mark ingress-nginx certs as encoded

### DIFF
--- a/applications/ingress-nginx/secrets.yaml
+++ b/applications/ingress-nginx/secrets.yaml
@@ -3,6 +3,8 @@
     Private key of the TLS certificate to use for all connections to the
     Phalanx environment.
   if: vaultCertificate.enabled
+  onepassword:
+    encoded: true
 "tls.crt":
   description: >-
     Signed public TLS certificate, including any required chain certificates
@@ -11,3 +13,5 @@
     be valid for every hostname that will be used to connect to this Phalanx
     environment.
   if: vaultCertificate.enabled
+  onepassword:
+    encoded: true


### PR DESCRIPTION
The certificates used by ingress-nginx in environments that don't use cert-manager contain newlines and therefore have to be encoded when being stored in 1Password.