### PR TITLE
DM-41424: Disable HTTP/2 in ingress-nginx

### DIFF
--- a/applications/ingress-nginx/README.md
+++ b/applications/ingress-nginx/README.md
@@ -19,6 +19,7 @@ Ingress controller
 | ingress-nginx.controller.config.server-snippet | string | See `values.yaml` | Add additional per-server configuration used by Gafaelfawr to report errors from the authorization layer |
 | ingress-nginx.controller.config.ssl-redirect | string | `"true"` | Redirect all non-SSL access to SSL |
 | ingress-nginx.controller.config.use-forwarded-headers | string | `"true"` | Enable the `X-Forwarded-For` processing |
+| ingress-nginx.controller.config.use-http2 | string | `"false"` | Disable HTTP/2, since it interferes with keepalive for auth subrequests. We don't use TLS internally anyway, so we can't use HTTP/2 effectively. |
 | ingress-nginx.controller.metrics.enabled | bool | `true` | Enable metrics reporting via Prometheus |
 | ingress-nginx.controller.podLabels | object | See `values.yaml` | Add labels used by `NetworkPolicy` objects to restrict access to the ingress and thus ensure that auth subrequest handlers run |
 | ingress-nginx.controller.service.externalTrafficPolicy | string | `"Local"` | Force traffic routing policy to Local so that the external IP in `X-Forwarded-For` will be correct |

--- a/applications/ingress-nginx/values.yaml
+++ b/applications/ingress-nginx/values.yaml
@@ -21,6 +21,11 @@ ingress-nginx:
       # -- Enable the `X-Forwarded-For` processing
       use-forwarded-headers: "true"
 
+      # -- Disable HTTP/2, since it interferes with keepalive for auth
+      # subrequests. We don't use TLS internally anyway, so we can't use
+      # HTTP/2 effectively.
+      use-http2: "false"
+
       # -- Add additional per-server configuration used by Gafaelfawr to
       # report errors from the authorization layer
       # @default -- See `values.yaml`


### PR DESCRIPTION
This interferes with keepalive for auth subrequests, and we can't use it effectively anyway for internal connections since we don't use TLS internal to the cluster.