### PR TITLE
DM-36957: Add GCP information to documentation

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -69,4 +69,4 @@ jobs:
         if: >-
           (github.event_name == 'push' && github.head_ref == 'main' && steps.filter.outputs.docs == 'true')
           || (github.event_name == 'workflow_dispatch' && steps.filter.outputs.docs == 'true')
-          || (github.event_name == 'pull_request' && startsWith(github.head_ref, 'tickets/') && steps.filter.outputs.docSpecific == 'true')
+          || (github.event_name == 'pull_request' && startsWith(github.head_ref, 'tickets/') && steps.filter.outputs.docsSpecific == 'true')

--- a/docs/about/repository.rst
+++ b/docs/about/repository.rst
@@ -2,7 +2,7 @@
 Phalanx Git repository structure
 ################################
 
-Phalanx is an open source Git repository hosted on `GitHub <https://github.com/lsst-sqre/phalanx>`__.
+Phalanx is an open source Git repository hosted at https://github.com/lsst-sqre/phalanx.
 This page provides an overview of this repository's structure, for both application developers and environment administrators alike.
 For background on Phalanx and its technologies, see :doc:`introduction` first.
 
@@ -73,7 +73,7 @@ This directory contains Helm charts shared by multiple Phalanx applications that
 
 In some cases, several Phalanx applications should use common Helm templates to avoid duplication.
 The best way to do this within Helm is to use a subchart.
-This can be done by publishing a separate Helm chart using the `charts repository <https://github.com/lsst-sqre/charts>`__, but publication as a Helm chart implies that the chart may be useful outside of Phalanx.
+This can be done by publishing a separate Helm chart in https://github.com/lsst-sqre/charts, but publication as a Helm chart implies that the chart may be useful outside of Phalanx.
 Sometimes these shared subcharts are merely artifacts of code organization and deduplication within Phalanx, and should not have an independent existence outside of Phalanx.
 In those cases, they're maintained in the :file:`charts` directory.
 
@@ -118,7 +118,7 @@ The default branch is ``main``.
 This default branch is considered the source of truth for fullly synchronized Phalanx environments.
 
 Updates to Phalanx are introduced as pull requests on GitHub.
-Repository members create branches directly in the `GitHub lsst-sqre/phalanx repository <https://github.com/lsst-sqre/phalanx>`__ (see the `Data Management workflow guide`_)
+Repository members create branches directly in https://github.com/lsst-sqre/phalanx (see the `Data Management workflow guide`_)
 External collaborators should fork Phalanx and create pull requests.
 
 It is possible (particularly in non-production environments) to deploy applications from branches of Phalanx, which is useful for debugging new and updating applications before updating the ``main`` branch.

--- a/docs/admin/index.rst
+++ b/docs/admin/index.rst
@@ -36,6 +36,7 @@ Administrators operate infrastructure, manage secrets, and are involved in the d
    :caption: Infrastructure
    :maxdepth: 2
 
+   infrastructure/google/index
    infrastructure/filestore/index
    infrastructure/kubernetes-node-status-max-images
 

