### PR TITLE
DM-41664: Rename prompt_prototype package and containers

### DIFF
--- a/applications/prompt-proto-service-hsc/Chart.yaml
+++ b/applications/prompt-proto-service-hsc/Chart.yaml
@@ -4,9 +4,9 @@ version: 1.0.0
 description: >-
   Prompt Proto Service is an event driven service for processing camera
   images. This instance of the service handles HSC images.
-home: https://github.com/lsst-dm/prompt_prototype/blob/main/doc/playbook.rst
+home: https://github.com/lsst-dm/prompt_processing/blob/main/doc/playbook.rst
 sources:
-  - https://github.com/lsst-dm/prompt_prototype
+  - https://github.com/lsst-dm/prompt_processing
 annotations:
   phalanx.lsst.io/docs: |
     - id: "DMTN-219"

--- a/applications/prompt-proto-service-hsc/Chart.yaml
+++ b/applications/prompt-proto-service-hsc/Chart.yaml
@@ -12,6 +12,9 @@ annotations:
     - id: "DMTN-219"
       title: "Proposal and Prototype for Prompt Processing"
       url: "https://dmtn-219.lsst.io/"
+    - id: "DMTN-260"
+      title: "Failure Modes and Error Handling for Prompt Processing"
+      url: "https://dmtn-260.lsst.io/"
 dependencies:
   - name: prompt-proto-service
     version: 1.0.0

--- a/applications/prompt-proto-service-hsc/README.md
+++ b/applications/prompt-proto-service-hsc/README.md
@@ -2,11 +2,11 @@
 
 Prompt Proto Service is an event driven service for processing camera images. This instance of the service handles HSC images.
 
-**Homepage:** <https://github.com/lsst-dm/prompt_prototype/blob/main/doc/playbook.rst>
+**Homepage:** <https://github.com/lsst-dm/prompt_processing/blob/main/doc/playbook.rst>
 
 ## Source Code
 
-* <https://github.com/lsst-dm/prompt_prototype>
+* <https://github.com/lsst-dm/prompt_processing>
 
 ## Values
 
@@ -26,14 +26,14 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.imageNotifications.topic | string | None, must be set | Topic where raw image arrival notifications appear |
 | prompt-proto-service.instrument.calibRepo | string | None, must be set | URI to the shared repo used for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself. |
 | prompt-proto-service.instrument.name | string | `"HSC"` | The "short" name of the instrument |
-| prompt-proto-service.instrument.pipelines | string | None, must be set | Machine-readable string describing which pipeline(s) should be run for which visits. Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_prototype/blob/main/python/activator/config.py) for examples. |
+| prompt-proto-service.instrument.pipelines | string | None, must be set | Machine-readable string describing which pipeline(s) should be run for which visits. Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |
 | prompt-proto-service.instrument.skymap | string | `"hsc_rings_v1"` | Skymap to use with the instrument |
 | prompt-proto-service.knative.ephemeralStorageLimit | string | `"20Gi"` | The maximum storage space allowed for each container (mostly local Butler). |
 | prompt-proto-service.knative.ephemeralStorageRequest | string | `"20Gi"` | The storage space reserved for each container (mostly local Butler). |
 | prompt-proto-service.knative.idleTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service (seconds). |
 | prompt-proto-service.knative.responseStartTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service after initial submission (seconds). |
 | prompt-proto-service.knative.timeout | int | `900` | Maximum time that a container can respond to a next_visit request (seconds). |
-| prompt-proto-service.logLevel | string | log prompt_prototype at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
+| prompt-proto-service.logLevel | string | log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
 | prompt-proto-service.podAnnotations | object | See the `values.yaml` file. | Annotations for the prompt-proto-service pod |
 | prompt-proto-service.registry.centralRepoFile | bool | `false` | If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted. |
 | prompt-proto-service.registry.db | string | None, must be set | PostgreSQL database name for the Butler registry database (deprecated) |

--- a/applications/prompt-proto-service-hsc/README.md
+++ b/applications/prompt-proto-service-hsc/README.md
@@ -19,7 +19,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.apdb.url | string | None, must be set | URL to the APDB, in any form recognized by SQLAlchemy |
 | prompt-proto-service.apdb.user | string | `"rubin"` | Database user for the APDB (deprecated for apdb.url) |
 | prompt-proto-service.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
