### PR TITLE
DM-41259: Add Strimzi Connect and Connector for flexible metadata.

### DIFF
--- a/applications/sasquatch/charts/strimzi-kafka/templates/connect.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/connect.yaml
@@ -7,7 +7,6 @@ metadata:
     # Use Connect REST API to configure connectors
     strimzi.io/use-connector-resources: "false"
 spec:
-  image:  {{ .Values.connect.image | quote }}
   replicas: {{ .Values.connect.replicas }}
   bootstrapServers: {{ .Values.cluster.name }}-kafka-bootstrap:9093
   tls:

--- a/applications/sasquatch/charts/strimzi-kafka/templates/connect.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/connect.yaml
@@ -73,6 +73,11 @@ spec:
           - type: jar
             url: {{ .Values.connect.avroConverter.url }}
             sha512sum: {{ .Values.connect.avroConverter.sha512sum }}
+      - name: confluent-schema
+        artifacts:
+          - type: jar
+            url: {{ .Values.connect.schemaClient.url }}
+            sha512sum: {{ .Values.connect.schemaClient.sha512sum }}
   resources:
     requests:
       cpu: "2"

--- a/applications/sasquatch/charts/strimzi-kafka/templates/connect.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/connect.yaml
@@ -68,6 +68,11 @@ spec:
           - type: jar
             url: {{ .Values.connect.jdbcConnector.url }}
             sha512sum: {{ .Values.connect.jdbcConnector.sha512sum }}
+      - name: confluent-avro
+        artifacts:
+          - type: jar
+            url: {{ .Values.connect.avroConverter.url }}
+            sha512sum: {{ .Values.connect.avroConverter.sha512sum }}
   resources:
     requests:
       cpu: "2"

--- a/applications/sasquatch/charts/strimzi-kafka/templates/connect.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/connect.yaml
@@ -20,6 +20,23 @@ spec:
       secretName: {{ .Values.cluster.name }}-connect
       certificate: user.crt
       key: user.key
+  externalConfiguration:
+    env:
+      - name: PGPASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: sasquatch
+            key: connect-postgres-password
+      - name: PG_JDBC_URL
+        valueFrom:
+          secretKeyRef:
+            name: sasquatch
+            key: connect-postgres-url
+      - name: PGUSER
+        valueFrom:
+          secretKeyRef:
+            name: sasquatch
+            key: connect-postgres-user
   config:
     group.id: {{ .Values.cluster.name }}-connect
     offset.storage.topic: {{ .Values.cluster.name }}-connect-offsets
@@ -92,4 +109,25 @@ spec:
     consumerByteRate: 1073741824
     requestPercentage: 90
     controllerMutationRate: 1000
+{{- range $key, $value := .Values.connectors }}
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaConnector
+metadata:
+  name: {{ $value.name }}
+  labels:
+    strimzi.io/cluster: {{ .Values.cluster.name }}
+spec:
+  class: {{ default "io.confluent.connect.jdbc.JdbcSinkConnector" $value.class }}
+  tasksMax: 2
+  config:
+    topics: {{ $value.config.topics }}
+    table.name.format: {{ $value.config.table_name_format }}
+    connection.url: "$PG_JDBC_URL"
+    connection.user: "$PGUSER"
+    connection.password: "$PGPASSWORD"
+    insert.mode: {{ default "upsert" $value.config.insert_mode }}
+    pk.mode: {{ default "record_key" $value.config.pk_mode }}
+    pk.fields: {{ $value.config.pk_fields }}
+{{- end }}
 {{- end }}

--- a/applications/sasquatch/charts/strimzi-kafka/templates/connect.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/connect.yaml
@@ -28,14 +28,14 @@ spec:
             key: connect-postgres-password
       - name: PG_JDBC_URL
         valueFrom:
-          secretKeyRef:
-            name: sasquatch
-            key: connect-postgres-url
+          configMapKeyRef:
+            name: sasquatch-connect-postgres
+            key: jdbcUrl
       - name: PGUSER
         valueFrom:
-          secretKeyRef:
-            name: sasquatch
-            key: connect-postgres-user
+          configMapKeyRef:
+            name: sasquatch-connect-postgres
+            key: jdbcUser
   config:
     group.id: {{ .Values.cluster.name }}-connect
     offset.storage.topic: {{ .Values.cluster.name }}-connect-offsets
@@ -57,13 +57,13 @@ spec:
     output:
       type: docker
       image: {{ .Values.connect.image | quote }}
