### PR TITLE
DM-42460: Add new jira-data-proxy application

### DIFF
--- a/applications/jira-data-proxy/.helmignore
+++ b/applications/jira-data-proxy/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/applications/jira-data-proxy/Chart.yaml
+++ b/applications/jira-data-proxy/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+appVersion: "tickets-DM-42460"
+description: Jira API read-only proxy for Times Square users.
+name: jira-data-proxy
+sources:
+  - https://github.com/lsst-sqre/jira-data-proxy
+type: application
+version: 1.0.0

--- a/applications/jira-data-proxy/README.md
+++ b/applications/jira-data-proxy/README.md
@@ -1,0 +1,32 @@
+# jira-data-proxy
+
+Jira API read-only proxy for Times Square users.
+
+## Source Code
+
+* <https://github.com/lsst-sqre/jira-data-proxy>
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Affinity rules for the jira-data-proxy deployment pod |
+| autoscaling.enabled | bool | `false` | Enable autoscaling of jira-data-proxy deployment |
+| autoscaling.maxReplicas | int | `100` | Maximum number of jira-data-proxy deployment pods |
+| autoscaling.minReplicas | int | `1` | Minimum number of jira-data-proxy deployment pods |
+| autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU utilization of jira-data-proxy deployment pods |
+| config.jiraUrl | string | `"https://jira.lsstcorp.org/"` | Jira base URL |
+| config.logLevel | string | `"info"` | Logging level |
+| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
+| global.host | string | Set by Argo CD | Host name for ingress |
+| global.vaultSecretsPathPrefix | string | Set by Argo CD | Base path for Vault secrets |
+| image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the jira-data-proxy image |
+| image.repository | string | `"ghcr.io/lsst-sqre/jira-data-proxy"` | Image to use in the jira-data-proxy deployment |
+| image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
+| ingress.annotations | object | `{}` | Additional annotations for the ingress rule |
+| ingress.path | string | `"/jira-data-proxy"` | Path prefix where jira-data-proxy is served |
+| nodeSelector | object | `{}` | Node selection rules for the jira-data-proxy deployment pod |
+| podAnnotations | object | `{}` | Annotations for the jira-data-proxy deployment pod |
+| replicaCount | int | `1` | Number of web deployment pods to start |
+| resources | object | `{}` | Resource limits and requests for the jira-data-proxy deployment pod |
+| tolerations | list | `[]` | Tolerations for the jira-data-proxy deployment pod |

--- a/applications/jira-data-proxy/secrets.yaml
+++ b/applications/jira-data-proxy/secrets.yaml
@@ -1,0 +1,4 @@
+JIRA_USERNAME:
+  description: JIRA account username.
+JIRA_PASSWORD:
+  description: JIRA account password.