-| prompt-proto-service.image.repository | string | `"ghcr.io/lsst-dm/prompt-proto-service"` | Image to use in the PP deployment |
+| prompt-proto-service.image.repository | string | `"ghcr.io/lsst-dm/prompt-service"` | Image to use in the PP deployment |
 | prompt-proto-service.image.tag | string | `"latest"` | Overrides the image tag whose default is the chart appVersion. |
 | prompt-proto-service.imageNotifications.imageTimeout | string | `"120"` | Timeout to wait after expected script completion for raw image arrival (seconds). |
 | prompt-proto-service.imageNotifications.kafkaClusterAddress | string | None, must be set | Hostname and port of the Kafka provider |

--- a/applications/prompt-proto-service-hsc/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-hsc/values-usdfdev-prompt-processing.yaml
@@ -11,7 +11,7 @@ prompt-proto-service:
     tag: latest
 
   instrument:
-    pipelines: (survey="SURVEY")=[${PROMPT_PROTOTYPE_DIR}/pipelines/HSC/ApPipe.yaml]
+    pipelines: (survey="SURVEY")=[${PROMPT_PROCESSING_DIR}/pipelines/HSC/ApPipe.yaml]
     calibRepo: s3://rubin:rubin-pp-users/central_repo/
 
   s3:

--- a/applications/prompt-proto-service-hsc/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-hsc/values-usdfdev-prompt-processing.yaml
@@ -5,7 +5,7 @@ prompt-proto-service:
     revision: "1"
 
   image:
-    repository: ghcr.io/lsst-dm/prompt-proto-service
+    repository: ghcr.io/lsst-dm/prompt-service
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: latest

--- a/applications/prompt-proto-service-hsc/values.yaml
+++ b/applications/prompt-proto-service-hsc/values.yaml
@@ -23,7 +23,7 @@ prompt-proto-service:
     # -- The "short" name of the instrument
     name: HSC
     # -- Machine-readable string describing which pipeline(s) should be run for which visits.
-    # Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_prototype/blob/main/python/activator/config.py) for examples.
+    # Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples.
     # @default -- None, must be set
     pipelines: ""
     # -- Skymap to use with the instrument
@@ -83,7 +83,7 @@ prompt-proto-service:
     centralRepoFile: false
 
   # -- Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level).
-  # @default -- log prompt_prototype at DEBUG, other LSST code at INFO, and third-party code at WARNING.
+  # @default -- log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING.
   logLevel: ""
 
   knative:

--- a/applications/prompt-proto-service-hsc/values.yaml
+++ b/applications/prompt-proto-service-hsc/values.yaml
@@ -12,7 +12,7 @@ prompt-proto-service:
 
   image:
     # -- Image to use in the PP deployment
-    repository: ghcr.io/lsst-dm/prompt-proto-service
+    repository: ghcr.io/lsst-dm/prompt-service
     # -- Pull policy for the PP image
     # @default -- `IfNotPresent` in prod, `Always` in dev
     pullPolicy: IfNotPresent

--- a/applications/prompt-proto-service-latiss/Chart.yaml
+++ b/applications/prompt-proto-service-latiss/Chart.yaml
@@ -4,9 +4,9 @@ version: 1.0.0
 description: >-
   Prompt Proto Service is an event driven service for processing camera
   images. This instance of the service handles LATISS images.
-home: https://github.com/lsst-dm/prompt_prototype/blob/main/doc/playbook.rst
+home: https://github.com/lsst-dm/prompt_processing/blob/main/doc/playbook.rst
 sources:
-  - https://github.com/lsst-dm/prompt_prototype
+  - https://github.com/lsst-dm/prompt_processing
 annotations:
   phalanx.lsst.io/docs: |
     - id: "DMTN-219"

--- a/applications/prompt-proto-service-latiss/Chart.yaml
+++ b/applications/prompt-proto-service-latiss/Chart.yaml
@@ -12,6 +12,9 @@ annotations:
     - id: "DMTN-219"
       title: "Proposal and Prototype for Prompt Processing"
       url: "https://dmtn-219.lsst.io/"
+    - id: "DMTN-260"
+      title: "Failure Modes and Error Handling for Prompt Processing"
+      url: "https://dmtn-260.lsst.io/"
 dependencies:
   - name: prompt-proto-service
     version: 1.0.0

--- a/applications/prompt-proto-service-latiss/README.md
+++ b/applications/prompt-proto-service-latiss/README.md
@@ -2,11 +2,11 @@
 
 Prompt Proto Service is an event driven service for processing camera images. This instance of the service handles LATISS images.
 
