### PR TITLE
DM-40839: Remove obsolete environment variables from prompt-proto-service

### DIFF
--- a/applications/prompt-proto-service-hsc/README.md
+++ b/applications/prompt-proto-service-hsc/README.md
@@ -18,7 +18,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
 | prompt-proto-service.image.repository | string | `"ghcr.io/lsst-dm/prompt-service"` | Image to use in the PP deployment |
 | prompt-proto-service.image.tag | string | `"latest"` | Overrides the image tag whose default is the chart appVersion. |
-| prompt-proto-service.imageNotifications.imageTimeout | string | `"120"` | Timeout to wait after expected script completion for raw image arrival (seconds). |
+| prompt-proto-service.imageNotifications.imageTimeout | string | `"20"` | Timeout to wait after expected script completion for raw image arrival (seconds). |
 | prompt-proto-service.imageNotifications.kafkaClusterAddress | string | None, must be set | Hostname and port of the Kafka provider |
 | prompt-proto-service.imageNotifications.topic | string | None, must be set | Topic where raw image arrival notifications appear |
 | prompt-proto-service.instrument.calibRepo | string | None, must be set | URI to the shared repo used for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself. |

--- a/applications/prompt-proto-service-hsc/README.md
+++ b/applications/prompt-proto-service-hsc/README.md
@@ -13,11 +13,8 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | prompt-proto-service.additionalVolumeMounts | list | `[]` | Kubernetes YAML configs for extra container volume(s). Any volumes required by other config options are automatically handled by the Helm chart. |
-| prompt-proto-service.apdb.db | string | `"lsst-devl"` | PostgreSQL database name for the APDB (deprecated for apdb.url) |
-| prompt-proto-service.apdb.ip | string | None, must be set | IP address or hostname and port of the APDB (deprecated for apdb.url) |
 | prompt-proto-service.apdb.namespace | string | `"pp_apdb"` | Database namespace for the APDB |
 | prompt-proto-service.apdb.url | string | None, must be set | URL to the APDB, in any form recognized by SQLAlchemy |
-| prompt-proto-service.apdb.user | string | `"rubin"` | Database user for the APDB (deprecated for apdb.url) |
 | prompt-proto-service.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
 | prompt-proto-service.image.repository | string | `"ghcr.io/lsst-dm/prompt-service"` | Image to use in the PP deployment |
 | prompt-proto-service.image.tag | string | `"latest"` | Overrides the image tag whose default is the chart appVersion. |
@@ -36,9 +33,6 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.logLevel | string | log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
 | prompt-proto-service.podAnnotations | object | See the `values.yaml` file. | Annotations for the prompt-proto-service pod |
 | prompt-proto-service.registry.centralRepoFile | bool | `false` | If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted. |
-| prompt-proto-service.registry.db | string | None, must be set | PostgreSQL database name for the Butler registry database (deprecated) |
-| prompt-proto-service.registry.ip | string | None, must be set | IP address or hostname and port of the Butler registry database (deprecated) |
-| prompt-proto-service.registry.user | string | None, must be set | Database user for the Butler registry database (deprecated) |
 | prompt-proto-service.s3.auth_env | bool | `true` | If set, get S3 credentials from this application's Vault secret. |
 | prompt-proto-service.s3.disableBucketValidation | string | `"0"` | Set this to disable validation of S3 bucket names, allowing Ceph multi-tenant colon-separated names to be used. |
 | prompt-proto-service.s3.endpointUrl | string | None, must be set | S3 endpoint containing `imageBucket` |

--- a/applications/prompt-proto-service-hsc/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-hsc/values-usdfdev-prompt-processing.yaml
@@ -25,11 +25,5 @@ prompt-proto-service:
 
   apdb:
     url: postgresql://rubin@usdf-prompt-processing-dev.slac.stanford.edu:5432/lsst-devl
-    ip: usdf-prompt-processing-dev.slac.stanford.edu:5432  # TODO: remove on DM-40839
-
-  registry:  # TODO: remove on DM-40839
-    ip: usdf-prompt-processing-dev.slac.stanford.edu:5432
-    db: ppcentralbutler
-    user: pp
 
   fullnameOverride: "prompt-proto-service-hsc"

