### PR TITLE
DM-40497: Add empty values file for strimzi

### DIFF
--- a/applications/strimzi/README.md
+++ b/applications/strimzi/README.md
@@ -1,0 +1,6 @@
+# strimzi
+
+Strimzi Kafka Operator
+
+**Homepage:** <https://strimzi.io>
+

--- a/src/phalanx/storage/config.py
+++ b/src/phalanx/storage/config.py
@@ -533,7 +533,7 @@ class ConfigStorage:
         values_path = base_path / "values.yaml"
         if values_path.exists():
             with values_path.open("r") as fh:
-                values = yaml.safe_load(fh)
+                values = yaml.safe_load(fh) or {}
         else:
             values = {}
 


### PR DESCRIPTION
Although this chart does not need a non-environment values file, accounting for the case where it could be missing would require special code in the Phalanx tooling. It's easier to create an empty file and make the chart consistent with other charts.

Fix another warning during documentation generation.