### PR TITLE
DM-40497: Exit non-zero on secrets audit failure

### DIFF
--- a/src/phalanx/cli.py
+++ b/src/phalanx/cli.py
@@ -209,7 +209,10 @@ def secrets_audit(
     static_secrets = StaticSecrets.from_path(secrets) if secrets else None
     factory = Factory(config)
     secrets_service = factory.create_secrets_service()
-    sys.stdout.write(secrets_service.audit(environment, static_secrets))
+    report = secrets_service.audit(environment, static_secrets)
+    if report:
+        sys.stdout.write(report)
+        sys.exit(1)
 
 
 @secrets.command("list")

--- a/tests/cli/secrets_test.py
+++ b/tests/cli/secrets_test.py
@@ -59,7 +59,7 @@ def test_audit(factory: Factory, mock_vault: MockVaultClient) -> None:
     result = run_cli(
         "secrets", "audit", "--secrets", str(secrets_path), "idfdev"
     )
-    assert result.exit_code == 0
+    assert result.exit_code == 1
     assert result.output == read_output_data("idfdev", "secrets-audit")
 
 
@@ -78,7 +78,7 @@ def test_audit_onepassword_missing(
     mock_vault.load_test_data(environment.vault_path_prefix, "minikube")
 
     result = run_cli("secrets", "audit", "minikube")
-    assert result.exit_code == 0
+    assert result.exit_code == 1
     assert result.output == read_output_data(
         "minikube", "audit-missing-output"
     )


### PR DESCRIPTION
phalanx vault audit returned non-zero if there was audit output, but phalanx secrets audit did not. Make it match, and match the normal expectations of an audit tool.