-      pushSecret: connect-push-secret
+      pushSecret: sasquatch-connect-push-secret
     plugins:
       - name: confluent-jdbc
         artifacts:
           - type: jar
-            url: {{ .Values.connect.jdbc.url }}
-            sha512sum: {{ .Values.connect.jdbc.sha512sum }}
+            url: {{ .Values.connect.jdbcConnector.url }}
+            sha512sum: {{ .Values.connect.jdbcConnector.sha512sum }}
   resources:
     requests:
       cpu: "2"
@@ -74,6 +74,14 @@ spec:
   jvmOptions:
     "-Xmx": "8g"
     "-Xms": "8g"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sasquatch-connect-postgres
+data:
+  jdbcUrl: {{ .Values.connect.postgres.jdbcUrl | quote }}
+  jdbcUser: {{ .Values.connect.postgres.jdbcUser | quote }}
 ---
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaUser

--- a/applications/sasquatch/charts/strimzi-kafka/templates/connect.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/connect.yaml
@@ -37,6 +37,17 @@ spec:
     value.converter.schemas.enable: true
     value.converter.schema.registry.url: http://sasquatch-schema-registry.sasquatch:8081
     request.timeout.ms: 120000
+  build:
+    output:
+      type: docker
+      image: {{ .Values.connect.image | quote }}
+      pushSecret: connect-push-secret
+    plugins:
+      - name: confluent-jdbc
+        artifacts:
+          - type: jar
+            url: {{ .Values.connect.jdbc.url }}
+            sha512sum: {{ .Values.connect.jdbc.sha512sum }}
   resources:
     requests:
       cpu: "2"

--- a/applications/sasquatch/charts/strimzi-kafka/templates/connect.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/connect.yaml
@@ -53,6 +53,10 @@ spec:
     value.converter.schemas.enable: true
     value.converter.schema.registry.url: http://sasquatch-schema-registry.sasquatch:8081
     request.timeout.ms: 120000
+  template:
+    pod:
+      imagePullSecrets:
+        - name: sasquatch-connect-push-secret
   build:
     output:
       type: docker

--- a/applications/sasquatch/secrets-idfdev.yaml
+++ b/applications/sasquatch/secrets-idfdev.yaml
@@ -1,12 +1,6 @@
 connect-postgres-password:
   description: >-
     ?
-connect-postgres-url:
-  description: >-
-    ?
-connect-postgres-user:
-  description: >-
-    ?
 connect-push-secret:
   description: >-
     ?

--- a/applications/sasquatch/secrets-idfdev.yaml
+++ b/applications/sasquatch/secrets-idfdev.yaml
@@ -1,0 +1,12 @@
+connect-postgres-password:
+  description: >-
+    ?
+connect-postgres-url:
+  description: >-
+    ?
+connect-postgres-user:
+  description: >-
+    ?
+connect-push-secret:
+  description: >-
+    ?

--- a/applications/sasquatch/secrets.yaml
+++ b/applications/sasquatch/secrets.yaml
@@ -69,14 +69,6 @@ connect-postgres-password:
   description: >-
     Password for connecting to Postgres database
   if: strimzi-kafka.connect.enabled
-connect-postgres-url:
-  description: >-
-    URL for connecting to Postgres database
-  if: strimzi-kafka.connect.enabled
-connect-postgres-user:
-  description: >-
-    Username for connecting to Postgres database
-  if: strimzi-kafka.connect.enabled
 connect-push-secret:
   description: >-
     Write token for pushing generated Strimzi Kafka Connect image to GitHub Container Registry.

--- a/applications/sasquatch/secrets.yaml
+++ b/applications/sasquatch/secrets.yaml
@@ -65,6 +65,18 @@ ts-salkafka-password:
   description: >-
     ts-salkafka KafkaUser password.
   if: strimzi-kafka.users.ts-salkafka.enabled
+connect-postgres-password:
+  description: >-
+    Password for connecting to Postgres database
+  if: strimzi-kafka.connect.enabled
+connect-postgres-url:
+  description: >-
+    URL for connecting to Postgres database
+  if: strimzi-kafka.connect.enabled
+connect-postgres-user:
+  description: >-
+    Username for connecting to Postgres database
+  if: strimzi-kafka.connect.enabled
 connect-push-secret:
   description: >-
     Write token for pushing generated Strimzi Kafka Connect image to GitHub Container Registry.

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -33,9 +33,12 @@ strimzi-kafka:
   connect:
     enabled: true
     image: ghcr.io/lsst-sqre/strimzi-jdbc-connector:latest