--- a/applications/prompt-proto-service-hsc/values.yaml
+++ b/applications/prompt-proto-service-hsc/values.yaml
@@ -59,26 +59,10 @@ prompt-proto-service:
     # -- URL to the APDB, in any form recognized by SQLAlchemy
     # @default -- None, must be set
     url: ""
-    # -- IP address or hostname and port of the APDB (deprecated for apdb.url)
-    # @default -- None, must be set
-    ip: ""  # TODO: remove on DM-40839
-    # -- PostgreSQL database name for the APDB (deprecated for apdb.url)
-    db: lsst-devl  # TODO: remove on DM-40839
-    # -- Database user for the APDB (deprecated for apdb.url)
-    user: rubin  # TODO: remove on DM-40839
     # -- Database namespace for the APDB
     namespace: pp_apdb
 
   registry:
-    # -- IP address or hostname and port of the Butler registry database (deprecated)
-    # @default -- None, must be set
-    ip: ""  # TODO: remove on DM-40839
-    # -- PostgreSQL database name for the Butler registry database (deprecated)
-    # @default -- None, must be set
-    db: ""  # TODO: remove on DM-40839
-    # -- Database user for the Butler registry database (deprecated)
-    # @default -- None, must be set
-    user: ""  # TODO: remove on DM-40839
     # -- If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted.
     centralRepoFile: false
 

--- a/applications/prompt-proto-service-hsc/values.yaml
+++ b/applications/prompt-proto-service-hsc/values.yaml
@@ -53,7 +53,7 @@ prompt-proto-service:
     # @default -- None, must be set
     topic: ""
     # -- Timeout to wait after expected script completion for raw image arrival (seconds).
-    imageTimeout: '120'
+    imageTimeout: '20'
 
   apdb:
     # -- URL to the APDB, in any form recognized by SQLAlchemy

--- a/applications/prompt-proto-service-latiss/README.md
+++ b/applications/prompt-proto-service-latiss/README.md
@@ -18,7 +18,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
 | prompt-proto-service.image.repository | string | `"ghcr.io/lsst-dm/prompt-service"` | Image to use in the PP deployment |
 | prompt-proto-service.image.tag | string | `"latest"` | Overrides the image tag whose default is the chart appVersion. |
-| prompt-proto-service.imageNotifications.imageTimeout | string | `"120"` | Timeout to wait after expected script completion for raw image arrival (seconds). |
+| prompt-proto-service.imageNotifications.imageTimeout | string | `"20"` | Timeout to wait after expected script completion for raw image arrival (seconds). |
 | prompt-proto-service.imageNotifications.kafkaClusterAddress | string | None, must be set | Hostname and port of the Kafka provider |
 | prompt-proto-service.imageNotifications.topic | string | None, must be set | Topic where raw image arrival notifications appear |
 | prompt-proto-service.instrument.calibRepo | string | None, must be set | URI to the shared repo used for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself. |

--- a/applications/prompt-proto-service-latiss/README.md
+++ b/applications/prompt-proto-service-latiss/README.md
@@ -13,11 +13,8 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | prompt-proto-service.additionalVolumeMounts | list | `[]` | Kubernetes YAML configs for extra container volume(s). Any volumes required by other config options are automatically handled by the Helm chart. |
-| prompt-proto-service.apdb.db | string | `"lsst-devl"` | PostgreSQL database name for the APDB (deprecated for apdb.url) |
-| prompt-proto-service.apdb.ip | string | None, must be set | IP address or hostname and port of the APDB (deprecated for apdb.url) |
 | prompt-proto-service.apdb.namespace | string | `"pp_apdb"` | Database namespace for the APDB |
 | prompt-proto-service.apdb.url | string | None, must be set | URL to the APDB, in any form recognized by SQLAlchemy |
-| prompt-proto-service.apdb.user | string | `"rubin"` | Database user for the APDB (deprecated for apdb.url) |
 | prompt-proto-service.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
 | prompt-proto-service.image.repository | string | `"ghcr.io/lsst-dm/prompt-service"` | Image to use in the PP deployment |
 | prompt-proto-service.image.tag | string | `"latest"` | Overrides the image tag whose default is the chart appVersion. |
@@ -36,9 +33,6 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.logLevel | string | log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
 | prompt-proto-service.podAnnotations | object | See the `values.yaml` file. | Annotations for the prompt-proto-service pod |
 | prompt-proto-service.registry.centralRepoFile | bool | `false` | If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted. |
