### PR TITLE
DM-41658: Register spec-survey with Prompt Processing.

### DIFF
--- a/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
@@ -8,7 +8,7 @@ prompt-proto-service:
     repository: ghcr.io/lsst-dm/prompt-proto-service
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: w_2023_44
+    tag: d_2023_11_06
 
   instrument:
     pipelines: >-

--- a/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
@@ -19,6 +19,7 @@ prompt-proto-service:
       ${PROMPT_PROTOTYPE_DIR}/pipelines/LATISS/SingleFrame.yaml,
       ${PROMPT_PROTOTYPE_DIR}/pipelines/LATISS/Isr.yaml]
       (survey="spec")=[]
+      (survey="spec-survey")=[]
       (survey="spec_with_rotation")=[]
       (survey="spec_bright")=[]
       (survey="spec_bright_with_rotation")=[]


### PR DESCRIPTION
This PR restores the configuration added in #2711 and reverted in #2712. It must be merged after lsst-dm/prompt_prototype#94 (which fixes the config parser so that it can actually handle hyphens).