--- a/docs/admin/infrastructure/google/credentials.rst
+++ b/docs/admin/infrastructure/google/credentials.rst
@@ -20,16 +20,15 @@ Google provides a mechanism to obtain those credentials using the :command:`gclo
 
 #. `Install kubectl and the GKE auth plugin <https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl>`__.
    As part of that installation, you will run the :command:`gcloud` command that obtains credentials usable by :command:`kubectl` and other privileged Kubernetes commands.
-   See below for assistance with the precise :command:`gcloud` command to run.
-
-You will only have to follow this process once on each machine from which you want to use Kubernetes.
 
 The final step has an example :command:`gcloud` command, but it assumes that you are getting credentials for your default project.
 Rubin uses multiple Google Cloud Platform projects for different environments, so you may have to provide the project ID as well.
 For the full command to run, see the bottom of the relevant :doc:`environments page </environments>`.
 
+Once you have followed this process on a system, the credentials will remain valid unless the Kubernetes control plane credentials are rotated.
+
 .. note::
 
-   The Kubernetes control plane credentials eventually expire and have to be rotated.
+   The Kubernetes control plane credentials eventually expire and have to periodically be rotated.
    If the control plane credentials of the Kubernetes cluster are rotated, you will have to re-run the :command:`gcloud` command to refresh your credentials.
    If you discover that your credentials are no longer working, try that command and see if the problem persists.

--- a/docs/admin/infrastructure/google/credentials.rst
+++ b/docs/admin/infrastructure/google/credentials.rst
@@ -2,9 +2,8 @@
 Getting GKE Kubernetes credentials
 ##################################
 
-In order to use the standard Kubernetes administrative command :command:`kubectl` or other commands built on the same protocol (such as Helm_ or the Phalanx installer), you must first have stored authentication credentials for the target Kubernetes cluster.
-Google provides a mechanism to obtain those credentials using the :command:`gcloud` command.
-Here are the steps:
+To use the standard Kubernetes administrative command :command:`kubectl` or other commands built on the same protocol (such as Helm_ or the Phalanx installer), you must have authentication credentials stored for the target Kubernetes cluster.
+Google provides a mechanism to obtain those credentials using the :command:`gcloud` command:
 
 #. Ensure you have a Google account with access to the Google Cloud Platform project where your target Kubernetes cluster is running.
    For Phalanx environments run by SQuaRE, this access must be via an ``lsst.cloud`` Google account that is used only for Rubin activities.

--- a/docs/admin/infrastructure/google/credentials.rst
+++ b/docs/admin/infrastructure/google/credentials.rst
@@ -1,0 +1,42 @@
+##################################
+Getting GKE Kubernetes credentials
+##################################
+
+In order to use the standard Kubernetes administrative command :command:`kubectl` or other commands built on the same protocol (such as Helm_ or the Phalanx installer), you must first have stored authentication credentials for the target Kubernetes cluster.
+Google provides a mechanism to obtain those credentials using the :command:`gcloud` command.
+Here are the steps:
+
+#. Ensure you have a Google account with access to the Google Cloud Platform project where your target Kubernetes cluster is running.
+   For Phalanx environments run by SQuaRE, this access must be via an ``lsst.cloud`` Google account that is used only for Rubin activities.
+   If you do not already have such an account or permissions and need administrative access to a Phalanx environment maintained by SQuaRE, contact SQuaRE for access.
+
+#. `Install gcloud <https://cloud.google.com/sdk/docs/install>`__ on the system on which you want to run privileged Kubernetes commands.
+
+#. `Initialize gcloud <https://cloud.google.com/sdk/docs/initializing>`__.
+   You will need to have access to the Google Cloud Platform project where your target Kubernetes cluster is running.
+
+   If you have access to multiple Google Cloud Platform projects, you will be asked to select one as your default project.
+   You may wish to choose the project for the Phalanx environment you use most often.
+   You can find the project ID of a Phalanx project hosted on GKE in its :doc:`environments page </environments>`.
+
+#. `Install kubectl and the GKE auth plugin <https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl>`__.
+   As part of that installation, you will run the :command:`gcloud` command that obtains credentials usable by :command:`kubectl` and other privileged Kubernetes commands.
+   See below for assistance with the precise :command:`gcloud` command to run.
+
+You will only have to follow this process once on each machine from which you want to use Kubernetes.
+
+The final step has an example :command:`gcloud` command, but it assumes that you are getting credentials for your default project.
+Rubin uses multiple Google Cloud Platform projects for different environments, so you may have to provide the project ID as well.
+Here is the full command to run:
+
+.. prompt:: bash
+
+   gcloud container clusters get-credentials <cluster-name> --project <project-id> --region <region>
+
+You can get the cluster name, project ID, and region of a Phalanx environment hosted on Google Cloud Platform from its :doc:`environments page </environments>`.
+
+.. note::
+
+   If the control plane credentials of the Kubernetes cluster are rotated, you will have to re-run the above command to refresh your credentials.
+   The Kubernetes control plane credentials eventually expire and have to be rotated.
+   If you discover that your credentials are no longer working, try running the above command again to refresh your credentials and see if the problem persists.

--- a/docs/admin/infrastructure/google/credentials.rst
+++ b/docs/admin/infrastructure/google/credentials.rst
@@ -27,16 +27,10 @@ You will only have to follow this process once on each machine from which you wa
 
 The final step has an example :command:`gcloud` command, but it assumes that you are getting credentials for your default project.
 Rubin uses multiple Google Cloud Platform projects for different environments, so you may have to provide the project ID as well.
