### PR TITLE
DM-42093: Update Gafaelafwr to 9.6.1

### DIFF
--- a/applications/gafaelfawr/Chart.yaml
+++ b/applications/gafaelfawr/Chart.yaml
@@ -5,7 +5,7 @@ description: Authentication and identity system
 home: https://gafaelfawr.lsst.io/
 sources:
   - https://github.com/lsst-sqre/gafaelfawr
-appVersion: 9.6.0
+appVersion: 9.6.1
 
 dependencies:
   - name: redis


### PR DESCRIPTION
Includes a fix for recovery after the Redis server was restarted.