### PR TITLE
DM-40947: Improve generated schemas

### DIFF
--- a/docs/admin/installation.rst
+++ b/docs/admin/installation.rst
@@ -23,6 +23,7 @@ To create a new Phalanx environment, take the following steps:
 #. Create a new :file:`values-{environment}.yaml` file in `environments <https://github.com/lsst-sqre/phalanx/tree/main/environments/>`__.
    Start with a template copied from an existing environment that's similar to the new environment.
    Edit it so that ``name``, ``fqdn``, ``vaultUrl``, and ``vaultPathPrefix`` at the top match your new environment.
+   You may omit ``vaultUrl`` for SQuaRE-managed environments.
    See :doc:`secrets-setup` for more information about the latter two settings and additional settings you may need.
    Enable the applications this environment should include.
 

--- a/docs/admin/secrets-setup.rst
+++ b/docs/admin/secrets-setup.rst
@@ -32,7 +32,7 @@ The name of each secret other than ``pull-secret`` matches the name of the appli
 So, for example, all secrets for Gafaelfawr for a given environment may be stored as key/value pairs in the secret named :samp:`secrets/phalanx/{environment}/gafaelfawr`.
 
 This path is configured for each environment via the ``vaultPathPrefix`` setting in the environment :file:`values-{environment}.yaml` file.
-The URL to the Vault server is set via the ``vaultUrl`` setting in the same file.
+The URL to the Vault server is set via the ``vaultUrl`` setting in the same file and defaults to the SQuaRE-run Vault server.
 
 Vault credentials
 =================

--- a/docs/extras/schemas/environment.json
+++ b/docs/extras/schemas/environment.json
@@ -4,13 +4,15 @@
       "description": "Configuration for 1Password static secrets source.",
       "properties": {
         "connectUrl": {
+          "description": "URL to the 1Password Connect API server",
           "format": "uri",
           "minLength": 1,
-          "title": "Connecturl",
+          "title": "1Password Connect URL",
           "type": "string"
         },
         "vaultTitle": {
-          "title": "Vaulttitle",
+          "description": "Title of the 1Password vault from which to retrieve secrets",
+          "title": "1Password vault title",
           "type": "string"
         }
       },
@@ -27,11 +29,13 @@
   "description": "Configuration for a Phalanx environment.\n\nThis is a model for the :file:`values-{environment}.yaml` files for each\nenvironment and is also used to validate those files. For the complete\nconfiguration for an environment, initialize this model with the merger of\n:file:`values.yaml` and :file:`values-{environment}.yaml`.",
   "properties": {
     "name": {
+      "description": "Name of the environment",
       "title": "Name",
       "type": "string"
     },
     "fqdn": {
-      "title": "Fqdn",
+      "description": "Fully-qualified domain name on which the environment listens",
+      "title": "Domain name",
       "type": "string"
     },
     "onepassword": {
@@ -43,21 +47,36 @@
           "type": "null"
         }
       ],
-      "default": null
+      "default": null,
+      "description": "Configuration for using 1Password as a static secrets source",
+      "title": "1Password configuration"
     },
     "vaultUrl": {
-      "title": "Vaulturl",
-      "type": "string"
+      "anyOf": [
+        {
+          "format": "uri",
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "URL of the Vault server. This is required in the merged values file that includes environment overrides, but the environment override file doesn't need to set it, so it's marked as optional for schema checking purposes to allow the override file to be schema-checked independently.",
+      "title": "Vault server URL"
     },
     "vaultPathPrefix": {
-      "title": "Vaultpathprefix",
+      "description": "Prefix of Vault paths, including the KV v2 mount point",
+      "title": "Vault path prefix",
       "type": "string"
     },
     "applications": {
       "additionalProperties": {
         "type": "boolean"
       },
-      "title": "Applications",
+      "description": "List of applications and whether they are enabled",
+      "title": "Enabled applications",
       "type": "object"
     },
     "butlerRepositoryIndex": {
@@ -70,19 +89,8 @@
         }
       ],
       "default": null,
-      "title": "Butlerrepositoryindex"
-    },
-    "onepasswordUuid": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "title": "Onepassworduuid"
+      "description": "URL to Butler repository index",
+      "title": "Butler repository index URL"
     },
     "repoUrl": {
       "anyOf": [
@@ -94,7 +102,8 @@
         }
       ],
       "default": null,
