### PR TITLE
Update prompt processing to use d_2023_11_22.

### DIFF
--- a/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
@@ -7,7 +7,7 @@ prompt-proto-service:
   image:
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: d_2023_11_06
+    tag: d_2023_11_22
 
   instrument:
     pipelines: >-


### PR DESCRIPTION
This PR updates the release branch of Prompt Processing to use the `d_2023_11_22` tag as its "latest stable" version.