### PR TITLE
DM-40952: Add secrets.yaml for Ook and Squarebot

### DIFF
--- a/applications/ook/secrets.yaml
+++ b/applications/ook/secrets.yaml
@@ -1,0 +1,26 @@
+ALGOLIA_APP_ID:
+  description: >-
+    The ID of the Algolia application.
+ALGOLIA_API_KEY:
+  description: >-
+    The admin API key for the Algolia application.
+OOK_GITHUB_APP_ID:
+  description: >-
+    The ID of the GitHub App shared by all Squarebot services.
+  copy:
+    application: squarebot
+    key: SQUAREBOT_GITHUB_APP_ID
+OOK_GITHUB_APP_KEY:
+  description: >-
+    The private key for the GitHub App shared by all Squarebot services.
+  copy:
+    application: squarebot
+    key: SQUAREBOT_GITHUB_APP_KEY
+ca.crt:
+  description: >-
+    The cluster CA certificate for the Kubernetes cluster. This is available
+    on the Kafka resource in the sasquatch application under the
+    ``status.listeners[].certificate`` field.
+  copy:
+    application: squarebot
+    key: ca.crt

--- a/applications/squarebot/secrets.yaml
+++ b/applications/squarebot/secrets.yaml
@@ -1,0 +1,28 @@
+SQUAREBOT_GITHUB_APP_ID:
+  description: >-
+    The ID of the GitHub App shared by all Squarebot services.
+SQUAREBOT_GITHUB_APP_KEY:
+  description: >-
+    The private key for the GitHub App shared by all Squarebot services.
+  onepassword:
+    encoded: true
+SQUAREBOT_SLACK_APP_ID:
+  description: >-
+    The ID of the Slack App shared by all Squarebot services.
+SQUAREBOT_SLACK_TOKEN:
+  description: >-
+    The Slack bot user oauth token for the Slack App shared by all Squarebot services.
+  onepassword:
+    encoded: true
+SQUAREBOT_SLACK_SIGNING:
+  description: >-
+    The signing secret for all webhook payloads from Slack.
+  onepassword:
+    encoded: true
+ca.crt:
+  description: >-
+    The cluster CA certificate for the Kubernetes cluster. This is available
+    on the Kafka resource in the sasquatch application under the
+    ``status.listeners[].certificate`` field.
+  onepassword:
+    encoded: true

--- a/environments/values-roundtable-dev.yaml
+++ b/environments/values-roundtable-dev.yaml
@@ -3,6 +3,7 @@ fqdn: roundtable-dev.lsst.cloud
 vaultUrl: "https://vault.lsst.codes"
 vaultPathPrefix: secret/k8s_operator/roundtable-dev.lsst.cloud
 onepassword:
+  connectUrl: https://roundtable-dev.lsst.cloud/1password
   vaultTitle: "RSP roundtable-dev.lsst.cloud"
 
 applications:

--- a/environments/values-roundtable-dev.yaml
+++ b/environments/values-roundtable-dev.yaml
@@ -2,6 +2,8 @@ name: roundtable-dev
 fqdn: roundtable-dev.lsst.cloud
 vaultUrl: "https://vault.lsst.codes"
 vaultPathPrefix: secret/k8s_operator/roundtable-dev.lsst.cloud
+onepassword:
+  vaultTitle: "RSP roundtable-dev.lsst.cloud"
 
 applications:
   giftless: true

--- a/environments/values-roundtable-prod.yaml
+++ b/environments/values-roundtable-prod.yaml
@@ -2,6 +2,8 @@ name: roundtable-prod
 fqdn: roundtable.lsst.cloud
 vaultUrl: "https://vault.lsst.codes"
 vaultPathPrefix: secret/k8s_operator/roundtable.lsst.cloud
+onepassword:
+  vaultTitle: "RSP roundtable-dev.lsst.cloud"
 
 applications:
   kubernetes-replicator: true

--- a/environments/values-roundtable-prod.yaml
+++ b/environments/values-roundtable-prod.yaml
@@ -3,6 +3,7 @@ fqdn: roundtable.lsst.cloud
 vaultUrl: "https://vault.lsst.codes"
 vaultPathPrefix: secret/k8s_operator/roundtable.lsst.cloud
 onepassword:
+  connectUrl: https://roundtable.lsst.cloud/1password
   vaultTitle: "RSP roundtable-dev.lsst.cloud"
 
 applications:


### PR DESCRIPTION
This adds new `secrets.yaml` file for ook and squarebot that should be sufficient to get the roundtable-dev and roundtable-prod environments running under the new secrets infrastructure and 1Password Connect.