-Here is the full command to run:
-
-.. prompt:: bash
-
-   gcloud container clusters get-credentials <cluster-name> --project <project-id> --region <region>
-
-You can get the cluster name, project ID, and region of a Phalanx environment hosted on Google Cloud Platform from its :doc:`environments page </environments>`.
+For the full command to run, see the bottom of the relevant :doc:`environments page </environments>`.
 
 .. note::
 
-   If the control plane credentials of the Kubernetes cluster are rotated, you will have to re-run the above command to refresh your credentials.
    The Kubernetes control plane credentials eventually expire and have to be rotated.
-   If you discover that your credentials are no longer working, try running the above command again to refresh your credentials and see if the problem persists.
+   If the control plane credentials of the Kubernetes cluster are rotated, you will have to re-run the :command:`gcloud` command to refresh your credentials.
+   If you discover that your credentials are no longer working, try that command and see if the problem persists.

--- a/docs/admin/infrastructure/google/index.rst
+++ b/docs/admin/infrastructure/google/index.rst
@@ -1,0 +1,13 @@
+##############################
+Using Google Kubernetes Engine
+##############################
+
+Google Kubernetes Engine (GKE) is the Google Cloud Platform (GCP) implementation of Kubernetes.
+It is an excellent hosting platform for Phalanx environments.
+
+This page collects advice and supplemental documentation for Phalanx administrators of environments hosted on GKE.
+
+.. toctree::
+
+   credentials
+   terraform

--- a/docs/admin/infrastructure/google/terraform.rst
+++ b/docs/admin/infrastructure/google/terraform.rst
@@ -1,0 +1,9 @@
+#####################################
+Managing GCP resources with Terraform
+#####################################
+
+All SQuaRE-managed Google Cloud Platform projects use Terraform to manage all GCP resources outside of Kubernetes.
+These include CLoud SQL databases used by Phalanx applications, Google Firestore for UID and GID assignment, service accounts used with workload identity for authenticated access to Google services, and so forth.
+
+The Terraform configuration for all SQuaRE-managed projects and most other Rubin Observatory GCP projects is maintained in https://github.com/lsst/idf_deploy.
+Changes to this repository are automatically applied to the relevant Google Cloud Platform project when the pull request has been reviewed and merged.

--- a/docs/admin/installation.rst
+++ b/docs/admin/installation.rst
@@ -25,6 +25,7 @@ To create a new Phalanx environment, take the following steps:
    Edit it so that ``name``, ``fqdn``, ``vaultUrl``, and ``vaultPathPrefix`` at the top match your new environment.
    You may omit ``vaultUrl`` for SQuaRE-managed environments.
    See :doc:`secrets-setup` for more information about the latter two settings and additional settings you may need.
+   If the environment will be hosted on Google Kubernetes Engine, also fill out ``gcp.projectId``, ``gcp.region``, and ``gcp.clusterName`` with metadata about where the environment will be hosted.
    Enable the applications this environment should include.
 
 #. Decide on your approach to TLS certificates.

--- a/docs/applications/livetap/index.rst
+++ b/docs/applications/livetap/index.rst
@@ -5,11 +5,11 @@ livetap — IVOA livetap Table Access Protocol
 ############################################
 
 LIVETAP (Live Obscore Table Access Protocol) is an IVOA_ service that provides access to the live obscore table which is hosted on postgres.
-On the Rubin Science Platform, it is provided by `tap-postgres <https://github.com/lsst-sqre/tap-postgres>`__, which is derived from the `CADC TAP service <https://github.com/opencadc/tap>`__.
+On the Rubin Science Platform, it is provided by https://github.com/lsst-sqre/tap-postgres, which is derived from the `CADC TAP service <https://github.com/opencadc/tap>`__.
 This service provides access to the ObsCore tables that are created and served by the butler and updated live.
 
 The TAP data itself, apart from schema queries, comes from Postgres.
-The TAP schema is provided by images built from the `sdm_schemas <https://github.com/lsst/sdm_schemas/>`__ repository.
+The TAP schema is provided by images built from https://github.com/lsst/sdm_schemas.
 
 .. jinja:: tap
    :file: applications/_summary.rst.jinja

