### PR TITLE
Make telegraf-password unconditional in sasquatch

### DIFF
--- a/applications/sasquatch/secrets.yaml
+++ b/applications/sasquatch/secrets.yaml
@@ -60,7 +60,6 @@ sasquatch-test-password:
 telegraf-password:
   description: >-
     ?
-  if: strimzi-kafka.users.telegraf.enabled
 ts-salkafka-password:
   description: >-
     ?


### PR DESCRIPTION
This appears to always be referenced by the strimzi-kafka subchart since it is referenced in the values.yaml file. For the time being, make it unconditional, although I think the logic for deciding what secrets are required may still not be correct.