### PR TITLE
DM-38714: General Nublado configuration cleanups

### DIFF
--- a/applications/nublado/README.md
+++ b/applications/nublado/README.md
@@ -23,18 +23,21 @@ JupyterHub and custom spawner for the Rubin Science Platform
 | cloudsql.resources | object | See `values.yaml` | Resource limits and requests for the Cloud SQL Proxy pod |
 | cloudsql.serviceAccount | string | None, must be set if Cloud SQL Auth Proxy is enabled | The Google service account that has an IAM binding to the `gafaelfawr` Kubernetes service account and has the `cloudsql.client` role |
 | cloudsql.tolerations | list | `[]` | Tolerations for the Cloud SQL Proxy pod |
-| controller.affinity | object | `{}` | Affinity rules for the lab controller pod |
-| controller.config.fileserver.application | string | `"fileservers"` | ArgcoCD application in which to collect user file servers |
+| controller.affinity | object | `{}` | Affinity rules for the Nublado controller |
+| controller.config.fileserver.affinity | object | `{}` | Affinity rules for user file server pods |
+| controller.config.fileserver.application | string | `"fileservers"` | Argo CD application in which to collect user file servers |
 | controller.config.fileserver.creationTimeout | int | `120` | Timeout to wait for Kubernetes to create file servers, in seconds |
 | controller.config.fileserver.deleteTimeout | int | 60 (1 minute) | Timeout for deleting a user's file server from Kubernetes, in seconds |
-| controller.config.fileserver.enabled | bool | `false` | Enable fileserver management |
+| controller.config.fileserver.enabled | bool | `false` | Enable user file servers |
 | controller.config.fileserver.idleTimeout | int | `3600` | Timeout for idle user fileservers, in seconds |
 | controller.config.fileserver.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for file server image |
 | controller.config.fileserver.image.repository | string | `"ghcr.io/lsst-sqre/worblehat"` | File server image to use |
 | controller.config.fileserver.image.tag | string | `"0.1.0"` | Tag of file server image to use |
-| controller.config.fileserver.namespace | string | `"fileservers"` | Namespace for user fileservers |
+| controller.config.fileserver.namespace | string | `"fileservers"` | Namespace for user file servers |
+| controller.config.fileserver.nodeSelector | object | `{}` | Node selector rules for user file server pods |
 | controller.config.fileserver.pathPrefix | string | `"/files"` | Path prefix for user file servers |
 | controller.config.fileserver.resources | object | See `values.yaml` | Resource requests and limits for user file servers |
+| controller.config.fileserver.tolerations | list | `[]` | Tolerations for user file server pods |
 | controller.config.images.aliasTags | list | `[]` | Additional tags besides `recommendedTag` that should be recognized as aliases. |
 | controller.config.images.cycle | string | `nil` | Restrict images to this SAL cycle, if given. |
 | controller.config.images.numDailies | int | `3` | Number of most-recent dailies to prepull. |
@@ -43,38 +46,40 @@ JupyterHub and custom spawner for the Rubin Science Platform
 | controller.config.images.pin | list | `[]` | List of additional image tags to prepull. Listing the image tagged as recommended here is recommended when using a Docker image source to ensure its name can be expanded properly in the menu. |
 | controller.config.images.recommendedTag | string | `"recommended"` | Tag marking the recommended image (shown first in the menu) |
 | controller.config.images.source | object | None, must be specified | Source for prepulled images. For Docker, set `type` to `docker`, `registry` to the hostname and `repository` to the name of the repository. For Google Artifact Repository, set `type` to `google`, `location` to the region, `projectId` to the Google project, `repository` to the name of the repository, and `image` to the name of the image. |
