### PR TITLE
DM-42155: LATISS image timeouts too short for start of imaging sequence

### DIFF
--- a/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
@@ -34,6 +34,10 @@ prompt-proto-service:
   imageNotifications:
     kafkaClusterAddress: prompt-processing-kafka-bootstrap.kafka:9092
     topic: rubin-prompt-processing-prod
+    # Scheduler adds an extra 60-80-second delay for first visit in a sequence,
+    # and files can take up to 20 seconds to arrive. Scheduler delay associated
+    # with CWFS engineering data, should not apply to other cameras.
+    imageTimeout: '110'
 
   apdb:
     url: postgresql://rubin@usdf-prompt-processing.slac.stanford.edu:5432/lsst-devl


### PR DESCRIPTION
This PR reverses the timeout decrease added on #2784 for LATISS only, as it turns out that some LATISS visits really do have a long delay.