### PR TITLE
[DM-42456] Add the ghcr.io write token to Sasquatch secrets

### DIFF
--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -84,7 +84,7 @@ Rubin Observatory's telemetry service.
 | source-kapacitor.resources.requests.cpu | int | `1` |  |
 | source-kapacitor.resources.requests.memory | string | `"1Gi"` |  |
 | squareEvents.enabled | bool | `false` | Enable the Square Events subchart with topic and user configurations. |
-| strimzi-kafka | object | `{}` | Override strimzi-kafka configuration. |
+| strimzi-kafka | object | `{"connect":{"enabled":true},"kafka":{"listeners":{"external":{"enabled":true},"plain":{"enabled":true},"tls":{"enabled":true}}}}` | Override strimzi-kafka subchart configuration. |
 | strimzi-registry-operator | object | `{"clusterName":"sasquatch","clusterNamespace":"sasquatch","operatorNamespace":"sasquatch"}` | strimzi-registry-operator configuration. |
 | telegraf-kafka-consumer | object | `{}` | Override telegraf-kafka-consumer configuration. |
 | influxdb-enterprise.bootstrap.auth.secretName | string | `"sasquatch"` |  |
@@ -320,7 +320,7 @@ Rubin Observatory's telemetry service.
 | source-kafka-connect-manager.s3Sink.topicsRegex | string | `".*"` | Regex to select topics from Kafka. |
 | square-events.cluster.name | string | `"sasquatch"` |  |
 | strimzi-kafka.cluster.name | string | `"sasquatch"` | Name used for the Kafka cluster, and used by Strimzi for many annotations. |
-| strimzi-kafka.connect.enabled | bool | `true` | Enable Kafka Connect. |
+| strimzi-kafka.connect.enabled | bool | `false` | Enable Kafka Connect. |
 | strimzi-kafka.connect.image | string | `"ghcr.io/lsst-sqre/strimzi-0.36.1-kafka-3.5.1:tickets-dm-40655"` | Custom strimzi-kafka image with connector plugins used by sasquatch. |
 | strimzi-kafka.connect.replicas | int | `3` | Number of Kafka Connect replicas to run. |
 | strimzi-kafka.kafka.affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchExpressions":[{"key":"app.kubernetes.io/name","operator":"In","values":["kafka"]}]},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for Kafka pod assignment. |
@@ -336,9 +336,9 @@ Rubin Observatory's telemetry service.
 | strimzi-kafka.kafka.externalListener.brokers | list | `[]` | Borkers configuration. host is used in the brokers' advertised.brokers configuration and for TLS hostname verification. The format is a list of maps. |
 | strimzi-kafka.kafka.externalListener.tls.certIssuerName | string | `"letsencrypt-dns"` | Name of a ClusterIssuer capable of provisioning a TLS certificate for the broker. |
 | strimzi-kafka.kafka.externalListener.tls.enabled | bool | `false` | Whether TLS encryption is enabled. |
-| strimzi-kafka.kafka.listeners.external.enabled | bool | `true` | Whether external listener is enabled. |
-| strimzi-kafka.kafka.listeners.plain.enabled | bool | `true` | Whether internal plaintext listener is enabled. |
-| strimzi-kafka.kafka.listeners.tls.enabled | bool | `true` | Whether internal TLS listener is enabled. |
+| strimzi-kafka.kafka.listeners.external.enabled | bool | `false` | Whether external listener is enabled. |
+| strimzi-kafka.kafka.listeners.plain.enabled | bool | `false` | Whether internal plaintext listener is enabled. |
+| strimzi-kafka.kafka.listeners.tls.enabled | bool | `false` | Whether internal TLS listener is enabled. |
 | strimzi-kafka.kafka.replicas | int | `3` | Number of Kafka broker replicas to run. |
 | strimzi-kafka.kafka.storage.size | string | `"500Gi"` | Size of the backing storage disk for each of the Kafka brokers. |
 | strimzi-kafka.kafka.storage.storageClassName | string | `""` | Name of a StorageClass to use when requesting persistent volumes. |
