### PR TITLE
DM-40947: Refactor static secret loading

### DIFF
--- a/src/phalanx/cli.py
+++ b/src/phalanx/cli.py
@@ -71,24 +71,6 @@ def _find_config() -> Path:
     return current
 
 
-def _load_static_secrets(path: Path) -> StaticSecrets:
-    """Load static secrets from a file.
-
-    Parameters
-    ----------
-    path
-        Path to the file.
-
-    Returns
-    -------
-    dict of dict
-        Map from application to secret key to
-        `~phalanx.models.secrets.StaticSecret`.
-    """
-    with path.open() as fh:
-        return StaticSecrets.model_validate(yaml.safe_load(fh))
-
-
 @click.group(context_settings={"help_option_names": ["-h", "--help"]})
 @click.version_option(message="%(version)s")
 def main() -> None:
@@ -224,9 +206,7 @@ def secrets_audit(
     """
     if not config:
         config = _find_config()
-    static_secrets = None
-    if secrets:
-        static_secrets = _load_static_secrets(secrets)
+    static_secrets = StaticSecrets.from_path(secrets) if secrets else None
     factory = Factory(config)
     secrets_service = factory.create_secrets_service()
     sys.stdout.write(secrets_service.audit(environment, static_secrets))
@@ -409,9 +389,7 @@ def secrets_sync(
     """
     if not config:
         config = _find_config()
-    static_secrets = None
-    if secrets:
-        static_secrets = _load_static_secrets(secrets)
+    static_secrets = StaticSecrets.from_path(secrets) if secrets else None
     factory = Factory(config)
     secrets_service = factory.create_secrets_service()
     secrets_service.sync(

--- a/src/phalanx/models/secrets.py
+++ b/src/phalanx/models/secrets.py
@@ -7,9 +7,11 @@ import secrets
 from base64 import b64encode
 from datetime import UTC, datetime
 from enum import Enum
+from pathlib import Path
 from typing import Literal, Self
 
 import bcrypt
+import yaml
 from cryptography.fernet import Fernet
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
@@ -356,6 +358,23 @@ class StaticSecrets(BaseModel):
     )
 
     model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    @classmethod
+    def from_path(cls, path: Path) -> Self:
+        """Load static secrets from a file on disk.
+
+        Parameters
+        ----------
+        path
+            Path to the file.
+
+        Returns
+        -------
+        StaticSecrets
+            Parsed static secrets.
+        """
+        with path.open() as fh:
+            return cls.model_validate(yaml.safe_load(fh))
 
     def for_application(self, application: str) -> dict[str, StaticSecret]:
         """Return any known secrets for an application.


### PR DESCRIPTION
Now that we have a proper Pydantic model for static secrets, that class can gain a class method for loading it from a path, which can be used to simplify the CLI code.