### PR TITLE
DM-23878: Bump version of Gafaelfawr

### DIFF
--- a/applications/gafaelfawr/Chart.yaml
+++ b/applications/gafaelfawr/Chart.yaml
@@ -5,7 +5,7 @@ description: Authentication and identity system
 home: https://gafaelfawr.lsst.io/
 sources:
   - https://github.com/lsst-sqre/gafaelfawr
-appVersion: 9.3.1
+appVersion: 9.4.0
 
 dependencies:
   - name: redis


### PR DESCRIPTION
Pick up the new Gafaelfawr release, which has support for finding group membership by user DN. This will be required for the new Keycloak and LDAP configuration on T&S sites.