### PR TITLE
DM-41979: Require explicit volume mounts for Nublado file servers

### DIFF
--- a/applications/nublado/README.md
+++ b/applications/nublado/README.md
@@ -38,6 +38,7 @@ JupyterHub and custom spawner for the Rubin Science Platform
 | controller.config.fileserver.pathPrefix | string | `"/files"` | Path prefix for user file servers |
 | controller.config.fileserver.resources | object | See `values.yaml` | Resource requests and limits for user file servers |
 | controller.config.fileserver.tolerations | list | `[]` | Tolerations for user file server pods |
+| controller.config.fileserver.volumeMounts | list | `[]` | Volumes that should be made available via WebDAV |
 | controller.config.images.aliasTags | list | `[]` | Additional tags besides `recommendedTag` that should be recognized as aliases. |
 | controller.config.images.cycle | string | `nil` | Restrict images to this SAL cycle, if given. |
 | controller.config.images.numDailies | int | `3` | Number of most-recent dailies to prepull. |

--- a/applications/nublado/values-base.yaml
+++ b/applications/nublado/values-base.yaml
@@ -21,10 +21,10 @@ controller:
         PGPASSFILE: "/opt/lsst/software/jupyterlab/secrets/postgres-credentials.txt"
         PGUSER: "oods"
       initContainers:
-        - name: "initdir"
+        - name: "inithome"
           image:
-            repository: "ghcr.io/lsst-sqre/initdir"
-            tag: "0.0.4"
+            repository: "ghcr.io/lsst-sqre/nublado-inithome"
+            tag: "4.0.0"
           privileged: true
           volumeMounts:
             - containerPath: "/home"

--- a/applications/nublado/values-idfdev.yaml
+++ b/applications/nublado/values-idfdev.yaml
@@ -5,7 +5,9 @@ controller:
     logLevel: "DEBUG"
     fileserver:
       enabled: true
-      idleTimeout: 43200  # 12 hours
+      volumeMounts:
+        - containerPath: "/home"
+          volumeName: "home"
     images:
       source:
         type: "google"

--- a/applications/nublado/values-idfdev.yaml
+++ b/applications/nublado/values-idfdev.yaml
@@ -24,10 +24,10 @@ controller:
         GOOGLE_APPLICATION_CREDENTIALS: "/opt/lsst/software/jupyterlab/secrets/butler-gcs-idf-creds.json"
         S3_ENDPOINT_URL: "https://storage.googleapis.com"
       initContainers:
-        - name: "initdir"
+        - name: "inithome"
           image:
-            repository: "ghcr.io/lsst-sqre/initdir"
-            tag: "0.0.4"
+            repository: "ghcr.io/lsst-sqre/nublado-inithome"
+            tag: "4.0.0"
           privileged: true
           volumeMounts:
             - containerPath: "/home"

--- a/applications/nublado/values-idfint.yaml
+++ b/applications/nublado/values-idfint.yaml
@@ -46,10 +46,10 @@ controller:
           cpu: 8.0
           memory: 32Gi
       initContainers:
-        - name: "initdir"
+        - name: "inithome"
           image:
-            repository: "ghcr.io/lsst-sqre/initdir"
-            tag: "0.0.4"
+            repository: "ghcr.io/lsst-sqre/nublado-inithome"
+            tag: "4.0.0"
           privileged: true
           volumeMounts:
             - containerPath: "/home"

--- a/applications/nublado/values-idfint.yaml
+++ b/applications/nublado/values-idfint.yaml
@@ -4,6 +4,9 @@ controller:
   config:
     fileserver:
       enabled: true
+      volumeMounts:
+        - containerPath: "/home"
+          volumeName: "home"
     images:
       source:
         type: "google"

--- a/applications/nublado/values-idfprod.yaml
+++ b/applications/nublado/values-idfprod.yaml
@@ -31,10 +31,10 @@ controller:
           cpu: 4.0
           memory: 16Gi
       initContainers:
-        - name: "initdir"
+        - name: "inithome"
           image:
-            repository: "ghcr.io/lsst-sqre/initdir"
-            tag: "0.0.4"
+            repository: "ghcr.io/lsst-sqre/nublado-inithome"
+            tag: "4.0.0"
           privileged: true
           volumeMounts:
             - containerPath: "/home"

--- a/applications/nublado/values-summit.yaml
+++ b/applications/nublado/values-summit.yaml
@@ -21,10 +21,10 @@ controller:
         PGPASSFILE: "/opt/lsst/software/jupyterlab/secrets/postgres-credentials.txt"
         PGUSER: "oods"
       initContainers:
-        - name: "initdir"
+        - name: "inithome"
           image:
-            repository: "ghcr.io/lsst-sqre/initdir"
-            tag: "0.0.4"
+            repository: "ghcr.io/lsst-sqre/nublado-inithome"
+            tag: "4.0.0"
           privileged: true
           volumeMounts:
             - containerPath: "/home"

--- a/applications/nublado/values-tucson-teststand.yaml
+++ b/applications/nublado/values-tucson-teststand.yaml
@@ -21,10 +21,10 @@ controller:
         PGPASSFILE: "/opt/lsst/software/jupyterlab/secrets/postgres-credentials.txt"
         PGUSER: "oods"
       initContainers:
-        - name: "initdir"
+        - name: "inithome"
           image:
-            repository: "ghcr.io/lsst-sqre/initdir"
-            tag: "0.0.4"
+            repository: "ghcr.io/lsst-sqre/nublado-inithome"
+            tag: "4.0.0"
           privileged: true
           volumeMounts:
             - containerPath: "/home"

--- a/applications/nublado/values.yaml
+++ b/applications/nublado/values.yaml
@@ -109,6 +109,13 @@ controller:
       # -- Tolerations for user file server pods
       tolerations: []
 
+      # -- Volumes that should be made available via WebDAV
+      volumeMounts: []
+      # volumeMounts:
+      # - containerPath: "/project"
+      #   readOnly: true
+      #   volumeName: "project"
+
     images:
       # -- Source for prepulled images. For Docker, set `type` to `docker`,
       # `registry` to the hostname and `repository` to the name of the


### PR DESCRIPTION
The Nublado file servers should not expose every volume mounted in lab containers. Instead, expose only explicitly configured mounts, similiar to init containers, and expose only the home directory mount on idfdev and idfint.
