### PR TITLE
Revert "Register spec-survey with Prompt Processing."

### DIFF
--- a/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
@@ -19,7 +19,6 @@ prompt-proto-service:
       ${PROMPT_PROTOTYPE_DIR}/pipelines/LATISS/SingleFrame.yaml,
       ${PROMPT_PROTOTYPE_DIR}/pipelines/LATISS/Isr.yaml]
       (survey="spec")=[]
-      (survey="spec-survey")=[]
       (survey="spec_with_rotation")=[]
       (survey="spec_bright")=[]
       (survey="spec_bright_with_rotation")=[]


### PR DESCRIPTION
This is a partial revert of #2711, which ran afoul of a bug in `prompt_prototype` itself.