### PR TITLE
DM-41350: Tell vault-secrets-operator to quote secrets

### DIFF
--- a/applications/argocd/templates/vault-secrets.yaml
+++ b/applications/argocd/templates/vault-secrets.yaml
@@ -6,11 +6,11 @@ spec:
   path: "{{ .Values.global.vaultSecretsPath }}/argocd"
   templates:
     "admin.password": >-
-      {% index .Secrets "admin.password" %}
+      {% index .Secrets "admin.password" | quote %}
     "admin.passwordMtime": >-
-      {% index .Secrets "admin.passwordMtime" %}
+      {% index .Secrets "admin.passwordMtime" | quote %}
     "dex.clientSecret": >-
-      {% index .Secrets "dex.clientSecret" %}
+      {% index .Secrets "dex.clientSecret" | quote %}
     "server.secretkey": >-
-      {% index .Secrets "server.secretkey" %}
+      {% index .Secrets "server.secretkey" | quote %}
   type: Opaque

--- a/applications/nublado/templates/vault-secrets.yaml
+++ b/applications/nublado/templates/vault-secrets.yaml
@@ -40,12 +40,17 @@ spec:
 
     {{- /* dump in the rest of the keys in this path and their values */}}
     {{- /* this uses the templating provided by vault-secrets-operator */}}
-    hub.db.password: "{% .Secrets.hub_db_password %}"
-    hub.config.JupyterHub.cookie_secret: "{% .Secrets.crypto_key %}"
-    hub.config.CryptKeeper.keys: "{% .Secrets.cryptkeeper_key %}"
-    hub.config.ConfigurableHTTPProxy.auth_token: "{% .Secrets.proxy_token %}"
+    "hub.db.password": >-
+      {% .Secrets.hub_db_password | quote %}
+    "hub.config.JupyterHub.cookie_secret": >-
+      {% .Secrets.crypto_key | quote %}
+    "hub.config.CryptKeeper.keys": >-
+      {% .Secrets.cryptkeeper_key | quote %}
+    "hub.config.ConfigurableHTTPProxy.auth_token": >-
+      {% .Secrets.proxy_token | quote %}
     {{- if .Values.controller.slackAlerts }}
-    slack-webhook: "{% .Secrets.slack_webhook %}"
+    "slack-webhook": >-
+      {% .Secrets.slack_webhook | quote %}
     {{- end }}
 {{- if eq "docker" .Values.controller.config.images.source.type }}
 ---


### PR DESCRIPTION
The templating in vault-secrets-operator apparently does support the quote function, so use it. This should fix problems with a Nublado database password that includes characters like ".