### PR TITLE
DM-40947: Better handling of missing 1Password secrets

### DIFF
--- a/src/phalanx/exceptions.py
+++ b/src/phalanx/exceptions.py
@@ -116,6 +116,24 @@ class InvalidSecretConfigError(Exception):
         super().__init__(msg)
 
 
+class MissingOnepasswordSecretsError(Exception):
+    """Secrets are missing from 1Password.
+
+    Parameters
+    ----------
+    secrets
+        List of strings identifying missing secrets. These will either be a
+        bare application name, indicating the entire application item is
+        missing from 1Password, or the application name followed by a space,
+        indicating the 1Password item doesn't have that field.
+    """
+
+    def __init__(self, secrets: Iterable[str]) -> None:
+        self.secrets = list(secrets)
+        msg = f'Missing 1Password items or fields: {", ".join(self.secrets)}'
+        super().__init__(msg)
+
+
 class NoOnepasswordConfigError(Exception):
     """Environment does not use 1Password."""
 

--- a/src/phalanx/services/secrets.py
+++ b/src/phalanx/services/secrets.py
@@ -55,7 +55,8 @@ class SecretsAuditReport:
             report += "Missing secrets:\n• " + secrets + "\n"
         if self.mismatch:
             secrets = "\n• ".join(sorted(self.mismatch))
-            report += "Incorrect secrets:\n• " + secrets + "\n"
+            heading = "Secrets that do not have their expected value:"
+            report += f"{heading}\n• " + secrets + "\n"
         if self.unknown:
             secrets = "\n• ".join(sorted(self.unknown))
             report += "Unknown secrets in Vault:\n• " + secrets + "\n"

--- a/tests/cli/secrets_test.py
+++ b/tests/cli/secrets_test.py
@@ -61,6 +61,27 @@ def test_audit(factory: Factory, mock_vault: MockVaultClient) -> None:
     assert result.output == read_output_data("idfdev", "secrets-audit")
 
 
+def test_audit_onepassword_missing(
+    factory: Factory,
+    mock_onepassword: MockOnepasswordClient,
+    mock_vault: MockVaultClient,
+) -> None:
+    """Check reporting of missing 1Password secrets."""
+    phalanx_test_path()
+    config_storage = factory.create_config_storage()
+    environment = config_storage.load_environment("minikube")
+    assert environment.onepassword
+    vault_title = environment.onepassword.vault_title
+    mock_onepassword.create_empty_test_vault(vault_title)
+    mock_vault.load_test_data(environment.vault_path_prefix, "minikube")
+
+    result = run_cli("secrets", "audit", "minikube")
+    assert result.exit_code == 0
+    assert result.output == read_output_data(
+        "minikube", "audit-missing-output"
+    )
+
+
 def test_list() -> None:
     result = run_cli("secrets", "list", "idfdev")
     assert result.exit_code == 0

--- a/tests/data/output/idfdev/secrets-audit
+++ b/tests/data/output/idfdev/secrets-audit
@@ -9,7 +9,7 @@ Missing secrets:
 • nublado postgres-credentials.txt
 • nublado proxy_token
 • portal ADMIN_PASSWORD
-Incorrect secrets:
+Secrets that do not have their expected value:
 • gafaelfawr database-password
 • postgres nublado3_password
 Unknown secrets in Vault:

--- a/tests/data/output/minikube/audit-missing-output
+++ b/tests/data/output/minikube/audit-missing-output
@@ -1,0 +1,4 @@
+Missing static secrets from 1Password:
+• argocd
+• gafaelfawr
+• mobu

--- a/tests/support/onepassword.py
+++ b/tests/support/onepassword.py
@@ -37,6 +37,19 @@ class MockOnepasswordClient:
         self._data: dict[str, dict[str, Item]] = {}
         self._uuids: dict[str, str] = {}
 
+    def create_empty_test_vault(self, vault: str) -> None:
+        """Create an empty 1Password vault for testing.
+
+        This method is not part of the 1Password Connect API. It is intended
+        for use by the test suite to set up a test.
+
+        Parameters
+        ----------
+        vault
+            Name of the 1Password vault.
+        """
+        self._data[vault] = {}
+
     def load_test_data(self, vault: str, environment: str) -> None:
         """Load 1Password test data for the given environment.
 


### PR DESCRIPTION
Retrieve each 1Password item separately rather than using the bulk API so that we can do proper error reporting of all of the missing secrets we expected to be in 1Password but which weren't found. Throw that as an exception up through sync, but, in audit, catch that exception and properly report the missing secrets.