### PR TITLE
Register spec-survey with Prompt Processing.

### DIFF
--- a/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
@@ -18,7 +18,13 @@ prompt-proto-service:
       (survey="AUXTEL_DRP_IMAGING")=[${PROMPT_PROTOTYPE_DIR}/pipelines/LATISS/ApPipe.yaml,
       ${PROMPT_PROTOTYPE_DIR}/pipelines/LATISS/SingleFrame.yaml,
       ${PROMPT_PROTOTYPE_DIR}/pipelines/LATISS/Isr.yaml]
-      (survey="spec")=[] (survey="spec_with_rotation")=[] (survey="spec_bright")=[] (survey="spec_bright_with_rotation")=[] (survey="spec_pole")=[] (survey="spec_pole_with_rotation")=[] (survey="")=[]
+      (survey="spec")=[]
+      (survey="spec_with_rotation")=[]
+      (survey="spec_bright")=[]
+      (survey="spec_bright_with_rotation")=[]
+      (survey="spec_pole")=[]
+      (survey="spec_pole_with_rotation")=[]
+      (survey="")=[]
     calibRepo: /app/butler
 
   s3:

--- a/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
@@ -19,6 +19,7 @@ prompt-proto-service:
       ${PROMPT_PROTOTYPE_DIR}/pipelines/LATISS/SingleFrame.yaml,
       ${PROMPT_PROTOTYPE_DIR}/pipelines/LATISS/Isr.yaml]
       (survey="spec")=[]
+      (survey="spec-survey")=[]
       (survey="spec_with_rotation")=[]
       (survey="spec_bright")=[]
       (survey="spec_bright_with_rotation")=[]


### PR DESCRIPTION
The `spec-survey` survey is a new survey being run on AuxTel. Register it as a known survey that we _don't_ want to process.