### PR TITLE
DM-40497: Remove unused usdfdev cert-manager configuration

### DIFF
--- a/applications/cert-manager/values-usdfdev.yaml
+++ b/applications/cert-manager/values-usdfdev.yaml
@@ -1,5 +1,0 @@
-solver:
-  route53:
-    aws_access_key_id: AKIAQSJOS2SFL5I4TYND
-    hosted_zone: Z0567328105IEHEMIXLCO
-    vault_secret_path: "secret/rubin/data-dev.lsst.cloud/cert-manager"


### PR DESCRIPTION
cert-manager is disabled on usdfdev and the values-usdfdev.yaml file was out of date and didn't have the correct spelling of settings. Delete it; we can always make a new one should usdfdev start running cert-manager again.