### PR TITLE
DM-42477: Add NetworkPolicy for Nublado file servers

### DIFF
--- a/applications/nublado-fileservers/templates/_helpers.tpl
+++ b/applications/nublado-fileservers/templates/_helpers.tpl
@@ -1,0 +1,26 @@
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "nublado-fileservers.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "nublado-fileservers.labels" -}}
+helm.sh/chart: {{ include "nublado-fileservers.chart" . }}
+{{ include "nublado-fileservers.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "nublado-fileservers.selectorLabels" -}}
+app.kubernetes.io/name: "nublado-fileservers"
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/applications/nublado-fileservers/templates/networkpolicy.yaml
+++ b/applications/nublado-fileservers/templates/networkpolicy.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: "nublado-fileservers"
+  labels:
+    {{- include "nublado-fileservers.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      nublado.lsst.io/category: "fileserver"
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        # Allow inbound access from pods (in any namespace) labeled
+        # gafaelfawr.lsst.io/ingress: true.
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              gafaelfawr.lsst.io/ingress: "true"
+      ports:
+        - protocol: "TCP"
+          port: 8000


### PR DESCRIPTION
Add a NetworkPolicy to the nublado-fileservers namespace that affects all file servers and restricts access to Gafaelfawr. Otherwise, users inside the cluster can connect directly to anyone's file server as them.