### PR TITLE
DM-41350: Update version of Nublado

### DIFF
--- a/applications/nublado/Chart.yaml
+++ b/applications/nublado/Chart.yaml
@@ -6,7 +6,7 @@ sources:
   - https://github.com/lsst-sqre/jupyterlab-controller
   - https://github.com/lsst-sqre/rsp-restspawner
 home: https://github.com/lsst-sqre/jupyterlab-controller
-appVersion: 0.8.0
+appVersion: 0.9.0
 
 dependencies:
   - name: jupyterhub

--- a/applications/nublado/values-idfdev.yaml
+++ b/applications/nublado/values-idfdev.yaml
@@ -70,7 +70,7 @@ controller:
 jupyterhub:
   hub:
     image:
-      tag: "0.4.1"
+      tag: "0.5.0"
     db:
       url: "postgresql://nublado@cloud-sql-proxy.nublado/nublado"
       upgrade: true

--- a/applications/nublado/values-idfint.yaml
+++ b/applications/nublado/values-idfint.yaml
@@ -90,7 +90,7 @@ controller:
 jupyterhub:
   hub:
     image:
-      tag: "0.4.1"
+      tag: "0.5.0"
     config:
       ServerApp:
         shutdown_no_activity_timeout: 432000


### PR DESCRIPTION
Update all environments to a new version of the Nublado controller, and update IDF dev and IDF int to the latest version of the RSP REST spawner container, which also uses the new JupyterHub.