### PR TITLE
Disable nublado2 at the summit

### DIFF
--- a/environments/values-summit.yaml
+++ b/environments/values-summit.yaml
@@ -3,12 +3,9 @@ fqdn: summit-lsp.lsst.codes
 vaultPathPrefix: secret/k8s_operator/summit-lsp.lsst.codes
 
 applications:
-  cachemachine: true
   exposurelog: true
-  moneypenny: true
   narrativelog: true
   nublado: true
-  nublado2: true
   portal: true
   postgres: true
   sasquatch: true


### PR DESCRIPTION
We've been running Nublado v3 by default for a while.