### PR TITLE
Increase number of connector tasks for M1M3 and MTMount

### DIFF
--- a/applications/sasquatch/values-summit.yaml
+++ b/applications/sasquatch/values-summit.yaml
@@ -58,6 +58,7 @@ kafka-connect-manager:
         enabled: true
         repairerConnector: false
         topicsRegex: ".*MTMount"
+        tasksMax: "8"
       comcam:
         enabled: true
         repairerConnector: false
@@ -74,6 +75,7 @@ kafka-connect-manager:
         enabled: true
         repairerConnector: false
         topicsRegex: ".*MTM1M3"
+        tasksMax: "8"
       m2:
         enabled: true
         repairerConnector: false


### PR DESCRIPTION
- Increase the number of connector tasks to improve latency issues as reported by Petr when TMA/M1M3 tests restarted at the Summit.