### PR TITLE
Fix nublado-lab-secret on old secret system

### DIFF
--- a/applications/nublado/templates/vault-secrets.yaml
+++ b/applications/nublado/templates/vault-secrets.yaml
@@ -6,8 +6,8 @@ metadata:
   labels:
     {{- include "nublado.labels" . | nindent 4 }}
 spec:
-  path: "{{- .Values.global.vaultSecretsPath }}/nublado"
   {{- if .Values.secrets.templateSecrets }}
+  path: "{{- .Values.global.vaultSecretsPath }}/nublado"
   templates:
     {{- range .Values.controller.config.lab.secrets }}
     {{- if eq .secretName "nublado-lab-secret" }}
@@ -15,6 +15,8 @@ spec:
       {% index .Secrets "{{ .secretKey }}" %}
     {{- end }}
     {{- end }}
+  {{- else }}
+  path: "{{- .Values.global.vaultSecretsPath }}/nublado-lab-secret"
   {{- end }}
   type: Opaque
 ---


### PR DESCRIPTION
The change to support the new secret management system accidentally changed the path of the nublado lab secret on older environments. Fix that.