### PR TITLE
DM-40889: Improve developer documentation

### DIFF
--- a/applications/exposurelog/secrets.yaml
+++ b/applications/exposurelog/secrets.yaml
@@ -1,4 +1,4 @@
-database-password:
+exposurelog_password:
   description: "Password for the exposurelog database."
   generate:
     type: password

--- a/applications/narrativelog/secrets.yaml
+++ b/applications/narrativelog/secrets.yaml
@@ -1,4 +1,4 @@
-database-password:
+narrativelog_password:
   description: "Password for the narrativelog database."
   generate:
     type: password

--- a/docs/about/repository.rst
+++ b/docs/about/repository.rst
@@ -12,7 +12,7 @@ Key directories
 applications directory
 ----------------------
 
-:bdg-link-primary-line:`Browse /applications/ on GitHub <https://github.com/lsst-sqre/phalanx/tree/main/applications>`
+:bdg-link-primary-line:`Browse applications/ on GitHub <https://github.com/lsst-sqre/phalanx/tree/main/applications>`
 
 Every Phalanx application has its own sub-directory within :file:`applications` named after the application itself (commonly the name is also used as a Kubernetes Namespace_).
 A Phalanx application is itself a Helm_ chart.
@@ -36,14 +36,14 @@ See the `Helm documentation on chart dependencies. <https://helm.sh/docs/topics/
 environments directory
 ----------------------
 
-:bdg-link-primary-line:`Browse /environments/ on GitHub <https://github.com/lsst-sqre/phalanx/tree/main/environments>`
+:bdg-link-primary-line:`Browse environments/ on GitHub <https://github.com/lsst-sqre/phalanx/tree/main/environments>`
 
 The :file:`environments` directory is where environments are defined (an environment is a distinct Kubernetes cluster).
 
 The :file:`environments/templates` directory contains a Helm template per application, like this one for the ``noteburst`` application:
 
 .. literalinclude:: ../../environments/templates/noteburst-application.yaml
-   :caption: /environments/templates/noteburst-application.yaml
+   :caption: environments/templates/noteburst-application.yaml
 
 The template defines a Kubernetes Namespace_ and an Argo CD ``Application`` for each Phalanx application.
 ``Application`` resources direct Argo CD to deploy and synchronize the corresponding application Helm chart from the Phalanx :file:`applications` directory.
@@ -56,7 +56,7 @@ Each environment then has a file named :file:`values-{environment}.yaml` that de
 installer directory
 -------------------
 
-:bdg-link-primary-line:`Browse /installer/ on GitHub <https://github.com/lsst-sqre/phalanx/tree/main/installer>`
+:bdg-link-primary-line:`Browse installer/ on GitHub <https://github.com/lsst-sqre/phalanx/tree/main/installer>`
 
 This directory contains a script named `install.sh <https://github.com/lsst-sqre/phalanx/blob/main/installer/install.sh>`__.
 The arguments to this are the name of the environment, the FQDN, and the read key for Vault (see :ref:`secrets` for more details on Vault).
@@ -67,7 +67,7 @@ See the :ref:`environment bootstrapping documentation <bootstrapping-toc>` for d
 docs directory
 --------------
 
-:bdg-link-primary-line:`Browse /docs/ on GitHub <https://github.com/lsst-sqre/phalanx/tree/main/docs>`
+:bdg-link-primary-line:`Browse docs/ on GitHub <https://github.com/lsst-sqre/phalanx/tree/main/docs>`
 
 This directory contains the Sphinx_ documentation that you are reading now.
 See :doc:`contributing-docs`.
@@ -75,7 +75,7 @@ See :doc:`contributing-docs`.
 src directory
 -------------
 
-:bdg-link-primary-line:`Browse /src/ on GitHub <https://github.com/lsst-sqre/phalanx/tree/main/src>`
+:bdg-link-primary-line:`Browse src/ on GitHub <https://github.com/lsst-sqre/phalanx/tree/main/src>`
 
 This directory contains the source of the Phalanx command-line tool (see :doc:`/admin/cli`).
 The Python dependencies for that command-line tool are managed in the :file:`requirements` directory.