--- a/docs/applications/nublado/updating-recommended.rst
+++ b/docs/applications/nublado/updating-recommended.rst
@@ -12,7 +12,7 @@ Tagging a new container version
 
 When a new version has been approved (after passing through its prior QA and sign-off gates), the ``recommended`` tag must be updated to point to the new version.
 
-To do this, run the GitHub retag workflow for the `sciplat-lab <https://github.com/lsst-sqre/sciplat-lab>`__ repository, as follows:
+To do this, run the GitHub retag workflow for https://github.com/lsst-sqre/sciplat-lab repository, as follows:
 
 #. Go to `the retag workflow page <https://github.com/lsst-sqre/sciplat-lab/actions/workflows/retag.yaml>`__.
 #. Click :guilabel:`Run workflow`.
@@ -38,7 +38,7 @@ If you do not find it, then that environment is currently using ``recommended`` 
 
 Set this key (creating it if necessary) to whatever string represents the correct recommended-by-default image for that instance.
 For instance, for a Telescope and Site environment, this will likely look something like ``recommended_c0032``.
-Create a pull request against `Phalanx <https://github.com/lsst-sqre/phalanx>`__ that updates the tag.
+Create a pull request against https://github.com/lsst-sqre/phalanx that updates the tag.
 Once this change is merged, sync the nublado application (using Argo CD) in the affected environments.
 
 You do not have to wait for a maintenance window to do this, since the change is low risk, although it will result in a very brief outage for Notebook Aspect lab spawning while the JupyterLab Controller is restarted.

--- a/docs/applications/semaphore/index.rst
+++ b/docs/applications/semaphore/index.rst
@@ -7,7 +7,7 @@ semaphore — User notification
 Semaphore is the user notification and messaging service for the Rubin Science Platform.
 UI applications like :px-app:`squareone` can display messages from Semaphore's API.
 
-Edit broadcast messages for SQuaRE-managed environments at `lsst-sqre/rsp_broadcast <https://github.com/lsst-sqre/rsp_broadcast>`__.
+Edit broadcast messages for SQuaRE-managed environments at https://github.com/lsst-sqre/rsp_broadcast.
 
 .. jinja:: semaphore
    :file: applications/_summary.rst.jinja

--- a/docs/applications/ssotap/index.rst
+++ b/docs/applications/ssotap/index.rst
@@ -5,11 +5,11 @@ ssotap — IVOA DP03 Solar System Table Access Protocol
 #####################################################
 
 SSOTAP (SSO Table Access Protocol) is an IVOA_ service that provides access to the ObsCore table which is hosted on postgres.
-On the Rubin Science Platform, it is provided by `tap-postgres <https://github.com/lsst-sqre/tap-postgres>`__, which is derived from the `CADC TAP service <https://github.com/opencadc/tap>`__.
+On the Rubin Science Platform, it is provided by https://github.com/lsst-sqre/tap-postgres, which is derived from the `CADC TAP service <https://github.com/opencadc/tap>`__.
 This service provides access to the Solar System tables that are created and served by the butler.
 
 The TAP data itself, apart from schema queries, comes from Postgres.
-The TAP schema is provided by images built from the `sdm_schemas <https://github.com/lsst/sdm_schemas/>`__ repository.
+The TAP schema is provided by images built from https://github.com/lsst/sdm_schemas.
 
 .. jinja:: tap
    :file: applications/_summary.rst.jinja

--- a/docs/applications/tap/index.rst
+++ b/docs/applications/tap/index.rst
@@ -5,11 +5,11 @@ tap — IVOA Table Access Protocol
 ################################
 
 TAP_ (Table Access Protocol) is an IVOA_ service that provides access to general table data, including astronomical catalogs.
-On the Rubin Science Platform, it is provided by `lsst-tap-service <https://github.com/lsst-sqre/lsst-tap-service>`__, which is derived from the `CADC TAP service <https://github.com/opencadc/tap>`__.
+On the Rubin Science Platform, it is provided by https://github.com/lsst-sqre/lsst-tap-service, which is derived from the `CADC TAP service <https://github.com/opencadc/tap>`__.
 The same service provides both TAP and ObsTAP_ schemas.
 
 The TAP data itself, apart from schema queries, comes from Qserv.
