### PR TITLE
DM-41950: Don't upload docs on PRs that don't modify docs/ itself.

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -39,6 +39,7 @@ jobs:
               - "docs/**"
               - "applications/*/Chart.yaml"
               - "applications/*/values.yaml"
+              - "applications/argocd/values-*.yaml"
               - "applications/gafaelfawr/values-*.yaml"
               - "environments/values-*.yaml"
               - "src/phalanx/**"

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -14,8 +14,6 @@ name: Docs
       - "renovate/**"
       - "tickets/**"
       - "u/**"
-    tags:
-      - "*"
   workflow_dispatch: {}
 
 jobs:
@@ -43,6 +41,8 @@ jobs:
               - "applications/gafaelfawr/values-*.yaml"
               - "environments/values-*.yaml"
               - "src/phalanx/**"
+            docsSpecific:
+              - "docs/**"
 
       - name: Install graphviz
         if: steps.filter.outputs.docs == 'true'
@@ -55,10 +55,10 @@ jobs:
           python-version: "3.11"
           tox-envs: docs
 
-      # Only attempt documentation uploads for tagged releases and pull
-      # requests from ticket branches in the same repository. This avoids
-      # version clutter in the docs and failures when a PR doesn't have access
-      # to secrets.
+      # Upload docs:
+      # - on pushes to main if *any* documentation content might have changed
+      # - on workflow dispatches if any documentation content might have changed
+      # - on pushes to tickets/ branches if docs/ directory content changed
       - name: Upload to LSST the Docs
         uses: lsst-sqre/ltd-upload@v1
         with:
@@ -67,7 +67,6 @@ jobs:
           username: ${{ secrets.LTD_USERNAME }}
           password: ${{ secrets.LTD_PASSWORD }}
         if: >-
-          steps.filter.outputs.docs == 'true'
-          && github.event_name != 'merge_group'
-          && (github.event_name != 'pull_request'
-              || startsWith(github.head_ref, 'tickets/'))
+          (github.event_name == 'push' && github.head_ref == 'main' && steps.filter.outputs.docs == 'true')
+          || (github.event_name == 'workflow_dispatch' && steps.filter.outputs.docs == 'true')
+          || (github.event_name == 'pull_request' && startsWith(github.head_ref, 'tickets/') && steps.filter.outputs.docSpecific == 'true')


### PR DESCRIPTION
Now on pull requests, only upload the docs if the content in the `docs/` directory itself changes. This saves us CI time for changes that incidentally change the docs; we still CI that the docs will build and the docs themselves will update on the final merge to main.

In re-working the conditional, I've also found that we don't have a good overall strategy for tags; we'd need to generally build the docs for any tag. I've dropped "tags" from the `on` clause. But if we decide to start tagging Phalanx we'd want to revisit that.

This also adds `applications/argocd/values-*.yaml` to the paths considered as sources for docs.