-**Homepage:** <https://github.com/lsst-dm/prompt_prototype/blob/main/doc/playbook.rst>
+**Homepage:** <https://github.com/lsst-dm/prompt_processing/blob/main/doc/playbook.rst>
 
 ## Source Code
 
-* <https://github.com/lsst-dm/prompt_prototype>
+* <https://github.com/lsst-dm/prompt_processing>
 
 ## Values
 
@@ -26,14 +26,14 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.imageNotifications.topic | string | None, must be set | Topic where raw image arrival notifications appear |
 | prompt-proto-service.instrument.calibRepo | string | None, must be set | URI to the shared repo used for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself. |
 | prompt-proto-service.instrument.name | string | `"LATISS"` | The "short" name of the instrument |
-| prompt-proto-service.instrument.pipelines | string | None, must be set | Machine-readable string describing which pipeline(s) should be run for which visits. Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_prototype/blob/main/python/activator/config.py) for examples. |
+| prompt-proto-service.instrument.pipelines | string | None, must be set | Machine-readable string describing which pipeline(s) should be run for which visits. Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |
 | prompt-proto-service.instrument.skymap | string | `"latiss_v1"` | Skymap to use with the instrument |
 | prompt-proto-service.knative.ephemeralStorageLimit | string | `"20Gi"` | The maximum storage space allowed for each container (mostly local Butler). |
 | prompt-proto-service.knative.ephemeralStorageRequest | string | `"20Gi"` | The storage space reserved for each container (mostly local Butler). |
 | prompt-proto-service.knative.idleTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service (seconds). |
 | prompt-proto-service.knative.responseStartTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service after initial submission (seconds). |
 | prompt-proto-service.knative.timeout | int | `900` | Maximum time that a container can respond to a next_visit request (seconds). |
-| prompt-proto-service.logLevel | string | log prompt_prototype at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
+| prompt-proto-service.logLevel | string | log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
 | prompt-proto-service.podAnnotations | object | See the `values.yaml` file. | Annotations for the prompt-proto-service pod |
 | prompt-proto-service.registry.centralRepoFile | bool | `false` | If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted. |
 | prompt-proto-service.registry.db | string | None, must be set | PostgreSQL database name for the Butler registry database (deprecated) |

--- a/applications/prompt-proto-service-latiss/README.md
+++ b/applications/prompt-proto-service-latiss/README.md
@@ -19,7 +19,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.apdb.url | string | None, must be set | URL to the APDB, in any form recognized by SQLAlchemy |
 | prompt-proto-service.apdb.user | string | `"rubin"` | Database user for the APDB (deprecated for apdb.url) |
 | prompt-proto-service.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
-| prompt-proto-service.image.repository | string | `"ghcr.io/lsst-dm/prompt-proto-service"` | Image to use in the PP deployment |
+| prompt-proto-service.image.repository | string | `"ghcr.io/lsst-dm/prompt-service"` | Image to use in the PP deployment |
 | prompt-proto-service.image.tag | string | `"latest"` | Overrides the image tag whose default is the chart appVersion. |
 | prompt-proto-service.imageNotifications.imageTimeout | string | `"120"` | Timeout to wait after expected script completion for raw image arrival (seconds). |
 | prompt-proto-service.imageNotifications.kafkaClusterAddress | string | None, must be set | Hostname and port of the Kafka provider |

--- a/applications/prompt-proto-service-latiss/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfdev-prompt-processing.yaml
@@ -5,7 +5,7 @@ prompt-proto-service:
     revision: "1"
 
   image:
-    repository: ghcr.io/lsst-dm/prompt-proto-service
+    repository: ghcr.io/lsst-dm/prompt-service
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: latest

--- a/applications/prompt-proto-service-latiss/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfdev-prompt-processing.yaml
@@ -11,7 +11,7 @@ prompt-proto-service:
     tag: latest
 
   instrument:
-    pipelines: (survey="SURVEY")=[${PROMPT_PROTOTYPE_DIR}/pipelines/LATISS/ApPipe.yaml]
+    pipelines: (survey="SURVEY")=[${PROMPT_PROCESSING_DIR}/pipelines/LATISS/ApPipe.yaml]
     calibRepo: s3://rubin-pp-users/central_repo/
 
   s3:

--- a/applications/prompt-proto-service-latiss/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfdev-prompt-processing.yaml
@@ -11,7 +11,7 @@ prompt-proto-service:
     tag: latest
 
   instrument:
-    pipelines: (survey="SURVEY")=[${PROMPT_PROTOTYPE_DIR}/pipelines/${RUBIN_INSTRUMENT}/ApPipe.yaml]
+    pipelines: (survey="SURVEY")=[${PROMPT_PROTOTYPE_DIR}/pipelines/LATISS/ApPipe.yaml]
     calibRepo: s3://rubin-pp-users/central_repo/
 
   s3:

--- a/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
@@ -12,12 +12,12 @@ prompt-proto-service:
 
   instrument:
     pipelines: >-
-      (survey="AUXTEL_PHOTO_IMAGING")=[${PROMPT_PROTOTYPE_DIR}/pipelines/LATISS/ApPipe.yaml,
-      ${PROMPT_PROTOTYPE_DIR}/pipelines/LATISS/SingleFrame.yaml,
-      ${PROMPT_PROTOTYPE_DIR}/pipelines/LATISS/Isr.yaml]
-      (survey="AUXTEL_DRP_IMAGING")=[${PROMPT_PROTOTYPE_DIR}/pipelines/LATISS/ApPipe.yaml,
-      ${PROMPT_PROTOTYPE_DIR}/pipelines/LATISS/SingleFrame.yaml,
-      ${PROMPT_PROTOTYPE_DIR}/pipelines/LATISS/Isr.yaml]
+      (survey="AUXTEL_PHOTO_IMAGING")=[${PROMPT_PROCESSING_DIR}/pipelines/LATISS/ApPipe.yaml,
+      ${PROMPT_PROCESSING_DIR}/pipelines/LATISS/SingleFrame.yaml,
+      ${PROMPT_PROCESSING_DIR}/pipelines/LATISS/Isr.yaml]
+      (survey="AUXTEL_DRP_IMAGING")=[${PROMPT_PROCESSING_DIR}/pipelines/LATISS/ApPipe.yaml,
+      ${PROMPT_PROCESSING_DIR}/pipelines/LATISS/SingleFrame.yaml,
+      ${PROMPT_PROCESSING_DIR}/pipelines/LATISS/Isr.yaml]
       (survey="spec")=[]
       (survey="spec-survey")=[]
       (survey="spec_with_rotation")=[]

--- a/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
@@ -5,7 +5,6 @@ prompt-proto-service:
     revision: "12"
 
   image:
-    repository: ghcr.io/lsst-dm/prompt-proto-service
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
     tag: d_2023_11_06

--- a/applications/prompt-proto-service-latiss/values.yaml
+++ b/applications/prompt-proto-service-latiss/values.yaml
@@ -13,7 +13,7 @@ prompt-proto-service:
 
   image:
     # -- Image to use in the PP deployment
-    repository: ghcr.io/lsst-dm/prompt-proto-service
+    repository: ghcr.io/lsst-dm/prompt-service
     # -- Pull policy for the PP image
     # @default -- `IfNotPresent` in prod, `Always` in dev
     pullPolicy: IfNotPresent

--- a/applications/prompt-proto-service-latiss/values.yaml
+++ b/applications/prompt-proto-service-latiss/values.yaml
@@ -24,7 +24,7 @@ prompt-proto-service:
     # -- The "short" name of the instrument
     name: LATISS
     # -- Machine-readable string describing which pipeline(s) should be run for which visits.
-    # Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_prototype/blob/main/python/activator/config.py) for examples.
+    # Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples.
     # @default -- None, must be set
     pipelines: ""
     # -- Skymap to use with the instrument
@@ -83,7 +83,7 @@ prompt-proto-service:
     centralRepoFile: false
 
   # -- Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level).
-  # @default -- log prompt_prototype at DEBUG, other LSST code at INFO, and third-party code at WARNING.
+  # @default -- log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING.
   logLevel: ""
 
   knative:

--- a/applications/prompt-proto-service-lsstcam/Chart.yaml
+++ b/applications/prompt-proto-service-lsstcam/Chart.yaml
@@ -4,9 +4,9 @@ version: 1.0.0
 description: >-
   Prompt Proto Service is an event driven service for processing camera
   images. This instance of the service handles LSSTCam images.
-home: https://github.com/lsst-dm/prompt_prototype/blob/main/doc/playbook.rst
+home: https://github.com/lsst-dm/prompt_processing/blob/main/doc/playbook.rst
 sources:
-  - https://github.com/lsst-dm/prompt_prototype
+  - https://github.com/lsst-dm/prompt_processing
 annotations:
   phalanx.lsst.io/docs: |
     - id: "DMTN-219"