-The TAP schema is provided by images built from the `sdm_schemas <https://github.com/lsst/sdm_schemas/>`__ repository.
+The TAP schema is provided by images built from https://github.com/lsst/sdm_schemas.
 
 .. jinja:: tap
    :file: applications/_summary.rst.jinja

--- a/docs/environments/_summary.rst.jinja
+++ b/docs/environments/_summary.rst.jinja
@@ -64,3 +64,13 @@
           {{ line }}
           {%- endfor %}
    {%- endif %}
+{%- if env.gcp %}
+
+To obtain Kubernetes admin credentials for this cluster, run:
+
+.. prompt:: bash
+
+   gcloud container clusters get-credentials {{ env.gcp.cluster_name }} --project {{ env.gcp.project_id }} --region {{ env.gcp.region }}
+
+For details on how to set up :command:`gcloud` and the necessarily plugins, see :doc:`/admin/infrastructure/google/credentials`.
+{%- endif %}

--- a/docs/environments/_summary.rst.jinja
+++ b/docs/environments/_summary.rst.jinja
@@ -4,8 +4,24 @@
      - ``{{ env.name }}``
    * - Root domain
      - `{{ env.fqdn }} <https://{{ env.fqdn }}>`__
+   * - Identity provider
+     - {{ env.identity_provider.value }}
    * - Argo CD
      - {% if env.argocd_url %}{{ env.argocd_url }}{% else %}N/A{% endif %}
+   {%- if env.gcp %}
+   * - Google console
+     - - `Log Explorer <https://console.cloud.google.com/logs/query?project={{ env.gcp.project_id }}>`__
+       - `Google Kubernetes Engine <https://console.cloud.google.com/kubernetes/clusters/details/{{ env.gcp.region }}/{{ env.gcp.cluster_name }}/details?project={{ env.gcp.project_id }}>`__
+   * - Google Cloud Platform
+     - .. list-table::
+
+          * - Project ID
+            - {{ env.gcp.project_id }}
+          * - Region
+            - {{ env.gcp.region }}
+          * - Cluster name
+            - {{ env.gcp.cluster_name }}
+   {%- endif %}
    * - Applications
      - .. list-table::
 
@@ -25,9 +41,7 @@
             -
             {%- endif %}
           {% endfor %}
-   * - Identity provider
-     - {{ env.identity_provider.value }}
-   {% if env.gafaelfawr_scopes %}
+   {%- if env.gafaelfawr_scopes %}
    * - Gafaelfawr groups
      - .. list-table::
 
@@ -43,7 +57,7 @@
             {%- endif %}
           {%- endfor %}
    {%- endif %}
-   {% if env.argocd_rbac %}
+   {%- if env.argocd_rbac %}
    * - Argo CD RBAC
      - .. csv-table::
           {% for line in env.argocd_rbac_csv %}

