### PR TITLE
prompt processing: prompt proto service pod anti affinity and k8s requests

### DIFF
--- a/applications/prompt-proto-service-hsc/README.md
+++ b/applications/prompt-proto-service-hsc/README.md
@@ -32,7 +32,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.knative.ephemeralStorageRequest | string | `"20Gi"` | The storage space reserved for each container (mostly local Butler). |
 | prompt-proto-service.knative.idleTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service (seconds). |
 | prompt-proto-service.knative.memoryLimit | string | `"32Gi"` | The memory limit for the activator. |
-| prompt-proto-service.knative.memoryRequest | string | `"4Gi"` | The memory requested for the activator. |
+| prompt-proto-service.knative.memoryRequest | string | `"2Gi"` | The memory requested for the activator. |
 | prompt-proto-service.knative.responseStartTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service after initial submission (seconds). |
 | prompt-proto-service.knative.timeout | int | `900` | Maximum time that a container can respond to a next_visit request (seconds). |
 | prompt-proto-service.logLevel | string | log prompt_prototype at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |

--- a/applications/prompt-proto-service-hsc/README.md
+++ b/applications/prompt-proto-service-hsc/README.md
@@ -31,6 +31,8 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.knative.ephemeralStorageLimit | string | `"20Gi"` | The maximum storage space allowed for each container (mostly local Butler). |
 | prompt-proto-service.knative.ephemeralStorageRequest | string | `"20Gi"` | The storage space reserved for each container (mostly local Butler). |
 | prompt-proto-service.knative.idleTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service (seconds). |
+| prompt-proto-service.knative.memoryLimit | string | `"32Gi"` | The memory limit for the activator. |
+| prompt-proto-service.knative.memoryRequest | string | `"4Gi"` | The memory requested for the activator. |
 | prompt-proto-service.knative.responseStartTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service after initial submission (seconds). |
 | prompt-proto-service.knative.timeout | int | `900` | Maximum time that a container can respond to a next_visit request (seconds). |
 | prompt-proto-service.logLevel | string | log prompt_prototype at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |

--- a/applications/prompt-proto-service-hsc/values.yaml
+++ b/applications/prompt-proto-service-hsc/values.yaml
@@ -88,7 +88,7 @@ prompt-proto-service:
 
   knative:
     # -- The memory requested for the activator.
-    memoryRequest: "4Gi"
+    memoryRequest: "2Gi"
     # -- The memory limit for the activator.
     memoryLimit: "32Gi"
     # -- The storage space reserved for each container (mostly local Butler).

--- a/applications/prompt-proto-service-hsc/values.yaml
+++ b/applications/prompt-proto-service-hsc/values.yaml
@@ -87,6 +87,10 @@ prompt-proto-service:
   logLevel: ""
 
   knative:
+    # -- The memory requested for the activator.
+    memoryRequest: "4Gi"
+    # -- The memory limit for the activator.
+    memoryLimit: "32Gi"
     # -- The storage space reserved for each container (mostly local Butler).
     ephemeralStorageRequest: "20Gi"
     # -- The maximum storage space allowed for each container (mostly local Butler).

--- a/applications/prompt-proto-service-latiss/README.md
+++ b/applications/prompt-proto-service-latiss/README.md
@@ -32,7 +32,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.knative.ephemeralStorageRequest | string | `"20Gi"` | The storage space reserved for each container (mostly local Butler). |
 | prompt-proto-service.knative.idleTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service (seconds). |
 | prompt-proto-service.knative.memoryLimit | string | `"32Gi"` | The memory limit for the activator. |
-| prompt-proto-service.knative.memoryRequest | string | `"4Gi"` | The memory requested for the activator. |
+| prompt-proto-service.knative.memoryRequest | string | `"2Gi"` | The memory requested for the activator. |
 | prompt-proto-service.knative.responseStartTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service after initial submission (seconds). |
 | prompt-proto-service.knative.timeout | int | `900` | Maximum time that a container can respond to a next_visit request (seconds). |
 | prompt-proto-service.logLevel | string | log prompt_prototype at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |

