### PR TITLE
Bump Gafaelfawr Redis limit to 40MiB

### DIFF
--- a/applications/gafaelfawr/values.yaml
+++ b/applications/gafaelfawr/values.yaml
@@ -434,7 +434,7 @@ redis:
   resources:
     limits:
       cpu: "1"
-      memory: "20Mi"
+      memory: "40Mi"
     requests:
       cpu: "50m"
       memory: "6Mi"


### PR DESCRIPTION
USDF dev was using 32MiB of memory for Gafaelfawr Redis for reasons that we don't understand, but this limit is low and there's no reason not to make it larger.