--- a/docs/extras/schemas/environment.json
+++ b/docs/extras/schemas/environment.json
@@ -1,5 +1,32 @@
 {
   "$defs": {
+    "GCPMetadata": {
+      "description": "Google Cloud Platform hosting metadata.\n\nHolds information about where in Google Cloud Platform this Phalanx\nenvironment is hosted. This supports generating documentation that\nincludes this metadata, making it easier for administrators to know what\noptions to pass to :command:`gcloud` to do things such as get Kubernetes\ncredentials.",
+      "properties": {
+        "projectId": {
+          "description": "Project ID of GCP project hosting this environment",
+          "title": "GCP project ID",
+          "type": "string"
+        },
+        "region": {
+          "description": "GCP region in which this environment is hosted",
+          "title": "GCP region",
+          "type": "string"
+        },
+        "clusterName": {
+          "description": "Name of the GKE cluster hosting this environment",
+          "title": "Kubernetes cluster name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "projectId",
+        "region",
+        "clusterName"
+      ],
+      "title": "GCPMetadata",
+      "type": "object"
+    },
     "OnepasswordConfig": {
       "description": "Configuration for 1Password static secrets source.",
       "properties": {
@@ -50,6 +77,19 @@
       "default": null,
       "description": "URL to Butler repository index",
       "title": "Butler repository index URL"
+    },
+    "gcp": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/GCPMetadata"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "If this environment is hosted on Google Cloud Platform, metadata about the hosting project, location, and other details. Used to generate additional environment documentation.",
+      "title": "GCP hosting metadata"
     },
     "onepassword": {
       "anyOf": [

--- a/environments/values-idfdev.yaml
+++ b/environments/values-idfdev.yaml
@@ -1,10 +1,14 @@
+name: "idfdev"
+fqdn: "data-dev.lsst.cloud"
 butlerRepositoryIndex: "s3://butler-us-central1-repo-locations/data-dev-repos.yaml"
-fqdn: data-dev.lsst.cloud
-name: idfdev
+gcp:
+  projectId: "science-platform-dev-7696"
+  region: "us-central1"
+  clusterName: "science-platform-dev"
 onepassword:
   connectUrl: "https://roundtable-dev.lsst.cloud/1password"
   vaultTitle: "RSP data-dev.lsst.cloud"
-vaultPathPrefix: secret/phalanx/idfdev
+vaultPathPrefix: "secret/phalanx/idfdev"
 
 applications:
   argo-workflows: true

--- a/environments/values-idfint.yaml
+++ b/environments/values-idfint.yaml
@@ -1,10 +1,14 @@
+name: "idfint"
+fqdn: "data-int.lsst.cloud"
 butlerRepositoryIndex: "s3://butler-us-central1-repo-locations/data-int-repos.yaml"
-fqdn: data-int.lsst.cloud
-name: idfint
+gcp:
+  projectId: "science-platform-int-dc5d"
+  region: "us-central1"
+  clusterName: "science-platform-int"
 onepassword:
   connectUrl: "https://roundtable.lsst.cloud/1password"
   vaultTitle: "RSP data-int.lsst.cloud"
-vaultPathPrefix: secret/phalanx/idfint
+vaultPathPrefix: "secret/phalanx/idfint"
 
 applications:
   alert-stream-broker: true

--- a/environments/values-idfprod.yaml
+++ b/environments/values-idfprod.yaml
@@ -1,10 +1,14 @@
+name: "idfprod"
+fqdn: "data.lsst.cloud"
 butlerRepositoryIndex: "s3://butler-us-central1-repo-locations/data-repos.yaml"
-fqdn: data.lsst.cloud
-name: idfprod
+gcp:
+  projectId: "science-platform-stable-6994"
+  region: "us-central1"
+  clusterName: "science-platform-stable"
 onepassword:
   connectUrl: "https://roundtable.lsst.cloud/1password"
   vaultTitle: "RSP data.lsst.cloud"
-vaultPathPrefix: secret/phalanx/idfprod
+vaultPathPrefix: "secret/phalanx/idfprod"
 
 applications:
   datalinker: true

--- a/environments/values-roundtable-dev.yaml
+++ b/environments/values-roundtable-dev.yaml
@@ -1,10 +1,13 @@
-name: roundtable-dev
-fqdn: roundtable-dev.lsst.cloud
+name: "roundtable-dev"
+fqdn: "roundtable-dev.lsst.cloud"
+gcp:
+  projectId: "roundtable-dev-abe2"
+  region: "us-central1"
+  clusterName: "roundtable-dev"
 onepassword:
   connectUrl: "https://roundtable-dev.lsst.cloud/1password"
   vaultTitle: "RSP roundtable-dev.lsst.cloud"
-vaultUrl: "https://vault.lsst.codes"
-vaultPathPrefix: secret/phalanx/roundtable-dev
+vaultPathPrefix: "secret/phalanx/roundtable-dev"
 
 applications:
   giftless: true

--- a/environments/values-roundtable-prod.yaml
+++ b/environments/values-roundtable-prod.yaml
@@ -1,9 +1,13 @@
-name: roundtable-prod
-fqdn: roundtable.lsst.cloud
+name: "roundtable-prod"
+fqdn: "roundtable.lsst.cloud"
+gcp:
+  projectId: "roundtable-prod-f6fd"
+  region: "us-central1"
+  clusterName: "roundtable-prod"
 onepassword:
   connectUrl: "https://roundtable.lsst.cloud/1password"
   vaultTitle: "RSP roundtable.lsst.cloud"
-vaultPathPrefix: secret/phalanx/roundtable-prod
+vaultPathPrefix: "secret/phalanx/roundtable-prod"
 
 applications:
   giftless: true

--- a/src/phalanx/models/environments.py
+++ b/src/phalanx/models/environments.py
@@ -24,6 +24,7 @@ __all__ = [
     "EnvironmentBaseConfig",
     "EnvironmentConfig",
     "EnvironmentDetails",
+    "GCPMetadata",
     "GafaelfawrGitHubGroup",
     "GafaelfawrGitHubTeam",
     "GafaelfawrScope",
@@ -31,6 +32,35 @@ __all__ = [
     "OnepasswordConfig",
     "PhalanxConfig",
 ]
+
+
+class GCPMetadata(CamelCaseModel):
+    """Google Cloud Platform hosting metadata.
+
+    Holds information about where in Google Cloud Platform this Phalanx
+    environment is hosted. This supports generating documentation that
+    includes this metadata, making it easier for administrators to know what
+    options to pass to :command:`gcloud` to do things such as get Kubernetes
+    credentials.
+    """
+
+    project_id: str = Field(
+        ...,
+        title="GCP project ID",
+        description="Project ID of GCP project hosting this environment",
+    )
+
+    region: str = Field(
+        ...,
+        title="GCP region",
+        description="GCP region in which this environment is hosted",
+    )
+
+    cluster_name: str = Field(
+        ...,
+        title="Kubernetes cluster name",
+        description="Name of the GKE cluster hosting this environment",
+    )
 
 
 class OnepasswordConfig(CamelCaseModel):
@@ -68,6 +98,16 @@ class EnvironmentBaseConfig(CamelCaseModel):
         None,
         title="Butler repository index URL",
         description="URL to Butler repository index",
+    )
+
+    gcp: GCPMetadata | None = Field(
+        None,
+        title="GCP hosting metadata",
+        description=(
+            "If this environment is hosted on Google Cloud Platform,"
+            " metadata about the hosting project, location, and other details."
+            " Used to generate additional environment documentation."
+        ),
     )
 
     onepassword: OnepasswordConfig | None = Field(

--- a/tests/data/input/environments/values-idfdev.yaml
+++ b/tests/data/input/environments/values-idfdev.yaml
@@ -1,5 +1,9 @@
 name: idfdev
 fqdn: data-dev.lsst.cloud
+gcp:
+  projectId: science-platform-dev-7696
+  region: us-central1
+  clusterName: science-platform
 vaultUrl: https://vault.lsst.codes/
 vaultPathPrefix: secret/phalanx/idfdev
 

--- a/tests/docs/jinja_test.py
+++ b/tests/docs/jinja_test.py
@@ -44,10 +44,14 @@ def test_build_jinja_contexts(factory: Factory) -> None:
         assert idfdev.fqdn == "data-dev.lsst.cloud"
         assert idfdev.argocd_url == "https://data-dev.lsst.cloud/argo-cd"
         assert idfdev.identity_provider == IdentityProvider.CILOGON
+        assert idfdev.gcp.project_id == "science-platform-dev-7696"
+        assert idfdev.gcp.region == "us-central1"
+        assert idfdev.gcp.cluster_name == "science-platform"
         assert minikube.name == "minikube"
         assert minikube.fqdn == "minikube.lsst.cloud"
         assert minikube.argocd_url is None
         assert minikube.identity_provider == IdentityProvider.GITHUB
+        assert minikube.gcp is None
 
         # Check some of the more complex data.
         expected = read_output_data("idfdev", "argocd-rbac-rst")


### PR DESCRIPTION
Add a way to fill out GCP hosting information for environments running on GKE, and expose that information in the generated environments documentation along with links to the Google Console and Log Explorer.

Relocate the authentication source information nearer to the top of the environment documentation both to consolidate shorter data and to move it above the application list, which is usually long enough to push it off the first page.

Document how to get Kubernetes credentials for GKE-hosted projects (the goal that started this PR), and add a stub page about Terraform with little useful content as yet.

While working on this, I noticed that bare GitHub links get useful automatic formatting, so did a pass through all the documentation and used that construction in more places where the link text wasn't adding anything of value and the link was to a simple GitHub repository.