### PR TITLE
DM-42189: Update Butler for multi-repo server

### DIFF
--- a/applications/butler/Chart.yaml
+++ b/applications/butler/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.0.1
+appVersion: 0.0.2
 description: Server for Butler data abstraction service
 name: butler
 sources:

--- a/applications/butler/README.md
+++ b/applications/butler/README.md
@@ -15,8 +15,9 @@ Server for Butler data abstraction service
 | autoscaling.maxReplicas | int | `100` | Maximum number of butler deployment pods |
 | autoscaling.minReplicas | int | `1` | Minimum number of butler deployment pods |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU utilization of butler deployment pods |
-| config.configUri | string | `""` | URI to the file specifying the DirectButler configuration to be used by the butler server |
+| config.indexUri | string | `""` | URI to the DirectButler repository index file listing the configurations for each repository to be hosted by this server. |
 | config.pathPrefix | string | `"/api/butler"` | The prefix of the path portion of the URL where the Butler service will be exposed.  For example, if the service should be exposed at `https://data.lsst.cloud/api/butler`, this should be set to `/api/butler` |
+| config.repositoryLabels | list | `[]` | List of Butler repository labels which will be hosted by this server, matching those from the index file. |
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |

--- a/applications/butler/templates/deployment.yaml
+++ b/applications/butler/templates/deployment.yaml
@@ -50,8 +50,8 @@ spec:
               value: "/opt/lsst/butler/secrets/butler-gcs-creds.json"
             - name: S3_ENDPOINT_URL
               value: "https://storage.googleapis.com"
-            - name: BUTLER_SERVER_CONFIG_URI
-              value: {{ .Values.config.configUri | quote }}
+            - name: DAF_BUTLER_REPOSITORY_INDEX
+              value: {{ .Values.config.indexUri | quote }}
           volumeMounts:
             - name: "butler-secrets"
               mountPath: "/opt/lsst/butler/secrets"

--- a/applications/butler/templates/ingress-anonymous.yaml
+++ b/applications/butler/templates/ingress-anonymous.yaml
@@ -20,7 +20,6 @@ template:
       - host: {{ required "global.host must be set" .Values.global.host | quote }}
         http:
           paths:
-            {{- range $repositoryLabel := .Values.config.repositoryLabels }}
             # For direct end-user use of the Butler client library, the
             # Butler() convenience constructor must be able to load a
             # configuration file via unauthenticated HTTP.  This exists for
@@ -28,6 +27,7 @@ template:
             # to the existence of the Butler server -- they are passed the URI
             # for a repository root on the filesystem or HTTP, from which a
             # configuration file is loaded.
+            {{- range $repositoryLabel := .Values.config.repositoryLabels }}
             - path: "{{ $.Values.config.pathPrefix }}/repo/{{ $repositoryLabel }}/butler.yaml"
               pathType: "Exact"
               backend:

--- a/applications/butler/templates/ingress-anonymous.yaml
+++ b/applications/butler/templates/ingress-anonymous.yaml
@@ -20,6 +20,7 @@ template:
       - host: {{ required "global.host must be set" .Values.global.host | quote }}
         http:
           paths:
+            {{- range $repositoryLabel := .Values.config.repositoryLabels }}
             # For direct end-user use of the Butler client library, the
             # Butler() convenience constructor must be able to load a
             # configuration file via unauthenticated HTTP.  This exists for
@@ -27,18 +28,18 @@ template:
             # to the existence of the Butler server -- they are passed the URI
             # for a repository root on the filesystem or HTTP, from which a
             # configuration file is loaded.
-            - path: "{{ .Values.config.pathPrefix }}/butler.yaml"
+            - path: "{{ $.Values.config.pathPrefix }}/repo/{{ $repositoryLabel }}/butler.yaml"
               pathType: "Exact"
               backend:
                 service:
                   name: "butler"
                   port:
                     number: 8080
-            - path: "{{ .Values.config.pathPrefix }}/butler.json"
+            - path: "{{ $.Values.config.pathPrefix }}/repo/{{ $repositoryLabel }}/butler.json"
               pathType: "Exact"
               backend:
                 service:
                   name: "butler"
                   port:
                     number: 8080
-
+            {{- end }}

--- a/applications/butler/templates/ingress-authenticated.yaml
+++ b/applications/butler/templates/ingress-authenticated.yaml
@@ -29,10 +29,12 @@ template:
       - host: {{ required "global.host must be set" .Values.global.host | quote }}
         http:
           paths:
-            - path: {{ .Values.config.pathPrefix | quote }}
+            {{- range $repositoryLabel := .Values.config.repositoryLabels }}
+            - path: "{{ $.Values.config.pathPrefix }}/repo/{{ $repositoryLabel }}"
               pathType: "Prefix"
               backend:
                 service:
                   name: "butler"
                   port:
                     number: 8080
+            {{- end }}

--- a/applications/butler/values-idfdev.yaml
+++ b/applications/butler/values-idfdev.yaml
@@ -2,4 +2,6 @@ image:
   pullPolicy: Always
 
 config:
-  configUri: "s3://butler-us-central1-panda-dev/dc2/butler-external-idfdev.yaml"
+  indexUri: "s3://butler-us-central1-repo-locations/data-dev-repos.yaml"
+  repositoryLabels:
+    - dp02

--- a/applications/butler/values-idfint.yaml
+++ b/applications/butler/values-idfint.yaml
@@ -1,0 +1,4 @@
+config:
+  indexUri: "s3://butler-us-central1-repo-locations/data-int-repos.yaml"
+  repositoryLabels:
+    - dp02

--- a/applications/butler/values-idfprod.yaml
+++ b/applications/butler/values-idfprod.yaml
@@ -1,0 +1,5 @@
+config:
+  indexUri: "s3://butler-us-central1-repo-locations/data-repos.yaml"
+  repositoryLabels:
+    - dp01
+    - dp02

--- a/applications/butler/values.yaml
+++ b/applications/butler/values.yaml
@@ -64,9 +64,13 @@ global:
   vaultSecretsPath: ""
 
 config:
-  # -- URI to the file specifying the DirectButler configuration to be used
-  # by the butler server
-  configUri: ""
+  # -- URI to the DirectButler repository index file listing the configurations
+  # for each repository to be hosted by this server.
+  indexUri: ""
+
+  # -- List of Butler repository labels which will be hosted by this server,
+  # matching those from the index file.
+  repositoryLabels: []
 
   # -- The prefix of the path portion of the URL where the Butler service will
   # be exposed.  For example, if the service should be exposed at

--- a/environments/values-idfint.yaml
+++ b/environments/values-idfint.yaml
@@ -12,6 +12,7 @@ vaultPathPrefix: "secret/phalanx/idfint"
 
 applications:
   alert-stream-broker: true
+  butler: true
   datalinker: true
   hips: true
   linters: true


### PR DESCRIPTION
Butler server is now able to serve multiple repositories from a single service.  Updated configuration to point to a repository index file instead of a single Butler configuration file.  Added ingresses for each of the repositories.

From the client's perspective, the server it is connecting to is "/api/butler/repo/dp02".  The theory is that in the future we may need separate Butler services for each repository, but at the moment it is excessive to have a separate Butler server for each.  

Also went ahead and added Butler to idfint, as well as a disabled configuration for idfprod.