@@ -83,7 +83,7 @@ The Python dependencies for that command-line tool are managed in the :file:`req
 starters directory
 ------------------
 
-:bdg-link-primary-line:`Browse /starters/ on GitHub <https://github.com/lsst-sqre/phalanx/tree/main/starters>`
+:bdg-link-primary-line:`Browse starters/ on GitHub <https://github.com/lsst-sqre/phalanx/tree/main/starters>`
 
 This directory contains templates for contributing new applications to Phalanx.
 See :doc:`/developers/write-a-helm-chart`.
@@ -91,7 +91,7 @@ See :doc:`/developers/write-a-helm-chart`.
 tests directory
 ---------------
 
-:bdg-link-primary-line:`Browse /tests/ on GitHub <https://github.com/lsst-sqre/phalanx/tree/main/tests>`
+:bdg-link-primary-line:`Browse tests/ on GitHub <https://github.com/lsst-sqre/phalanx/tree/main/tests>`
 
 This directory primarily contains tests for the Phalanx command-line tool.
 However, it also contains some tests written in Python that check the consistency of the Phalanx configuration, and therefore runs for all changes, not just those that change the source of the command-line tool.

--- a/docs/applications/_summary.rst.jinja
+++ b/docs/applications/_summary.rst.jinja
@@ -1,7 +1,7 @@
 .. list-table::
 
    * - View on GitHub
-     - :bdg-link-primary-line:`/applications/{{ app.name }} <https://github.com/lsst-sqre/phalanx/tree/main/applications/{{app.name}}>`
+     - :bdg-link-primary-line:`applications/{{ app.name }} <https://github.com/lsst-sqre/phalanx/tree/main/applications/{{app.name}}>`
        :bdg-link-primary-line:`Application template <https://github.com/lsst-sqre/phalanx/blob/main/environments/templates/{{app.name}}-application.yaml>`
    {% if app.homepage %}
    * - Homepage

--- a/docs/developers/deploy-from-a-branch.rst
+++ b/docs/developers/deploy-from-a-branch.rst
@@ -183,8 +183,7 @@ Once your branch is merged, remember to reset your application's Argo CD ``Appli
 
 #. In the application's page in Argo CD, click on the :guilabel:`Sync` button to redeploy the application from the default branch.
 
-You can also find your application in the ``science-platform`` Argo CD application and sync it from there to reset the default branch and any other settings you changed.
-Either approach works; use whichever you find more convenient.
+Alternatively, you can find the application in the ``science-platform`` Argo CD application and sync it from there to reset the default branch and any other settings you changed.
 
 Next steps
 ==========

--- a/docs/developers/deploy-from-a-branch.rst
+++ b/docs/developers/deploy-from-a-branch.rst
@@ -97,10 +97,9 @@ The fastest method for trying out changes to Kubernetes resources is to directly
 In your application's Argo CD page you can click on a specific resource (such as a ConfigMap_ or Deployment_) and click the :guilabel:`Edit` button on the live manifest.
 Make your changes, then click :guilabel:`Save`.
 
-Normally, these changes will immediately take effect.
-Sometimes if you change a ``ConfigMap`` you will need to restart the relevant deployments to pick up that change.
+Changes made to a ``ConfigMap`` are often not automatically applied, since pods usually read their ``ConfigMap`` on startup and never again.
+If you change a ``ConfigMap``, you may therefore have to restart the relevant deployments to pick up that change.
 For instructions on how to do that, see :ref:`branch-deploy-restart`.
-(However, see :ref:`dev-deployment-restart` for a better way.)
 
 After you have made this type of manual edit, the application will show as out of sync, since its configuration in the Kubernetes cluster no longer matches its configuration in Phalanx.
 If you click the :guilabel:`Sync` button, it will revert your changes and again make the application match its Phalanx configuration.

--- a/docs/developers/deploy-from-a-branch.rst
+++ b/docs/developers/deploy-from-a-branch.rst
@@ -14,7 +14,7 @@ Through this process it is possible to develop an application in a fairly tight 
 .. seealso::
 
    This page focuses on using a development environment to iteratively develop and test changes to an application, ultimately yielding a applicatino upgrade in Phalanx.
