### PR TITLE
DM-40416: Add test alert topic

### DIFF
--- a/applications/alert-stream-broker/Chart.yaml
+++ b/applications/alert-stream-broker/Chart.yaml
@@ -7,7 +7,7 @@ sources:
   - https://github.com/lsst-dm/alert-stream-simulator
 dependencies:
   - name: alert-stream-broker
-    version: 2.5.1
+    version: 2.5.2
 
   # The schema registry is bundled together in the same application as the
   # Kafka broker because Strimzi Registry Operator expects everything (the

--- a/applications/alert-stream-broker/README.md
+++ b/applications/alert-stream-broker/README.md
@@ -50,6 +50,8 @@ Alert transmission to community brokers
 | alert-database.storage.gcp.project | string | `""` | Name of a GCP project that has a bucket for database storage |
 | alert-database.storage.gcp.schemaBucket | string | `""` | Name of a Google Cloud Storage bucket in GCP with schema data |
 | alert-stream-broker.cluster.name | string | `"alert-broker"` | Name used for the Kafka broker, and used by Strimzi for many annotations. |
+| alert-stream-broker.clusterName | string | `"alert-broker"` | Name of a Strimzi Kafka cluster to connect to. |
+| alert-stream-broker.clusterPort | int | `9092` | Port to connect to on the Strimzi Kafka cluster. It should be an internal TLS listener. |
 | alert-stream-broker.fullnameOverride | string | `""` | Override for the full name used for Kubernetes resources; by default one will be created based on the chart name and helm release name. |
 | alert-stream-broker.kafka.config | object | `{"log.retention.bytes":"42949672960","log.retention.hours":168,"offsets.retention.minutes":1440}` | Configuration overrides for the Kafka server. |
 | alert-stream-broker.kafka.config."log.retention.bytes" | string | `"42949672960"` | Maximum retained number of bytes for a broker's data. This is a string to avoid YAML type conversion issues for large numbers. |
@@ -76,14 +78,20 @@ Alert transmission to community brokers
 | alert-stream-broker.kafkaExporter.groupRegex | string | `".*"` | Consumer groups to monitor |
 | alert-stream-broker.kafkaExporter.logLevel | string | `"warning"` | Log level for Sarama logging |
 | alert-stream-broker.kafkaExporter.topicRegex | string | `".*"` | Kafka topics to monitor |
+| alert-stream-broker.maxBytesRetained | string | `"24000000000"` | Maximum number of bytes for the replay topic, per partition, per replica. Default is 100GB, but should be lower to not fill storage. |
+| alert-stream-broker.maxMillisecondsRetained | string | `"604800000"` | Maximum amount of time to save simulated alerts in the replay topic, in milliseconds. Default is 7 days. |
 | alert-stream-broker.nameOverride | string | `""` |  |