--- a/applications/prompt-proto-service-lsstcam/Chart.yaml
+++ b/applications/prompt-proto-service-lsstcam/Chart.yaml
@@ -12,6 +12,9 @@ annotations:
     - id: "DMTN-219"
       title: "Proposal and Prototype for Prompt Processing"
       url: "https://dmtn-219.lsst.io/"
+    - id: "DMTN-260"
+      title: "Failure Modes and Error Handling for Prompt Processing"
+      url: "https://dmtn-260.lsst.io/"
 dependencies:
   - name: prompt-proto-service
     version: 1.0.0

--- a/applications/prompt-proto-service-lsstcam/README.md
+++ b/applications/prompt-proto-service-lsstcam/README.md
@@ -2,11 +2,11 @@
 
 Prompt Proto Service is an event driven service for processing camera images. This instance of the service handles LSSTCam images.
 
-**Homepage:** <https://github.com/lsst-dm/prompt_prototype/blob/main/doc/playbook.rst>
+**Homepage:** <https://github.com/lsst-dm/prompt_processing/blob/main/doc/playbook.rst>
 
 ## Source Code
 
-* <https://github.com/lsst-dm/prompt_prototype>
+* <https://github.com/lsst-dm/prompt_processing>
 
 ## Values
 
@@ -26,14 +26,14 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.imageNotifications.topic | string | None, must be set | Topic where raw image arrival notifications appear |
 | prompt-proto-service.instrument.calibRepo | string | None, must be set | URI to the shared repo used for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself. |
 | prompt-proto-service.instrument.name | string | `""` | The "short" name of the instrument |
-| prompt-proto-service.instrument.pipelines | string | None, must be set | Machine-readable string describing which pipeline(s) should be run for which visits. Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_prototype/blob/main/python/activator/config.py) for examples. |
+| prompt-proto-service.instrument.pipelines | string | None, must be set | Machine-readable string describing which pipeline(s) should be run for which visits. Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |
 | prompt-proto-service.instrument.skymap | string | `""` | Skymap to use with the instrument |
 | prompt-proto-service.knative.ephemeralStorageLimit | string | `"20Gi"` | The maximum storage space allowed for each container (mostly local Butler). |
 | prompt-proto-service.knative.ephemeralStorageRequest | string | `"20Gi"` | The storage space reserved for each container (mostly local Butler). |
 | prompt-proto-service.knative.idleTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service (seconds). |
 | prompt-proto-service.knative.responseStartTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service after initial submission (seconds). |
 | prompt-proto-service.knative.timeout | int | `900` | Maximum time that a container can respond to a next_visit request (seconds). |
-| prompt-proto-service.logLevel | string | log prompt_prototype at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
+| prompt-proto-service.logLevel | string | log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
 | prompt-proto-service.podAnnotations | object | See the `values.yaml` file. | Annotations for the prompt-proto-service pod |
 | prompt-proto-service.registry.centralRepoFile | bool | `false` | If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted. |
 | prompt-proto-service.registry.db | string | None, must be set | PostgreSQL database name for the Butler registry database (deprecated) |

--- a/applications/prompt-proto-service-lsstcam/README.md
+++ b/applications/prompt-proto-service-lsstcam/README.md
@@ -19,7 +19,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.apdb.url | string | None, must be set | URL to the APDB, in any form recognized by SQLAlchemy |
 | prompt-proto-service.apdb.user | string | `"rubin"` | Database user for the APDB (deprecated for apdb.url) |
 | prompt-proto-service.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
-| prompt-proto-service.image.repository | string | `"ghcr.io/lsst-dm/prompt-proto-service"` | Image to use in the PP deployment |
+| prompt-proto-service.image.repository | string | `"ghcr.io/lsst-dm/prompt-service"` | Image to use in the PP deployment |
 | prompt-proto-service.image.tag | string | `"latest"` | Overrides the image tag whose default is the chart appVersion. |
 | prompt-proto-service.imageNotifications.imageTimeout | string | `"120"` | Timeout to wait after expected script completion for raw image arrival (seconds). |
 | prompt-proto-service.imageNotifications.kafkaClusterAddress | string | None, must be set | Hostname and port of the Kafka provider |

--- a/applications/prompt-proto-service-lsstcam/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcam/values-usdfdev-prompt-processing.yaml
@@ -5,7 +5,7 @@ prompt-proto-service:
     revision: "1"
 
   image:
-    repository: ghcr.io/lsst-dm/prompt-proto-service
+    repository: ghcr.io/lsst-dm/prompt-service
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: latest

--- a/applications/prompt-proto-service-lsstcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcam/values.yaml
@@ -23,7 +23,7 @@ prompt-proto-service:
     # -- The "short" name of the instrument
     name: ""
     # -- Machine-readable string describing which pipeline(s) should be run for which visits.
-    # Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_prototype/blob/main/python/activator/config.py) for examples.
+    # Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples.
     # @default -- None, must be set
     pipelines: ""
     # -- Skymap to use with the instrument
@@ -83,7 +83,7 @@ prompt-proto-service:
     centralRepoFile: false
 
   # -- Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level).
-  # @default -- log prompt_prototype at DEBUG, other LSST code at INFO, and third-party code at WARNING.
+  # @default -- log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING.
   logLevel: ""
 
   knative:

--- a/applications/prompt-proto-service-lsstcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcam/values.yaml
@@ -12,7 +12,7 @@ prompt-proto-service:
 
   image:
     # -- Image to use in the PP deployment
-    repository: ghcr.io/lsst-dm/prompt-proto-service
+    repository: ghcr.io/lsst-dm/prompt-service
     # -- Pull policy for the PP image
     # @default -- `IfNotPresent` in prod, `Always` in dev
     pullPolicy: IfNotPresent

--- a/applications/prompt-proto-service-lsstcomcam/Chart.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/Chart.yaml
@@ -12,6 +12,9 @@ annotations:
     - id: "DMTN-219"
       title: "Proposal and Prototype for Prompt Processing"
       url: "https://dmtn-219.lsst.io/"
+    - id: "DMTN-260"
+      title: "Failure Modes and Error Handling for Prompt Processing"
+      url: "https://dmtn-260.lsst.io/"
 dependencies:
   - name: prompt-proto-service
     version: 1.0.0

--- a/applications/prompt-proto-service-lsstcomcam/Chart.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/Chart.yaml
@@ -4,9 +4,9 @@ version: 1.0.0
 description: >-
   Prompt Proto Service is an event driven service for processing camera
   images. This instance of the service handles LSSTComCam images.
-home: https://github.com/lsst-dm/prompt_prototype/blob/main/doc/playbook.rst
+home: https://github.com/lsst-dm/prompt_processing/blob/main/doc/playbook.rst
 sources:
-  - https://github.com/lsst-dm/prompt_prototype
+  - https://github.com/lsst-dm/prompt_processing
 annotations:
   phalanx.lsst.io/docs: |
     - id: "DMTN-219"

--- a/applications/prompt-proto-service-lsstcomcam/README.md
+++ b/applications/prompt-proto-service-lsstcomcam/README.md
@@ -2,11 +2,11 @@
 
 Prompt Proto Service is an event driven service for processing camera images. This instance of the service handles LSSTComCam images.
 
-**Homepage:** <https://github.com/lsst-dm/prompt_prototype/blob/main/doc/playbook.rst>
+**Homepage:** <https://github.com/lsst-dm/prompt_processing/blob/main/doc/playbook.rst>
 
 ## Source Code
 
-* <https://github.com/lsst-dm/prompt_prototype>
+* <https://github.com/lsst-dm/prompt_processing>
 
 ## Values
 
@@ -25,14 +25,14 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.imageNotifications.topic | string | None, must be set | Topic where raw image arrival notifications appear |
 | prompt-proto-service.instrument.calibRepo | string | None, must be set | URI to the shared repo used for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself. |
 | prompt-proto-service.instrument.name | string | `""` | The "short" name of the instrument |
-| prompt-proto-service.instrument.pipelines | string | None, must be set | Machine-readable string describing which pipeline(s) should be run for which visits. Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_prototype/blob/main/python/activator/config.py) for examples. |
+| prompt-proto-service.instrument.pipelines | string | None, must be set | Machine-readable string describing which pipeline(s) should be run for which visits. Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |
 | prompt-proto-service.instrument.skymap | string | `""` | Skymap to use with the instrument |
 | prompt-proto-service.knative.ephemeralStorageLimit | string | `"20Gi"` | The maximum storage space allowed for each container (mostly local Butler). |
 | prompt-proto-service.knative.ephemeralStorageRequest | string | `"20Gi"` | The storage space reserved for each container (mostly local Butler). |
 | prompt-proto-service.knative.idleTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service (seconds). |
 | prompt-proto-service.knative.responseStartTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service after initial submission (seconds). |
 | prompt-proto-service.knative.timeout | int | `900` | Maximum time that a container can respond to a next_visit request (seconds). |