--- a/applications/jira-data-proxy/templates/_helpers.tpl
+++ b/applications/jira-data-proxy/templates/_helpers.tpl
@@ -1,0 +1,26 @@
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "jira-data-proxy.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "jira-data-proxy.labels" -}}
+helm.sh/chart: {{ include "jira-data-proxy.chart" . }}
+{{ include "jira-data-proxy.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "jira-data-proxy.selectorLabels" -}}
+app.kubernetes.io/name: "jira-data-proxy"
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/applications/jira-data-proxy/templates/configmap.yaml
+++ b/applications/jira-data-proxy/templates/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "jira-data-proxy"
+  labels:
+    {{- include "jira-data-proxy.labels" . | nindent 4 }}
+data:
+  SAFIR_LOG_LEVEL: {{ .Values.config.logLevel | quote }}
+  SAFIR_PATH_PREFIX: {{ .Values.ingress.path | quote }}
+  JIRA_BASE_URL: {{ .Values.config.jiraUrl | quote }}

--- a/applications/jira-data-proxy/templates/deployment.yaml
+++ b/applications/jira-data-proxy/templates/deployment.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "jira-data-proxy"
+  labels:
+    {{- include "jira-data-proxy.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
+    app.kubernetes.io/part-of: "jira-data-proxy"
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "jira-data-proxy.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "jira-data-proxy.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: "server"
+        app.kubernetes.io/part-of: "jira-data-proxy"
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+            readOnlyRootFilesystem: true
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: "http"
+              containerPort: 8080
+              protocol: "TCP"
+          readinessProbe:
+            httpGet:
+              path: "/"
+              port: "http"
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          envFrom:
+            - configMapRef:
+                name: "jira-data-proxy"
+          env:
+            - name: "JIRA_USERNAME"
+              valueFrom:
+                secretKeyRef:
+                  name: "jira-data-proxy"
+                  key: "JIRA_USERNAME"
+            - name: "JIRA_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  name: "jira-data-proxy"
+                  key: "JIRA_PASSWORD"
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/applications/jira-data-proxy/templates/hpa.yaml
+++ b/applications/jira-data-proxy/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: "jira-data-proxy"
+  labels:
+    {{- include "jira-data-proxy.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: "jira-data-proxy"
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: "cpu"
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: "memory"
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/applications/jira-data-proxy/templates/ingress.yaml
+++ b/applications/jira-data-proxy/templates/ingress.yaml
@@ -1,0 +1,31 @@
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
+metadata:
+  name: "jira-data-proxy"
+  labels:
+    {{- include "jira-data-proxy.labels" . | nindent 4 }}
+config:
+  baseUrl: {{ .Values.global.baseUrl | quote }}
+  scopes:
+    all:
+      - "exec:notebook"
+  loginRedirect: false # endpoint is for API use only
+template:
+  metadata:
+    name: "jira-data-proxy"
+    {{- with .Values.ingress.annotations }}
+    annotations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  spec:
+    rules:
+      - host: {{ required "global.host must be set" .Values.global.host | quote }}
+        http:
+          paths:
+            - path: {{ .Values.ingress.path | quote }}
+              pathType: "Prefix"
+              backend:
+                service:
+                  name: "jira-data-proxy"
+                  port:
+                    number: 8080

--- a/applications/jira-data-proxy/templates/networkpolicy.yaml
+++ b/applications/jira-data-proxy/templates/networkpolicy.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: "jira-data-proxy"
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "jira-data-proxy.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    # Allow inbound access from pods (in any namespace) labeled
+    # gafaelfawr.lsst.io/ingress: true.
+    - from:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              gafaelfawr.lsst.io/ingress: "true"
+      ports:
+        - protocol: "TCP"
+          port: 8080

--- a/applications/jira-data-proxy/templates/service.yaml
+++ b/applications/jira-data-proxy/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "jira-data-proxy"
+  labels:
+    {{- include "jira-data-proxy.labels" . | nindent 4 }}
+spec:
+  type: "ClusterIP"
+  ports:
+    - port: 8080
+      targetPort: "http"
+      protocol: "TCP"
+      name: "http"
+  selector:
+    {{- include "jira-data-proxy.selectorLabels" . | nindent 4 }}

--- a/applications/jira-data-proxy/templates/vault-secret.yaml
+++ b/applications/jira-data-proxy/templates/vault-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: ricoberger.de/v1alpha1
+kind: VaultSecret
+metadata:
+  name: "jira-data-proxy"
+  labels:
+    {{- include "jira-data-proxy.labels" . | nindent 4 }}
+spec:
+  path: "{{ .Values.global.vaultSecretsPathPrefix }}/jira-data-proxy"
+  type: Opaque

--- a/applications/jira-data-proxy/values-idfdev.yaml
+++ b/applications/jira-data-proxy/values-idfdev.yaml
@@ -1,0 +1,4 @@
+image:
+  pullPolicy: Always
+config:
+  logLevel: "DEBUG"

--- a/applications/jira-data-proxy/values-usdfdev.yaml
+++ b/applications/jira-data-proxy/values-usdfdev.yaml
@@ -1,0 +1,4 @@
+image:
+  pullPolicy: Always
+config:
+  logLevel: "DEBUG"

--- a/applications/jira-data-proxy/values.yaml
+++ b/applications/jira-data-proxy/values.yaml
@@ -1,0 +1,74 @@
+# Default values for jira-data-proxy.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+config:
+  # -- Logging level
+  logLevel: "info"
+
+  # -- Jira base URL
+  jiraUrl: "https://jira.lsstcorp.org/"
+
+# -- Number of web deployment pods to start
+replicaCount: 1
+
+image:
+  # -- Image to use in the jira-data-proxy deployment
+  repository: "ghcr.io/lsst-sqre/jira-data-proxy"
+
+  # -- Pull policy for the jira-data-proxy image
+  pullPolicy: "IfNotPresent"
+
+  # -- Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+ingress:
+  # -- Additional annotations for the ingress rule
+  annotations: {}
+
+  # -- Path prefix where jira-data-proxy is served
+  path: "/jira-data-proxy"
+
+autoscaling:
+  # -- Enable autoscaling of jira-data-proxy deployment
+  enabled: false
+
+  # -- Minimum number of jira-data-proxy deployment pods
+  minReplicas: 1
+
+  # -- Maximum number of jira-data-proxy deployment pods
+  maxReplicas: 100
+
+  # -- Target CPU utilization of jira-data-proxy deployment pods
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+# -- Annotations for the jira-data-proxy deployment pod
+podAnnotations: {}
+
+# -- Resource limits and requests for the jira-data-proxy deployment pod
+resources: {}
+
+# -- Node selection rules for the jira-data-proxy deployment pod
+nodeSelector: {}
+
+# -- Tolerations for the jira-data-proxy deployment pod
+tolerations: []
+
+# -- Affinity rules for the jira-data-proxy deployment pod
+affinity: {}
+
+# The following will be set by parameters injected by Argo CD and should not
+# be set in the individual environment values files.
+global:
+  # -- Base URL for the environment
+  # @default -- Set by Argo CD
+  baseUrl: ""
+
+  # -- Host name for ingress
+  # @default -- Set by Argo CD
+  host: ""
+
+  # -- Base path for Vault secrets
+  # @default -- Set by Argo CD
+  vaultSecretsPathPrefix: ""

--- a/docs/applications/index.rst
+++ b/docs/applications/index.rst
@@ -49,6 +49,7 @@ To learn how to develop applications for Phalanx, see the :doc:`/developers/inde
    argo-workflows/index
    alert-stream-broker/index
    exposurelog/index
+   jira-data-proxy/index
    narrativelog/index
    obsloctap/index
    plot-navigator/index

--- a/docs/applications/jira-data-proxy/index.rst
+++ b/docs/applications/jira-data-proxy/index.rst
@@ -1,0 +1,20 @@
+.. px-app:: jira-data-proxy
+
+###########################################################
+jira-data-proxy — Jira API read-only proxy for Times Square
+###########################################################
+
+jira-data-proxy provides read-only access to the Rubin Jira API.
+This app is built for Times Square so that notebooks can access the Jira API without external credentials.
+This app only implements GET endpoints.
+
+.. jinja:: jira-data-proxy
+   :file: applications/_summary.rst.jinja
+
+Guides
+======
+
+.. toctree::
+   :maxdepth: 1
+
+   values

--- a/docs/applications/jira-data-proxy/values.md
+++ b/docs/applications/jira-data-proxy/values.md
@@ -1,0 +1,12 @@
+```{px-app-values} jira-data-proxy
+```
+
+# jira-data-proxy Helm values reference
+
+Helm values reference table for the {px-app}`jira-data-proxy` application.
+
+```{include} ../../../applications/jira-data-proxy/README.md
+---
+start-after: "## Values"
+---
+```

--- a/environments/README.md
+++ b/environments/README.md
@@ -15,6 +15,7 @@
 | applications.giftless | bool | `false` | Enable the giftless application |
 | applications.hips | bool | `false` | Enable the HiPS application |
 | applications.ingress-nginx | bool | `true` | Enable the ingress-nginx application. This is required for all environments, but is still configurable because currently USDF uses an unsupported configuration with ingress-nginx deployed in a different cluster. |
+| applications.jira-data-proxy | bool | `false` | Enable the jira-data-proxy application |
 | applications.kubernetes-replicator | bool | `false` | Enable the kubernetes-replicator application |
 | applications.linters | bool | `false` | Enable the linters application |
 | applications.livetap | bool | `false` | Enable the livetap application |

--- a/environments/templates/jira-data-proxy-application.yaml
+++ b/environments/templates/jira-data-proxy-application.yaml
@@ -1,0 +1,34 @@
+{{- if (index .Values "applications" "jira-data-proxy") -}}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "jira-data-proxy"
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: "jira-data-proxy"
+  namespace: "argocd"
+  finalizers:
+    - "resources-finalizer.argocd.argoproj.io"
+spec:
+  destination:
+    namespace: "jira-data-proxy"
+    server: "https://kubernetes.default.svc"
+  project: "default"
+  source:
+    path: "applications/jira-data-proxy"
+    repoURL: {{ .Values.repoUrl | quote }}
+    targetRevision: {{ .Values.targetRevision | quote }}
+    helm:
+      parameters:
+        - name: "global.host"
+          value: {{ .Values.fqdn | quote }}
+        - name: "global.baseUrl"
+          value: "https://{{ .Values.fqdn }}"
+        - name: "global.vaultSecretsPath"
+          value: {{ .Values.vaultPathPrefix | quote }}
+      valueFiles:
+        - "values.yaml"
+        - "values-{{ .Values.name }}.yaml"
+{{- end -}}

--- a/environments/values-idfdev.yaml
+++ b/environments/values-idfdev.yaml
@@ -15,6 +15,7 @@ applications:
   butler: true
   datalinker: true
   hips: true
+  jira-data-proxy: true
   mobu: true
   noteburst: true
   nublado: true

--- a/environments/values-usdfdev.yaml
+++ b/environments/values-usdfdev.yaml
@@ -13,6 +13,7 @@ applications:
   alert-stream-broker: true
   datalinker: true
   exposurelog: true
+  jira-data-proxy: true
   livetap: true
   mobu: true
   narrativelog: true

--- a/environments/values.yaml
+++ b/environments/values.yaml
@@ -65,6 +65,9 @@ applications:
   # cluster.
   ingress-nginx: true
 
+  # -- Enable the jira-data-proxy application
+  jira-data-proxy: false
+
   # -- Enable the kubernetes-replicator application
   kubernetes-replicator: false
 


### PR DESCRIPTION
Developed at https://github.com/lsst-sqre/jira-data-proxy the jira-data-proxy provides a read-only (only GET methods) proxy to the Jira REST API. A user can access this proxy using their common Gafaelfawr token and send GET requests to the Jira API through the proxy, which uses a built-in LDAP credential.

This service is developed for Times Square reports and intended to be deployed for Rubin staff at USDF.