--- a/applications/prompt-proto-service-latiss/README.md
+++ b/applications/prompt-proto-service-latiss/README.md
@@ -31,6 +31,8 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.knative.ephemeralStorageLimit | string | `"20Gi"` | The maximum storage space allowed for each container (mostly local Butler). |
 | prompt-proto-service.knative.ephemeralStorageRequest | string | `"20Gi"` | The storage space reserved for each container (mostly local Butler). |
 | prompt-proto-service.knative.idleTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service (seconds). |
+| prompt-proto-service.knative.memoryLimit | string | `"32Gi"` | The memory limit for the activator. |
+| prompt-proto-service.knative.memoryRequest | string | `"4Gi"` | The memory requested for the activator. |
 | prompt-proto-service.knative.responseStartTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service after initial submission (seconds). |
 | prompt-proto-service.knative.timeout | int | `900` | Maximum time that a container can respond to a next_visit request (seconds). |
 | prompt-proto-service.logLevel | string | log prompt_prototype at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |

--- a/applications/prompt-proto-service-latiss/values.yaml
+++ b/applications/prompt-proto-service-latiss/values.yaml
@@ -88,7 +88,7 @@ prompt-proto-service:
 
   knative:
     # -- The memory requested for the activator.
-    memoryRequest: "4Gi"
+    memoryRequest: "2Gi"
     # -- The memory limit for the activator.
     memoryLimit: "32Gi"
     # -- The storage space reserved for each container (mostly local Butler).

--- a/applications/prompt-proto-service-latiss/values.yaml
+++ b/applications/prompt-proto-service-latiss/values.yaml
@@ -87,6 +87,10 @@ prompt-proto-service:
   logLevel: ""
 
   knative:
+    # -- The memory requested for the activator.
+    memoryRequest: "4Gi"
+    # -- The memory limit for the activator.
+    memoryLimit: "32Gi"
     # -- The storage space reserved for each container (mostly local Butler).
     ephemeralStorageRequest: "20Gi"
     # -- The maximum storage space allowed for each container (mostly local Butler).

--- a/applications/prompt-proto-service-lsstcam/README.md
+++ b/applications/prompt-proto-service-lsstcam/README.md
@@ -32,7 +32,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.knative.ephemeralStorageRequest | string | `"20Gi"` | The storage space reserved for each container (mostly local Butler). |
 | prompt-proto-service.knative.idleTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service (seconds). |
 | prompt-proto-service.knative.memoryLimit | string | `"32Gi"` | The memory limit for the activator. |
-| prompt-proto-service.knative.memoryRequest | string | `"4Gi"` | The memory requested for the activator. |
+| prompt-proto-service.knative.memoryRequest | string | `"2Gi"` | The memory requested for the activator. |
 | prompt-proto-service.knative.responseStartTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service after initial submission (seconds). |
 | prompt-proto-service.knative.timeout | int | `900` | Maximum time that a container can respond to a next_visit request (seconds). |
 | prompt-proto-service.logLevel | string | log prompt_prototype at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |

--- a/applications/prompt-proto-service-lsstcam/README.md
+++ b/applications/prompt-proto-service-lsstcam/README.md
@@ -31,6 +31,8 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.knative.ephemeralStorageLimit | string | `"20Gi"` | The maximum storage space allowed for each container (mostly local Butler). |
 | prompt-proto-service.knative.ephemeralStorageRequest | string | `"20Gi"` | The storage space reserved for each container (mostly local Butler). |
 | prompt-proto-service.knative.idleTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service (seconds). |
+| prompt-proto-service.knative.memoryLimit | string | `"32Gi"` | The memory limit for the activator. |
+| prompt-proto-service.knative.memoryRequest | string | `"4Gi"` | The memory requested for the activator. |
 | prompt-proto-service.knative.responseStartTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service after initial submission (seconds). |
 | prompt-proto-service.knative.timeout | int | `900` | Maximum time that a container can respond to a next_visit request (seconds). |
 | prompt-proto-service.logLevel | string | log prompt_prototype at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |

