### PR TITLE
DM-40947: Update documentation for where to find tokens

### DIFF
--- a/docs/admin/audit-secrets.rst
+++ b/docs/admin/audit-secrets.rst
@@ -9,6 +9,7 @@ To check that all of the necessary secrets for an environment named ``<environme
    phalanx secrets audit <environment>
 
 The ``VAULT_TOKEN`` environment variable must be set to the Vault write token for this environment (or a read token; this command will not make any changes).
+For SQuaRE-managed environments, you can get the write token from the ``Phalanx Vault write tokens`` item in the SQuaRE 1Password vault.
 
 The output of the command will be a report of any inconsistencies or problems found in the Vault secrets for this environment.
 No output indicates no problems.

--- a/docs/admin/migrating-secrets.rst
+++ b/docs/admin/migrating-secrets.rst
@@ -52,7 +52,7 @@ The new secret management system uses Vault AppRoles instead, which are the reco
    If you are using some other Vault server with its own path conventions, you can skip this step, although it is easier to do the migration if you can set up the new secrets in a new Vault path without having to change the old Vault path.
 
 #. Set the ``VAULT_TOKEN`` environment variable to a token with access to create new AppRoles and tokens and to list token accessors and secret IDs.
-   If you are using the SQuaRE Vault server, use the admin token.
+   If you are using the SQuaRE Vault server, use the admin token from the ``Phalanx Vault admin credentials`` 1Password item in the SQuaRE 1Password vault.
    This environment variable will be used for multiple following commands.
    You will be told when you can clear it again.
 
@@ -85,7 +85,7 @@ The new secret management system uses Vault AppRoles instead, which are the reco
 
    The new token will be printed to standard output along with some metadata about it.
 
-   For SQuaRE-managed environments, save that token in the ``SQuaRE`` 1Password vault (**not** the vault for the RSP environment) in the item named ``RSP Vault write tokens``.
+   For SQuaRE-managed environments, save that token in the ``SQuaRE`` 1Password vault (**not** the vault for the RSP environment) in the item named ``Phalanx Vault write tokens``.
    Add a key for the short environment identifier and set the value to the newly-created write token.
    Don't forget to mark it as a password using the icon on the right.
    Then, add a key under the :guilabel:`Accessors` heading for the environment and set the value to the token accessor.

--- a/docs/admin/secrets-setup.rst
+++ b/docs/admin/secrets-setup.rst
@@ -81,6 +81,7 @@ This normally requires a Vault admin or provisioner token or some equivalent.
     The output includes the new Vault token, which you should save somewhere secure where you store other secrets.
     (The running Phalanx environment does not need and should not have access to this token.)
     You will later set the environment variable ``VAULT_TOKEN`` to this token when running other :command:`phalanx` commands.
+    For SQuaRE-managed environments, always update the ``Phalanx Vault write tokens`` 1Password item in the SQuaRE 1Password vault after running this command.
 
 :samp:`phalanx vault audit {environment}`
     Check the authentication credentials created by the previous two commands in the given environment for any misconfiguration.

--- a/docs/admin/sync-secrets.rst
+++ b/docs/admin/sync-secrets.rst
@@ -12,8 +12,10 @@ To populate Vault with all of the necessary secrets for an environment named ``<
    phalanx secrets sync <environment>
 
 The ``VAULT_TOKEN`` environment variable must be set to the Vault write token for this environment.
+For SQuaRE-managed environments, you can get the write token from the ``Phalanx Vault write tokens`` item in the SQuaRE 1Password vault.
+
 Add the ``--secrets`` command-line option or set ``OP_CONNECT_TOKEN`` if needed for your choice of a :ref:`static secrets source <admin-static-secrets>`.
-For SQuaRE-managed deployments, the 1Password token for ``OP_CONNECT_TOKEN`` comes from the ``RSP 1Password tokens`` item in the SQuaRE 1Password vault.
+For SQuaRE-managed deployments, the 1Password token for ``OP_CONNECT_TOKEN`` comes from the ``Phalanx 1Password tokens`` item in the SQuaRE 1Password vault.
 
 This must be done before installing a Phalanx environment for the first time.
 It can then be run again whenever the secrets for that environment change.


### PR DESCRIPTION
Rename the 1Password items used by SQuaRE to use Phalanx instead of RSP in the titles, since we include roundtable as well. Document where to find the admin token now that it's been moved back into the SQuaRE vault.