### PR TITLE
Fix default value for replication.policy.separator

### DIFF
--- a/applications/sasquatch/charts/strimzi-kafka/templates/mirrormaker2.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/mirrormaker2.yaml
@@ -57,7 +57,7 @@ spec:
         # Policy to define the remote topic naming convention.
         # The default is to preserve topic names in the target cluster.
         # To add the source cluster alias as a prefix to the topic name, use replication.policy.separator="." and replication.policy.class="org.apache.kafka.connect.mirror.DefaultReplicationPolicy"
-        replication.policy.separator: {{ default "" .Values.mirrormaker2.replication.policy.separator }}
+        replication.policy.separator: {{ default "." .Values.mirrormaker2.replication.policy.separator }}
         replication.policy.class: {{ default "org.apache.kafka.connect.mirror.IdentityReplicationPolicy" .Values.mirrormaker2.replication.policy.class }}
         # Handling high volumes of messages
         # By increasing the batch size, produce requests are delayed and more messages are


### PR DESCRIPTION
- This fixes the warning "replication.policy.separator: A null value is not allowed for this key" that's spamming the Strimzi operator logs