-| prompt-proto-service.registry.db | string | None, must be set | PostgreSQL database name for the Butler registry database (deprecated) |
-| prompt-proto-service.registry.ip | string | None, must be set | IP address or hostname and port of the Butler registry database (deprecated) |
-| prompt-proto-service.registry.user | string | None, must be set | Database user for the Butler registry database (deprecated) |
 | prompt-proto-service.s3.auth_env | bool | `true` | If set, get S3 credentials from this application's Vault secret. |
 | prompt-proto-service.s3.disableBucketValidation | string | `"0"` | Set this to disable validation of S3 bucket names, allowing Ceph multi-tenant colon-separated names to be used. |
 | prompt-proto-service.s3.endpointUrl | string | `""` |  |

--- a/applications/prompt-proto-service-latiss/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfdev-prompt-processing.yaml
@@ -24,11 +24,5 @@ prompt-proto-service:
 
   apdb:
     url: postgresql://rubin@usdf-prompt-processing-dev.slac.stanford.edu/lsst-devl
-    ip: usdf-prompt-processing-dev.slac.stanford.edu:5432  # TODO: remove on DM-40839
-
-  registry:  # TODO: remove on DM-40839
-    ip: usdf-prompt-processing-dev.slac.stanford.edu:5432
-    db: ppcentralbutler
-    user: pp
 
   fullnameOverride: "prompt-proto-service-latiss"

--- a/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
@@ -37,10 +37,6 @@ prompt-proto-service:
 
   apdb:
     url: postgresql://rubin@usdf-prompt-processing.slac.stanford.edu:5432/lsst-devl
-    ip: usdf-prompt-processing.slac.stanford.edu:5432  # TODO: remove on DM-40839
-
-  registry:
-    ip: usdf-butler.slac.stanford.edu:5432  # TODO: remove on DM-40839
 
   logLevel: lsst.resources=DEBUG
 

--- a/applications/prompt-proto-service-latiss/values.yaml
+++ b/applications/prompt-proto-service-latiss/values.yaml
@@ -59,26 +59,10 @@ prompt-proto-service:
     # -- URL to the APDB, in any form recognized by SQLAlchemy
     # @default -- None, must be set
     url: ""
-    # -- IP address or hostname and port of the APDB (deprecated for apdb.url)
-    # @default -- None, must be set
-    ip: ""  # TODO: remove on DM-40839
-    # -- PostgreSQL database name for the APDB (deprecated for apdb.url)
-    db: lsst-devl  # TODO: remove on DM-40839
-    # -- Database user for the APDB (deprecated for apdb.url)
-    user: rubin  # TODO: remove on DM-40839
     # -- Database namespace for the APDB
     namespace: pp_apdb
 
   registry:
-    # -- IP address or hostname and port of the Butler registry database (deprecated)
-    # @default -- None, must be set
-    ip: ""  # TODO: remove on DM-40839
-    # -- PostgreSQL database name for the Butler registry database (deprecated)
-    # @default -- None, must be set
-    db: lsstdb1  # TODO: remove on DM-40839
-    # -- Database user for the Butler registry database (deprecated)
-    # @default -- None, must be set
-    user: rubin  # TODO: remove on DM-40839
     # -- If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted.
     centralRepoFile: false
 

--- a/applications/prompt-proto-service-latiss/values.yaml
+++ b/applications/prompt-proto-service-latiss/values.yaml
@@ -53,7 +53,7 @@ prompt-proto-service:
     # @default -- None, must be set
     topic: ""
     # -- Timeout to wait after expected script completion for raw image arrival (seconds).
-    imageTimeout: '120'
+    imageTimeout: '20'
 
   apdb:
     # -- URL to the APDB, in any form recognized by SQLAlchemy

--- a/applications/prompt-proto-service-lsstcam/README.md
+++ b/applications/prompt-proto-service-lsstcam/README.md
@@ -18,7 +18,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
 | prompt-proto-service.image.repository | string | `"ghcr.io/lsst-dm/prompt-service"` | Image to use in the PP deployment |
 | prompt-proto-service.image.tag | string | `"latest"` | Overrides the image tag whose default is the chart appVersion. |
