### PR TITLE
DM-42337: More granular permissions for Nublado controller

### DIFF
--- a/applications/nublado/templates/controller-ingress-hub.yaml
+++ b/applications/nublado/templates/controller-ingress-hub.yaml
@@ -1,23 +1,25 @@
 apiVersion: gafaelfawr.lsst.io/v1alpha1
 kind: GafaelfawrIngress
 metadata:
-  name: "nublado-controller-admin"
+  name: "nublado-controller-hub"
   labels:
     {{- include "nublado.labels" . | nindent 4 }}
 config:
   baseUrl: {{ .Values.global.baseUrl | quote }}
   scopes:
     all:
-      - "exec:admin"
+      - "admin:jupyterlab"
 template:
   metadata:
-    name: "controller-admin"
+    name: "controller-hub"
+    annotations:
+      nginx.ingress.kubernetes.io/use-regex: "true"
   spec:
     rules:
       - host: {{ .Values.global.host | quote }}
         http:
           paths:
-            - path: {{ .Values.controller.config.pathPrefix | quote }}
+            - path: "{{ .Values.controller.config.pathPrefix }}/spawner/v1/labs"
               pathType: "Prefix"
               backend:
                 service:


### PR DESCRIPTION
Ensure that JupyterHub only has access to the routes that it needs to use, and block access to the prepuller and fileserver admin routes to anyone other than exec:admin.