-| controller.config.lab.application | string | `"nublado-users"` | ArgoCD application in which to collect user lab objects |
+| controller.config.lab.affinity | object | `{}` | Affinity rules for user lab pods |
+| controller.config.lab.application | string | `"nublado-users"` | Argo CD application in which to collect user lab objects |
 | controller.config.lab.deleteTimeout | int | 60 (1 minute) | Timeout for deleting a user's lab resources from Kubernetes in seconds |
 | controller.config.lab.env | object | See `values.yaml` | Environment variables to set for every user lab |
 | controller.config.lab.extraAnnotations | object | `{}` | Extra annotations to add to user lab pods |
 | controller.config.lab.files | object | See `values.yaml` | Files to be mounted as ConfigMaps inside the user lab pod. `contents` contains the file contents. Set `modify` to true to make the file writable in the pod. |
 | controller.config.lab.initContainers | list | `[]` | Containers run as init containers with each user pod. Each should set `name`, `image` (a Docker image and pull policy specification), and `privileged`, and may contain `volumeMounts` (similar to the main `volumeMountss` configuration). If `privileged` is true, the container will run as root with all capabilities. Otherwise it will run as the user. |
 | controller.config.lab.namespacePrefix | string | `"nublado"` | Prefix for namespaces for user labs. To this will be added a dash (`-`) and the user's username. |
+| controller.config.lab.nodeSelector | object | `{}` | Node selector rules for user lab pods |
 | controller.config.lab.nss.baseGroup | string | See `values.yaml` | Base `/etc/group` file for lab containers |
 | controller.config.lab.nss.basePasswd | string | See `values.yaml` | Base `/etc/passwd` file for lab containers |
 | controller.config.lab.pullSecret | string | Do not use a pull secret | Pull secret to use for labs. Set to the string `pull-secret` to use the normal pull secret from Vault. |
 | controller.config.lab.secrets | list | `[]` | Secrets to set in the user pods. Each should have a `secretKey` key pointing to a secret in the same namespace as the controller (generally `nublado-secret`) and `secretRef` pointing to a field in that key. |
 | controller.config.lab.sizes | list | See `values.yaml` (specifies `small`, `medium`, and | Available lab sizes. Sizes must be chosen from `fine`, `diminutive`, `tiny`, `small`, `medium`, `large`, `huge`, `gargantuan`, and `colossal` in that order. Each should specify the maximum CPU equivalents and memory. SI suffixes for memory are supported. Sizes will be shown in the order defined here, and the first defined size will be the default. `large` with `small` as the default) |
 | controller.config.lab.spawnTimeout | int | `600` | How long to wait for Kubernetes to spawn a lab in seconds. This should generally be shorter than the spawn timeout set in JupyterHub. |
+| controller.config.lab.tolerations | list | `[]` | Tolerations for user lab pods |
 | controller.config.lab.volumeMounts | list | `[]` | Volumes that should be mounted in lab pods. |
 | controller.config.lab.volumes | list | `[]` | Volumes that will be in lab pods or init containers. This supports NFS, HostPath, and PVC volume types (differentiated in source.type). |
 | controller.config.logLevel | string | `"INFO"` | Level of Python logging |
 | controller.config.pathPrefix | string | `"/nublado"` | Path prefix that will be routed to the controller |
 | controller.googleServiceAccount | string | None, must be set when using Google Artifact Registry | If Google Artifact Registry is used as the image source, the Google service account that has an IAM binding to the `nublado-controller` Kubernetes service account and has the Artifact Registry reader role |
-| controller.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the nublado image |
-| controller.image.repository | string | `"ghcr.io/lsst-sqre/nublado-controller"` | nublado image to use |
-| controller.image.tag | string | The appVersion of the chart | Tag of nublado image to use |
-| controller.ingress.annotations | object | `{}` | Additional annotations to add for the lab controller pod ingress |
-| controller.nodeSelector | object | `{}` | Node selector rules for the lab controller pod |
-| controller.podAnnotations | object | `{}` | Annotations for the lab controller pod |
-| controller.resources | object | `{}` | Resource limits and requests for the lab controller pod |
+| controller.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the controller image |
+| controller.image.repository | string | `"ghcr.io/lsst-sqre/nublado-controller"` | Nublado controller image to use |
+| controller.image.tag | string | The appVersion of the chart | Tag of Nublado controller image to use |
+| controller.ingress.annotations | object | `{}` | Additional annotations to add for the Nublado controller ingress |
+| controller.nodeSelector | object | `{}` | Node selector rules for the Nublado controller |
+| controller.podAnnotations | object | `{}` | Annotations for the Nublado controller |
+| controller.resources | object | See `values.yaml` | Resource limits and requests for the Nublado controller |
 | controller.slackAlerts | bool | `false` | Whether to enable Slack alerts. If set to true, `slack_webhook` must be set in the corresponding Nublado Vault secret. |
