### PR TITLE
DM-41090: Set Gafaelfawr CronJob time limits, tweak resource limits

### DIFF
--- a/applications/gafaelfawr/README.md
+++ b/applications/gafaelfawr/README.md
@@ -83,6 +83,8 @@ Authentication and identity system
 | ingress.additionalHosts | list | `[]` | Defines additional FQDNs for Gafaelfawr.  This doesn't work for cookie or browser authentication, but for token-based services like git-lfs or the webdav server it does. |
 | maintenance.affinity | object | `{}` | Affinity rules for Gafaelfawr maintenance and audit pods |
 | maintenance.auditSchedule | string | `"30 3 * * *"` | Cron schedule string for Gafaelfawr data consistency audit (in UTC) |
+| maintenance.cleanupSeconds | int | 86400 (1 day) | How long to keep old jobs around before deleting them |
+| maintenance.deadlineSeconds | int | 300 (5 minutes) | How long the job is allowed to run before it will be terminated |
 | maintenance.maintenanceSchedule | string | `"5 * * * *"` | Cron schedule string for Gafaelfawr periodic maintenance (in UTC) |
 | maintenance.nodeSelector | object | `{}` | Node selection rules for Gafaelfawr maintenance and audit pods |
 | maintenance.podAnnotations | object | `{}` | Annotations for Gafaelfawr maintenance and audit pods |

--- a/applications/gafaelfawr/templates/cronjob-audit.yaml
+++ b/applications/gafaelfawr/templates/cronjob-audit.yaml
@@ -10,6 +10,8 @@ spec:
   concurrencyPolicy: "Forbid"
   jobTemplate:
     spec:
+      activeDeadlineSeconds: {{ .Values.maintenance.deadlineSeconds }}
+      ttlSecondsAfterFinished: {{ .Values.maintenance.cleanupSeconds }}
       template:
         metadata:
           {{- with .Values.maintenance.podAnnotations }}

--- a/applications/gafaelfawr/templates/cronjob-maintenance.yaml
+++ b/applications/gafaelfawr/templates/cronjob-maintenance.yaml
@@ -9,6 +9,8 @@ spec:
   concurrencyPolicy: "Forbid"
   jobTemplate:
     spec:
+      activeDeadlineSeconds: {{ .Values.maintenance.deadlineSeconds }}
+      ttlSecondsAfterFinished: {{ .Values.maintenance.cleanupSeconds }}
       template:
         metadata:
           {{- with .Values.maintenance.podAnnotations }}

--- a/applications/gafaelfawr/values.yaml
+++ b/applications/gafaelfawr/values.yaml
@@ -347,6 +347,14 @@ maintenance:
   # -- Cron schedule string for Gafaelfawr periodic maintenance (in UTC)
   maintenanceSchedule: "5 * * * *"
 
+  # -- How long the job is allowed to run before it will be terminated
+  # @default -- 300 (5 minutes)
+  deadlineSeconds: 300
+
+  # -- How long to keep old jobs around before deleting them
+  # @default -- 86400 (1 day)
+  cleanupSeconds: 86400
+
   # -- Resource limits and requests for Gafaelfawr maintenance and audit pods
   # @default -- See `values.yaml`
   resources:

--- a/applications/gafaelfawr/values.yaml
+++ b/applications/gafaelfawr/values.yaml
@@ -351,7 +351,7 @@ maintenance:
   # @default -- See `values.yaml`
   resources:
     limits:
-      cpu: "100m"
+      cpu: "1"
       memory: "300Mi"
     requests:
       cpu: "100m"


### PR DESCRIPTION
Set a deadline of five minutes for the Gafaelfawr cron jobs to run, and clean them up after a day (although the limit on the number of successful jobs to retain will override this for audits). Increase the CPU limits of these jobs, since they appear to use most of a CPU when running but don't really need it.