--- a/applications/prompt-proto-service-lsstcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcam/values.yaml
@@ -88,7 +88,7 @@ prompt-proto-service:
 
   knative:
     # -- The memory requested for the activator.
-    memoryRequest: "4Gi"
+    memoryRequest: "2Gi"
     # -- The memory limit for the activator.
     memoryLimit: "32Gi"
     # -- The storage space reserved for each container (mostly local Butler).

--- a/applications/prompt-proto-service-lsstcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcam/values.yaml
@@ -87,6 +87,10 @@ prompt-proto-service:
   logLevel: ""
 
   knative:
+    # -- The memory requested for the activator.
+    memoryRequest: "4Gi"
+    # -- The memory limit for the activator.
+    memoryLimit: "32Gi"
     # -- The storage space reserved for each container (mostly local Butler).
     ephemeralStorageRequest: "20Gi"
     # -- The maximum storage space allowed for each container (mostly local Butler).

--- a/applications/prompt-proto-service-lsstcomcam/README.md
+++ b/applications/prompt-proto-service-lsstcomcam/README.md
@@ -30,6 +30,8 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.knative.ephemeralStorageLimit | string | `"20Gi"` | The maximum storage space allowed for each container (mostly local Butler). |
 | prompt-proto-service.knative.ephemeralStorageRequest | string | `"20Gi"` | The storage space reserved for each container (mostly local Butler). |
 | prompt-proto-service.knative.idleTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service (seconds). |
+| prompt-proto-service.knative.memoryLimit | string | `"32Gi"` | The memory limit for the activator. |
+| prompt-proto-service.knative.memoryRequest | string | `"4Gi"` | The memory requested for the activator. |
 | prompt-proto-service.knative.responseStartTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service after initial submission (seconds). |
 | prompt-proto-service.knative.timeout | int | `900` | Maximum time that a container can respond to a next_visit request (seconds). |
 | prompt-proto-service.logLevel | string | log prompt_prototype at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |

--- a/applications/prompt-proto-service-lsstcomcam/README.md
+++ b/applications/prompt-proto-service-lsstcomcam/README.md
@@ -31,7 +31,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.knative.ephemeralStorageRequest | string | `"20Gi"` | The storage space reserved for each container (mostly local Butler). |
 | prompt-proto-service.knative.idleTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service (seconds). |
 | prompt-proto-service.knative.memoryLimit | string | `"32Gi"` | The memory limit for the activator. |
-| prompt-proto-service.knative.memoryRequest | string | `"4Gi"` | The memory requested for the activator. |
+| prompt-proto-service.knative.memoryRequest | string | `"2Gi"` | The memory requested for the activator. |
 | prompt-proto-service.knative.responseStartTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service after initial submission (seconds). |
 | prompt-proto-service.knative.timeout | int | `900` | Maximum time that a container can respond to a next_visit request (seconds). |
 | prompt-proto-service.logLevel | string | log prompt_prototype at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |

--- a/applications/prompt-proto-service-lsstcomcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/values.yaml
@@ -88,7 +88,7 @@ prompt-proto-service:
 
   knative:
     # -- The memory requested for the activator.
-    memoryRequest: "4Gi"
+    memoryRequest: "2Gi"
     # -- The memory limit for the activator.
     memoryLimit: "32Gi"
     # -- The storage space reserved for each container (mostly local Butler).

--- a/applications/prompt-proto-service-lsstcomcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/values.yaml
@@ -87,6 +87,10 @@ prompt-proto-service:
   logLevel: ""
 
   knative:
+    # -- The memory requested for the activator.
+    memoryRequest: "4Gi"
+    # -- The memory limit for the activator.
+    memoryLimit: "32Gi"
     # -- The storage space reserved for each container (mostly local Butler).
     ephemeralStorageRequest: "20Gi"
     # -- The maximum storage space allowed for each container (mostly local Butler).

