### PR TITLE
Fix broken links

### DIFF
--- a/applications/nublado/Chart.yaml
+++ b/applications/nublado/Chart.yaml
@@ -3,9 +3,8 @@ name: nublado
 version: 1.0.0
 description: JupyterHub and custom spawner for the Rubin Science Platform
 sources:
-  - https://github.com/lsst-sqre/jupyterlab-controller
-  - https://github.com/lsst-sqre/rsp-restspawner
-home: https://github.com/lsst-sqre/jupyterlab-controller
+  - https://github.com/lsst-sqre/nublado
+home: https://nublado.lsst.io/
 appVersion: 0.9.0
 
 dependencies:

--- a/applications/nublado/README.md
+++ b/applications/nublado/README.md
@@ -2,12 +2,11 @@
 
 JupyterHub and custom spawner for the Rubin Science Platform
 
-**Homepage:** <https://github.com/lsst-sqre/jupyterlab-controller>
+**Homepage:** <https://nublado.lsst.io/>
 
 ## Source Code
 
-* <https://github.com/lsst-sqre/jupyterlab-controller>
-* <https://github.com/lsst-sqre/rsp-restspawner>
+* <https://github.com/lsst-sqre/nublado>
 
 ## Values
 

--- a/applications/ook/Chart.yaml
+++ b/applications/ook/Chart.yaml
@@ -2,7 +2,10 @@ apiVersion: v2
 name: ook
 version: 1.0.0
 appVersion: "0.9.0"
-description: Ook is the librarian service for Rubin Observatory. Ook indexes documentation content into the Algolia search engine that powers the Rubin Observatory documentation portal, www.lsst.io.
+description: >
+  Ook is the librarian service for Rubin Observatory. Ook indexes
+  documentation content into the Algolia search engine that powers the Rubin
+  Observatory documentation portal, lsst.io.
 type: application
 home: https://ook.lsst.io/
 sources:

--- a/applications/ook/README.md
+++ b/applications/ook/README.md
@@ -1,6 +1,6 @@
 # ook
 
-Ook is the librarian service for Rubin Observatory. Ook indexes documentation content into the Algolia search engine that powers the Rubin Observatory documentation portal, www.lsst.io.
+Ook is the librarian service for Rubin Observatory. Ook indexes documentation content into the Algolia search engine that powers the Rubin Observatory documentation portal, lsst.io.
 
 **Homepage:** <https://ook.lsst.io/>
 

--- a/applications/siav2/Chart.yaml
+++ b/applications/siav2/Chart.yaml
@@ -2,7 +2,5 @@ apiVersion: v2
 appVersion: 0.1.0
 description: Simple Image Access v2 service
 name: siav2
-sources:
-- https://github.com/lsst-sqre/siav2
 type: application
 version: 1.0.0

--- a/applications/siav2/README.md
+++ b/applications/siav2/README.md
@@ -2,10 +2,6 @@
 
 Simple Image Access v2 service
 
-## Source Code
-
-* <https://github.com/lsst-sqre/siav2>
-
 ## Values
 
 | Key | Type | Default | Description |

--- a/applications/squareone/values-idfdev.yaml
+++ b/applications/squareone/values-idfdev.yaml
@@ -90,7 +90,7 @@ config:
 
       Want to dive deeper into the Rubin Observatory and Legacy Survey of
       Space and Time? [Search in our technical documentation
-      portal.](https://www.lsst.io)
+      portal.](https://lsst.io)
 
     </Section>
 

--- a/applications/squareone/values-idfint.yaml
+++ b/applications/squareone/values-idfint.yaml
@@ -154,7 +154,7 @@ config:
 
       Want to dive deeper into the Rubin Observatory and Legacy Survey of
       Space and Time? [Search in our technical documentation
-      portal.](https://www.lsst.io)
+      portal.](https://lsst.io)
 
     </Section>
   supportPageMdx: |

--- a/applications/squareone/values.yaml
+++ b/applications/squareone/values.yaml
@@ -229,7 +229,7 @@ config:
 
       Want to dive deeper into the Rubin Observatory and Legacy Survey of
       Space and Time? [Search in our technical documentation
-      portal.](https://www.lsst.io)
+      portal.](https://lsst.io)
 
     </Section>
 

--- a/applications/tap/values-idfdev.yaml
+++ b/applications/tap/values-idfdev.yaml
@@ -6,3 +6,4 @@ cadc-tap:
   config:
     qserv:
       host: "10.136.1.211:4040"
+      # Change to 134.79.23.209:4040 to point to USDF qserv

--- a/docs/_rst_epilog.rst
+++ b/docs/_rst_epilog.rst
@@ -34,7 +34,7 @@
 .. _Pod: https://kubernetes.io/docs/concepts/workloads/pods/
 .. _pre-commit: https://pre-commit.com
 .. _Roundtable: https://roundtable.lsst.io/
-.. _Ruff: https://beta.ruff.rs/docs/
+.. _Ruff: https://docs.astral.sh/ruff/
 .. _Safir: https://safir.lsst.io/
 .. _Secret: https://kubernetes.io/docs/concepts/configuration/secret/
 .. _semantic versioning: https://semver.org/

--- a/docs/applications/ook/index.rst
+++ b/docs/applications/ook/index.rst
@@ -5,7 +5,7 @@ ook — Documentation indexing
 ############################
 
 Ook is the librarian service for Rubin Observatory.
-Ook indexes documentation content into the Algolia search engine that powers the Rubin Observatory documentation portal, https://www.lsst.io.
+Ook indexes documentation content into the Algolia search engine that powers the Rubin Observatory documentation portal, https://lsst.io.
 
 .. jinja:: ook
    :file: applications/_summary.rst.jinja

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,7 @@ Phalanx [#name]_ is a GitOps repository for Rubin Observatory's Kubernetes envir
 Using Helm_ and `Argo CD`_, Phalanx defines the configurations of applications in each environment.
 
 This documentation is for Rubin team members that are developing applications and administering Kubernetes clusters.
-Astronomers and other end-users can visit the `Rubin Documentation Portal <https://www.lsst.io>`__ to learn how to use Rubin Observatory's software, services, and datasets.
+Astronomers and other end-users can visit the `Rubin Documentation Portal <https://lsst.io>`__ to learn how to use Rubin Observatory's software, services, and datasets.
 
 Phalanx is on GitHub at https://github.com/lsst-sqre/phalanx.
 


### PR DESCRIPTION
Change www.lsst.io links to lsst.io, since www.lsst.io is now a redirect. Update the URLs for Nublado. Remove the link for SIAv2, which points to a nonexistent repository. Update the link for Ruff documentation.