-| prompt-proto-service.logLevel | string | log prompt_prototype at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
+| prompt-proto-service.logLevel | string | log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
 | prompt-proto-service.podAnnotations | object | See the `values.yaml` file. | Annotations for the prompt-proto-service pod |
 | prompt-proto-service.registry.centralRepoFile | bool | `false` | If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted. |
 | prompt-proto-service.registry.db | string | None, must be set | PostgreSQL database name for the Butler registry database (deprecated) |

--- a/applications/prompt-proto-service-lsstcomcam/README.md
+++ b/applications/prompt-proto-service-lsstcomcam/README.md
@@ -18,7 +18,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.apdb.url | string | None, must be set | URL to the APDB, in any form recognized by SQLAlchemy |
 | prompt-proto-service.apdb.user | string | `"rubin"` | Database user for the APDB (deprecated for apdb.url) |
 | prompt-proto-service.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
-| prompt-proto-service.image.repository | string | `"ghcr.io/lsst-dm/prompt-proto-service"` | Image to use in the PP deployment |
+| prompt-proto-service.image.repository | string | `"ghcr.io/lsst-dm/prompt-service"` | Image to use in the PP deployment |
 | prompt-proto-service.image.tag | string | `"latest"` | Overrides the image tag whose default is the chart appVersion. |
 | prompt-proto-service.imageNotifications.imageTimeout | string | `"120"` | Timeout to wait after expected script completion for raw image arrival (seconds). |
 | prompt-proto-service.imageNotifications.kafkaClusterAddress | string | None, must be set | Hostname and port of the Kafka provider |

--- a/applications/prompt-proto-service-lsstcomcam/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/values-usdfdev-prompt-processing.yaml
@@ -5,7 +5,7 @@ prompt-proto-service:
     revision: "1"
 
   image:
-    repository: ghcr.io/lsst-dm/prompt-proto-service
+    repository: ghcr.io/lsst-dm/prompt-service
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: latest

--- a/applications/prompt-proto-service-lsstcomcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/values.yaml
@@ -23,7 +23,7 @@ prompt-proto-service:
     # -- The "short" name of the instrument
     name: ""
     # -- Machine-readable string describing which pipeline(s) should be run for which visits.
-    # Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_prototype/blob/main/python/activator/config.py) for examples.
+    # Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples.
     # @default -- None, must be set
     pipelines: ""
     # -- Skymap to use with the instrument
@@ -83,7 +83,7 @@ prompt-proto-service:
     centralRepoFile: false
 
   # -- Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level).
-  # @default -- log prompt_prototype at DEBUG, other LSST code at INFO, and third-party code at WARNING.
+  # @default -- log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING.
   logLevel: ""
 
   knative:

--- a/applications/prompt-proto-service-lsstcomcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/values.yaml
@@ -12,7 +12,7 @@ prompt-proto-service:
 
   image:
     # -- Image to use in the PP deployment
-    repository: ghcr.io/lsst-dm/prompt-proto-service
+    repository: ghcr.io/lsst-dm/prompt-service
     # -- Pull policy for the PP image
     # @default -- `IfNotPresent` in prod, `Always` in dev
     pullPolicy: IfNotPresent

--- a/charts/prompt-proto-service/Chart.yaml
+++ b/charts/prompt-proto-service/Chart.yaml
@@ -4,9 +4,9 @@ version: 1.0.0
 appVersion: "0.1.0"
 description: Event-driven processing of camera images
 type: application
-home: https://github.com/lsst-dm/prompt_prototype/blob/main/doc/playbook.rst
+home: https://github.com/lsst-dm/prompt_processing/blob/main/doc/playbook.rst
 sources:
-  - https://github.com/lsst-dm/prompt_prototype
+  - https://github.com/lsst-dm/prompt_processing
 annotations:
   phalanx.lsst.io/docs: |
     - id: "DMTN-219"

--- a/charts/prompt-proto-service/Chart.yaml
+++ b/charts/prompt-proto-service/Chart.yaml
@@ -12,3 +12,6 @@ annotations:
     - id: "DMTN-219"
       title: "Proposal and Prototype for Prompt Processing"
       url: "https://dmtn-219.lsst.io/"
+    - id: "DMTN-260"
+      title: "Failure Modes and Error Handling for Prompt Processing"
+      url: "https://dmtn-260.lsst.io/"