-   You can achieve the same result, without the iterative deployment testing, following the steps in :doc:`upgrade`.
+   You can achieve the same result without the iterative deployment testing by following the steps in :doc:`upgrade`.
 
 .. _deploy-branch-prep:
 
@@ -100,6 +100,7 @@ Make your changes, then click :guilabel:`Save`.
 Normally, these changes will immediately take effect.
 Sometimes if you change a ``ConfigMap`` you will need to restart the relevant deployments to pick up that change.
 For instructions on how to do that, see :ref:`branch-deploy-restart`.
+(However, see :ref:`dev-deployment-restart` for a better way.)
 
 After you have made this type of manual edit, the application will show as out of sync, since its configuration in the Kubernetes cluster no longer matches its configuration in Phalanx.
 If you click the :guilabel:`Sync` button, it will revert your changes and again make the application match its Phalanx configuration.
@@ -132,8 +133,8 @@ Besides developing the Helm chart, you can also test branch builds of your appli
 
 To start, ensure that the Deployment_ is using development builds of your application's Docker images.
 The best way to do this is to edit the application's Helm chart for the application in the development environment and to :ref:`sync those changes <updating-and-resyncing-from-branch>`.
-For many applications you can set the ``appVersion`` in the field in the application's ``Chart.yaml`` file to the name of the development Docker tag (see also :doc:`upgrade`).
-You may instead change the ``image.tag`` setting in the :file:`values-{environment}.yaml` file for that environment.
+For development changes, you should usually override just the ``image.tag`` setting in the :file:`values-{environment}.yaml` file for that environment, which makes it clear that this change is temporary.
+Save changes to the ``appVersion`` in :file:`Chart.yaml` for new releases.
 
 You should also ensure that the Deployment_ is always pulling new images, rather than caching them, by setting the ``imagePullPolicy`` to ``Always``.
 This is covered in :ref:`deploy-branch-prep`.
@@ -182,6 +183,9 @@ Once your branch is merged, remember to reset your application's Argo CD ``Appli
    - Finally, click on the :guilabel:`Save` button.
 
 #. In the application's page in Argo CD, click on the :guilabel:`Sync` button to redeploy the application from the default branch.
+
+You can also find your application in the ``science-platform`` Argo CD application and sync it from there to reset the default branch and any other settings you changed.
+Either approach works; use whichever you find more convenient.
 
 Next steps
 ==========

--- a/docs/developers/upgrade.rst
+++ b/docs/developers/upgrade.rst
@@ -2,14 +2,16 @@
 Upgrading an application
 ########################
 
-First, release a new version of the application by pushing an image with the new version tag to whichever Docker repository is used.
+First, for first-party applications, release a new version of the application by pushing an image with the new version tag to whichever Docker repository is used.
 For most applications, this should be done via GitHub Actions when a tag is created by adding a new release.
 
 Then, update Phalanx to install the new version of the application.
 
 - If it is a first-party application such as ``mobu``, with its chart directly in Phalanx, update the ``appVersion`` in :file:`Chart.yaml`.
+
 - If it is a third-party application such as ``cert-manager`` and you are updating to a newer version of the third-party Helm chart, update the ``version`` in the relevant dependency in :file:`Chart.yaml`.
   Normally `Mend Renovate`_ will create PRs to do this automatically.
+
 - If it is a complex application such as ``sasquatch`` that bundles first- and third-party applications, you may need to do both, including making updates to ``appVersion`` or dependency versions in the :file:`charts` subdirectory.
   Tricky cases such as these may require some study before deciding on the best course of action.
 


### PR DESCRIPTION
Document the trick of adding a checksum annotation to force restarts of the deployment. Stop telling people to add development versions to the Chart.yaml appVersion; for development tags, just use overrides of image.tag. Tell people they can sync their application in the science-platform app to revert development changes. Clarify documentation about Chart.yaml and pull secrets.