### PR TITLE
DM-40947: Ensure all application charts use 1.0.0

### DIFF
--- a/applications/alert-stream-broker/Chart.yaml
+++ b/applications/alert-stream-broker/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: alert-stream-broker
-version: "3"
+version: 1.0.0
 description: Alert transmission to community brokers
 sources:
   - https://github.com/lsst-dm/alert_database_ingester

--- a/applications/giftless/Chart.yaml
+++ b/applications/giftless/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: giftless
-version: 0.0.1
+version: 1.0.0
 description: Git-LFS server with GCS S3 backend, with Rubin-specific auth
 sources:
   - https://github.com/datopian/giftless

--- a/applications/moneypenny/Chart.yaml
+++ b/applications/moneypenny/Chart.yaml
@@ -6,7 +6,7 @@ sources:
   - https://github.com/lsst-sqre/moneypenny
   - https://github.com/lsst-sqre/farthing
   - https://github.com/lsst-sqre/inituserhome
-version: 1.0.2
+version: 1.0.0
 annotations:
   phalanx.lsst.io/docs: |
     - id: "SQR-052"

--- a/applications/monitoring/Chart.yaml
+++ b/applications/monitoring/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: monitoring
-version: 0.0.1
+version: 1.0.0
 description: Chronograf-based UI for monitoring (data stored in InfluxDBv2)
 sources:
   - https://github.com/lsst-sqre/rubin-influx-tools

--- a/applications/plot-navigator/Chart.yaml
+++ b/applications/plot-navigator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: plot-navigator
 description: Panel-based plot viewer
-version: 1.7.0
+version: 1.0.0
 sources:
   - https://github.com/lsst-dm/pipetask-plot-navigator
 appVersion: "0.10.2"

--- a/applications/strimzi/Chart.yaml
+++ b/applications/strimzi/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: strimzi
 type: application
-version: 0.1.0
+version: 1.0.0
 description: Strimzi Kafka Operator
 home: https://strimzi.io
 appVersion: "0.26.0"

--- a/applications/telegraf/Chart.yaml
+++ b/applications/telegraf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: telegraf
-version: 1.0.1
+version: 1.0.0
 description: Application telemetry collection service
 home: https://www.influxdata.com/time-series-platform/telegraf/
 sources:

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1,0 +1,29 @@
+"""Tests for the Phalanx configuration itself."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+def test_application_version() -> None:
+    """Test that all application charts have version 1.0.0."""
+    applications_path = Path(__file__).parent.parent / "applications"
+    for application in applications_path.iterdir():
+        if not application.is_dir():
+            continue
+        chart = yaml.safe_load((application / "Chart.yaml").read_text())
+        assert (
+            chart["version"] == "1.0.0"
+        ), f"Chart for application {application.name} has incorrect version"
+
+    # Check the same thing for shared charts.
+    Path(__file__).parent.parent / "charts"
+    for shared_chart in applications_path.iterdir():
+        if not shared_chart.is_dir():
+            continue
+        chart = yaml.safe_load((shared_chart / "Chart.yaml").read_text())
+        assert (
+            chart["version"] == "1.0.0"
+        ), f"Shared chart {shared_chart.name} has incorrect version"


### PR DESCRIPTION
The application chart version is meaningless in Phalanx because of how we use Helm and those charts, as is the chart version for shared charts in the charts directory. Enforce that it is always 1.0.0, matching the documentation, to ensure that no one gets confused by supposed semantic information in the chart version that doesn't mean anything.