### PR TITLE
DM-41954: Add secrets configuration for linters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,11 @@ clean:
 
 .PHONY: init
 init:
+	pip install --upgrade pip pre-commit tox
+	pre-commit install
 	pip install --editable .
 	pip install --upgrade -r requirements/main.txt -r requirements/dev.txt
 	rm -rf .tox
-	pip install --upgrade pre-commit tox
-	pre-commit install
 
 # This is defined as a Makefile target instead of only a tox command because
 # if the command fails we want to cat output.txt, which contains the

--- a/applications/linters/secrets.yaml
+++ b/applications/linters/secrets.yaml
@@ -1,0 +1,12 @@
+aws:
+  description: >-
+    Shell commands to set the environment variables required for
+    authentication to AWS.
+  onepassword:
+    encoded: true
+slack:
+  description: >-
+    Shell commands to set the environment variable pointing to a Slack
+    incoming webhook for reporting status.
+  onepassword:
+    encoded: true


### PR DESCRIPTION
The linters application was missing a secrets configuration. Add one.