### PR TITLE
DM-41075: Switch idfdev and idfint back to test CILogon

### DIFF
--- a/applications/gafaelfawr/values-idfdev.yaml
+++ b/applications/gafaelfawr/values-idfdev.yaml
@@ -10,7 +10,7 @@ config:
   cilogon:
     clientId: "cilogon:/client_id/46f9ae932fd30e9fb1b246972a3c0720"
     enrollmentUrl: "https://id-dev.lsst.cloud/registry/co_petitions/start/coef:6"
-    test: false
+    test: true
     usernameClaim: "username"
 
   ldap:

--- a/applications/gafaelfawr/values-idfint.yaml
+++ b/applications/gafaelfawr/values-idfint.yaml
@@ -11,7 +11,7 @@ config:
   cilogon:
     clientId: "cilogon:/client_id/6b3f86ecfe74f14afa81b73a76be0868"
     enrollmentUrl: "https://id-int.lsst.cloud/registry/co_petitions/start/coef:10"
-    test: false
+    test: true
     usernameClaim: "username"
 
   ldap:


### PR DESCRIPTION
The problem was due to a bad WAF rule in their AWS infrastructure that was blocking connections from Google Cloud. This has now been fixed, so switch those environments back to the test CILogon.