### PR TITLE
DM-40497: Stop installing Python for minikube testing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,14 +88,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.11"
-
-      - name: Install test dependencies
-        run: make init
-
       - name: Filter paths
         uses: dorny/paths-filter@v2
         id: filter


### PR DESCRIPTION
The current installer script doesn't use any Python at all, so we don't need to install Python or any of its dependencies for minikube testing.