### PR TITLE
DM-40889: Stop telling people about hard refresh

### DIFF
--- a/docs/admin/sync-argo-cd.rst
+++ b/docs/admin/sync-argo-cd.rst
@@ -24,10 +24,7 @@ Sync the application
 
 Out-of-date applications will show as yellow in Argo CD.
 Click on the application to see its current resources and more details about its status.
-
 If the update was made recently, you may have to click :guilabel:`Refresh` first.
-If the update was to a chart whose version is not pinned, click on the small arrow next to :guilabel:`Refresh` and select :guilabel:`Hard Refresh`.
-(You will need to click directly on the small arrow, to the pixel, to see this option.)
 
 To review the changes before applying them, select :guilabel:`App Diff`.
 


### PR DESCRIPTION
Having to use hard refresh in Argo CD was an artifact of using unpinned chart dependencies, which we have thankfully stopped using in favor of Mend Renovate PRs. This documentation is now therefore obsolete.