### PR TITLE
Disable InfluxDB v2 at the summit

### DIFF
--- a/applications/sasquatch/values-summit.yaml
+++ b/applications/sasquatch/values-summit.yaml
@@ -33,7 +33,7 @@ influxdb:
     hostname: summit-lsp.lsst.codes
 
 influxdb2:
-  enabled: true
+  enabled: false
   persistence:
     storageClass: rook-ceph-block
     size: 5Ti


### PR DESCRIPTION
- Disable InfluxDB v2 in favor of InfluxDB Enterprise