### PR TITLE
Add 60s query timeout to InfluxDB

### DIFF
--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -22,7 +22,7 @@ Rubin Observatory's telemetry service.
 | chronograf.resources.limits.memory | string | `"64Gi"` |  |
 | chronograf.resources.requests.cpu | int | `1` |  |
 | chronograf.resources.requests.memory | string | `"4Gi"` |  |
-| influxdb-staging.config | object | `{"continuous_queries":{"enabled":false},"coordinator":{"log-queries-after":"15s","max-concurrent-queries":0,"query-timeout":"0s","write-timeout":"1h"},"data":{"cache-max-memory-size":0,"trace-logging-enabled":true,"wal-fsync-delay":"100ms"},"http":{"auth-enabled":true,"enabled":true,"flux-enabled":true,"max-row-limit":0},"logging":{"level":"debug"}}` | Override InfluxDB configuration. See https://docs.influxdata.com/influxdb/v1.8/administration/config |
+| influxdb-staging.config | object | `{"continuous_queries":{"enabled":false},"coordinator":{"log-queries-after":"15s","max-concurrent-queries":0,"query-timeout":"60s","write-timeout":"1h"},"data":{"cache-max-memory-size":0,"trace-logging-enabled":true,"wal-fsync-delay":"100ms"},"http":{"auth-enabled":true,"enabled":true,"flux-enabled":true,"max-row-limit":0},"logging":{"level":"debug"}}` | Override InfluxDB configuration. See https://docs.influxdata.com/influxdb/v1.8/administration/config |
 | influxdb-staging.enabled | bool | `false` | Enable InfluxDB staging deployment. |
 | influxdb-staging.image | object | `{"tag":"1.8.10"}` | InfluxDB image tag. |
 | influxdb-staging.ingress | object | disabled | InfluxDB ingress configuration. |
@@ -34,7 +34,7 @@ Rubin Observatory's telemetry service.
 | influxdb-staging.resources.requests.cpu | int | `8` |  |
 | influxdb-staging.resources.requests.memory | string | `"96Gi"` |  |
 | influxdb-staging.setDefaultUser | object | `{"enabled":true,"user":{"existingSecret":"sasquatch"}}` | Default InfluxDB user, use influxb-user and influxdb-password keys from secret. |
-| influxdb.config | object | `{"continuous_queries":{"enabled":false},"coordinator":{"log-queries-after":"15s","max-concurrent-queries":0,"query-timeout":"0s","write-timeout":"1h"},"data":{"cache-max-memory-size":0,"trace-logging-enabled":true,"wal-fsync-delay":"100ms"},"http":{"auth-enabled":true,"enabled":true,"flux-enabled":true,"max-row-limit":0},"logging":{"level":"debug"}}` | Override InfluxDB configuration. See https://docs.influxdata.com/influxdb/v1.8/administration/config |
+| influxdb.config | object | `{"continuous_queries":{"enabled":false},"coordinator":{"log-queries-after":"15s","max-concurrent-queries":0,"query-timeout":"60s","write-timeout":"1h"},"data":{"cache-max-memory-size":0,"trace-logging-enabled":true,"wal-fsync-delay":"100ms"},"http":{"auth-enabled":true,"enabled":true,"flux-enabled":true,"max-row-limit":0},"logging":{"level":"debug"}}` | Override InfluxDB configuration. See https://docs.influxdata.com/influxdb/v1.8/administration/config |
 | influxdb.enabled | bool | `true` | Enable InfluxDB. |
 | influxdb.image | object | `{"tag":"1.8.10"}` | InfluxDB image tag. |
 | influxdb.ingress | object | disabled | InfluxDB ingress configuration. |
@@ -85,7 +85,7 @@ Rubin Observatory's telemetry service.
 | kapacitor.resources.requests.cpu | int | `1` |  |
 | kapacitor.resources.requests.memory | string | `"1Gi"` |  |
 | rest-proxy | object | `{"enabled":false}` | Override rest-proxy configuration. |
-| source-influxdb.config | object | `{"continuous_queries":{"enabled":false},"coordinator":{"log-queries-after":"15s","max-concurrent-queries":0,"query-timeout":"0s","write-timeout":"1h"},"data":{"cache-max-memory-size":0,"trace-logging-enabled":true,"wal-fsync-delay":"100ms"},"http":{"auth-enabled":true,"enabled":true,"flux-enabled":true,"max-row-limit":0},"logging":{"level":"debug"}}` | Override InfluxDB configuration. See https://docs.influxdata.com/influxdb/v1.8/administration/config |
+| source-influxdb.config | object | `{"continuous_queries":{"enabled":false},"coordinator":{"log-queries-after":"15s","max-concurrent-queries":0,"query-timeout":"60s","write-timeout":"1h"},"data":{"cache-max-memory-size":0,"trace-logging-enabled":true,"wal-fsync-delay":"100ms"},"http":{"auth-enabled":true,"enabled":true,"flux-enabled":true,"max-row-limit":0},"logging":{"level":"debug"}}` | Override InfluxDB configuration. See https://docs.influxdata.com/influxdb/v1.8/administration/config |
 | source-influxdb.enabled | bool | `false` | Enable InfluxDB staging deployment. |
 | source-influxdb.image | object | `{"tag":"1.8.10"}` | InfluxDB image tag. |
 | source-influxdb.ingress | object | disabled | InfluxDB ingress configuration. |

--- a/applications/sasquatch/values.yaml
+++ b/applications/sasquatch/values.yaml
@@ -53,7 +53,7 @@ influxdb:
     coordinator:
       write-timeout: "1h"
       max-concurrent-queries: 0
-      query-timeout: "0s"
+      query-timeout: "60s"
       log-queries-after: "15s"
     continuous_queries:
       enabled: false
@@ -116,7 +116,7 @@ influxdb-staging:
     coordinator:
       write-timeout: "1h"
       max-concurrent-queries: 0
-      query-timeout: "0s"
+      query-timeout: "60s"
       log-queries-after: "15s"
     continuous_queries:
       enabled: false
@@ -179,7 +179,7 @@ source-influxdb:
     coordinator:
       write-timeout: "1h"
       max-concurrent-queries: 0
-      query-timeout: "0s"
+      query-timeout: "60s"
       log-queries-after: "15s"
     continuous_queries:
       enabled: false


### PR DESCRIPTION
- Set this limit by default to prevent long queries to use memory excessively and eventually restart the InfluxDB pod.