### PR TITLE
DM-40947: Properly diagnose 1Password encoding errors

### DIFF
--- a/src/phalanx/exceptions.py
+++ b/src/phalanx/exceptions.py
@@ -116,6 +116,28 @@ class InvalidSecretConfigError(Exception):
         super().__init__(msg)
 
 
+class MalformedOnepasswordSecretError(Exception):
+    """A secret stored in 1Password was malformed.
+
+    The most common cause of this error is that the secret was marked as
+    encoded in base64 but couldn't be decoded.
+
+    Parameters
+    ----------
+    application
+        Name of the application.
+    key
+        Secret key.
+    error
+        Error message.
+    """
+
+    def __init__(self, application: str, key: str, error: str) -> None:
+        name = f"{application}/{key}"
+        msg = f"Value of secret {name} is malformed: {error}"
+        super().__init__(msg)
+
+
 class MissingOnepasswordSecretsError(Exception):
     """Secrets are missing from 1Password.
 

--- a/tests/support/onepassword.py
+++ b/tests/support/onepassword.py
@@ -97,7 +97,9 @@ class MockOnepasswordClient:
         Returns
         -------
         Item
-            Corresponding item.
+            Corresponding item. This is the exact item that is stored in the
+            mock, so tests can mutate it to affect future calls to `get_item`
+            if they wish.
 
         Raises
         ------


### PR DESCRIPTION
Report a proper exception including the application and secret key names if the value of a secret in 1Password that is marked as encoded is either invalid base64 or decodes to something that cannot be represented as a Unicode string.