### PR TITLE
Remove the 1s refresh option for Chronograf dashboards

### DIFF
--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -13,7 +13,7 @@ Rubin Observatory's telemetry service.
 | bucketmapper.image.repository | string | `"ghcr.io/lsst-sqre/rubin-influx-tools"` | repository for rubin-influx-tools |
 | bucketmapper.image.tag | string | `"0.2.0"` | tag for rubin-influx-tools |
 | chronograf.enabled | bool | `true` | Enable Chronograf. |
-| chronograf.env | object | `{"BASE_PATH":"/chronograf","CUSTOM_AUTO_REFRESH":"1s=1000","HOST_PAGE_DISABLED":true}` | Chronograf environment variables. |
+| chronograf.env | object | `{"BASE_PATH":"/chronograf","HOST_PAGE_DISABLED":true}` | Chronograf environment variables. |
 | chronograf.envFromSecret | string | `"sasquatch"` | Chronograf secrets, expected keys generic_client_id, generic_client_secret and token_secret. |
 | chronograf.image | object | `{"repository":"quay.io/influxdb/chronograf","tag":"1.10.2"}` | Chronograf image tag. |
 | chronograf.ingress | object | disabled | Chronograf ingress configuration. |

--- a/applications/sasquatch/values.yaml
+++ b/applications/sasquatch/values.yaml
@@ -288,7 +288,6 @@ chronograf:
   env:
     HOST_PAGE_DISABLED: true
     BASE_PATH: /chronograf
-    CUSTOM_AUTO_REFRESH: "1s=1000"
   # -- Chronograf secrets, expected keys generic_client_id, generic_client_secret and token_secret.
   envFromSecret: "sasquatch"
   resources:


### PR DESCRIPTION
- The 1s refresh option in Chronograf only works with dashboards that take less than 1s to update, most dashboards take longer, and this option is causing some confusion.It also seems unnecessary as human reactions to displays take longer than that. Users agree that a 5s refresh is enough, and the decision is to remove the 1s refresh option.