-      "title": "Repourl"
+      "description": "URL of the Git repository holding Argo CD configuration. This is required in the merged values file that includes environment overrides, but the environment override file doesn't need to set it, so it's marked as optional for schema checking purposes to allow the override file to be schema-checked independently.",
+      "title": "URL of Git repository"
     },
     "targetRevision": {
       "anyOf": [
@@ -106,13 +115,13 @@
         }
       ],
       "default": null,
-      "title": "Targetrevision"
+      "description": "Branch of the Git repository holding Argo CD configuration. This is required in the merged values file that includes environment overrides, but the environment override file doesn't need to set it, so it's marked as optional for schema checking purposes to allow the override file to be schema-checked independently.",
+      "title": "Git repository branch"
     }
   },
   "required": [
     "name",
     "fqdn",
-    "vaultUrl",
     "vaultPathPrefix",
     "applications"
   ],

--- a/docs/extras/schemas/secrets.json
+++ b/docs/extras/schemas/secrets.json
@@ -14,9 +14,11 @@
             }
           ],
           "default": null,
-          "description": "Rules for where the secret should be copied from"
+          "description": "Rules for where the secret should be copied from",
+          "title": "Copy rules"
         },
         "description": {
+          "description": "Description of the secret",
           "title": "Description",
           "type": "string"
         },
@@ -33,7 +35,8 @@
             }
           ],
           "default": null,
-          "title": "Generate"
+          "description": "Rules for how the secret should be generated",
+          "title": "Generation rules"
         },
         "if": {
           "anyOf": [
@@ -54,9 +57,8 @@
               "$ref": "#/$defs/SecretOnepasswordConfig"
             }
           ],
-          "default": {
-            "encoded": false
-          }
+          "description": "Configuration for how the secret is stored in 1Password",
+          "title": "1Password configuration"
         },
         "value": {
           "anyOf": [
@@ -70,6 +72,7 @@
             }
           ],
           "default": null,
+          "description": "Fixed value of secret",
           "title": "Value"
         }
       },
@@ -84,6 +87,7 @@
       "description": "Possibly conditional rules for copying a secret value from another.",
       "properties": {
         "application": {
+          "description": "Application from which the secret should be copied",
           "title": "Application",
           "type": "string"
         },
@@ -101,6 +105,7 @@
           "title": "Condition"
         },
         "key": {
+          "description": "Secret key from which the secret should be copied",
           "title": "Key",
           "type": "string"
         }
@@ -130,13 +135,14 @@
           "title": "Condition"
         },
         "type": {
+          "description": "Type of secret",
           "enum": [
             "password",
             "gafaelfawr-token",
             "fernet-key",
             "rsa-private-key"
           ],
-          "title": "Type",
+          "title": "Secret type",
           "type": "string"
         }
       },
@@ -163,15 +169,17 @@
           "title": "Condition"
         },
         "source": {
-          "title": "Source",
+          "description": "Key of secret on which this secret is based. This may only be set by secrets of type `bcrypt-password-hash` or `mtime`.",
+          "title": "Source key",
           "type": "string"
         },
         "type": {
+          "description": "Type of secret",
           "enum": [
             "bcrypt-password-hash",
             "mtime"
           ],
-          "title": "Type",
+          "title": "Secret type",
           "type": "string"
         }
       },
@@ -187,7 +195,8 @@
       "properties": {
         "encoded": {
           "default": false,
-          "title": "Encoded",
+          "description": "Whether the 1Password copy of the secret is encoded in base64. 1Password doesn't support newlines in secrets, so secrets that contain significant newlines have to be encoded when storing them in 1Password. This flag indicates that this has been done, and therefore when retrieving the secret from 1Password, its base64-encoding must be undone.",
+          "title": "Is base64-encoded",
           "type": "boolean"
         }
       },

--- a/environments/README.md
+++ b/environments/README.md
@@ -56,8 +56,7 @@
 | butlerRepositoryIndex | string | None, must be set | Butler repository index to use for this environment |
 | fqdn | string | None, must be set | Fully-qualified domain name where the environment is running |
 | name | string | None, must be set | Name of the environment |