-| controller.tolerations | list | `[]` | Tolerations for the lab controller pod |
+| controller.tolerations | list | `[]` | Tolerations for the Nublado controller |
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | hub.internalDatabase | bool | `true` | Whether to use the cluster-internal PostgreSQL server instead of an external server. This is not used directly by the Nublado chart, but controls how the database password is managed. |
-| hub.timeout.spawn | int | `600` | Timeout for the Kubernetes spawn process in seconds. (Allow long enough to pull uncached images if needed.) |
 | hub.timeout.startup | int | `90` | Timeout for JupyterLab to start. Currently this sometimes takes over 60 seconds for reasons we don't understand. |
 | jupyterhub.cull.enabled | bool | `true` | Enable the lab culler. |
 | jupyterhub.cull.every | int | 600 (10 minutes) | How frequently to check for idle labs in seconds |
@@ -104,8 +109,5 @@ JupyterHub and custom spawner for the Rubin Science Platform
 | jupyterhub.proxy.service.type | string | `"ClusterIP"` | Only expose the proxy to the cluster, overriding the default of exposing the proxy directly to the Internet |
 | jupyterhub.scheduling.userPlaceholder.enabled | bool | `false` | Whether to spawn placeholder pods representing fake users to force autoscaling in advance of running out of resources |
 | jupyterhub.scheduling.userScheduler.enabled | bool | `false` | Whether the user scheduler should be enabled |
-| jupyterhub.singleuser.cloudMetadata.blockWithIptables | bool | `false` | Whether to configure iptables to block cloud metadata endpoints. This is unnecessary in our environments (they are blocked by cluster configuration) and thus is disabled to reduce complexity. |
-| jupyterhub.singleuser.cmd | string | `"/opt/lsst/software/jupyterlab/runlab.sh"` | Start command for labs |
-| jupyterhub.singleuser.defaultUrl | string | `"/lab"` | Default URL prefix for lab endpoints |
 | proxy.ingress.annotations | object | Increase `proxy-read-timeout` and `proxy-send-timeout` to 5m | Additional annotations to add to the proxy ingress (also used to talk to JupyterHub and all user labs) |
 | secrets.templateSecrets | bool | `false` | Whether to use the new secrets management mechanism. If enabled, the Vault nublado secret will be split into a nublado secret for JupyterHub and a nublado-lab-secret secret used as a source for secret values for the user's lab. |

--- a/applications/nublado/README.md
+++ b/applications/nublado/README.md
@@ -12,17 +12,17 @@ JupyterHub and custom spawner for the Rubin Science Platform
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| cloudsql.affinity | object | `{}` | Affinity rules for the Cloud SQL Proxy pod |
-| cloudsql.enabled | bool | `false` | Enable the Cloud SQL Auth Proxy, used with CloudSQL databases on Google Cloud. |
+| cloudsql.affinity | object | `{}` | Affinity rules for the Cloud SQL Auth Proxy pod |
+| cloudsql.enabled | bool | `false` | Enable the Cloud SQL Auth Proxy, used with Cloud SQL databases on Google Cloud |
 | cloudsql.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for Cloud SQL Auth Proxy images |
 | cloudsql.image.repository | string | `"gcr.io/cloudsql-docker/gce-proxy"` | Cloud SQL Auth Proxy image to use |
-| cloudsql.image.tag | string | `"1.33.15"` | Cloud SQL Auth Proxy tag to use |
-| cloudsql.instanceConnectionName | string | None, must be set if Cloud SQL Auth Proxy is enabled | Instance connection name for a CloudSQL PostgreSQL instance |
-| cloudsql.nodeSelector | object | `{}` | Node selection rules for the Cloud SQL Proxy pod |
-| cloudsql.podAnnotations | object | `{}` | Annotations for the Cloud SQL Proxy pod |
+| cloudsql.image.tag | string | `"1.33.14"` | Cloud SQL Auth Proxy tag to use |
+| cloudsql.instanceConnectionName | string | None, must be set if Cloud SQL Auth Proxy is enabled | Instance connection name for a Cloud SQL PostgreSQL instance |
+| cloudsql.nodeSelector | object | `{}` | Node selection rules for the Cloud SQL Auth Proxy pod |
+| cloudsql.podAnnotations | object | `{}` | Annotations for the Cloud SQL Auth Proxy pod |
 | cloudsql.resources | object | See `values.yaml` | Resource limits and requests for the Cloud SQL Proxy pod |
