### PR TITLE
Switch lsst.io back to www.lsst.io

### DIFF
--- a/applications/squareone/values-idfdev.yaml
+++ b/applications/squareone/values-idfdev.yaml
@@ -90,7 +90,7 @@ config:
 
       Want to dive deeper into the Rubin Observatory and Legacy Survey of
       Space and Time? [Search in our technical documentation
-      portal.](https://lsst.io)
+      portal.](https://www.lsst.io)
 
     </Section>
 

--- a/applications/squareone/values-idfint.yaml
+++ b/applications/squareone/values-idfint.yaml
@@ -154,7 +154,7 @@ config:
 
       Want to dive deeper into the Rubin Observatory and Legacy Survey of
       Space and Time? [Search in our technical documentation
-      portal.](https://lsst.io)
+      portal.](https://www.lsst.io)
 
     </Section>
   supportPageMdx: |

--- a/applications/squareone/values.yaml
+++ b/applications/squareone/values.yaml
@@ -229,7 +229,7 @@ config:
 
       Want to dive deeper into the Rubin Observatory and Legacy Survey of
       Space and Time? [Search in our technical documentation
-      portal.](https://lsst.io)
+      portal.](https://www.lsst.io)
 
     </Section>
 

--- a/docs/applications/ook/index.rst
+++ b/docs/applications/ook/index.rst
@@ -5,7 +5,7 @@ ook — Documentation indexing
 ############################
 
 Ook is the librarian service for Rubin Observatory.
-Ook indexes documentation content into the Algolia search engine that powers the Rubin Observatory documentation portal, https://lsst.io.
+Ook indexes documentation content into the Algolia search engine that powers the Rubin Observatory documentation portal, https://www.lsst.io.
 
 .. jinja:: ook
    :file: applications/_summary.rst.jinja

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,7 @@ Phalanx [#name]_ is a GitOps repository for Rubin Observatory's Kubernetes envir
 Using Helm_ and `Argo CD`_, Phalanx defines the configurations of applications in each environment.
 
 This documentation is for Rubin team members that are developing applications and administering Kubernetes clusters.
-Astronomers and other end-users can visit the `Rubin Documentation Portal <https://lsst.io>`__ to learn how to use Rubin Observatory's software, services, and datasets.
+Astronomers and other end-users can visit the `Rubin Documentation Portal <https://www.lsst.io>`__ to learn how to use Rubin Observatory's software, services, and datasets.
 
 Phalanx is on GitHub at https://github.com/lsst-sqre/phalanx.
 


### PR DESCRIPTION
www.lsst.io is the canonical URL, so use that everywhere.  It's no longer a redirect.