@@ -357,12 +357,12 @@ Rubin Observatory's telemetry service.
 | strimzi-kafka.registry.ingress.hostname | string | `""` | Hostname for the Schema Registry. |
 | strimzi-kafka.registry.schemaTopic | string | `"registry-schemas"` | Name of the topic used by the Schema Registry |
 | strimzi-kafka.superusers | list | `["kafka-admin"]` | A list of usernames for users who should have global admin permissions. These users will be created, along with their credentials. |
-| strimzi-kafka.users.kafdrop.enabled | bool | `true` | Enable user Kafdrop (deployed by parent Sasquatch chart). |
-| strimzi-kafka.users.kafkaConnectManager.enabled | bool | `true` | Enable user kafka-connect-manager |
-| strimzi-kafka.users.promptProcessing.enabled | bool | `true` | Enable user prompt-processing |
-| strimzi-kafka.users.replicator.enabled | bool | `false` | Enabled user replicator (used by Mirror Maker 2 and required at both source and target clusters) |
-| strimzi-kafka.users.telegraf.enabled | bool | `true` | Enable user telegraf (deployed by parent Sasquatch chart) |
-| strimzi-kafka.users.tsSalKafka.enabled | bool | `true` | Enable user ts-salkafka. |
+| strimzi-kafka.users.kafdrop.enabled | bool | `false` | Enable user Kafdrop (deployed by parent Sasquatch chart). |
+| strimzi-kafka.users.kafkaConnectManager.enabled | bool | `false` | Enable user kafka-connect-manager |
+| strimzi-kafka.users.promptProcessing.enabled | bool | `false` | Enable user prompt-processing |
+| strimzi-kafka.users.replicator.enabled | bool | `false` | Enable user replicator (used by Mirror Maker 2 and required at both source and target clusters) |
+| strimzi-kafka.users.telegraf.enabled | bool | `false` | Enable user telegraf (deployed by parent Sasquatch chart) |
+| strimzi-kafka.users.tsSalKafka.enabled | bool | `false` | Enable user ts-salkafka, used at the telescope environments |
 | strimzi-kafka.zookeeper.affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchExpressions":[{"key":"app.kubernetes.io/name","operator":"In","values":["zookeeper"]}]},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for Zookeeper pod assignment. |
 | strimzi-kafka.zookeeper.replicas | int | `3` | Number of Zookeeper replicas to run. |
 | strimzi-kafka.zookeeper.storage.size | string | `"100Gi"` | Size of the backing storage disk for each of the Zookeeper instances. |

--- a/applications/sasquatch/charts/strimzi-kafka/README.md
+++ b/applications/sasquatch/charts/strimzi-kafka/README.md
@@ -7,7 +7,7 @@ A subchart to deploy Strimzi Kafka components for Sasquatch.
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | cluster.name | string | `"sasquatch"` | Name used for the Kafka cluster, and used by Strimzi for many annotations. |
-| connect.enabled | bool | `true` | Enable Kafka Connect. |
+| connect.enabled | bool | `false` | Enable Kafka Connect. |
 | connect.image | string | `"ghcr.io/lsst-sqre/strimzi-0.36.1-kafka-3.5.1:tickets-dm-40655"` | Custom strimzi-kafka image with connector plugins used by sasquatch. |
 | connect.replicas | int | `3` | Number of Kafka Connect replicas to run. |
 | kafka.affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchExpressions":[{"key":"app.kubernetes.io/name","operator":"In","values":["kafka"]}]},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for Kafka pod assignment. |
