### PR TITLE
DM-42477: Rename fileservers to nublado-fileservers

### DIFF
--- a/applications/nublado-fileservers/Chart.yaml
+++ b/applications/nublado-fileservers/Chart.yaml
@@ -1,3 +1,3 @@
 apiVersion: v2
-name: fileservers
+name: nublado-fileservers
 version: 1.0.0

--- a/applications/nublado/README.md
+++ b/applications/nublado/README.md
@@ -25,7 +25,7 @@ JupyterHub and custom spawner for the Rubin Science Platform
 | cloudsql.tolerations | list | `[]` | Tolerations for the Cloud SQL Auth Proxy pod |
 | controller.affinity | object | `{}` | Affinity rules for the Nublado controller |
 | controller.config.fileserver.affinity | object | `{}` | Affinity rules for user file server pods |
-| controller.config.fileserver.application | string | `"fileservers"` | Argo CD application in which to collect user file servers |
+| controller.config.fileserver.application | string | `"nublado-fileservers"` | Argo CD application in which to collect user file servers |
 | controller.config.fileserver.creationTimeout | int | `120` | Timeout to wait for Kubernetes to create file servers, in seconds |
 | controller.config.fileserver.deleteTimeout | int | 60 (1 minute) | Timeout for deleting a user's file server from Kubernetes, in seconds |
 | controller.config.fileserver.enabled | bool | `false` | Enable user file servers |
@@ -33,7 +33,7 @@ JupyterHub and custom spawner for the Rubin Science Platform
 | controller.config.fileserver.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for file server image |
 | controller.config.fileserver.image.repository | string | `"ghcr.io/lsst-sqre/worblehat"` | File server image to use |
 | controller.config.fileserver.image.tag | string | `"0.1.0"` | Tag of file server image to use |
-| controller.config.fileserver.namespace | string | `"fileservers"` | Namespace for user file servers |
+| controller.config.fileserver.namespace | string | `"nublado-fileservers"` | Namespace for user file servers |
 | controller.config.fileserver.nodeSelector | object | `{}` | Node selector rules for user file server pods |
 | controller.config.fileserver.pathPrefix | string | `"/files"` | Path prefix for user file servers |
 | controller.config.fileserver.resources | object | See `values.yaml` | Resource requests and limits for user file servers |

--- a/applications/nublado/values.yaml
+++ b/applications/nublado/values.yaml
@@ -64,7 +64,7 @@ controller:
       affinity: {}
 
       # -- Argo CD application in which to collect user file servers
-      application: "fileservers"
+      application: "nublado-fileservers"
 
       # -- Timeout to wait for Kubernetes to create file servers, in seconds
       creationTimeout: 120
@@ -88,7 +88,7 @@ controller:
         tag: "0.1.0"
 
       # -- Namespace for user file servers
-      namespace: "fileservers"
+      namespace: "nublado-fileservers"
 
       # -- Node selector rules for user file server pods
       nodeSelector: {}

--- a/environments/templates/nublado-fileservers-application.yaml
+++ b/environments/templates/nublado-fileservers-application.yaml
@@ -2,22 +2,22 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: "fileservers"
+  name: "nublado-fileservers"
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: "fileservers"
+  name: "nublado-fileservers"
   namespace: "argocd"
   finalizers:
     - "resources-finalizer.argocd.argoproj.io"
 spec:
   destination:
-    namespace: "fileservers"
+    namespace: "nublado-fileservers"
     server: "https://kubernetes.default.svc"
   project: "default"
   source:
-    path: "applications/fileservers"
+    path: "applications/nublado-fileservers"
     repoURL: {{ .Values.repoUrl | quote }}
     targetRevision: {{ .Values.targetRevision | quote }}
 {{- end -}}

--- a/tests/docs/applications_test.py
+++ b/tests/docs/applications_test.py
@@ -37,7 +37,7 @@ def test_applications_index() -> None:
     for application in root_path.iterdir():
         if not application.is_dir():
             continue
-        if application.name in ("fileservers", "nublado-users"):
+        if application.name in ("nublado-fileservers", "nublado-users"):
             continue
         assert (
             application.name in seen


### PR DESCRIPTION
For consistency with nublado-users, and to ensure that both of the user application buckets sort together, rename fileservers to nublado-fileservers. This is the application and namespace in which Nublado creates user file servers.