### PR TITLE
Update pre-commit and CI dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,14 +15,14 @@ jobs:
         uses: actions/setup-go@v4
 
       - name: Install helm-docs
-        run: go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.11.0
+        run: go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.11.3
         env:
           GOBIN: /usr/local/bin/
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.0
@@ -35,6 +35,7 @@ jobs:
       matrix:
         python:
           - "3.11"
+          - "3.12"
 
     steps:
       - uses: actions/checkout@v4
@@ -44,8 +45,6 @@ jobs:
           python-version: ${{ matrix.python }}
           tox-envs: "typing,py,coverage-report"
           cache-key-prefix: test
-        env:
-          COLUMNS: 120
 
   helm:
     runs-on: ubuntu-latest
@@ -63,7 +62,7 @@ jobs:
 
       - uses: lsst-sqre/run-tox@v1
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           tox-envs: phalanx-lint-change
           cache-key-prefix: test
 
@@ -113,11 +112,11 @@ jobs:
       - name: Download installer dependencies
         if: steps.filter.outputs.minikube == 'true'
         run: |
-          curl -sSL -o /tmp/vault.zip https://releases.hashicorp.com/vault/1.14.0/vault_1.14.0_linux_amd64.zip
+          curl -sSL -o /tmp/vault.zip https://releases.hashicorp.com/vault/1.15.4/vault_1.15.4_linux_amd64.zip
           unzip /tmp/vault.zip
           sudo mv vault /usr/local/bin/vault
           sudo chmod +x /usr/local/bin/vault
-          sudo curl -sSL -o /usr/local/bin/argocd https://github.com/argoproj/argo-cd/releases/download/v2.7.10/argocd-linux-amd64
+          sudo curl -sSL -o /usr/local/bin/argocd https://github.com/argoproj/argo-cd/releases/download/v2.8.6/argocd-linux-amd64
           sudo chmod +x /usr/local/bin/argocd
           sudo apt-get install socat
 

--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Run neophile
         uses: lsst-sqre/run-neophile@v1
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           mode: pr
           types: python
           app-id: ${{ secrets.NEOPHILE_APP_ID }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -52,7 +52,7 @@ jobs:
         if: steps.filter.outputs.docs == 'true'
         uses: lsst-sqre/run-tox@v1
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           tox-envs: docs
 
       # Upload docs:

--- a/.github/workflows/linkcheck.yaml
+++ b/.github/workflows/linkcheck.yaml
@@ -48,5 +48,5 @@ jobs:
       - name: Check links
         uses: lsst-sqre/run-tox@v1
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           tox-envs: docs-linkcheck

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,20 +1,20 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: check-merge-conflict
       - id: check-toml
       - id: trailing-whitespace
 
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.32.0
+    rev: v1.33.0
     hooks:
       - id: yamllint
         args:
           - -c=.yamllint.yml
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.26.3
+    rev: 0.27.3
     hooks:
       - id: check-jsonschema
         files: ^applications/.*/secrets(-[^./-]+)?\.yaml
@@ -26,7 +26,7 @@ repos:
         files: ^docs/extras/schemas/.*\.json
 
   - repo: https://github.com/norwoodj/helm-docs
-    rev: v1.11.0
+    rev: v1.11.3
     hooks:
       - id: helm-docs
         args:
@@ -46,15 +46,11 @@ repos:
           - --template-files=../helm-docs.md.gotmpl
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.292
+    rev: v0.1.8
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
-
-  - repo: https://github.com/psf/black
-    rev: 23.7.0
-    hooks:
-      - id: black
+      - id: ruff-format
 
   - repo: https://github.com/adamchainz/blacken-docs
     rev: 1.16.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,8 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Intended Audience :: Developers",
     "Operating System :: POSIX",
 ]
@@ -138,16 +140,21 @@ ignore = [
     "D104",    # don't see the point of documenting every package
     "D105",    # our style doesn't require docstrings for magic methods
     "D106",    # Pydantic uses a nested Config class that doesn't warrant docs
+    "D205",    # our documentation style allows a folded first line
     "EM101",   # justification (duplicate string in traceback) is silly
     "EM102",   # justification (duplicate string in traceback) is silly
     "FBT003",  # positional booleans are normal for Pydantic field defaults
+    "FIX002",  # point of a TODO comment is that we're not ready to fix it
     "G004",    # forbidding logging f-strings is appealing, but not our style
     "PD011",   # false positive with non-NumPY code that uses .values
+    "RET505",  # disagree that omitting else always makes code more readable
+    "PLR0911", # often many returns is clearer and simpler style
     "PLR0913", # factory pattern uses constructors with many arguments
     "PLR2004", # too aggressive about magic values
-    "RET505",  # disagree that omitting else always makes code more readable
+    "PLW0603", # yes global is discouraged but if needed, it's needed
     "S105",    # good idea but too many false positives on non-passwords
     "S106",    # good idea but too many false positives on non-passwords
+    "S107",    # good idea but too many false positives on non-passwords
     "S603",    # impossible to write subprocess code without triggering this
     "S607",    # searching for executables on PATH is often correct
     "SIM102",  # sometimes the formatting of nested if statements is clearer
@@ -158,14 +165,32 @@ ignore = [
     "TCH003",  # we decided to not maintain separate TYPE_CHECKING blocks
     "TID252",  # if we're going to use relative imports, use them always
     "TRY003",  # good general advice but lint is way too aggressive
+    "TRY301",  # sometimes raising exceptions inside try is the best flow
 
-    # Phalanx-specific exclusions.
-    "T201",    # print makes sense to use because Phalanx is interactive
+    # The following settings should be disabled when using ruff format
+    # per https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
+    "W191",
+    "E111",
+    "E114",
+    "E117",
+    "D206",
+    "D300",
+    "Q000",
+    "Q001",
+    "Q002",
+    "Q003",
+    "COM812",
+    "COM819",
+    "ISC001",
+    "ISC002",
 ]
 select = ["ALL"]
-target-version = "py311"
+target-version = "py312"
 
 [tool.ruff.per-file-ignores]
+"src/phalanx/**" = [
+    "T201",    # print makes sense to use because Phalanx is interactive
+]
 "tests/**" = [
     "D103",    # tests don't need docstrings
     "PLR0915", # tests are allowed to be long, sometimes that's convenient
@@ -202,12 +227,6 @@ builtins-ignorelist = [
 [tool.ruff.flake8-pytest-style]
 fixture-parentheses = false
 mark-parentheses = false
-
-[tool.ruff.pep8-naming]
-classmethod-decorators = [
-    "pydantic.root_validator",
-    "pydantic.validator",
-]
 
 [tool.ruff.pydocstyle]
 convention = "numpy"

--- a/tests/support/helm.py
+++ b/tests/support/helm.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 import subprocess
 from collections.abc import Iterator
 from pathlib import Path
+from typing import Protocol
 from unittest.mock import patch
-
-from typing_extensions import Protocol
 
 from phalanx.exceptions import HelmFailedError
 from phalanx.storage.helm import HelmStorage


### PR DESCRIPTION
- Update all pre-commit plugins to the latest versions
- Switch to using Ruff to format code instead of Black
- Update the Ruff configuration based on Nublado
- Update the versions of Vault and Argo CD used for minikube CI
- Update Python to 3.12 everywhere in CI except the Python tests
- Test Python code with both 3.11 and 3.12