@@ -23,9 +23,9 @@ A subchart to deploy Strimzi Kafka components for Sasquatch.
 | kafka.externalListener.brokers | list | `[]` | Borkers configuration. host is used in the brokers' advertised.brokers configuration and for TLS hostname verification. The format is a list of maps. |
 | kafka.externalListener.tls.certIssuerName | string | `"letsencrypt-dns"` | Name of a ClusterIssuer capable of provisioning a TLS certificate for the broker. |
 | kafka.externalListener.tls.enabled | bool | `false` | Whether TLS encryption is enabled. |
-| kafka.listeners.external.enabled | bool | `true` | Whether external listener is enabled. |
-| kafka.listeners.plain.enabled | bool | `true` | Whether internal plaintext listener is enabled. |
-| kafka.listeners.tls.enabled | bool | `true` | Whether internal TLS listener is enabled. |
+| kafka.listeners.external.enabled | bool | `false` | Whether external listener is enabled. |
+| kafka.listeners.plain.enabled | bool | `false` | Whether internal plaintext listener is enabled. |
+| kafka.listeners.tls.enabled | bool | `false` | Whether internal TLS listener is enabled. |
 | kafka.replicas | int | `3` | Number of Kafka broker replicas to run. |
 | kafka.storage.size | string | `"500Gi"` | Size of the backing storage disk for each of the Kafka brokers. |
 | kafka.storage.storageClassName | string | `""` | Name of a StorageClass to use when requesting persistent volumes. |
@@ -44,12 +44,12 @@ A subchart to deploy Strimzi Kafka components for Sasquatch.
 | registry.ingress.hostname | string | `""` | Hostname for the Schema Registry. |
 | registry.schemaTopic | string | `"registry-schemas"` | Name of the topic used by the Schema Registry |
 | superusers | list | `["kafka-admin"]` | A list of usernames for users who should have global admin permissions. These users will be created, along with their credentials. |
-| users.kafdrop.enabled | bool | `true` | Enable user Kafdrop (deployed by parent Sasquatch chart). |
-| users.kafkaConnectManager.enabled | bool | `true` | Enable user kafka-connect-manager |
-| users.promptProcessing.enabled | bool | `true` | Enable user prompt-processing |
-| users.replicator.enabled | bool | `false` | Enabled user replicator (used by Mirror Maker 2 and required at both source and target clusters) |
-| users.telegraf.enabled | bool | `true` | Enable user telegraf (deployed by parent Sasquatch chart) |
-| users.tsSalKafka.enabled | bool | `true` | Enable user ts-salkafka. |
+| users.kafdrop.enabled | bool | `false` | Enable user Kafdrop (deployed by parent Sasquatch chart). |
+| users.kafkaConnectManager.enabled | bool | `false` | Enable user kafka-connect-manager |
+| users.promptProcessing.enabled | bool | `false` | Enable user prompt-processing |
+| users.replicator.enabled | bool | `false` | Enable user replicator (used by Mirror Maker 2 and required at both source and target clusters) |
+| users.telegraf.enabled | bool | `false` | Enable user telegraf (deployed by parent Sasquatch chart) |
+| users.tsSalKafka.enabled | bool | `false` | Enable user ts-salkafka, used at the telescope environments |
 | zookeeper.affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchExpressions":[{"key":"app.kubernetes.io/name","operator":"In","values":["zookeeper"]}]},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for Zookeeper pod assignment. |
 | zookeeper.replicas | int | `3` | Number of Zookeeper replicas to run. |
 | zookeeper.storage.size | string | `"100Gi"` | Size of the backing storage disk for each of the Zookeeper instances. |

--- a/applications/sasquatch/charts/strimzi-kafka/values.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/values.yaml
@@ -30,15 +30,15 @@ kafka:
   listeners:
     plain:
       # -- Whether internal plaintext listener is enabled.
-      enabled: true
+      enabled: false
 
     tls:
       # -- Whether internal TLS listener is enabled.
-      enabled: true
+      enabled: false
 
     external:
       # -- Whether external listener is enabled.
-      enabled: true
+      enabled: false
 
   externalListener:
     tls:
@@ -115,7 +115,7 @@ zookeeper:
 
 connect:
   # -- Enable Kafka Connect.
-  enabled: true
+  enabled: false
   # -- Custom strimzi-kafka image with connector plugins used by sasquatch.
   image: ghcr.io/lsst-sqre/strimzi-0.36.1-kafka-3.5.1:tickets-dm-40655
   # -- Number of Kafka Connect replicas to run.
@@ -139,28 +139,28 @@ superusers:
 
 users:
   replicator:
-    # -- Enabled user replicator (used by Mirror Maker 2 and required at both source and target clusters)
+    # -- Enable user replicator (used by Mirror Maker 2 and required at both source and target clusters)
     enabled: false
 
   tsSalKafka:
-    # -- Enable user ts-salkafka.
-    enabled: true
+    # -- Enable user ts-salkafka, used at the telescope environments
+    enabled: false
 
   kafdrop:
     # -- Enable user Kafdrop (deployed by parent Sasquatch chart).
-    enabled: true
+    enabled: false
 
   telegraf:
     # -- Enable user telegraf (deployed by parent Sasquatch chart)
-    enabled: true
+    enabled: false
 
   promptProcessing:
     # -- Enable user prompt-processing
-    enabled: true
+    enabled: false
 
   kafkaConnectManager:
     # -- Enable user kafka-connect-manager
-    enabled: true
+    enabled: false
 
 mirrormaker2:
   # -- Enable replication in the target (passive) cluster.

--- a/applications/sasquatch/secrets-idfint.yaml
+++ b/applications/sasquatch/secrets-idfint.yaml
@@ -1,16 +1,16 @@
 "kafka-connect-manager-password":
-  description: "?"
+  description: "kafka-connect-manager KafkaUser password."
 "prompt-processing-password":
-  description: "?"
+  description: "prompt-processing KafkaUser password."
 "rest-proxy-password":
-  description: "?"
+  description: "rest-proxy-password KafkaUser password."
 "rest-proxy-sasl-jass-config":
-  description: "?"
+  description: "rest-proxy-sasl-jass-config for connection with the Kafka broker."
 "sasquatch-test-kafka-properties":
-  description: "?"
+  description: "sasquatch-test properties file for connection with the Kafka broker."
 "sasquatch-test-password":
-  description: "?"
+  description: "sasquatch-test KafkaUser password."
 "telegraf-password":
-  description: "?"
+  description: "Telegraf KafkaUser password."
 "ts-salkafka-password":
-  description: "?"
+  description: "ts-salkafka KafkaUser password."

--- a/applications/sasquatch/secrets.yaml
+++ b/applications/sasquatch/secrets.yaml
@@ -1,67 +1,67 @@
 GENERIC_CLIENT_ID:
   description: >-
-    ?
+    Chronograf client ID for OIDC authentication with Gafaelfawr.
   value: chronograf-client-id
 GENERIC_CLIENT_SECRET:
   description: >-
-    ?
+    Chronograf client secret for OIDC authentication with Gafaelfawr.
   generate:
     type: password
 TOKEN_SECRET:
   description: >-
-    ?
+    Chronograf token secret for OIDC authentication with Gafaelfawr.
   generate:
     type: password
 influxdb-password:
   description: >-
-    ?
+    InfluxDB admin password.
   generate:
     type: password
 influxdb-user:
   description: >-
-    ?
+    InfluxDB admin user.
   value: admin
 kafdrop-kafka-properties:
   description: >-
-    ?
+    Kafdrop properties file for connection with the Kafka broker.
   if: kafdrop.enabled
 kafdrop-password:
   description: >-
-    ?
+    Kafdrop KafkaUser password.
   if: kafdrop.enabled
 kafka-connect-manager-password:
   description: >-
-    ?
+    kafka-connect-manager Kafka user password.
   if: strimzi-kafka.users.kafkaConnectManager.enabled
 prompt-processing-password:
   description: >-