-| cloudsql.serviceAccount | string | None, must be set if Cloud SQL Auth Proxy is enabled | The Google service account that has an IAM binding to the `gafaelfawr` Kubernetes service account and has the `cloudsql.client` role |
-| cloudsql.tolerations | list | `[]` | Tolerations for the Cloud SQL Proxy pod |
+| cloudsql.serviceAccount | string | None, must be set if Cloud SQL Auth Proxy is enabled | The Google service account that has an IAM binding to the `cloud-sql-proxy` Kubernetes service account and has the `cloudsql.client` role |
+| cloudsql.tolerations | list | `[]` | Tolerations for the Cloud SQL Auth Proxy pod |
 | controller.affinity | object | `{}` | Affinity rules for the Nublado controller |
 | controller.config.fileserver.affinity | object | `{}` | Affinity rules for user file server pods |
 | controller.config.fileserver.application | string | `"fileservers"` | Argo CD application in which to collect user file servers |

--- a/applications/nublado/templates/hub-configmap.yaml
+++ b/applications/nublado/templates/hub-configmap.yaml
@@ -6,15 +6,10 @@ metadata:
     {{- include "nublado.labels" . | nindent 4 }}
 data:
   00_nublado.py: |
-    # It's not clear whether explicitly importing the spawner and
-    # authenticator modules is required or if JupyterHub will do this for us
-    # anyway, but it can't hurt.
-    import rubin.nublado.authenticator
-    import rubin.nublado.spawner
-
-    # Use our authenticator and spawner.
-    c.JupyterHub.authenticator_class = "rubin.nublado.authenticator.GafaelfawrAuthenticator"
-    c.JupyterHub.spawner_class = "rubin.nublado.spawner.RSPRestSpawner"
+    # Use our authenticator and spawner. Both register custom entry points,
+    # so the full module and class name is not required.
+    c.JupyterHub.authenticator_class = "gafaelfawr"
+    c.JupyterHub.spawner_class = "nublado"
 
     # Set internal Hub API URL.
     c.JupyterHub.hub_connect_url = (
@@ -43,4 +38,4 @@ data:
     c.Spawner.http_timeout = {{ .Values.hub.timeout.startup }}
 
     # Configure the URL to the lab controller.
-    c.RSPRestSpawner.controller_url = "{{ .Values.global.baseUrl }}{{ .Values.controller.config.pathPrefix }}"
+    c.NubladoSpawner.controller_url = "{{ .Values.global.baseUrl }}{{ .Values.controller.config.pathPrefix }}"

--- a/applications/nublado/templates/hub-configmap.yaml
+++ b/applications/nublado/templates/hub-configmap.yaml
@@ -6,6 +6,9 @@ metadata:
     {{- include "nublado.labels" . | nindent 4 }}
 data:
   00_nublado.py: |
+    # It's not clear whether explicitly importing the spawner and
+    # authenticator modules is required or if JupyterHub will do this for us
+    # anyway, but it can't hurt.
     import rubin.nublado.authenticator
     import rubin.nublado.spawner
 
@@ -31,12 +34,12 @@ data:
     # Use JupyterLab by default.
     c.Spawner.default_url = "/lab"
 
-    # Allow ten minutes for the lab to spawn in case it needs to be pulled.
-    c.Spawner.start_timeout = {{ .Values.hub.timeout.spawn }}
+    # How long to wait for Kubernetes to start the lab. This must match the
+    # corresponding setting in the Nublado controller.
+    c.Spawner.start_timeout = {{ .Values.controller.config.lab.spawnTimeout }}
 
-    # Allow 90 seconds for JupyterLab to start. For reasons we do not yet
-    # understand, it is often glacially slow and sometimes takes over 60
-    # seconds.
+    # How long to wait for the JupyterLab process to respond to network
+    # connections after the pod has started running.
     c.Spawner.http_timeout = {{ .Values.hub.timeout.startup }}
 
     # Configure the URL to the lab controller.

--- a/applications/nublado/values.yaml
+++ b/applications/nublado/values.yaml
@@ -2,33 +2,40 @@
 
 controller:
   image:
-    # -- nublado image to use
-    repository: ghcr.io/lsst-sqre/nublado-controller
+    # -- Nublado controller image to use
+    repository: "ghcr.io/lsst-sqre/nublado-controller"
 
-    # -- Pull policy for the nublado image
-    pullPolicy: IfNotPresent
+    # -- Pull policy for the controller image
+    pullPolicy: "IfNotPresent"
 
-    # -- Tag of nublado image to use
+    # -- Tag of Nublado controller image to use
     # @default -- The appVersion of the chart
     tag: ""
 
-  # -- Affinity rules for the lab controller pod
+  # -- Affinity rules for the Nublado controller
   affinity: {}
 
-  # -- Node selector rules for the lab controller pod
+  # -- Node selector rules for the Nublado controller
   nodeSelector: {}
 
-  # -- Annotations for the lab controller pod
+  # -- Annotations for the Nublado controller
   podAnnotations: {}
 
-  # -- Resource limits and requests for the lab controller pod
-  resources: {}
+  # -- Resource limits and requests for the Nublado controller
+  # @default -- See `values.yaml`
+  resources:
+    limits:
+      cpu: "0.25"
+      memory: "200Mi"
+    requests:
+      cpu: "0.05"
+      memory: "120Mi"
 
-  # -- Tolerations for the lab controller pod
+  # -- Tolerations for the Nublado controller
   tolerations: []
 
   ingress:
-    # -- Additional annotations to add for the lab controller pod ingress
+    # -- Additional annotations to add for the Nublado controller ingress
     annotations: {}
 
   # -- If Google Artifact Registry is used as the image source, the Google
@@ -50,10 +57,13 @@ controller:
     pathPrefix: "/nublado"
 
     fileserver:
-      # -- Enable fileserver management
+      # -- Enable user file servers
       enabled: false
 
-      # -- ArgcoCD application in which to collect user file servers
+      # -- Affinity rules for user file server pods
+      affinity: {}
+
+      # -- Argo CD application in which to collect user file servers
       application: "fileservers"
 
       # -- Timeout to wait for Kubernetes to create file servers, in seconds
@@ -69,16 +79,19 @@ controller:
 
       image:
         # -- File server image to use
-        repository: ghcr.io/lsst-sqre/worblehat
+        repository: "ghcr.io/lsst-sqre/worblehat"
 
         # -- Pull policy for file server image
-        pullPolicy: IfNotPresent
+        pullPolicy: "IfNotPresent"
 
         # -- Tag of file server image to use
-        tag: 0.1.0
+        tag: "0.1.0"
 
-      # -- Namespace for user fileservers
-      namespace: fileservers
+      # -- Namespace for user file servers
+      namespace: "fileservers"
+
+      # -- Node selector rules for user file server pods
+      nodeSelector: {}
 
       # -- Path prefix for user file servers
       pathPrefix: "/files"
@@ -88,10 +101,13 @@ controller:
       resources:
         requests:
           cpu: 0.1
-          memory: 1Gi
+          memory: "1Gi"
         limits:
           cpu: 1
-          memory: 10Gi
+          memory: "10Gi"
+
+      # -- Tolerations for user file server pods
+      tolerations: []
 
     images:
       # -- Source for prepulled images. For Docker, set `type` to `docker`,
@@ -128,7 +144,10 @@ controller:
       aliasTags: []
 
     lab:
-      # -- ArgoCD application in which to collect user lab objects
+      # -- Affinity rules for user lab pods
+      affinity: {}
+
+      # -- Argo CD application in which to collect user lab objects
       application: "nublado-users"
 
       # -- Timeout for deleting a user's lab resources from Kubernetes in
@@ -193,6 +212,9 @@ controller:
       # -- Prefix for namespaces for user labs. To this will be added a dash
       # (`-`) and the user's username.
       namespacePrefix: "nublado"
+
+      # -- Node selector rules for user lab pods
+      nodeSelector: {}
 
       nss:
         # -- Base `/etc/passwd` file for lab containers
@@ -274,19 +296,22 @@ controller:
       # @default -- See `values.yaml` (specifies `small`, `medium`, and
       # `large` with `small` as the default)
       sizes:
-        - size: small
+        - size: "small"
           cpu: 1.0
-          memory: 4Gi
-        - size: medium
+          memory: "4Gi"
+        - size: "medium"
           cpu: 2.0
-          memory: 8Gi
-        - size: large
+          memory: "8Gi"
+        - size: "large"
           cpu: 4.0
-          memory: 16Gi
+          memory: "16Gi"
 
       # -- How long to wait for Kubernetes to spawn a lab in seconds. This
       # should generally be shorter than the spawn timeout set in JupyterHub.
       spawnTimeout: 600
+
+      # -- Tolerations for user lab pods
+      tolerations: []
 
       # -- Volumes that will be in lab pods or init containers. This supports
       # NFS, HostPath, and PVC volume types (differentiated in source.type).
@@ -315,10 +340,6 @@ hub:
   internalDatabase: true
 
   timeout:
-    # -- Timeout for the Kubernetes spawn process in seconds. (Allow long
-    # enough to pull uncached images if needed.)
-    spawn: 600
-
     # -- Timeout for JupyterLab to start. Currently this sometimes takes over
     # 60 seconds for reasons we don't understand.
     startup: 90
@@ -358,8 +379,8 @@ jupyterhub:
     # -- Resource limits and requests
     resources:
       limits:
-        cpu: 900m
-        memory: 1Gi  # Should support about 200 users
+        cpu: "900m"
+        memory: "1Gi"  # Should support about 200 users
 
     db:
       # -- Type of database to use
@@ -434,30 +455,17 @@ jupyterhub:
       # controller does its own prepulling)
       enabled: false
 
-  singleuser:
-    cloudMetadata:
-      # -- Whether to configure iptables to block cloud metadata endpoints.
-      # This is unnecessary in our environments (they are blocked by cluster
-      # configuration) and thus is disabled to reduce complexity.
-      blockWithIptables: false
-
-    # -- Start command for labs
-    cmd: "/opt/lsst/software/jupyterlab/runlab.sh"
-
-    # -- Default URL prefix for lab endpoints
-    defaultUrl: "/lab"
-
   proxy:
     service:
       # -- Only expose the proxy to the cluster, overriding the default of
       # exposing the proxy directly to the Internet
-      type: ClusterIP
+      type: "ClusterIP"
 
     chp:
       networkPolicy:
         # -- Enable access to the proxy from other namespaces, since we put
         # each user's lab environment in its own namespace
-        interNamespaceAccessLabels: accept
+        interNamespaceAccessLabels: "accept"
 
         # This currently causes Minikube deployment in GH-actions to fail.
         # We want it sometime but it's not critical; it will help with

--- a/applications/nublado/values.yaml
+++ b/applications/nublado/values.yaml
@@ -1,6 +1,15 @@
 # Default values for Nublado.
 
 controller:
+  # -- Affinity rules for the Nublado controller
+  affinity: {}
+
+  # -- If Google Artifact Registry is used as the image source, the Google
+  # service account that has an IAM binding to the `nublado-controller`
+  # Kubernetes service account and has the Artifact Registry reader role
+  # @default -- None, must be set when using Google Artifact Registry
+  googleServiceAccount: ""
+
   image:
     # -- Nublado controller image to use
     repository: "ghcr.io/lsst-sqre/nublado-controller"
@@ -12,8 +21,9 @@ controller:
     # @default -- The appVersion of the chart
     tag: ""
 
-  # -- Affinity rules for the Nublado controller
-  affinity: {}
+  ingress:
+    # -- Additional annotations to add for the Nublado controller ingress
+    annotations: {}
 
   # -- Node selector rules for the Nublado controller
   nodeSelector: {}
@@ -31,22 +41,12 @@ controller:
       cpu: "0.05"
       memory: "120Mi"
 
-  # -- Tolerations for the Nublado controller
-  tolerations: []
-
-  ingress:
-    # -- Additional annotations to add for the Nublado controller ingress
-    annotations: {}
-
-  # -- If Google Artifact Registry is used as the image source, the Google
-  # service account that has an IAM binding to the `nublado-controller`
-  # Kubernetes service account and has the Artifact Registry reader role
-  # @default -- None, must be set when using Google Artifact Registry
-  googleServiceAccount: ""
-
   # -- Whether to enable Slack alerts. If set to true, `slack_webhook` must be
   # set in the corresponding Nublado Vault secret.
   slackAlerts: false
+
+  # -- Tolerations for the Nublado controller
+  tolerations: []
 
   # Passed as YAML to the lab controller.
   config:
@@ -516,28 +516,26 @@ jupyterhub:
       enabled: false
 
 cloudsql:
-  # -- Enable the Cloud SQL Auth Proxy, used with CloudSQL databases on Google
-  # Cloud.
+  # -- Enable the Cloud SQL Auth Proxy, used with Cloud SQL databases on
+  # Google Cloud
   enabled: false
+
+  # -- Affinity rules for the Cloud SQL Auth Proxy pod
+  affinity: {}
 
   image:
     # -- Cloud SQL Auth Proxy image to use
     repository: "gcr.io/cloudsql-docker/gce-proxy"
 
-    # -- Cloud SQL Auth Proxy tag to use
-    tag: "1.33.15"
-
     # -- Pull policy for Cloud SQL Auth Proxy images
     pullPolicy: "IfNotPresent"
 
-  # -- Instance connection name for a CloudSQL PostgreSQL instance
+    # -- Cloud SQL Auth Proxy tag to use
+    tag: "1.33.14"
+
+  # -- Instance connection name for a Cloud SQL PostgreSQL instance
   # @default -- None, must be set if Cloud SQL Auth Proxy is enabled
   instanceConnectionName: ""
-
-  # -- The Google service account that has an IAM binding to the `gafaelfawr`
-  # Kubernetes service account and has the `cloudsql.client` role
-  # @default -- None, must be set if Cloud SQL Auth Proxy is enabled
-  serviceAccount: ""
 
   # -- Resource limits and requests for the Cloud SQL Proxy pod
   # @default -- See `values.yaml`
@@ -549,17 +547,20 @@ cloudsql:
       cpu: "5m"
       memory: "7Mi"
 
-  # -- Annotations for the Cloud SQL Proxy pod
+  # -- Annotations for the Cloud SQL Auth Proxy pod
   podAnnotations: {}
 
-  # -- Node selection rules for the Cloud SQL Proxy pod
+  # -- Node selection rules for the Cloud SQL Auth Proxy pod
   nodeSelector: {}
 
-  # -- Tolerations for the Cloud SQL Proxy pod
-  tolerations: []
+  # -- The Google service account that has an IAM binding to the
+  # `cloud-sql-proxy` Kubernetes service account and has the `cloudsql.client`
+  # role
+  # @default -- None, must be set if Cloud SQL Auth Proxy is enabled
+  serviceAccount: ""
 
-  # -- Affinity rules for the Cloud SQL Proxy pod
-  affinity: {}
+  # -- Tolerations for the Cloud SQL Auth Proxy pod
+  tolerations: []
 
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.

--- a/docs/applications/onepassword-connect/add-new-environment.rst
+++ b/docs/applications/onepassword-connect/add-new-environment.rst
@@ -28,7 +28,7 @@ When following these instructions, you will be modifying a `Secrets Automation w
 You will need to have permissions to modify the workflow for the 1Password Connet server that will be serving your environment.
 
 Process
-=======
+========
 
 In the following steps, you'll change the permissions of the 1Password Connect server to add the new 1Password vault for your environment and create a new token with access to that vault.
 


### PR DESCRIPTION
Clean up various bits of configuration found while working on the Nublado manual.
    
- Use the Nublado controller lab spawn timeout as the JupyterHub lab spawn timeout as well, rather than having two separate configuration settings.
- Remove possibly-outdated information from the JupyterHub ConfigMap.
- Add default resource limits for the Nublado controller.
- Add affinity, nodeSelector, and tolerations settings for user labs and user file servers to values.yaml.
- Delete the hopefully-now-obsolete singleuser Zero to JupyterHub settings.
- Quote all strings in the Nublado values.yaml.
- Use entry points for JupyterHub plugins.
- Sort and improve descriptions of Nublado Helm values.