-| onepasswordUuid | string | `"dg5afgiadsffeklfr6jykqymeu"` | UUID of the 1Password item in which to find Vault tokens |
 | repoUrl | string | `"https://github.com/lsst-sqre/phalanx.git"` | URL of the repository for all applications |
 | targetRevision | string | `"main"` | Revision of repository to use for all applications |
 | vaultPathPrefix | string | None, must be set | Prefix for Vault secrets for this environment |
-| vaultUrl | string | None, must be set | URL of Vault server for this environment |
+| vaultUrl | string | `"https://vault.lsst.codes/"` | URL of Vault server for this environment |

--- a/environments/values-base.yaml
+++ b/environments/values-base.yaml
@@ -1,6 +1,5 @@
 name: base
 fqdn: base-lsp.lsst.codes
-vaultUrl: "https://vault.lsst.codes"
 vaultPathPrefix: secret/k8s_operator/base-lsp.lsst.codes
 
 applications:

--- a/environments/values-ccin2p3.yaml
+++ b/environments/values-ccin2p3.yaml
@@ -1,6 +1,5 @@
 name: ccin2p3
 fqdn: data-dev.lsst.eu
-vaultUrl: "https://vault.lsst.codes"
 vaultPathPrefix: secret/k8s_operator/rsp-cc
 
 applications:

--- a/environments/values-idfdev.yaml
+++ b/environments/values-idfdev.yaml
@@ -4,7 +4,6 @@ name: idfdev
 onepassword:
   connectUrl: "https://roundtable-dev.lsst.cloud/1password"
   vaultTitle: "RSP data-dev.lsst.cloud"
-vaultUrl: "https://vault.lsst.codes"
 vaultPathPrefix: secret/phalanx/idfdev
 
 applications:

--- a/environments/values-idfint.yaml
+++ b/environments/values-idfint.yaml
@@ -1,7 +1,6 @@
 butlerRepositoryIndex: "s3://butler-us-central1-repo-locations/data-int-repos.yaml"
 fqdn: data-int.lsst.cloud
 name: idfint
-vaultUrl: "https://vault.lsst.codes"
 vaultPathPrefix: secret/k8s_operator/data-int.lsst.cloud
 
 applications:

--- a/environments/values-idfprod.yaml
+++ b/environments/values-idfprod.yaml
@@ -1,7 +1,6 @@
 butlerRepositoryIndex: "s3://butler-us-central1-repo-locations/data-repos.yaml"
 fqdn: data.lsst.cloud
 name: idfprod
-vaultUrl: "https://vault.lsst.codes"
 vaultPathPrefix: secret/k8s_operator/data.lsst.cloud
 
 applications:

--- a/environments/values-minikube.yaml
+++ b/environments/values-minikube.yaml
@@ -3,7 +3,6 @@ fqdn: minikube.lsst.codes
 onepassword:
   connectUrl: "https://roundtable-dev.lsst.cloud/1password"
   vaultTitle: "RSP minikube.lsst.codes"
-vaultUrl: "https://vault.lsst.codes"
 vaultPathPrefix: secret/phalanx/minikube
 
 # The primary constraint on enabling applications is the low available memory

--- a/environments/values-roundtable-dev.yaml
+++ b/environments/values-roundtable-dev.yaml
@@ -3,7 +3,6 @@ fqdn: roundtable-dev.lsst.cloud
 onepassword:
   connectUrl: "https://roundtable-dev.lsst.cloud/1password"
   vaultTitle: "RSP roundtable-dev.lsst.cloud"
-vaultUrl: "https://vault.lsst.codes"
 vaultPathPrefix: secret/k8s_operator/roundtable-dev.lsst.cloud
 
 applications:

--- a/environments/values-roundtable-prod.yaml
+++ b/environments/values-roundtable-prod.yaml
@@ -3,7 +3,6 @@ fqdn: roundtable.lsst.cloud
 onepassword:
   connectUrl: "https://roundtable.lsst.cloud/1password"
   vaultTitle: "RSP roundtable.lsst.cloud"
-vaultUrl: "https://vault.lsst.codes"
 vaultPathPrefix: secret/k8s_operator/roundtable.lsst.cloud
 
 applications:

--- a/environments/values-summit.yaml
+++ b/environments/values-summit.yaml
@@ -1,6 +1,5 @@
 name: summit
 fqdn: summit-lsp.lsst.codes