-    ?
+    prompt-processing KafkaUser password.
   if: strimzi-kafka.users.promptProcessing.enabled
 replicator-password:
   description: >-
-    ?
+    replicator KafkaUser password.
   if: strimzi-kafka.users.replicator.enabled
 rest-proxy-password:
   description: >-
-    ?
+    rest-proxy-password KafkaUser password.
   if: rest-proxy.enabled
 rest-proxy-sasl-jass-config:
   description: >-
-    ?
+    rest-proxy-sasl-jass-config for connection with the Kafka broker.
   if: rest-proxy.enabled
 sasquatch-test-kafka-properties:
   description: >-
-    ?
+    sasquatch-test properties file for connection with the Kafka broker.
   if: strimzi-kafka.kafka.listeners.plain.enabled
 sasquatch-test-password:
   description: >-
-    ?
+    sasquatch-test KafkaUser password.
   if: strimzi-kafka.kafka.listeners.plain.enabled
 telegraf-password:
   description: >-
-    ?
+    Telegraf KafkaUser password.
   if: telegraf-kafka-consumer.enabled
 ts-salkafka-password:
   description: >-
-    ?
+    ts-salkafka KafkaUser password.
   if: strimzi-kafka.users.ts-salkafka.enabled

--- a/applications/sasquatch/secrets.yaml
+++ b/applications/sasquatch/secrets.yaml
@@ -32,7 +32,7 @@ kafdrop-password:
 kafka-connect-manager-password:
   description: >-
     ?
-  if: strimzi-kafka.connect.enabled
+  if: strimzi-kafka.users.kafkaConnectManager.enabled
 prompt-processing-password:
   description: >-
     ?
@@ -52,15 +52,16 @@ rest-proxy-sasl-jass-config:
 sasquatch-test-kafka-properties:
   description: >-
     ?
-  if: kafka.listeners.plain.enabled
+  if: strimzi-kafka.kafka.listeners.plain.enabled
 sasquatch-test-password:
   description: >-
     ?
-  if: kafka.listeners.plain.enabled
+  if: strimzi-kafka.kafka.listeners.plain.enabled
 telegraf-password:
   description: >-
     ?
+  if: telegraf-kafka-consumer.enabled
 ts-salkafka-password:
   description: >-
     ?
-  if: strimzi-kafka.users.telegraf.enabled
+  if: strimzi-kafka.users.ts-salkafka.enabled

--- a/applications/sasquatch/secrets.yaml
+++ b/applications/sasquatch/secrets.yaml
@@ -65,3 +65,7 @@ ts-salkafka-password:
   description: >-
     ts-salkafka KafkaUser password.
   if: strimzi-kafka.users.ts-salkafka.enabled
+connect-push-secret:
+  description: >-
+    Write token for pushing generated kafka-connect image to GitHub container registry.
+  if: strimzi-kafka.connect.enabled

--- a/applications/sasquatch/values-base.yaml
+++ b/applications/sasquatch/values-base.yaml
@@ -43,6 +43,14 @@ strimzi-kafka:
   users:
     replicator:
       enabled: true
+    tsSalKafka:
+      enabled: true
+    kafdrop:
+      enabled: true
+    telegraf:
+      enabled: true
+    kafkaConnectManager:
+      enabled: true
 
 influxdb:
   persistence:

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -16,6 +16,13 @@ strimzi-kafka:
   users:
     replicator:
       enabled: true
+    kafdrop:
+      enabled: true
+    telegraf:
+      enabled: true
+    kafkaConnectManager:
+      enabled: true
+
   registry:
     ingress:
       enabled: true

--- a/applications/sasquatch/values-idfint.yaml
+++ b/applications/sasquatch/values-idfint.yaml
@@ -29,6 +29,12 @@ strimzi-kafka:
   users:
     replicator:
       enabled: true
