### PR TITLE
DM-23878: Fix LDAP hostname for base

### DIFF
--- a/applications/gafaelfawr/values-base.yaml
+++ b/applications/gafaelfawr/values-base.yaml
@@ -18,7 +18,7 @@ config:
     usernameClaim: "preferred_username"
 
   ldap:
-    url: "ldap://ipa1.ls.lsst.org"
+    url: "ldap://ipa.lsst.org"
     userDn: "uid=svc_rsp,cn=users,cn=accounts,dc=lsst,dc=cloud"
     userBaseDn: "cn=users,cn=accounts,dc=lsst,dc=cloud"
     uidAttr: "uidNumber"


### PR DESCRIPTION
Use ipa.lsst.org (a dynamic DNS entry), not ipa1.ls.lsst.org (a single server that's currently down).