+| alert-stream-broker.schemaID | int | `1` | Integer ID to use in the prefix of alert data packets. This should be a valid Confluent Schema Registry ID associated with the schema used. |
 | alert-stream-broker.strimziAPIVersion | string | `"v1beta2"` | Version of the Strimzi Custom Resource API. The correct value depends on the deployed version of Strimzi. See [this blog post](https://strimzi.io/blog/2021/04/29/api-conversion/) for more. |
 | alert-stream-broker.superusers | list | `["kafka-admin"]` | A list of usernames for users who should have global admin permissions. These users will be created, along with their credentials. |
+| alert-stream-broker.testTopicName | string | `"alert-stream-test"` | Name of the topic which will be used to send test alerts. |
+| alert-stream-broker.testTopicPartitions | int | `8` |  |
+| alert-stream-broker.testTopicReplicas | int | `2` |  |
 | alert-stream-broker.tls.certIssuerName | string | `"letsencrypt-dns"` | Name of a ClusterIssuer capable of provisioning a TLS certificate for the broker. |
 | alert-stream-broker.tls.subject.organization | string | `"Vera C. Rubin Observatory"` | Organization to use in the 'Subject' field of the broker's TLS certificate. |
-| alert-stream-broker.users | list | `[{"groups":["rubin-testing"],"readonlyTopics":["alert-stream","alerts-simulated"],"username":"rubin-testing"}]` | A list of users that should be created and granted access.  Passwords for these users are not generated automatically; they are expected to be stored as 1Password secrets which are replicated into Vault. Each username should have a "{{ $username }}-password" secret associated with it. |
+| alert-stream-broker.users | list | `[{"groups":["rubin-testing"],"readonlyTopics":["alert-stream","alerts-simulated","alert-stream-test"],"username":"rubin-testing"}]` | A list of users that should be created and granted access.  Passwords for these users are not generated automatically; they are expected to be stored as 1Password secrets which are replicated into Vault. Each username should have a "{{ $username }}-password" secret associated with it. |
 | alert-stream-broker.users[0].groups | list | `["rubin-testing"]` | A list of string prefixes for groups that the user should get admin access to, allowing them to create, delete, describe, etc consumer groups. Note that these are prefix-matched, not just literal exact matches. |
-| alert-stream-broker.users[0].readonlyTopics | list | `["alert-stream","alerts-simulated"]` | A list of topics that the user should get read-only access to. |
+| alert-stream-broker.users[0].readonlyTopics | list | `["alert-stream","alerts-simulated","alert-stream-test"]` | A list of topics that the user should get read-only access to. |
 | alert-stream-broker.users[0].username | string | `"rubin-testing"` | The username for the user that should be created. |
 | alert-stream-broker.vaultSecretsPath | string | `""` | Path to the secret resource in Vault |
 | alert-stream-broker.zookeeper.replicas | int | `3` | Number of Zookeeper replicas to run. |

--- a/applications/alert-stream-broker/charts/alert-stream-broker/Chart.yaml
+++ b/applications/alert-stream-broker/charts/alert-stream-broker/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: alert-stream-broker
-version: 2.5.1
+version: 2.5.2
 description: Kafka broker cluster for distributing alerts
 maintainers:
   - name: bsmart

--- a/applications/alert-stream-broker/charts/alert-stream-broker/README.md
+++ b/applications/alert-stream-broker/charts/alert-stream-broker/README.md
@@ -7,6 +7,8 @@ Kafka broker cluster for distributing alerts
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | cluster.name | string | `"alert-broker"` | Name used for the Kafka broker, and used by Strimzi for many annotations. |
+| clusterName | string | `"alert-broker"` | Name of a Strimzi Kafka cluster to connect to. |
+| clusterPort | int | `9092` | Port to connect to on the Strimzi Kafka cluster. It should be an internal TLS listener. |
 | fullnameOverride | string | `""` | Override for the full name used for Kubernetes resources; by default one will be created based on the chart name and helm release name. |
 | kafka.config | object | `{"log.retention.bytes":"42949672960","log.retention.hours":168,"offsets.retention.minutes":1440}` | Configuration overrides for the Kafka server. |
 | kafka.config."log.retention.bytes" | string | `"42949672960"` | Maximum retained number of bytes for a broker's data. This is a string to avoid YAML type conversion issues for large numbers. |
@@ -33,14 +35,20 @@ Kafka broker cluster for distributing alerts
 | kafkaExporter.groupRegex | string | `".*"` | Consumer groups to monitor |
 | kafkaExporter.logLevel | string | `"warning"` | Log level for Sarama logging |
 | kafkaExporter.topicRegex | string | `".*"` | Kafka topics to monitor |
+| maxBytesRetained | string | `"24000000000"` | Maximum number of bytes for the replay topic, per partition, per replica. Default is 100GB, but should be lower to not fill storage. |
+| maxMillisecondsRetained | string | `"604800000"` | Maximum amount of time to save simulated alerts in the replay topic, in milliseconds. Default is 7 days. |
 | nameOverride | string | `""` |  |
+| schemaID | int | `1` | Integer ID to use in the prefix of alert data packets. This should be a valid Confluent Schema Registry ID associated with the schema used. |
 | strimziAPIVersion | string | `"v1beta2"` | Version of the Strimzi Custom Resource API. The correct value depends on the deployed version of Strimzi. See [this blog post](https://strimzi.io/blog/2021/04/29/api-conversion/) for more. |
 | superusers | list | `["kafka-admin"]` | A list of usernames for users who should have global admin permissions. These users will be created, along with their credentials. |
+| testTopicName | string | `"alert-stream-test"` | Name of the topic which will be used to send test alerts. |
+| testTopicPartitions | int | `8` |  |
+| testTopicReplicas | int | `2` |  |
 | tls.certIssuerName | string | `"letsencrypt-dns"` | Name of a ClusterIssuer capable of provisioning a TLS certificate for the broker. |
 | tls.subject.organization | string | `"Vera C. Rubin Observatory"` | Organization to use in the 'Subject' field of the broker's TLS certificate. |
-| users | list | `[{"groups":["rubin-testing"],"readonlyTopics":["alert-stream","alerts-simulated"],"username":"rubin-testing"}]` | A list of users that should be created and granted access.  Passwords for these users are not generated automatically; they are expected to be stored as 1Password secrets which are replicated into Vault. Each username should have a "{{ $username }}-password" secret associated with it. |
+| users | list | `[{"groups":["rubin-testing"],"readonlyTopics":["alert-stream","alerts-simulated","alert-stream-test"],"username":"rubin-testing"}]` | A list of users that should be created and granted access.  Passwords for these users are not generated automatically; they are expected to be stored as 1Password secrets which are replicated into Vault. Each username should have a "{{ $username }}-password" secret associated with it. |
 | users[0].groups | list | `["rubin-testing"]` | A list of string prefixes for groups that the user should get admin access to, allowing them to create, delete, describe, etc consumer groups. Note that these are prefix-matched, not just literal exact matches. |
-| users[0].readonlyTopics | list | `["alert-stream","alerts-simulated"]` | A list of topics that the user should get read-only access to. |
+| users[0].readonlyTopics | list | `["alert-stream","alerts-simulated","alert-stream-test"]` | A list of topics that the user should get read-only access to. |
 | users[0].username | string | `"rubin-testing"` | The username for the user that should be created. |
 | vaultSecretsPath | string | `""` | Path to the secret resource in Vault |
 | zookeeper.replicas | int | `3` | Number of Zookeeper replicas to run. |

--- a/applications/alert-stream-broker/charts/alert-stream-broker/templates/kafka-topics.yaml
+++ b/applications/alert-stream-broker/charts/alert-stream-broker/templates/kafka-topics.yaml
@@ -1,0 +1,13 @@
+apiVersion: "kafka.strimzi.io/{{ .Values.strimziAPIVersion }}"
+kind: KafkaTopic
+metadata:
+  name: "{{ .Values.testTopicName }}"
+  labels:
+    strimzi.io/cluster: "{{ .Values.clusterName }}"
+spec:
+  partitions: {{ .Values.testTopicPartitions }}
+  replicas: {{ .Values.testTopicReplicas }}
+  config:
+    cleanup.policy: "delete"
+    retention.ms: {{ .Values.maxMillisecondsRetained }} # 7 days
+    retention.bytes: {{ .Values.maxBytesRetained }}

--- a/applications/alert-stream-broker/charts/alert-stream-broker/values.yaml
+++ b/applications/alert-stream-broker/charts/alert-stream-broker/values.yaml
@@ -114,7 +114,7 @@ users:
   -  # -- The username for the user that should be created.
     username: rubin-testing
     # -- A list of topics that the user should get read-only access to.
-    readonlyTopics: ["alert-stream", "alerts-simulated"]
+    readonlyTopics: ["alert-stream", "alerts-simulated", "alert-stream-test"]
     # -- A list of string prefixes for groups that the user should get admin
     # access to, allowing them to create, delete, describe, etc consumer
     # groups. Note that these are prefix-matched, not just literal exact
@@ -148,3 +148,29 @@ vaultSecretsPath: ""
 fullnameOverride: ""
 
 nameOverride: ""
+
+# -- Name of the topic which will be used to send test alerts.
+testTopicName: alert-stream-test
+
+# -- Integer ID to use in the prefix of alert data packets. This should be a
+# valid Confluent Schema Registry ID associated with the schema used.
+schemaID: 1
+
+# -- Name of a Strimzi Kafka cluster to connect to.
+clusterName: alert-broker
+
+# -- Port to connect to on the Strimzi Kafka cluster. It should be an internal
+# TLS listener.
+clusterPort: 9092
+
+# -- Maximum amount of time to save simulated alerts in the replay topic, in
+# milliseconds. Default is 7 days.
+maxMillisecondsRetained: "604800000"
+
+# -- Maximum number of bytes for the replay topic, per partition, per replica.
+# Default is 100GB, but should be lower to not fill storage.
+maxBytesRetained: "24000000000"
+
+testTopicPartitions: 8
+
+testTopicReplicas: 2

--- a/applications/alert-stream-broker/values-usdfdev-alert-stream-broker.yaml
+++ b/applications/alert-stream-broker/values-usdfdev-alert-stream-broker.yaml
@@ -110,6 +110,10 @@ alert-stream-broker:
       readonlyTopics: ["alerts-simulated"]
       groups: ["pittgoogle-idfint"]
 
+  testTopicName: "alert-stream-test"
+  testTopicPartitions: 20
+  testTopicReplicas: 1
+
 alert-stream-schema-registry:
   hostname: "usdf-alert-schemas-dev.slac.stanford.edu"
   schemaTopic: "registry-schemas"


### PR DESCRIPTION
Adding a test alert topic to use for sending alerts from the pipeline to the broker. This is separate from the current alert stream which is receiving data from the simulator.