+    kafdrop:
+      enabled: true
+    telegraf:
+      enabled: true
+    kafkaConnectManager:
+      enabled: true
 
 influxdb:
   ingress:

--- a/applications/sasquatch/values-summit.yaml
+++ b/applications/sasquatch/values-summit.yaml
@@ -23,6 +23,12 @@ strimzi-kafka:
       enabled: true
     replicator:
       enabled: true
+    kafdrop:
+      enabled: true
+    telegraf:
+      enabled: true
+    kafkaConnectManager:
+      enabled: true
 
 influxdb:
   persistence:

--- a/applications/sasquatch/values-tucson-teststand.yaml
+++ b/applications/sasquatch/values-tucson-teststand.yaml
@@ -18,6 +18,15 @@ strimzi-kafka:
   zookeeper:
     storage:
       storageClassName: rook-ceph-block
+  users:
+    tsSalKafka:
+      enabled: true
+    kafdrop:
+      enabled: true
+    telegraf:
+      enabled: true
+    kafkaConnectManager:
+      enabled: true
   registry:
     ingress:
       enabled: true

--- a/applications/sasquatch/values-usdfdev.yaml
+++ b/applications/sasquatch/values-usdfdev.yaml
@@ -14,6 +14,14 @@ strimzi-kafka:
   users:
     replicator:
       enabled: true
+    kafdrop:
+      enabled: true
+    telegraf:
+      enabled: true
+    kafkaConnectManager:
+      enabled: true
+    promptProcessing:
+      enabled: true
 
 influxdb:
   ingress:

--- a/applications/sasquatch/values-usdfint.yaml
+++ b/applications/sasquatch/values-usdfint.yaml
@@ -12,7 +12,11 @@ strimzi-kafka:
         cpu: 4
         memory: 8Gi
   users:
-    replicator:
+    kafdrop:
+      enabled: true
+    telegraf:
+      enabled: true
+    kafkaConnectManager:
       enabled: true
 
 influxdb:

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -1,4 +1,12 @@
 strimzi-kafka:
+  kafka:
+    listeners:
+      tls:
+        enabled: true
+      plain:
+        enabled: true
+      external:
+        enabled: true
   mirrormaker2:
     enabled: true
     source:
@@ -13,6 +21,14 @@ strimzi-kafka:
         memory: 8Gi
   users:
     replicator:
+      enabled: true
+    kafdrop:
+      enabled: true
+    telegraf:
+      enabled: true
+    kafkaConnectManager:
+      enabled: true
+    promptProcessing:
       enabled: true
 
 influxdb:

--- a/applications/sasquatch/values.yaml
+++ b/applications/sasquatch/values.yaml
@@ -1,7 +1,17 @@
 # Default values for Sasquatch.
 
-# -- Override strimzi-kafka configuration.
-strimzi-kafka: {}
+# -- Override strimzi-kafka subchart configuration.
+strimzi-kafka:
+  kafka:
+    listeners:
+      tls:
+        enabled: true
+      plain:
+        enabled: true
+      external:
+        enabled: true
+  connect:
+    enabled: true
 
 # -- strimzi-registry-operator configuration.
 strimzi-registry-operator:


### PR DESCRIPTION
- Review Sasquatch secret definitions and conditionals. I've noticed that secret conditionals don't work if a component is enabled at the subchart level, for example, in `sasquatch/charts/strimzi-kafka/values.yaml`:

```
users:
  replicator:
    enabled: true
```
and  `sasquatch/secrets.yaml`:

```
replicator-password:
  description: >-
    replicator KafkaUser password.
  if: strimzi-kafka.users.replicator.enabled
```
A way around this was disabling the component by default at the subchart level and explicitly enabling it at the top level,  in `sasquatch/values-idfdev.yaml` in this case.

This is related to #2839,  where we made the `telegraf-password` secret unconditional in Sasquatch.

- Add ghcr.io write token to Sasquatch secrets, it is required by Strimzi to build custom Kafka Connect images.
