### PR TITLE
Add the lsst.prompt namespace to Sasquatch

### DIFF
--- a/applications/sasquatch/values-usdfdev.yaml
+++ b/applications/sasquatch/values-usdfdev.yaml
@@ -123,6 +123,12 @@ kafka-connect-manager:
         connectInfluxDb: "lsst.lf"
         topicsRegex: "lsst.lf.*"
         tags: benchmark_env,module,benchmark_type
+      lsstprompt:
+        enabled: true
+        timestamp: "timestamp"
+        connectInfluxDb: "lsst.prompt"
+        topicsRegex: "lsst.prompt.*"
+        tags: dataset_tag,band,instrument,skymap,detector,physical_filter,tract,exposure,patch,visit,run
 
 kafdrop:
   ingress:
@@ -146,6 +152,7 @@ rest-proxy:
       - lsst.camera
       - lsst.verify
       - lsst.lf
+      - lsst.prompt
 
 chronograf:
   ingress:

--- a/applications/sasquatch/values-usdfdev.yaml
+++ b/applications/sasquatch/values-usdfdev.yaml
@@ -128,7 +128,7 @@ kafka-connect-manager:
         timestamp: "timestamp"
         connectInfluxDb: "lsst.prompt"
         topicsRegex: "lsst.prompt.*"
-        tags: dataset_tag,band,instrument,skymap,detector,physical_filter,tract,exposure,patch,visit,run
+        tags: dataset_tag,band,instrument,skymap,detector,physical_filter,tract,exposure,patch,visit,group
 
 kafdrop:
   ingress:


### PR DESCRIPTION
Add the `lsst.prompt` namespace to Sasquatch, it assumes the messages have a `timestamp` column, and results will be recorded in the `lsst.prompt` database in InfluxDB. To start use the same set of tags used in `lsst.dm`.