-| prompt-proto-service.imageNotifications.imageTimeout | string | `"120"` | Timeout to wait after expected script completion for raw image arrival (seconds). |
+| prompt-proto-service.imageNotifications.imageTimeout | string | `"20"` | Timeout to wait after expected script completion for raw image arrival (seconds). |
 | prompt-proto-service.imageNotifications.kafkaClusterAddress | string | None, must be set | Hostname and port of the Kafka provider |
 | prompt-proto-service.imageNotifications.topic | string | None, must be set | Topic where raw image arrival notifications appear |
 | prompt-proto-service.instrument.calibRepo | string | None, must be set | URI to the shared repo used for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself. |

--- a/applications/prompt-proto-service-lsstcam/README.md
+++ b/applications/prompt-proto-service-lsstcam/README.md
@@ -13,11 +13,8 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | prompt-proto-service.additionalVolumeMounts | list | `[]` | Kubernetes YAML configs for extra container volume(s). Any volumes required by other config options are automatically handled by the Helm chart. |
-| prompt-proto-service.apdb.db | string | `"lsst-devl"` | PostgreSQL database name for the APDB (deprecated for apdb.url) |
-| prompt-proto-service.apdb.ip | string | None, must be set | IP address or hostname and port of the APDB (deprecated for apdb.url) |
 | prompt-proto-service.apdb.namespace | string | `"pp_apdb"` | Database namespace for the APDB |
 | prompt-proto-service.apdb.url | string | None, must be set | URL to the APDB, in any form recognized by SQLAlchemy |
-| prompt-proto-service.apdb.user | string | `"rubin"` | Database user for the APDB (deprecated for apdb.url) |
 | prompt-proto-service.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
 | prompt-proto-service.image.repository | string | `"ghcr.io/lsst-dm/prompt-service"` | Image to use in the PP deployment |
 | prompt-proto-service.image.tag | string | `"latest"` | Overrides the image tag whose default is the chart appVersion. |
@@ -36,9 +33,6 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.logLevel | string | log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
 | prompt-proto-service.podAnnotations | object | See the `values.yaml` file. | Annotations for the prompt-proto-service pod |
 | prompt-proto-service.registry.centralRepoFile | bool | `false` | If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted. |
-| prompt-proto-service.registry.db | string | None, must be set | PostgreSQL database name for the Butler registry database (deprecated) |
-| prompt-proto-service.registry.ip | string | None, must be set | IP address or hostname and port of the Butler registry database (deprecated) |
-| prompt-proto-service.registry.user | string | None, must be set | Database user for the Butler registry database (deprecated) |
 | prompt-proto-service.s3.auth_env | bool | `true` | If set, get S3 credentials from this application's Vault secret. |
 | prompt-proto-service.s3.disableBucketValidation | string | `"0"` | Set this to disable validation of S3 bucket names, allowing Ceph multi-tenant colon-separated names to be used. |
 | prompt-proto-service.s3.endpointUrl | string | None, must be set | S3 endpoint containing `imageBucket` |

--- a/applications/prompt-proto-service-lsstcam/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcam/values-usdfdev-prompt-processing.yaml
@@ -24,9 +24,5 @@ prompt-proto-service:
 
   apdb:
     url: postgresql://rubin@usdf-prompt-processing-dev.slac.stanford.edu:5432/lsst-devl
-    ip: usdf-prompt-processing-dev.slac.stanford.edu:5432  # TODO: remove on DM-40839
-
-  registry:  # TODO: remove on DM-40839
-    ip: usdf-butler.slac.stanford.edu:5432
 
   fullnameOverride: "prompt-proto-service-lsstcam"

--- a/applications/prompt-proto-service-lsstcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcam/values.yaml
@@ -59,26 +59,10 @@ prompt-proto-service:
     # -- URL to the APDB, in any form recognized by SQLAlchemy
     # @default -- None, must be set
     url: ""
-    # -- IP address or hostname and port of the APDB (deprecated for apdb.url)
-    # @default -- None, must be set
-    ip: ""  # TODO: remove on DM-40839
-    # -- PostgreSQL database name for the APDB (deprecated for apdb.url)
-    db: lsst-devl  # TODO: remove on DM-40839
-    # -- Database user for the APDB (deprecated for apdb.url)
-    user: rubin  # TODO: remove on DM-40839
     # -- Database namespace for the APDB
     namespace: pp_apdb
 
   registry:
-    # -- IP address or hostname and port of the Butler registry database (deprecated)
-    # @default -- None, must be set
-    ip: ""  # TODO: remove on DM-40839
-    # -- PostgreSQL database name for the Butler registry database (deprecated)
-    # @default -- None, must be set
-    db: lsstdb1  # TODO: remove on DM-40839
-    # -- Database user for the Butler registry database (deprecated)
-    # @default -- None, must be set
-    user: rubin  # TODO: remove on DM-40839
     # -- If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted.
     centralRepoFile: false
 

--- a/applications/prompt-proto-service-lsstcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcam/values.yaml
@@ -53,7 +53,7 @@ prompt-proto-service:
     # @default -- None, must be set
     topic: ""
     # -- Timeout to wait after expected script completion for raw image arrival (seconds).
-    imageTimeout: '120'
+    imageTimeout: '20'
 
   apdb:
     # -- URL to the APDB, in any form recognized by SQLAlchemy

--- a/applications/prompt-proto-service-lsstcomcam/README.md
+++ b/applications/prompt-proto-service-lsstcomcam/README.md
@@ -17,7 +17,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
 | prompt-proto-service.image.repository | string | `"ghcr.io/lsst-dm/prompt-service"` | Image to use in the PP deployment |
 | prompt-proto-service.image.tag | string | `"latest"` | Overrides the image tag whose default is the chart appVersion. |
-| prompt-proto-service.imageNotifications.imageTimeout | string | `"120"` | Timeout to wait after expected script completion for raw image arrival (seconds). |
+| prompt-proto-service.imageNotifications.imageTimeout | string | `"20"` | Timeout to wait after expected script completion for raw image arrival (seconds). |
 | prompt-proto-service.imageNotifications.kafkaClusterAddress | string | None, must be set | Hostname and port of the Kafka provider |
 | prompt-proto-service.imageNotifications.topic | string | None, must be set | Topic where raw image arrival notifications appear |
 | prompt-proto-service.instrument.calibRepo | string | None, must be set | URI to the shared repo used for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself. |

--- a/applications/prompt-proto-service-lsstcomcam/README.md
+++ b/applications/prompt-proto-service-lsstcomcam/README.md
@@ -12,11 +12,8 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| prompt-proto-service.apdb.db | string | `"lsst-devl"` | PostgreSQL database name for the APDB (deprecated for apdb.url) |
-| prompt-proto-service.apdb.ip | string | None, must be set | IP address or hostname and port of the APDB (deprecated for apdb.url) |
 | prompt-proto-service.apdb.namespace | string | `"pp_apdb"` | Database namespace for the APDB |
 | prompt-proto-service.apdb.url | string | None, must be set | URL to the APDB, in any form recognized by SQLAlchemy |
-| prompt-proto-service.apdb.user | string | `"rubin"` | Database user for the APDB (deprecated for apdb.url) |
 | prompt-proto-service.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
 | prompt-proto-service.image.repository | string | `"ghcr.io/lsst-dm/prompt-service"` | Image to use in the PP deployment |
 | prompt-proto-service.image.tag | string | `"latest"` | Overrides the image tag whose default is the chart appVersion. |
@@ -35,9 +32,6 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.logLevel | string | log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
 | prompt-proto-service.podAnnotations | object | See the `values.yaml` file. | Annotations for the prompt-proto-service pod |
 | prompt-proto-service.registry.centralRepoFile | bool | `false` | If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted. |
-| prompt-proto-service.registry.db | string | None, must be set | PostgreSQL database name for the Butler registry database (deprecated) |
-| prompt-proto-service.registry.ip | string | None, must be set | IP address or hostname and port of the Butler registry database (deprecated) |
-| prompt-proto-service.registry.user | string | None, must be set | Database user for the Butler registry database (deprecated) |
 | prompt-proto-service.s3.auth_env | bool | `true` | If set, get S3 credentials from this application's Vault secret. |
 | prompt-proto-service.s3.disableBucketValidation | string | `"0"` | Set this to disable validation of S3 bucket names, allowing Ceph multi-tenant colon-separated names to be used. |
 | prompt-proto-service.s3.endpointUrl | string | None, must be set | S3 endpoint containing `imageBucket` |

--- a/applications/prompt-proto-service-lsstcomcam/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/values-usdfdev-prompt-processing.yaml
@@ -24,9 +24,5 @@ prompt-proto-service:
 
   apdb:
     url: postgresql://rubin@usdf-prompt-processing-dev.slac.stanford.edu:5432/lsst-devl
