### PR TITLE
Add more documentation tests

### DIFF
--- a/tests/docs/applications_test.py
+++ b/tests/docs/applications_test.py
@@ -23,3 +23,22 @@ def test_descriptions() -> None:
         description = m.group(1)
         m = re.match("[A-Z0-9]", description)
         assert m, f"Description must start with capital letter in {index_path}"
+
+
+def test_applications_index() -> None:
+    """Ensure all applications are mentioned in the index."""
+    doc_root = Path(__file__).parent.parent.parent / "docs" / "applications"
+    seen = set()
+    with (doc_root / "index.rst").open() as fh:
+        for line in fh:
+            if m := re.match("^   ([^/]+)/index$", line):
+                seen.add(m.group(1))
+    root_path = Path(__file__).parent.parent.parent / "applications"
+    for application in root_path.iterdir():
+        if not application.is_dir():
+            continue
+        if application.name in ("fileservers", "nublado-users"):
+            continue
+        assert (
+            application.name in seen
+        ), f"{application.name} not lined in docs/applications/index.rst"

--- a/tests/docs/environments_test.py
+++ b/tests/docs/environments_test.py
@@ -1,0 +1,32 @@
+"""Tests for the environment documentation pages."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+def test_environments() -> None:
+    """Ensure all environments are documented."""
+    doc_root = Path(__file__).parent.parent.parent / "docs" / "environments"
+    seen_dir = set()
+    for environment in doc_root.iterdir():
+        if environment.is_dir():
+            seen_dir.add(environment.name)
+    seen_index = set()
+    with (doc_root / "index.rst").open() as fh:
+        for line in fh:
+            if m := re.match("^   ([^/]+)/index$", line):
+                seen_index.add(m.group(1))
+    root_path = Path(__file__).parent.parent.parent / "environments"
+    environments = [
+        v.stem.removeprefix("values-")
+        for v in sorted(root_path.glob("values-*.yaml"))
+    ]
+    for environment_name in environments:
+        assert (
+            environment_name in seen_dir
+        ), f"{environment_name} not documented in docs/environments"
+        assert (
+            environment_name in seen_index
+        ), f"{environment_name} not linked in docs/environments/index.rst"


### PR DESCRIPTION
Test that all environments are documented and linked in the index file, and that all applications are linked in the index file. These will probably be caught once we can re-enable fatal Sphinx warnings, but for right now PRs were merged failing these tests.