--- a/charts/prompt-proto-service/README.md
+++ b/charts/prompt-proto-service/README.md
@@ -22,7 +22,7 @@ Event-driven processing of camera images
 | containerConcurrency | int | `1` |  |
 | fullnameOverride | string | `"prompt-proto-service"` | Override the full name for resources (includes the release name) |
 | image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
-| image.repository | string | `"ghcr.io/lsst-dm/prompt-proto-service"` | Image to use in the PP deployment |
+| image.repository | string | `"ghcr.io/lsst-dm/prompt-service"` | Image to use in the PP deployment |
 | image.tag | string | `"latest"` | Overrides the image tag whose default is the chart appVersion. |
 | imageNotifications.imageTimeout | string | `"120"` | Timeout to wait after expected script completion for raw image arrival (seconds). |
 | imageNotifications.kafkaClusterAddress | string | None, must be set | Hostname and port of the Kafka provider |

--- a/charts/prompt-proto-service/README.md
+++ b/charts/prompt-proto-service/README.md
@@ -2,11 +2,11 @@
 
 Event-driven processing of camera images
 
-**Homepage:** <https://github.com/lsst-dm/prompt_prototype/blob/main/doc/playbook.rst>
+**Homepage:** <https://github.com/lsst-dm/prompt_processing/blob/main/doc/playbook.rst>
 
 ## Source Code
 
-* <https://github.com/lsst-dm/prompt_prototype>
+* <https://github.com/lsst-dm/prompt_processing>
 
 ## Values
 
@@ -30,14 +30,14 @@ Event-driven processing of camera images
 | imagePullSecrets | list | `[]` |  |
 | instrument.calibRepo | string | None, must be set | URI to the shared repo used for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself. |
 | instrument.name | string | None, must be set | The "short" name of the instrument |
-| instrument.pipelines | string | None, must be set | Machine-readable string describing which pipeline(s) should be run for which visits. Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_prototype/blob/main/python/activator/config.py) for examples. |
+| instrument.pipelines | string | None, must be set | Machine-readable string describing which pipeline(s) should be run for which visits. Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |
 | instrument.skymap | string | `""` | Skymap to use with the instrument |
 | knative.ephemeralStorageLimit | string | `"20Gi"` | The maximum storage space allowed for each container (mostly local Butler). |
 | knative.ephemeralStorageRequest | string | `"20Gi"` | The storage space reserved for each container (mostly local Butler). |
 | knative.idleTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service (seconds). |
 | knative.responseStartTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service after initial submission (seconds). |
 | knative.timeout | int | `900` | Maximum time that a container can respond to a next_visit request (seconds). |
-| logLevel | string | log prompt_prototype at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
+| logLevel | string | log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
 | nameOverride | string | `""` | Override the base name for resources |
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | See the `values.yaml` file. | Annotations for the prompt-proto-service pod |

--- a/charts/prompt-proto-service/values.yaml
+++ b/charts/prompt-proto-service/values.yaml
@@ -13,7 +13,7 @@ podAnnotations:
 
 image:
   # -- Image to use in the PP deployment
-  repository: ghcr.io/lsst-dm/prompt-proto-service
+  repository: ghcr.io/lsst-dm/prompt-service
   # -- Pull policy for the PP image
   # @default -- `IfNotPresent` in prod, `Always` in dev
   pullPolicy: IfNotPresent

--- a/charts/prompt-proto-service/values.yaml
+++ b/charts/prompt-proto-service/values.yaml
@@ -25,7 +25,7 @@ instrument:
   # @default -- None, must be set
   name: ""
   # -- Machine-readable string describing which pipeline(s) should be run for which visits.
-  # Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_prototype/blob/main/python/activator/config.py) for examples.
+  # Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples.
   # @default -- None, must be set
   pipelines: ""
   # -- Skymap to use with the instrument
@@ -85,7 +85,7 @@ registry:
   centralRepoFile: false
 
 # -- Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level).
-# @default -- log prompt_prototype at DEBUG, other LSST code at INFO, and third-party code at WARNING.
+# @default -- log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING.
 logLevel: ""
 
 knative:


### PR DESCRIPTION
This PR updates the Phanalx configuration for `prompt-proto-service-*` to point to the new package name and the new container names. It makes no attempt to rename the service itself (deferred to [DM-41665](https://jira.lsstcorp.org/browse/DM-41665)).

This PR should be merged after lsst-dm/prompt_processing#96, though most of the changes that affect this PR are already visible.