-    jdbc:
+    jdbcConnector:
       url: https://packages.confluent.io/maven/io/confluent/kafka-connect-jdbc/10.7.4/kafka-connect-jdbc-10.7.4.jar
       sha512sum: e424c09030c29db90f2403f1a004f649bef062500f00cdb00a4904ca6f3ec52349c6983efd18bb4cd92bff8b6766dd50a7b347df7fd7741aa9db0c69c708a727
+    postgres:
+      jdbcUrl: jdbc:postgresql://sqlproxy-butler-int.sqlproxy-cross-project/dp02
+      jdbcUser: postgres
     connectors:
       - name: sink-exposure-flexible-metadata
         config:

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -36,6 +36,9 @@ strimzi-kafka:
     jdbcConnector:
       url: https://packages.confluent.io/maven/io/confluent/kafka-connect-jdbc/10.7.4/kafka-connect-jdbc-10.7.4.jar
       sha512sum: e424c09030c29db90f2403f1a004f649bef062500f00cdb00a4904ca6f3ec52349c6983efd18bb4cd92bff8b6766dd50a7b347df7fd7741aa9db0c69c708a727
+    avroConverter:
+      url: https://packages.confluent.io/maven/io/confluent/kafka-connect-avro-converter/7.5.3/kafka-connect-avro-converter-7.5.3.jar
+      sha512sum: ee3da574360f0e6ac76b7d0397c3dfe39c18bffeef1bed5c68f116aebca0ea9ac6db5ac6515be9b83eba24b045f76d4b9b7413c9fce2a20fc5456cbfec62fbb2
     postgres:
       jdbcUrl: jdbc:postgresql://sqlproxy-butler-int.sqlproxy-cross-project/dp02
       jdbcUser: postgres

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -39,6 +39,9 @@ strimzi-kafka:
     avroConverter:
       url: https://packages.confluent.io/maven/io/confluent/kafka-connect-avro-converter/7.5.3/kafka-connect-avro-converter-7.5.3.jar
       sha512sum: ee3da574360f0e6ac76b7d0397c3dfe39c18bffeef1bed5c68f116aebca0ea9ac6db5ac6515be9b83eba24b045f76d4b9b7413c9fce2a20fc5456cbfec62fbb2
+    schemaClient:
+      url: https://packages.confluent.io/maven/io/confluent/kafka-schema-registry-client/7.5.3/kafka-schema-registry-client-7.5.3.jar
+      sha512sum: 02eb78a1596d7b61820d06dbea97e7d15e85698391af1b373ce88b3ba11ca743293f4861a5f5d24d47a2b16bf0aee165c90928e3870551a7601dc66700147857
     postgres:
       jdbcUrl: jdbc:postgresql://sqlproxy-butler-int.sqlproxy-cross-project/dp02
       jdbcUser: postgres

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -36,6 +36,12 @@ strimzi-kafka:
     jdbc:
       url: https://packages.confluent.io/maven/io/confluent/kafka-connect-jdbc/10.7.4/kafka-connect-jdbc-10.7.4.jar
       sha512sum: e424c09030c29db90f2403f1a004f649bef062500f00cdb00a4904ca6f3ec52349c6983efd18bb4cd92bff8b6766dd50a7b347df7fd7741aa9db0c69c708a727
+    connectors:
+      - name: sink-exposure-flexible-metadata
+        config:
+          topics: lsst.consdb.exposure_flexible_metadata
+          table_name_format: consdb.exposure_flexible_metadata
+          pk_fields: exposure
 
 influxdb:
   ingress:

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -30,6 +30,12 @@ strimzi-kafka:
         nginx.ingress.kubernetes.io/rewrite-target: /$2
       hostname: data-dev.lsst.cloud
       path: /schema-registry(/|$)(.*)
+  connect:
+    enabled: true
+    image: ghcr.io/lsst-sqre/strimzi-jdbc-connector:latest
+    jdbc:
+      url: https://packages.confluent.io/maven/io/confluent/kafka-connect-jdbc/10.7.4/kafka-connect-jdbc-10.7.4.jar
+      sha512sum: e424c09030c29db90f2403f1a004f649bef062500f00cdb00a4904ca6f3ec52349c6983efd18bb4cd92bff8b6766dd50a7b347df7fd7741aa9db0c69c708a727
 
 influxdb:
   ingress:


### PR DESCRIPTION
This PR adds the ability to build a Strimzi Connect container with a JDBC connector and run it within the Sasquatch cluster, using KafkaConnector resource definitions to define connections to a relational database (Postgres).  This capability is then used to connect a topic designed for flexible metadata to a table in the database.