### PR TITLE
DM-40952: Migrate roundtable-prod to new secrets infrastructure

### DIFF
--- a/applications/vault-secrets-operator/values-roundtable-prod.yaml
+++ b/applications/vault-secrets-operator/values-roundtable-prod.yaml
@@ -1,0 +1,14 @@
+vault-secrets-operator:
+  environmentVars:
+    - name: VAULT_ROLE_ID
+      valueFrom:
+        secretKeyRef:
+          name: vault-credentials
+          key: VAULT_ROLE_ID
+    - name: VAULT_SECRET_ID
+      valueFrom:
+        secretKeyRef:
+          name: vault-credentials
+          key: VAULT_SECRET_ID
+  vault:
+    authMethod: approle

--- a/environments/values-roundtable-prod.yaml
+++ b/environments/values-roundtable-prod.yaml
@@ -3,7 +3,7 @@ fqdn: roundtable.lsst.cloud
 onepassword:
   connectUrl: "https://roundtable.lsst.cloud/1password"
   vaultTitle: "RSP roundtable.lsst.cloud"
-vaultPathPrefix: secret/k8s_operator/roundtable.lsst.cloud
+vaultPathPrefix: secret/phalanx/roundtable-prod
 
 applications:
   kubernetes-replicator: true

--- a/environments/values-roundtable-prod.yaml
+++ b/environments/values-roundtable-prod.yaml
@@ -13,3 +13,4 @@ applications:
   squareone: true
   strimzi: true
   strimzi-access-operator: true
+  squarebot: true


### PR DESCRIPTION
This follows the steps at: https://phalanx.lsst.io/admin/migrating-secrets.html

This PR also enables Squarebot on roundtable-prod so it can be a secrets source for Ook.