-vaultUrl: "https://vault.lsst.codes"
 vaultPathPrefix: secret/k8s_operator/summit-lsp.lsst.codes
 
 applications:

--- a/environments/values-tucson-teststand.yaml
+++ b/environments/values-tucson-teststand.yaml
@@ -1,6 +1,5 @@
 name: tucson-teststand
 fqdn: tucson-teststand.lsst.codes
-vaultUrl: "https://vault.lsst.codes"
 vaultPathPrefix: secret/k8s_operator/tucson-teststand.lsst.codes
 
 applications:

--- a/environments/values.yaml
+++ b/environments/values.yaml
@@ -12,9 +12,6 @@ name: ""
 # @default -- None, must be set
 fqdn: ""
 
-# -- UUID of the 1Password item in which to find Vault tokens
-onepasswordUuid: "dg5afgiadsffeklfr6jykqymeu"
-
 # -- URL of the repository for all applications
 repoUrl: https://github.com/lsst-sqre/phalanx.git
 
@@ -22,8 +19,7 @@ repoUrl: https://github.com/lsst-sqre/phalanx.git
 targetRevision: "main"
 
 # -- URL of Vault server for this environment
-# @default -- None, must be set
-vaultUrl: ""
+vaultUrl: "https://vault.lsst.codes/"
 
 # -- Prefix for Vault secrets for this environment
 # @default -- None, must be set

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -13,7 +13,11 @@ GIT_URL=$(git config --get remote.origin.url)
 GIT_BRANCH=${GITHUB_HEAD_REF:-$(git branch --show-current)}
 
 echo "Logging on to Vault..."
