### PR TITLE
DM-23878: Add k8s-manke exec:admin on base

### DIFF
--- a/applications/gafaelfawr/values-base.yaml
+++ b/applications/gafaelfawr/values-base.yaml
@@ -35,6 +35,7 @@ config:
     "admin:provision":
       - "sqre"
     "exec:admin":
+      - "k8s-manke"
       - "sqre"
     "exec:internal-tools":
       - "rsp-bts"


### PR DESCRIPTION
exec:admin is used to control Argo Workflows. For now, grant access to everyone with Kubernetes access to the cluster until we have a proper group for this purpose.