### PR TITLE
Improve prompt-processing descriptions

### DIFF
--- a/applications/next-visit-fan-out/Chart.yaml
+++ b/applications/next-visit-fan-out/Chart.yaml
@@ -1,7 +1,8 @@
 apiVersion: v2
 appVersion: 0.1.0
-description: Application to poll next visit events from kafka, fan out/duplicate the
-  message, and send to knative.
+description: >-
+  Poll next visit events from Kafka, duplicate them, and send them to all
+  applications that need to receive them.
 name: next-visit-fan-out
 type: application
 version: 1.0.0

--- a/applications/next-visit-fan-out/README.md
+++ b/applications/next-visit-fan-out/README.md
@@ -1,6 +1,6 @@
 # next-visit-fan-out
 
-Application to poll next visit events from kafka, fan out/duplicate the message, and send to knative.
+Poll next visit events from Kafka, duplicate them, and send them to all applications that need to receive them.
 
 ## Values
 

--- a/applications/prompt-proto-service-hsc/Chart.yaml
+++ b/applications/prompt-proto-service-hsc/Chart.yaml
@@ -1,7 +1,9 @@
 apiVersion: v2
 name: prompt-proto-service-hsc
 version: 1.0.0
-description: Prompt Proto Service is an event driven service for processing camera images.  The service runs on knative. This deployment handles HSC images.
+description: >-
+  Prompt Proto Service is an event driven service for processing camera
+  images. This instance of the service handles HSC images.
 home: https://github.com/lsst-dm/prompt_prototype/blob/main/doc/playbook.rst
 sources:
   - https://github.com/lsst-dm/prompt_prototype

--- a/applications/prompt-proto-service-hsc/README.md
+++ b/applications/prompt-proto-service-hsc/README.md
@@ -1,6 +1,6 @@
 # prompt-proto-service-hsc
 
-Prompt Proto Service is an event driven service for processing camera images.  The service runs on knative. This deployment handles HSC images.
+Prompt Proto Service is an event driven service for processing camera images. This instance of the service handles HSC images.
 
 **Homepage:** <https://github.com/lsst-dm/prompt_prototype/blob/main/doc/playbook.rst>
 

--- a/applications/prompt-proto-service-latiss/Chart.yaml
+++ b/applications/prompt-proto-service-latiss/Chart.yaml
@@ -1,7 +1,9 @@
 apiVersion: v2
 name: prompt-proto-service-latiss
 version: 1.0.0
-description: Prompt Proto Service is an event driven service for processing camera images.  The service runs on knative. This deployment handles LATISS images.
+description: >-
+  Prompt Proto Service is an event driven service for processing camera
+  images. This instance of the service handles LATISS images.
 home: https://github.com/lsst-dm/prompt_prototype/blob/main/doc/playbook.rst
 sources:
   - https://github.com/lsst-dm/prompt_prototype

--- a/applications/prompt-proto-service-latiss/README.md
+++ b/applications/prompt-proto-service-latiss/README.md
@@ -1,6 +1,6 @@
 # prompt-proto-service-latiss
 
-Prompt Proto Service is an event driven service for processing camera images.  The service runs on knative. This deployment handles LATISS images.
+Prompt Proto Service is an event driven service for processing camera images. This instance of the service handles LATISS images.
 
 **Homepage:** <https://github.com/lsst-dm/prompt_prototype/blob/main/doc/playbook.rst>
 

--- a/applications/prompt-proto-service-lsstcam/Chart.yaml
+++ b/applications/prompt-proto-service-lsstcam/Chart.yaml
@@ -1,7 +1,9 @@
 apiVersion: v2
 name: prompt-proto-service-lsstcam
 version: 1.0.0
-description: Prompt Proto Service is an event driven service for processing camera images.  The service runs on knative. This deployment handles LSSTCam images.
+description: >-
+  Prompt Proto Service is an event driven service for processing camera
+  images. This instance of the service handles LSSTCam images.
 home: https://github.com/lsst-dm/prompt_prototype/blob/main/doc/playbook.rst
 sources:
   - https://github.com/lsst-dm/prompt_prototype

--- a/applications/prompt-proto-service-lsstcam/README.md
+++ b/applications/prompt-proto-service-lsstcam/README.md
@@ -1,6 +1,6 @@
 # prompt-proto-service-lsstcam
 
-Prompt Proto Service is an event driven service for processing camera images.  The service runs on knative. This deployment handles LSSTCam images.
+Prompt Proto Service is an event driven service for processing camera images. This instance of the service handles LSSTCam images.
 
 **Homepage:** <https://github.com/lsst-dm/prompt_prototype/blob/main/doc/playbook.rst>
 

--- a/applications/prompt-proto-service-lsstcomcam/Chart.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/Chart.yaml
@@ -1,7 +1,9 @@
 apiVersion: v2
 name: prompt-proto-service-lsstcomcam
 version: 1.0.0
-description: Prompt Proto Service is an event driven service for processing camera images.  The service runs on knative. This deployment handles LSSTComCam images.
+description: >-
+  Prompt Proto Service is an event driven service for processing camera
+  images. This instance of the service handles LSSTComCam images.
 home: https://github.com/lsst-dm/prompt_prototype/blob/main/doc/playbook.rst
 sources:
   - https://github.com/lsst-dm/prompt_prototype

--- a/applications/prompt-proto-service-lsstcomcam/README.md
+++ b/applications/prompt-proto-service-lsstcomcam/README.md
@@ -1,6 +1,6 @@
 # prompt-proto-service-lsstcomcam
 