-    ip: usdf-prompt-processing-dev.slac.stanford.edu:5432  # TODO: remove on DM-40839
-
-  registry:  # TODO: remove on DM-40839
-    ip: usdf-butler.slac.stanford.edu:5432
 
   fullnameOverride: "prompt-proto-service-lsstcomcam"

--- a/applications/prompt-proto-service-lsstcomcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/values.yaml
@@ -59,26 +59,10 @@ prompt-proto-service:
     # -- URL to the APDB, in any form recognized by SQLAlchemy
     # @default -- None, must be set
     url: ""
-    # -- IP address or hostname and port of the APDB (deprecated for apdb.url)
-    # @default -- None, must be set
-    ip: ""  # TODO: remove on DM-40839
-    # -- PostgreSQL database name for the APDB (deprecated for apdb.url)
-    db: lsst-devl  # TODO: remove on DM-40839
-    # -- Database user for the APDB (deprecated for apdb.url)
-    user: rubin  # TODO: remove on DM-40839
     # -- Database namespace for the APDB
     namespace: pp_apdb
 
   registry:
-    # -- IP address or hostname and port of the Butler registry database (deprecated)
-    # @default -- None, must be set
-    ip: ""  # TODO: remove on DM-40839
-    # -- PostgreSQL database name for the Butler registry database (deprecated)
-    # @default -- None, must be set
-    db: lsstdb1  # TODO: remove on DM-40839
-    # -- Database user for the Butler registry database (deprecated)
-    # @default -- None, must be set
-    user: rubin  # TODO: remove on DM-40839
     # -- If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted.
     centralRepoFile: false
 

--- a/applications/prompt-proto-service-lsstcomcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/values.yaml
@@ -53,7 +53,7 @@ prompt-proto-service:
     # @default -- None, must be set
     topic: ""
     # -- Timeout to wait after expected script completion for raw image arrival (seconds).
-    imageTimeout: '120'
+    imageTimeout: '20'
 
   apdb:
     # -- URL to the APDB, in any form recognized by SQLAlchemy

--- a/charts/prompt-proto-service/README.md
+++ b/charts/prompt-proto-service/README.md
@@ -14,11 +14,8 @@ Event-driven processing of camera images
 |-----|------|---------|-------------|
 | additionalVolumeMounts | list | `[]` | Kubernetes YAML configs for extra container volume(s). Any volumes required by other config options are automatically handled by the Helm chart. |
 | affinity | object | `{}` |  |
-| apdb.db | string | `""` | PostgreSQL database name for the APDB (deprecated for apdb.url) |
-| apdb.ip | string | None, must be set | IP address or hostname and port of the APDB (deprecated for apdb.url) |
 | apdb.namespace | string | `""` | Database namespace for the APDB |
 | apdb.url | string | None, must be set | URL to the APDB, in any form recognized by SQLAlchemy |
-| apdb.user | string | `""` | Database user for the APDB (deprecated for apdb.url) |
 | containerConcurrency | int | `1` |  |
 | fullnameOverride | string | `"prompt-proto-service"` | Override the full name for resources (includes the release name) |
 | image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
@@ -42,9 +39,6 @@ Event-driven processing of camera images
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | See the `values.yaml` file. | Annotations for the prompt-proto-service pod |
 | registry.centralRepoFile | bool | `false` | If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted. |
-| registry.db | string | None, must be set | PostgreSQL database name for the Butler registry database (deprecated) |
-| registry.ip | string | None, must be set | IP address or hostname and port of the Butler registry database (deprecated) |
-| registry.user | string | None, must be set | Database user for the Butler registry database (deprecated) |
 | s3.auth_env | bool | `true` | If set, get S3 credentials from this application's Vault secret. |
 | s3.disableBucketValidation | string | `"0"` | Set this to disable validation of S3 bucket names, allowing Ceph multi-tenant colon-separated names to be used. |
 | s3.endpointUrl | string | None, must be set | S3 endpoint containing `imageBucket` |

--- a/charts/prompt-proto-service/README.md
+++ b/charts/prompt-proto-service/README.md
@@ -21,7 +21,7 @@ Event-driven processing of camera images
 | image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
 | image.repository | string | `"ghcr.io/lsst-dm/prompt-service"` | Image to use in the PP deployment |
 | image.tag | string | `"latest"` | Overrides the image tag whose default is the chart appVersion. |
