### PR TITLE
[DM-40944] Get rid of ingressClass: nginx in the starter

### DIFF
--- a/starters/web-service/templates/ingress.yaml
+++ b/starters/web-service/templates/ingress.yaml
@@ -18,7 +18,6 @@ template:
       {{- toYaml . | nindent 6 }}
     {{- end }}
   spec:
-    ingressClassName: "nginx"
     rules:
       - host: {{ required "global.host must be set" .Values.global.host | quote }}
         http:


### PR DESCRIPTION
This is because this part of the yaml will be stripped after the CRD is made, making it look always out of sync.