### PR TITLE
DM-42225: Upgrade mobu to 7.0.0

### DIFF
--- a/applications/mobu/Chart.yaml
+++ b/applications/mobu/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: mobu
 version: 1.0.0
-description: Continuous integration testing
+description: "Continuous integration testing"
 sources:
-  - https://github.com/lsst-sqre/mobu
-appVersion: 6.1.1
+  - "https://github.com/lsst-sqre/mobu"
+appVersion: 7.0.0

--- a/applications/mobu/templates/deployment.yaml
+++ b/applications/mobu/templates/deployment.yaml
@@ -25,27 +25,27 @@ spec:
         - name: {{ .Chart.Name }}
           env:
             {{- if .Values.config.slackAlerts }}
-            - name: "ALERT_HOOK"
+            - name: "MOBU_ALERT_HOOK"
               valueFrom:
                 secretKeyRef:
                   name: {{ template "mobu.fullname" . }}-secret
                   key: "ALERT_HOOK"
             {{- end }}
             {{- if .Values.config.autostart }}
-            - name: "AUTOSTART"
+            - name: "MOBU_AUTOSTART_PATH"
               value: "/etc/mobu/autostart.yaml"
             {{- end }}
-            - name: "ENVIRONMENT_URL"
+            - name: "MOBU_ENVIRONMENT_URL"
               value: {{ .Values.global.baseUrl }}
-            - name: "GAFAELFAWR_TOKEN"
+            - name: "MOBU_GAFAELFAWR_TOKEN"
               valueFrom:
                 secretKeyRef:
                   name: {{ template "mobu.fullname" . }}-gafaelfawr-token
                   key: "token"
-            - name: "SAFIR_PATH_PREFIX"
+            - name: "MOBU_PATH_PREFIX"
               value: {{ .Values.config.pathPrefix | quote }}
             {{- if (not .Values.config.debug) }}
-            - name: "SAFIR_PROFILE"
+            - name: "MOBU_LOGGING_PROFILE"
               value: "production"
             {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/applications/mobu/values-idfdev.yaml
+++ b/applications/mobu/values-idfdev.yaml
@@ -15,7 +15,6 @@ config:
         options:
           repo_url: "https://github.com/lsst-sqre/system-test.git"
           repo_branch: "prod"
-          use_cachemachine: false
         restart: true
     - name: "tutorial"
       count: 1
@@ -33,7 +32,6 @@ config:
           repo_branch: "prod"
           max_executions: 1
           working_directory: "notebooks/tutorial-notebooks"
-          use_cachemachine: false
         restart: true
     - name: "tap"
       count: 1
@@ -41,7 +39,7 @@ config:
         - username: "bot-mobu-tap"
       scopes: ["read:tap"]
       business:
-        type: "TAPQueryRunner"
+        type: "TAPQuerySetRunner"
         options:
           query_set: "dp0.2"
         restart: true

--- a/applications/mobu/values-idfint.yaml
+++ b/applications/mobu/values-idfint.yaml
@@ -14,7 +14,6 @@ config:
         options:
           repo_url: "https://github.com/lsst-sqre/system-test.git"
           repo_branch: "prod"
-          use_cachemachine: false
         restart: true
     - name: "weekly"
       count: 1
@@ -30,7 +29,6 @@ config:
         options:
           repo_url: "https://github.com/lsst-sqre/system-test.git"
           repo_branch: "prod"
-          use_cachemachine: false
         restart: true
     - name: "tutorial"
       count: 1
@@ -48,7 +46,6 @@ config:
           repo_branch: "prod"
           max_executions: 1
           working_directory: "notebooks/tutorial-notebooks"
-          use_cachemachine: false
         restart: true
     - name: "tap"
       count: 1
@@ -56,7 +53,7 @@ config:
         - username: "bot-mobu-tap"
       scopes: ["read:tap"]
       business:
-        type: "TAPQueryRunner"
+        type: "TAPQuerySetRunner"
         options:
           query_set: "dp0.2"
         restart: true

--- a/applications/mobu/values-idfprod.yaml
+++ b/applications/mobu/values-idfprod.yaml
@@ -15,7 +15,6 @@ config:
           repo_url: "https://github.com/lsst-sqre/system-test.git"
           repo_branch: "prod"
           max_executions: 1
-          use_cachemachine: false
         restart: true
     - name: "quickbeam"
       count: 1
@@ -33,7 +32,6 @@ config:
           repo_branch: "prod"
           idle_time: 900
           delete_lab: false
-          use_cachemachine: false
         restart: true
     - name: "tutorial"
       count: 1
@@ -51,7 +49,6 @@ config:
           repo_branch: "prod"
           max_executions: 1
           working_directory: "notebooks/tutorial-notebooks"
-          use_cachemachine: false
         restart: true
     - name: "tutorial-weekly"
       count: 1
@@ -71,7 +68,6 @@ config:
           repo_branch: "prod"
           max_executions: 1
           working_directory: "notebooks/tutorial-notebooks"
-          use_cachemachine: false
         restart: true
     - name: "tap"
       count: 1
@@ -79,7 +75,7 @@ config:
         - username: "bot-mobu-tap"
       scopes: ["read:tap"]
       business:
-        type: "TAPQueryRunner"
+        type: "TAPQuerySetRunner"
         options:
           query_set: "dp0.2"
         restart: true

--- a/applications/mobu/values-usdfdev.yaml
+++ b/applications/mobu/values-usdfdev.yaml
@@ -19,7 +19,6 @@ config:
             image_class: "latest-weekly"
           repo_url: "https://github.com/lsst-sqre/system-test.git"
           repo_branch: "prod"
-          use_cachemachine: false
         restart: true
     - name: "tap"
       count: 1
@@ -29,7 +28,7 @@ config:
           gidnumber: 1126
       scopes: ["read:tap"]
       business:
-        type: "TAPQueryRunner"
+        type: "TAPQuerySetRunner"
         options:
           query_set: "dp0.2"
         restart: true

--- a/applications/mobu/values-usdfint.yaml
+++ b/applications/mobu/values-usdfint.yaml
@@ -19,5 +19,4 @@ config:
             image_class: "latest-weekly"
           repo_url: "https://github.com/lsst-sqre/system-test.git"
           repo_branch: "prod"
-          use_cachemachine: false
         restart: true

--- a/applications/mobu/values-usdfprod.yaml
+++ b/applications/mobu/values-usdfprod.yaml
@@ -17,7 +17,6 @@ config:
         options:
           repo_url: "https://github.com/lsst-sqre/system-test.git"
           repo_branch: "prod"
-          use_cachemachine: false
         restart: true
     - name: "tap"
       count: 1
@@ -27,7 +26,7 @@ config:
           gidnumber: 1126
       scopes: ["read:tap"]
       business:
-        type: "TAPQueryRunner"
+        type: "TAPQuerySetRunner"
         options:
           query_set: "dp0.2"
         restart: true


### PR DESCRIPTION
Update the Phalanx configuration for the mobu 7.0.0 release, which changes environment variable names, drops support for cachemachine, and renames some monkey businesses.