### PR TITLE
DM-40497: Improve pytest output with pytest-pretty

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,6 +44,8 @@ jobs:
           python-version: ${{ matrix.python }}
           tox-envs: "typing,py,coverage-report"
           cache-key-prefix: test
+        env:
+          COLUMNS: 120
 
   helm:
     runs-on: ubuntu-latest

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -13,6 +13,7 @@ mypy
 pre-commit
 pytest
 pytest-cov
+pytest-pretty
 ruff
 types-PyYAML
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -501,6 +501,7 @@ markdown-it-py[linkify]==3.0.0 \
     #   documenteer
     #   mdit-py-plugins
     #   myst-parser
+    #   rich
 markupsafe==2.1.3 \
     --hash=sha256:05fb21170423db021895e1ea1e1f3ab3adb85d1c2333cbc2310f2a26bc77272e \
     --hash=sha256:0a4e4a1aff6c7ac4cd55792abf96c915634c2b97e3cc1c7129578aa68ebd754e \
@@ -897,6 +898,7 @@ pygments==2.16.1 \
     --hash=sha256:1daff0494820c69bc8941e407aa20f577374ee88364ee10a98fdbe0aece96e29
     # via
     #   pydata-sphinx-theme
+    #   rich
     #   sphinx
     #   sphinx-prompt
 pyparsing==3.1.1 \
@@ -909,9 +911,14 @@ pytest==7.4.2 \
     # via
     #   -r requirements/dev.in
     #   pytest-cov
+    #   pytest-pretty
 pytest-cov==4.1.0 \
     --hash=sha256:3904b13dfbfec47f003b8e77fd5b589cd11904a21ddf1ab38a64f204d6a10ef6 \
     --hash=sha256:6ba70b9e97e69fcc3fb45bfeab2d0a138fb65c4d0d6a41ef33983ad114be8c3a
+    # via -r requirements/dev.in
+pytest-pretty==1.2.0 \
+    --hash=sha256:105a355f128e392860ad2c478ae173ff96d2f03044692f9818ff3d49205d3a60 \
+    --hash=sha256:6f79122bf53864ae2951b6c9e94d7a06a87ef753476acd4588aeac018f062036
     # via -r requirements/dev.in
 python-dateutil==2.8.2 \
     --hash=sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86 \
@@ -994,6 +1001,10 @@ requests==2.31.0 \
     #   -c requirements/main.txt
     #   documenteer
     #   sphinx
+rich==13.6.0 \
+    --hash=sha256:2b38e2fe9ca72c9a00170a1a2d20c63c790d0e10ef1fe35eba76e1e7b1d7d245 \
+    --hash=sha256:5c14d22737e6d5084ef4771b62d5d4363165b403455a30a1c8ca39dc7b644bef
+    # via pytest-pretty
 rpds-py==0.10.4 \
     --hash=sha256:00a88003db3cc953f8656b59fc9af9d0637a1fb93c235814007988f8c153b2f2 \
     --hash=sha256:049098dabfe705e9638c55a3321137a821399c50940041a6fcce267a22c70db2 \

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -552,9 +552,9 @@ starlette==0.27.0 \
     # via
     #   fastapi
     #   safir
-structlog==23.1.0 \
-    --hash=sha256:270d681dd7d163c11ba500bc914b2472d2b50a8ef00faa999ded5ff83a2f906b \
-    --hash=sha256:79b9e68e48b54e373441e130fa447944e6f87a05b35de23138e475c05d0f7e0e
+structlog==23.2.0 \
+    --hash=sha256:16a167e87b9fa7fae9a972d5d12805ef90e04857a93eba479d4be3801a6a1482 \
+    --hash=sha256:334666b94707f89dbc4c81a22a8ccd34449f0201d5b1ee097a030b577fa8c858
     # via safir
 typing-extensions==4.8.0 \
     --hash=sha256:8f92fc8806f9a6b641eaa5318da32b44d401efaac0f6678c9bc448ba3605faa0 \

--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,10 @@ commands = neophile update {posargs}
 [testenv:py]
 description = Run pytest
 commands =
-    pytest -vv --cov=phalanx --cov-branch --cov-report= {posargs}
+    pytest --cov=phalanx --cov-branch --cov-report= {posargs}
+# Ensure pytest never trucates diffs on assertions.
+setenv =
+    CI = true
 
 [testenv:typing]
 description = Run mypy.


### PR DESCRIPTION
Install pytest-pretty as a dev dependency for better test summary output. Set CI when running pytest to force verbose diffs of data structures, and drop -vv so that pytest will show the shorter summary of tests in progress instead of printing the name of every test function on its own line.

Increase the column width for pytest-pretty output on GitHub Actions so that the table is more useful.