--- a/charts/prompt-proto-service/README.md
+++ b/charts/prompt-proto-service/README.md
@@ -35,6 +35,8 @@ Event-driven processing of camera images
 | knative.ephemeralStorageLimit | string | `"20Gi"` | The maximum storage space allowed for each container (mostly local Butler). |
 | knative.ephemeralStorageRequest | string | `"20Gi"` | The storage space reserved for each container (mostly local Butler). |
 | knative.idleTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service (seconds). |
+| knative.memoryLimit | string | `"32Gi"` | The memory limit for the activator. |
+| knative.memoryRequest | string | `"4Gi"` | The memory requested for the activator. |
 | knative.responseStartTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service after initial submission (seconds). |
 | knative.timeout | int | `900` | Maximum time that a container can respond to a next_visit request (seconds). |
 | logLevel | string | log prompt_prototype at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |

--- a/charts/prompt-proto-service/templates/prompt-proto-service.yaml
+++ b/charts/prompt-proto-service/templates/prompt-proto-service.yaml
@@ -168,6 +168,16 @@ spec:
           - key: central_repo_file
             path: butler.yaml
       {{- end }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+                - key:  "serving.knative.dev/service"
+                  operator: In
+                  values:
+                  - {{ template "prompt-proto-service.fullname" . }}
+            topologyKey: "kubernetes.io/hostname"
       enableServiceLinks: false
       timeoutSeconds: {{ .Values.knative.timeout }}
       idleTimeoutSeconds: {{ .Values.knative.idleTimeout }}

--- a/charts/prompt-proto-service/templates/prompt-proto-service.yaml
+++ b/charts/prompt-proto-service/templates/prompt-proto-service.yaml
@@ -171,13 +171,15 @@ spec:
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
                 - key:  "serving.knative.dev/service"
                   operator: In
                   values:
                   - {{ template "prompt-proto-service.fullname" . }}
-            topologyKey: "kubernetes.io/hostname"
+              topologyKey: "kubernetes.io/hostname"
       enableServiceLinks: false
       timeoutSeconds: {{ .Values.knative.timeout }}
       idleTimeoutSeconds: {{ .Values.knative.idleTimeout }}

--- a/charts/prompt-proto-service/templates/prompt-proto-service.yaml
+++ b/charts/prompt-proto-service/templates/prompt-proto-service.yaml
@@ -137,9 +137,11 @@ spec:
         resources:
           requests:
             cpu: 1
+            memory: {{ .Values.knative.memoryRequest }}
             ephemeral-storage: {{ .Values.knative.ephemeralStorageRequest }}
           limits:
             cpu: 1
+            memory: {{ .Values.knative.memoryLimit }}
             ephemeral-storage: {{ .Values.knative.ephemeralStorageLimit }}
       volumes:
       - name: ephemeral

--- a/charts/prompt-proto-service/templates/prompt-proto-service.yaml
+++ b/charts/prompt-proto-service/templates/prompt-proto-service.yaml
@@ -136,8 +136,10 @@ spec:
             port: 0
         resources:
           requests:
+            cpu: 1
             ephemeral-storage: {{ .Values.knative.ephemeralStorageRequest }}
           limits:
+            cpu: 1
             ephemeral-storage: {{ .Values.knative.ephemeralStorageLimit }}
       volumes:
       - name: ephemeral

--- a/charts/prompt-proto-service/values.yaml
+++ b/charts/prompt-proto-service/values.yaml
@@ -89,6 +89,10 @@ registry:
 logLevel: ""
 
 knative:
+    # -- The memory requested for the activator.
+  memoryRequest: "4Gi"
+    # -- The memory limit for the activator.
+  memoryLimit: "32Gi"
     # -- The storage space reserved for each container (mostly local Butler).
   ephemeralStorageRequest: "20Gi"
     # -- The maximum storage space allowed for each container (mostly local Butler).


### PR DESCRIPTION
Add pod anti affinity to prefer spreading pods on nodes.  Resource requests for CPU and memory.  Values may need to be adjusted later.