### PR TITLE
DM-41350: Switch Nublado to new JupyterHub by default

### DIFF
--- a/applications/nublado/README.md
+++ b/applications/nublado/README.md
@@ -82,7 +82,7 @@ JupyterHub and custom spawner for the Rubin Science Platform
 | jupyterhub.hub.extraVolumeMounts | list | `hub-config` and the Gafaelfawr token | Additional volume mounts for JupyterHub |
 | jupyterhub.hub.extraVolumes | list | The `hub-config` `ConfigMap` and the Gafaelfawr token | Additional volumes to make available to JupyterHub |
 | jupyterhub.hub.image.name | string | `"ghcr.io/lsst-sqre/rsp-restspawner"` | Image to use for JupyterHub |
-| jupyterhub.hub.image.tag | string | `"0.3.2"` | Tag of image to use for JupyterHub |
+| jupyterhub.hub.image.tag | string | `"0.5.0"` | Tag of image to use for JupyterHub |
 | jupyterhub.hub.loadRoles.server.scopes | list | `["self"]` | Default scopes for the user's lab, overridden to allow the lab to delete itself (which we use for our added menu items) |
 | jupyterhub.hub.networkPolicy.enabled | bool | `false` | Whether to enable the default `NetworkPolicy` (currently, the upstream one does not work correctly) |
 | jupyterhub.hub.resources | object | `{"limits":{"cpu":"900m","memory":"1Gi"}}` | Resource limits and requests |

--- a/applications/nublado/values-idfdev.yaml
+++ b/applications/nublado/values-idfdev.yaml
@@ -69,8 +69,6 @@ controller:
             server: "10.87.86.26"
 jupyterhub:
   hub:
-    image:
-      tag: "0.5.0"
     db:
       url: "postgresql://nublado@cloud-sql-proxy.nublado/nublado"
       upgrade: true

--- a/applications/nublado/values-idfint.yaml
+++ b/applications/nublado/values-idfint.yaml
@@ -89,8 +89,6 @@ controller:
 
 jupyterhub:
   hub:
-    image:
-      tag: "0.5.0"
     config:
       ServerApp:
         shutdown_no_activity_timeout: 432000

--- a/applications/nublado/values.yaml
+++ b/applications/nublado/values.yaml
@@ -304,7 +304,7 @@ jupyterhub:
       name: ghcr.io/lsst-sqre/rsp-restspawner
 
       # -- Tag of image to use for JupyterHub
-      tag: 0.3.2
+      tag: 0.5.0
 
     # -- Resource limits and requests
     resources:


### PR DESCRIPTION
This includes the JupyterHub 4.x migration. Remove the override from IDF dev and IDF int.