### PR TITLE
DM-40947: Add encoded secret warnings to static templates

### DIFF
--- a/src/phalanx/constants.py
+++ b/src/phalanx/constants.py
@@ -10,6 +10,7 @@ from datetime import timedelta
 
 __all__ = [
     "HELM_DOCLINK_ANNOTATION",
+    "ONEPASSWORD_ENCODED_WARNING",
     "PULL_SECRET_DESCRIPTION",
     "VAULT_SECRET_TEMPLATE",
     "VAULT_WRITE_TOKEN_LIFETIME",
@@ -18,6 +19,12 @@ __all__ = [
 
 HELM_DOCLINK_ANNOTATION = "phalanx.lsst.io/docs"
 """Annotation in :file:`Chart.yaml` for application documentation links."""
+
+ONEPASSWORD_ENCODED_WARNING = (
+    "If you store this secret in a 1Password item, encode it with base64"
+    " first."
+)
+"""Warning to add to secrets that must be encoded in 1Password."""
 
 PULL_SECRET_DESCRIPTION = (
     "Pull secrets for Docker registries. Each key under registries is the name"

--- a/tests/data/output/idfdev/static-secrets.yaml
+++ b/tests/data/output/idfdev/static-secrets.yaml
@@ -29,6 +29,9 @@ applications:
       description: >-
         Slack web hook to which mobu should report failures and daily status.
       value: null
+      warning: >-
+        If you store this secret in a 1Password item, encode it with base64
+        first.
     app-alert-webhook:
       description: >-
         Slack web hook to which to post internal application alerts. This


### PR DESCRIPTION
If a secret is marked as base64-encoded in 1Password, add a warning to the static secret template saying so, in case people are using that as a reference to decide what to put into 1Password.

This required some refactoring to export the correct fields from the static secrets model for a template. In the process, I fixed a few places where we may have incorrectly synced an empty pull secret when no pull secret was specified.