### PR TITLE
DM-40890: Enable onepassword-connect on roundtable-prod

### DIFF
--- a/environments/values-roundtable-prod.yaml
+++ b/environments/values-roundtable-prod.yaml
@@ -1,13 +1,14 @@
 name: roundtable-prod
 fqdn: roundtable.lsst.cloud
+onepassword:
+  connectUrl: "https://roundtable.lsst.cloud/1password"
+  vaultTitle: "RSP roundtable.lsst.cloud"
 vaultUrl: "https://vault.lsst.codes"
 vaultPathPrefix: secret/k8s_operator/roundtable.lsst.cloud
-onepassword:
-  connectUrl: https://roundtable.lsst.cloud/1password
-  vaultTitle: "RSP roundtable-dev.lsst.cloud"
 
 applications:
   kubernetes-replicator: true
+  onepassword-connect: true
   ook: true
   sasquatch: true
   squareone: true


### PR DESCRIPTION
Set up the 1Password Connect server for production environments on roundtable-prod.
