### PR TITLE
Stop watching alert-stream-broker on idfint

### DIFF
--- a/applications/strimzi/values-idfint.yaml
+++ b/applications/strimzi/values-idfint.yaml
@@ -6,5 +6,4 @@ strimzi-kafka-operator:
       memory: "512Mi"
   watchNamespaces:
     - "sasquatch"
-    - "alert-stream-broker"
   logLevel: "INFO"


### PR DESCRIPTION
Tell strimzi to stop watching alert-stream-broker on idfint, since we no longer deploy it there.