-| imageNotifications.imageTimeout | string | `"120"` | Timeout to wait after expected script completion for raw image arrival (seconds). |
+| imageNotifications.imageTimeout | string | `"20"` | Timeout to wait after expected script completion for raw image arrival (seconds). |
 | imageNotifications.kafkaClusterAddress | string | None, must be set | Hostname and port of the Kafka provider |
 | imageNotifications.topic | string | None, must be set | Topic where raw image arrival notifications appear |
 | imagePullSecrets | list | `[]` |  |

--- a/charts/prompt-proto-service/templates/prompt-proto-service.yaml
+++ b/charts/prompt-proto-service/templates/prompt-proto-service.yaml
@@ -59,36 +59,12 @@ spec:
           value: {{ .Values.instrument.calibRepo }}
         - name: LSST_DISABLE_BUCKET_VALIDATION
           value: {{ .Values.s3.disableBucketValidation | quote }}
-        - name: IP_APDB  # TODO: remove on DM-40839
-          # Need explicit port for make_pgpass.py
-          value: {{ .Values.apdb.ip }}
-        - name: DB_APDB  # TODO: remove on DM-40839
-          value: {{ .Values.apdb.db }}
-        - name: USER_APDB  # TODO: remove on DM-40839
-          value: {{ .Values.apdb.user }}
         - name: URL_APDB
           value: {{ .Values.apdb.url }}
         - name: NAMESPACE_APDB
           value: {{ .Values.apdb.namespace }}
-        - name: IP_REGISTRY  # TODO: remove on DM-40839
-          # Need explicit port for make_pgpass.py
-          value: {{ .Values.registry.ip }}
-        - name: DB_REGISTRY  # TODO: remove on DM-40839
-          value: {{ .Values.registry.db }}
-        - name: USER_REGISTRY  # TODO: remove on DM-40839
-          value: {{ .Values.registry.user }}
         - name: KAFKA_CLUSTER
           value: {{ .Values.imageNotifications.kafkaClusterAddress }}
-        - name: PSQL_REGISTRY_PASS  # TODO: remove on DM-40839
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "prompt-proto-service.fullname" . }}-secret
-              key: registry_password
-        - name: PSQL_APDB_PASS  # TODO: remove on DM-40839
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "prompt-proto-service.fullname" . }}-secret
-              key: apdb_password
         - name: S3_ENDPOINT_URL
           value: {{ .Values.s3.endpointUrl }}
         {{- if .Values.s3.auth_env }}

--- a/charts/prompt-proto-service/values.yaml
+++ b/charts/prompt-proto-service/values.yaml
@@ -55,7 +55,7 @@ imageNotifications:
   # @default -- None, must be set
   topic: ""
   # -- Timeout to wait after expected script completion for raw image arrival (seconds).
-  imageTimeout: '120'
+  imageTimeout: '20'
 
 apdb:
   # -- URL to the APDB, in any form recognized by SQLAlchemy

--- a/charts/prompt-proto-service/values.yaml
+++ b/charts/prompt-proto-service/values.yaml
@@ -61,26 +61,10 @@ apdb:
   # -- URL to the APDB, in any form recognized by SQLAlchemy
   # @default -- None, must be set
   url: ""
-  # -- IP address or hostname and port of the APDB (deprecated for apdb.url)
-  # @default -- None, must be set
-  ip: ""  # TODO: remove on DM-40839
-  # -- PostgreSQL database name for the APDB (deprecated for apdb.url)
-  db: ""  # TODO: remove on DM-40839
-  # -- Database user for the APDB (deprecated for apdb.url)
-  user: ""  # TODO: remove on DM-40839
   # -- Database namespace for the APDB
   namespace: ""
 
 registry:
-  # -- IP address or hostname and port of the Butler registry database (deprecated)
-  # @default -- None, must be set
-  ip: ""  # TODO: remove on DM-40839
-  # -- PostgreSQL database name for the Butler registry database (deprecated)
-  # @default -- None, must be set
-  db: ""  # TODO: remove on DM-40839
-  # -- Database user for the Butler registry database (deprecated)
-  # @default -- None, must be set
-  user: ""  # TODO: remove on DM-40839
   # -- If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted.
   centralRepoFile: false
 


### PR DESCRIPTION
This PR cleans up environment variables that stopped being used in #2538. We no longer have any containers that assume these variables are defined.