-Prompt Proto Service is an event driven service for processing camera images.  The service runs on knative. This deployment handles LSSTComCam images.
+Prompt Proto Service is an event driven service for processing camera images. This instance of the service handles LSSTComCam images.
 
 **Homepage:** <https://github.com/lsst-dm/prompt_prototype/blob/main/doc/playbook.rst>
 

--- a/charts/prompt-proto-service/Chart.yaml
+++ b/charts/prompt-proto-service/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prompt-proto-service
 version: 1.0.0
 appVersion: "0.1.0"
-description: Prompt Proto Service is an event driven service for processing camera images.  The service runs on knative.
+description: Event-driven processing of camera images
 type: application
 home: https://github.com/lsst-dm/prompt_prototype/blob/main/doc/playbook.rst
 sources:

--- a/charts/prompt-proto-service/README.md
+++ b/charts/prompt-proto-service/README.md
@@ -1,6 +1,6 @@
 # prompt-proto-service
 
-Prompt Proto Service is an event driven service for processing camera images.  The service runs on knative.
+Event-driven processing of camera images
 
 **Homepage:** <https://github.com/lsst-dm/prompt_prototype/blob/main/doc/playbook.rst>
 

--- a/docs/applications/next-visit-fan-out/index.rst
+++ b/docs/applications/next-visit-fan-out/index.rst
@@ -1,8 +1,10 @@
 .. px-app:: next-visit-fan-out
 
-##########################################################################################################################
-next-visit-fan-out — Application to poll next visit events from kafka, fan out/duplicate the message, and send to knative.
-##########################################################################################################################
+#################################################
+next-visit-fan-out — Distribute next visit events
+#################################################
+
+The next-visit-fan-out application pulls next visit events from Kafka and duplicates and fans out the events to other components that need to receive them.
 
 .. jinja:: next-visit-fan-out
    :file: applications/_summary.rst.jinja

--- a/docs/applications/prompt-proto-service-hsc/index.rst
+++ b/docs/applications/prompt-proto-service-hsc/index.rst
@@ -1,10 +1,13 @@
 .. px-app:: prompt-proto-service-hsc
 
-#########################################
-prompt-proto-service-hsc
-#########################################
+###########################################################
+prompt-proto-service-hsc — Prompt processing for HSC images
+###########################################################
 
-Knative service to run the Prompt Processing framework for HSC images.
+Prompt Proto Service is an event driven service for processing camera images.
+This instance of the service handles HSC images.
+
+This and all of the other instances of the Prompt Proto Service use a shared chart in `charts/prompt-proto-service <https://github.com/lsst-sqre/phalanx/tree/main/charts/prompt-proto-service>`__.
 
 .. jinja:: prompt-proto-service-hsc
    :file: applications/_summary.rst.jinja

--- a/docs/applications/prompt-proto-service-latiss/index.rst
+++ b/docs/applications/prompt-proto-service-latiss/index.rst
@@ -1,10 +1,13 @@
 .. px-app:: prompt-proto-service-latiss
 
-#########################################
-prompt-proto-service-latiss
-#########################################
+#################################################################
+prompt-proto-service-latiss — Prompt processing for LATISS images
+#################################################################
 
-Knative service to run the Prompt Processing framework for LATISS images.
+Prompt Proto Service is an event driven service for processing camera images.
+This instance of the service handles LATISS images.
+
+This and all of the other instances of the Prompt Proto Service use a shared chart in `charts/prompt-proto-service <https://github.com/lsst-sqre/phalanx/tree/main/charts/prompt-proto-service>`__.
 
 .. jinja:: prompt-proto-service-latiss
    :file: applications/_summary.rst.jinja

--- a/docs/applications/prompt-proto-service-lsstcam/index.rst
+++ b/docs/applications/prompt-proto-service-lsstcam/index.rst
@@ -1,10 +1,13 @@
 .. px-app:: prompt-proto-service-lsstcam
 
-#########################################
-prompt-proto-service-lsstcam
-#########################################
+###################################################################
+prompt-proto-service-lsstcam — Prompt processing for LSSTCam images
+###################################################################
 
-Knative service to run the Prompt Processing framework for LSSTCam images.
+Prompt Proto Service is an event driven service for processing camera images.
+This instance of the service handles LSSTCam images.
+
+This and all of the other instances of the Prompt Proto Service use a shared chart in `charts/prompt-proto-service <https://github.com/lsst-sqre/phalanx/tree/main/charts/prompt-proto-service>`__.
 
 .. jinja:: prompt-proto-service-lsstcam
    :file: applications/_summary.rst.jinja

--- a/docs/applications/prompt-proto-service-lsstcomcam/index.rst
+++ b/docs/applications/prompt-proto-service-lsstcomcam/index.rst
@@ -1,10 +1,13 @@
 .. px-app:: prompt-proto-service-lsstcomcam
 
-#########################################
-prompt-proto-service-lsstcomcam
-#########################################
+#########################################################################
+prompt-proto-service-lsstcomcam — Prompt processing for LSSTComCam images
+#########################################################################
 
-Knative service to run the Prompt Processing framework for LSSTComCam images.
+Prompt Proto Service is an event driven service for processing camera images.
+This instance of the service handles LSSTComCam images.
+
+This and all of the other instances of the Prompt Proto Service use a shared chart in `charts/prompt-proto-service <https://github.com/lsst-sqre/phalanx/tree/main/charts/prompt-proto-service>`__.
 
 .. jinja:: prompt-proto-service-lsstcomcam
    :file: applications/_summary.rst.jinja


### PR DESCRIPTION
Improve the documentation pages, titles, and Chart.yaml descriptions for the prompt processing services. Explicitly note for the prompt processing services that they use a shared chart.