### PR TITLE
DM-40947: Add test for secrets.yaml files

### DIFF
--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -6,9 +6,20 @@ from pathlib import Path
 
 import yaml
 
+_ALLOW_NO_SECRETS = (
+    "giftless",
+    "linters",
+    "monitoring",
+    "obsloctap",
+    "next-visit-fan-out",
+    "plot-navigator",
+    "production-tools",
+)
+"""Temporary whitelist of applications that haven't added secrets.yaml."""
+
 
 def test_application_version() -> None:
-    """Test that all application charts have version 1.0.0."""
+    """All application charts should have version 1.0.0."""
     applications_path = Path(__file__).parent.parent / "applications"
     for application in applications_path.iterdir():
         if not application.is_dir():
@@ -27,3 +38,30 @@ def test_application_version() -> None:
         assert (
             chart["version"] == "1.0.0"
         ), f"Shared chart {shared_chart.name} has incorrect version"
+
+
+def test_secrets_defined() -> None:
+    """Any application with a VaultSecret should have secrets.yaml."""
+    applications_path = Path(__file__).parent.parent / "applications"
+    for application in applications_path.iterdir():
+        if not application.is_dir() or application.name in _ALLOW_NO_SECRETS:
+            continue
+        if list(application.glob("secrets*.yaml")):
+            continue
+        template_path = application / "templates"
+        if not template_path.is_dir():
+            continue
+        for template in (application / "templates").iterdir():
+            if not template.is_file():
+                continue
+            resources = template.read_text().split("---\n")
+            for resource in resources:
+                if "kind: VaultSecret" not in resource:
+                    continue
+                if "name: pull-secret" in resource:
+                    continue
+                msg = (
+                    f"Application {application.name} installs a VaultSecret"
+                    " resource but has no secrets.yaml configuration"
+                )
+                raise AssertionError(msg)


### PR DESCRIPTION
Test that every application that installs a VaultSecret resource has a secrets.yaml or secrets-<environment>.yaml file that defines its secrets. Add a whitelist of applications that have not yet done this.