### PR TITLE
DM-41051: Upgrade Nublado controller

### DIFF
--- a/applications/nublado/Chart.yaml
+++ b/applications/nublado/Chart.yaml
@@ -6,7 +6,7 @@ sources:
   - https://github.com/lsst-sqre/jupyterlab-controller
   - https://github.com/lsst-sqre/rsp-restspawner
 home: https://github.com/lsst-sqre/jupyterlab-controller
-appVersion: 0.7.3
+appVersion: 0.8.0
 
 dependencies:
   - name: jupyterhub


### PR DESCRIPTION
Install the 0.8.0 release, which has a lot of internal refactoring and better home directory configuration support.