### PR TITLE
tickets/PREOPS-4636 and tickets/PREOPS-4639: adjust schedview-snapshot readiness probe to avoid spurious failed checks

### DIFF
--- a/applications/schedview-snapshot/templates/deployment.yaml
+++ b/applications/schedview-snapshot/templates/deployment.yaml
@@ -42,6 +42,9 @@ spec:
             httpGet:
               path: "/schedview-snapshot/dashboard"
               port: "http"
+            initialDelaySeconds: 60
+            periodSeconds: 60
+            timeoutSeconds: 15
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/applications/schedview-snapshot/templates/deployment.yaml
+++ b/applications/schedview-snapshot/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
               protocol: "TCP"
           readinessProbe:
             httpGet:
-              path: "/schedview-snapshot"
+              path: "/schedview-snapshot/dashboard"
               port: "http"
           resources:
             {{- toYaml .Values.resources | nindent 12 }}


### PR DESCRIPTION
tickets/PREOPS-4639 is a branch of tickets/PREOPS-4636, not main, because I needed a branch that included both changes for testing before requesting a merge. It might've been better to have made one "bug" ticket describing the problem rather that two, each for a different piece that might be needed (or at least useful) for fixing it. In any case, the distinct changes are kept as discrete commits, so I'm hoping combining them into one pull request is okay.

I could, instead, make a merge request for tickets/PREOPS-4636, wait for that to get approved and pulled, then rebase tickets/PREOPS-4639 and make a separate pull request for that.