### PR TITLE
[DM-42069] Advance datalink to 2.1.6

### DIFF
--- a/charts/cadc-tap/README.md
+++ b/charts/cadc-tap/README.md
@@ -14,7 +14,7 @@ IVOA TAP service
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules for the TAP pod |
 | config.backend | string | None, must be set to "pg" or "qserv" | What type of backend are we connecting to? |
-| config.datalinkPayloadUrl | string | `"https://github.com/lsst/sdm_schemas/releases/download/1.2.2/datalink-snippets.zip"` | Datalink payload URL |
+| config.datalinkPayloadUrl | string | `"https://github.com/lsst/sdm_schemas/releases/download/2.1.6/datalink-snippets.zip"` | Datalink payload URL |
 | config.gcsBucket | string | The common GCS bucket | Name of GCS bucket in which to store results |
 | config.gcsBucketType | string | GCS | GCS bucket type (GCS or S3) |
 | config.gcsBucketUrl | string | The common GCS bucket | Base URL for results stored in GCS bucket |

--- a/charts/cadc-tap/values.yaml
+++ b/charts/cadc-tap/values.yaml
@@ -99,7 +99,7 @@ config:
   tapSchemaAddress: "cadc-tap-schema-db:3306"
 
   # -- Datalink payload URL
-  datalinkPayloadUrl: "https://github.com/lsst/sdm_schemas/releases/download/1.2.2/datalink-snippets.zip"
+  datalinkPayloadUrl: "https://github.com/lsst/sdm_schemas/releases/download/2.1.6/datalink-snippets.zip"
 
   # -- Name of GCS bucket in which to store results
   # @default -- The common GCS bucket


### PR DESCRIPTION
tap schema release is already there.