### PR TITLE
DM-41186: Add CADC auth support

### DIFF
--- a/applications/gafaelfawr/Chart.yaml
+++ b/applications/gafaelfawr/Chart.yaml
@@ -5,7 +5,7 @@ description: Authentication and identity system
 home: https://gafaelfawr.lsst.io/
 sources:
   - https://github.com/lsst-sqre/gafaelfawr
-appVersion: 9.4.0
+appVersion: 9.5.0
 
 dependencies:
   - name: redis

--- a/applications/gafaelfawr/README.md
+++ b/applications/gafaelfawr/README.md
@@ -24,6 +24,7 @@ Authentication and identity system
 | cloudsql.resources | object | See `values.yaml` | Resource limits and requests for the Cloud SQL Proxy pod |
 | cloudsql.serviceAccount | string | None, must be set if Cloud SQL Auth Proxy is enabled | The Google service account that has an IAM binding to the `gafaelfawr` Kubernetes service account and has the `cloudsql.client` role |
 | cloudsql.tolerations | list | `[]` | Tolerations for the Cloud SQL Proxy pod |
+| config.cadcBaseUuid | string | Disabled | Whether to support the `/auth/cadc/userinfo` route. If set, this UUID is used as the namespace to generate UUID v5 `sub` claims returned by this route to meet the needs of CADC authentication code. |
 | config.cilogon.clientId | string | `""` | CILogon client ID. One and only one of this, `config.github.clientId`, or `config.oidc.clientId` must be set. |
 | config.cilogon.enrollmentUrl | string | Login fails with an error | Where to send the user if their username cannot be found in LDAP |
 | config.cilogon.gidClaim | string | Do not set a primary GID | Claim from which to get the primary GID (only used if not retrieved from LDAP or Firestore) |

--- a/applications/gafaelfawr/templates/configmap.yaml
+++ b/applications/gafaelfawr/templates/configmap.yaml
@@ -27,6 +27,9 @@
     {{- if .Values.config.slackAlerts }}
     slackWebhookFile: "/etc/gafaelfawr/secrets/slack-webhook"
     {{- end }}
+    {{- if .Values.config.cadcBaseUuid }}
+    cadcBaseUuid: {{ .Values.config.cadcBaseUuid | quote }}
+    {{- end }}
 
     {{- if .Values.config.github.clientId }}
 

--- a/applications/gafaelfawr/values-idfdev.yaml
+++ b/applications/gafaelfawr/values-idfdev.yaml
@@ -1,7 +1,3 @@
-image:
-  tag: "tickets-DM-41186"
-  pullPolicy: "Always"
-
 # Use the CSI storage class so that we can use snapshots.
 redis:
   persistence:

--- a/applications/gafaelfawr/values-idfdev.yaml
+++ b/applications/gafaelfawr/values-idfdev.yaml
@@ -1,3 +1,7 @@
+image:
+  tag: "tickets-DM-41186"
+  pullPolicy: "Always"
+
 # Use the CSI storage class so that we can use snapshots.
 redis:
   persistence:
@@ -29,6 +33,9 @@ config:
   # Support OpenID Connect clients like Chronograf.
   oidcServer:
     enabled: true
+
+  # Support generating user metadata for CADC authentication code.
+  cadcBaseUuid: "db8626e0-3b93-45c0-89ab-3058b0ed39fe"
 
   # User quota settings for services.
   quota:

--- a/applications/gafaelfawr/values-idfint.yaml
+++ b/applications/gafaelfawr/values-idfint.yaml
@@ -31,6 +31,9 @@ config:
   oidcServer:
     enabled: true
 
+  # Support generating user metadata for CADC authentication code.
+  cadcBaseUuid: "dd5cd3ee-4239-48e4-b0e3-282f2328b9d1"
+
   # User quota settings for services.
   quota:
     default:

--- a/applications/gafaelfawr/values-idfprod.yaml
+++ b/applications/gafaelfawr/values-idfprod.yaml
@@ -26,6 +26,9 @@ config:
   firestore:
     project: "rsp-firestore-stable-e8eb"
 
+  # Support generating user metadata for CADC authentication code.
+  cadcBaseUuid: "5f0eb655-0e72-4948-a6a5-a94c0be9019f"
+
   # User quota settings for services.
   quota:
     default:

--- a/applications/gafaelfawr/values-usdfdev.yaml
+++ b/applications/gafaelfawr/values-usdfdev.yaml
@@ -1,7 +1,3 @@
-image:
-  tag: "tickets-DM-41186"
-  pullPolicy: "Always"
-
 replicaCount: 2
 
 # Use the CSI storage class so that we can use snapshots.

--- a/applications/gafaelfawr/values-usdfdev.yaml
+++ b/applications/gafaelfawr/values-usdfdev.yaml
@@ -1,3 +1,7 @@
+image:
+  tag: "tickets-DM-41186"
+  pullPolicy: "Always"
+
 replicaCount: 2
 
 # Use the CSI storage class so that we can use snapshots.
@@ -17,6 +21,9 @@ config:
 
   oidcServer:
     enabled: true
+
+  # Support generating user metadata for CADC authentication code.
+  cadcBaseUuid: "efa0a347-b648-4948-a987-055efbf6802a"
 
   oidc:
     clientId: rubin-usdf-rsp-dev

--- a/applications/gafaelfawr/values-usdfint.yaml
+++ b/applications/gafaelfawr/values-usdfint.yaml
@@ -11,6 +11,9 @@ config:
   oidcServer:
     enabled: true
 
+  # Support generating user metadata for CADC authentication code.
+  cadcBaseUuid: "82c6fc76-b7d3-4368-92a9-6a468dfa23dc"
+
   oidc:
     clientId: vcluster--usdf-rsp-int
     audience: "vcluster--usdf-rsp-int"

--- a/applications/gafaelfawr/values-usdfprod.yaml
+++ b/applications/gafaelfawr/values-usdfprod.yaml
@@ -11,6 +11,9 @@ config:
   oidcServer:
     enabled: true
 
+  # Support generating user metadata for CADC authentication code.
+  cadcBaseUuid: "595f5a03-bef4-473b-8e5a-588d87f13799"
+
   oidc:
     clientId: rubin-usdf-rsp
     audience: "rubin-usdf-rsp"

--- a/applications/gafaelfawr/values.yaml
+++ b/applications/gafaelfawr/values.yaml
@@ -74,6 +74,12 @@ config:
   # `slack-webhook` secret must also be set.
   slackAlerts: false
 
+  # -- Whether to support the `/auth/cadc/userinfo` route. If set, this UUID
+  # is used as the namespace to generate UUID v5 `sub` claims returned by this
+  # route to meet the needs of CADC authentication code.
+  # @default -- Disabled
+  cadcBaseUuid: ""
+
   github:
     # -- GitHub client ID. One and only one of this, `config.cilogon.clientId`,
     # or `config.oidc.clientId` must be set.


### PR DESCRIPTION
Update to Gafaelfawr 9.5.0 and add appropriate configuration to enable the CADC-specific user information endpoint on IDF and USDF environments running TAP servers.