### PR TITLE
Add missing secret definition for ssotap

### DIFF
--- a/applications/ssotap/Chart.yaml
+++ b/applications/ssotap/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: ssotap
 version: 1.0.0
-description: IVOA TAP service
+description: IVOA TAP service for Solar System Objects
 sources:
   - https://github.com/lsst-sqre/tap-postgres
   - https://github.com/opencadc/tap

--- a/applications/ssotap/README.md
+++ b/applications/ssotap/README.md
@@ -1,6 +1,6 @@
 # ssotap
 
-IVOA TAP service
+IVOA TAP service for Solar System Objects
 
 ## Source Code
 

--- a/applications/ssotap/secrets.yaml
+++ b/applications/ssotap/secrets.yaml
@@ -2,3 +2,7 @@
   description: >-
     Google service account credentials used to write async job output to
     Google Cloud Storage.
+pgpassword:
+  description: >-
+    Password to external PostgreSQL server that contains the Solar System
+    Objects data.


### PR DESCRIPTION
ssotap requires a PostgreSQL password, which was missing from the secrets.yaml. Add it in and fix the Chart.yaml short description.