### PR TITLE
DM-40947: Fix datalinker secrets

### DIFF
--- a/applications/datalinker/secrets.yaml
+++ b/applications/datalinker/secrets.yaml
@@ -1,18 +1,18 @@
-aws-credentials:
+"aws-credentials.ini":
   description: >-
     Google Cloud Storage credentials to the Butler data store, formatted using
     AWS syntax for use with boto.
   copy:
     application: nublado
     key: "aws-credentials.ini"
-google-credentials:
+"butler-gcs-idf-creds.json":
   description: >-
     Google Cloud Storage credentials to the Butler data store in the native
     Google syntax, containing the private asymmetric key.
   copy:
     application: nublado
     key: "butler-gcs-idf-creds.json"
-postgres-credentials:
+"postgres-credentials.txt":
   description: >-
     PostgreSQL credentials in its pgpass format for the Butler database.
   copy:


### PR DESCRIPTION
Currently, datalinker unconditionally expects the full Butler secret on every environment, so put that directly in secrets.yaml. Eventually that will change, but we'll cross that bridge later.

Change the names of the secrets to match what the application actually expects.