### PR TITLE
DM-42477: Switch back to fileservers for user file servers

### DIFF
--- a/applications/nublado/README.md
+++ b/applications/nublado/README.md
@@ -33,7 +33,7 @@ JupyterHub and custom spawner for the Rubin Science Platform
 | controller.config.fileserver.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for file server image |
 | controller.config.fileserver.image.repository | string | `"ghcr.io/lsst-sqre/worblehat"` | File server image to use |
 | controller.config.fileserver.image.tag | string | `"0.1.0"` | Tag of file server image to use |
-| controller.config.fileserver.namespace | string | `"nublado-fileservers"` | Namespace for user file servers |
+| controller.config.fileserver.namespace | string | `"fileservers"` | Namespace for user file servers |
 | controller.config.fileserver.nodeSelector | object | `{}` | Node selector rules for user file server pods |
 | controller.config.fileserver.pathPrefix | string | `"/files"` | Path prefix for user file servers |
 | controller.config.fileserver.resources | object | See `values.yaml` | Resource requests and limits for user file servers |

--- a/applications/nublado/values.yaml
+++ b/applications/nublado/values.yaml
@@ -88,7 +88,7 @@ controller:
         tag: "0.1.0"
 
       # -- Namespace for user file servers
-      namespace: "nublado-fileservers"
+      namespace: "fileservers"
 
       # -- Node selector rules for user file server pods
       nodeSelector: {}

--- a/environments/templates/nublado-fileservers-application.yaml
+++ b/environments/templates/nublado-fileservers-application.yaml
@@ -1,8 +1,13 @@
+{{/*
+     The namespace is fileservers even though the Argo CD application is
+     nublado-fileservers, since otherwise we have a conflict with the
+     lab namespace for a user with the username fileservers.
+*/}}
 {{- if .Values.applications.nublado -}}
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: "nublado-fileservers"
+  name: "fileservers"
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application
@@ -13,7 +18,7 @@ metadata:
     - "resources-finalizer.argocd.argoproj.io"
 spec:
   destination:
-    namespace: "nublado-fileservers"
+    namespace: "fileservers"
     server: "https://kubernetes.default.svc"
   project: "default"
   source:


### PR DESCRIPTION
Unfortunately, we cannot use nublado-fileservers as the namespace for user file servers since it conflicts with the namespace pattern used by Nublado for labs. Keep the namespace of fileservers but still use nublado-fileservers as the Argo CD application for appropriate sorting in the Argo CD application display.