-export VAULT_ADDR=$(yq -r .vaultUrl "$config")
+if grep '^vaultUrl:' "$config" >/dev/null; then
+    export VAULT_ADDR=$(yq -r .vaultUrl "$config")
+else
+    export VAULT_ADDR=$(yq -r .vaultUrl ../environments/values.yaml)
+fi
 export VAULT_TOKEN=$(vault write auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID" | grep 'token ' | awk '{ print $2 }')
 VAULT_PATH_PREFIX=$(yq -r .vaultPathPrefix "$config")
 ARGOCD_PASSWORD=$(vault kv get --field=admin.plaintext_password $VAULT_PATH_PREFIX/argocd)

--- a/src/phalanx/models/environments.py
+++ b/src/phalanx/models/environments.py
@@ -8,6 +8,7 @@ from pydantic import (
     AnyHttpUrl,
     BaseModel,
     ConfigDict,
+    Field,
     GetJsonSchemaHandler,
     field_validator,
 )
@@ -35,30 +36,59 @@ __all__ = [
 class OnepasswordConfig(CamelCaseModel):
     """Configuration for 1Password static secrets source."""
 
-    connect_url: AnyHttpUrl
-    """URL to the 1Password Connect API server."""
+    connect_url: AnyHttpUrl = Field(
+        ...,
+        title="1Password Connect URL",
+        description="URL to the 1Password Connect API server",
+    )
 
-    vault_title: str
-    """Title of the 1Password vault from which to retrieve secrets."""
+    vault_title: str = Field(
+        ...,
+        title="1Password vault title",
+        description=(
+            "Title of the 1Password vault from which to retrieve secrets"
+        ),
+    )
 
 
 class EnvironmentBaseConfig(CamelCaseModel):
     """Configuration common to `EnviromentConfig` and `Environment`."""
 
-    name: str
-    """Name of the environment."""
+    name: str = Field(..., title="Name", description="Name of the environment")
 
-    fqdn: str
-    """Fully-qualified domain name."""
+    fqdn: str = Field(
+        ...,
+        title="Domain name",
+        description=(
+            "Fully-qualified domain name on which the environment listens"
+        ),
+    )
 
-    onepassword: OnepasswordConfig | None = None
-    """Configuration for using 1Password as a static secrets source."""
+    onepassword: OnepasswordConfig | None = Field(
+        None,
+        title="1Password configuration",
+        description=(
+            "Configuration for using 1Password as a static secrets source"
+        ),
+    )
 
-    vault_url: str
-    """URL of Vault server."""
+    vault_url: AnyHttpUrl | None = Field(
+        None,
+        title="Vault server URL",
+        description=(
+            "URL of the Vault server. This is required in the merged values"
+            " file that includes environment overrides, but the environment"
+            " override file doesn't need to set it, so it's marked as"
+            " optional for schema checking purposes to allow the override"
+            " file to be schema-checked independently."
+        ),
+    )
 
-    vault_path_prefix: str
-    """Prefix of Vault paths, including the Kv2 mount point."""
+    vault_path_prefix: str = Field(
+        ...,
+        title="Vault path prefix",
+        description="Prefix of Vault paths, including the KV v2 mount point",
+    )
 
     @field_validator("onepassword", mode="before")
     @classmethod
@@ -125,36 +155,41 @@ class EnvironmentConfig(EnvironmentBaseConfig):
     :file:`values.yaml` and :file:`values-{environment}.yaml`.
     """
 
-    applications: dict[str, bool]
-    """List of applications and whether they are enabled."""
+    applications: dict[str, bool] = Field(
+        ...,
+        title="Enabled applications",
+        description="List of applications and whether they are enabled",
+    )
 
-    butler_repository_index: str | None = None
-    """URL to Butler repository index."""
+    butler_repository_index: str | None = Field(
+        None,
+        title="Butler repository index URL",
+        description="URL to Butler repository index",
+    )
 
-    onepassword_uuid: str | None = None
-    """UUID of 1Password item in which to find Vault tokens.
+    repo_url: str | None = Field(
+        None,
+        title="URL of Git repository",
+        description=(
+            "URL of the Git repository holding Argo CD configuration. This is"
+            " required in the merged values file that includes environment"
+            " overrides, but the environment override file doesn't need to"
+            " set it, so it's marked as optional for schema checking purposes"
+            " to allow the override file to be schema-checked independently."
+        ),
+    )
 
-    This is used only by the old installer and will be removed once the new
-    secrets management and 1Password integration is deployed everywhere.
-    """
-
-    repo_url: str | None = None
-    """URL of the Git repository holding Argo CD configuration.
-
-    This is required in the merged values file that includes environment
-    overrides, but the environment override file doesn't need to set it, so
-    it's marked as optional for schema checking purposes to allow the override
-    file to be schema-checked independently.
-    """
-
-    target_revision: str | None = None
-    """Branch of the Git repository holding Argo CD configuration.
-
-    This is required in the merged values file that includes environment
-    overrides, but the environment override file doesn't need to set it, so
-    it's marked as optional for schema checking purposes to allow the override
-    file to be schema-checked independently.
-    """
+    target_revision: str | None = Field(
+        None,
+        title="Git repository branch",
+        description=(
+            "Branch of the Git repository holding Argo CD configuration. This"
+            " is required in the merged values file that includes environment"
+            " overrides, but the environment override file doesn't need to set"
+            " it, so it's marked as optional for schema checking purposes to"
+            " allow the override file to be schema-checked independently."
+        ),
+    )
 
     model_config = ConfigDict(extra="forbid")
 

--- a/src/phalanx/models/secrets.py
+++ b/src/phalanx/models/secrets.py
@@ -62,11 +62,17 @@ class ConditionalMixin(BaseModel):
 class SecretCopyRules(BaseModel):
     """Rules for copying a secret value from another secret."""
 
-    application: str
-    """Application from which the secret should be copied."""
+    application: str = Field(
+        ...,
+        title="Application",
+        description="Application from which the secret should be copied",
+    )
 
-    key: str
-    """Secret key from which the secret should be copied."""
+    key: str = Field(
+        ...,
+        title="Key",
+        description="Secret key from which the secret should be copied",
+    )
 
     model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
@@ -94,8 +100,7 @@ class SimpleSecretGenerateRules(BaseModel):
         SecretGenerateType.gafaelfawr_token,
         SecretGenerateType.fernet_key,
         SecretGenerateType.rsa_private_key,
-    ]
-    """Type of secret."""
+    ] = Field(..., title="Secret type", description="Type of secret")
 
     model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
@@ -134,15 +139,16 @@ class SourceSecretGenerateRules(BaseModel):
     type: Literal[
         SecretGenerateType.bcrypt_password_hash,
         SecretGenerateType.mtime,
-    ]
-    """Type of secret."""
+    ] = Field(..., title="Secret type", description="Type of secret")
 
-    source: str
-    """Key of secret on which this secret is based.
-
-    This may only be set by secrets of type ``bcrypt-password-hash`` or
-    ``mtime``.
-    """
+    source: str = Field(
+        ...,
+        title="Source key",
+        description=(
+            "Key of secret on which this secret is based. This may only be"
+            " set by secrets of type `bcrypt-password-hash` or `mtime`."
+        ),
+    )
 
     def generate(self, source: SecretStr) -> SecretStr:
         match self.type:
@@ -172,36 +178,49 @@ ConditionalSecretGenerateRules = (
 class SecretOnepasswordConfig(BaseModel):
     """Configuration for how a static secret is stored in 1Password."""
 
-    encoded: bool = False
-    """Whether the 1Password copy of the secret is encoded in base64.
-
-    1Password doesn't support newlines in secrets, so secrets that contain
-    significant newlines have to be encoded when storing them in 1Password.
-    This flag indicates that this has been done, and therefore when retrieving
-    the secret from 1Password, its base64-encoding must be undone.
-    """
+    encoded: bool = Field(
+        False,
+        title="Is base64-encoded",
+        description=(
+            "Whether the 1Password copy of the secret is encoded in base64."
+            " 1Password doesn't support newlines in secrets, so secrets that"
+            " contain significant newlines have to be encoded when storing"
+            " them in 1Password. This flag indicates that this has been done,"
+            " and therefore when retrieving the secret from 1Password, its"
+            " base64-encoding must be undone."
+        ),
+    )
 
 
 class SecretConfig(BaseModel):
     """Specification for an application secret."""
 
-    description: str
-    """Description of the secret."""
+    description: str = Field(
+        ..., title="Description", description="Description of the secret"
+    )
 
     copy_rules: SecretCopyRules | None = Field(
         None,
+        title="Copy rules",
         description="Rules for where the secret should be copied from",
         alias="copy",
     )
 
-    generate: SecretGenerateRules | None = None
-    """Rules for how the secret should be generated."""
+    generate: SecretGenerateRules | None = Field(
+        None,
+        title="Generation rules",
+        description="Rules for how the secret should be generated",
+    )
 
-    onepassword: SecretOnepasswordConfig = SecretOnepasswordConfig()
-    """Configuration for how the secret is stored in 1Password."""
+    onepassword: SecretOnepasswordConfig = Field(
+        default_factory=SecretOnepasswordConfig,
+        title="1Password configuration",
+        description="Configuration for how the secret is stored in 1Password",
+    )
 
-    value: SecretStr | None = None
-    """Secret value."""
+    value: SecretStr | None = Field(
+        None, title="Value", description="Fixed value of secret"
+    )
 
     model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
@@ -211,12 +230,16 @@ class ConditionalSecretConfig(SecretConfig, ConditionalMixin):
 
     copy_rules: ConditionalSecretCopyRules | None = Field(
         None,
+        title="Copy rules",
         description="Rules for where the secret should be copied from",
         alias="copy",
     )
 
-    generate: ConditionalSecretGenerateRules | None = None
-    """Rules for how the secret should be generated."""
+    generate: ConditionalSecretGenerateRules | None = Field(
+        None,
+        title="Generation rules",
+        description="Rules for how the secret should be generated",
+    )
 
     @model_validator(mode="after")
     def _validate_generate(self) -> Self:

--- a/src/phalanx/storage/vault.py
+++ b/src/phalanx/storage/vault.py
@@ -359,4 +359,6 @@ class VaultStorage:
         """
         if not path_prefix:
             path_prefix = env.vault_path_prefix
-        return VaultClient(env.vault_url, path_prefix)
+        if not env.vault_url:
+            raise ValueError("vaultUrl not set for this environment")
+        return VaultClient(str(env.vault_url), path_prefix)


### PR DESCRIPTION
Add more annotations to the Pydantic models so that the generated schemas contain more details. Mark the Vault URL as an HTTP URL for Pydantic validation purposes. Set a default URL pointing to the SQuaRE Vault server so that most environments don't need to set it, and adjust the schema so that this will validate. Drop the now-obsolete onepasswordUuid enviroment setting.