### PR TITLE
DM-40414: Write PipelineTask to transmit alerts to Kafka

### DIFF
--- a/applications/alert-stream-broker/README.md
+++ b/applications/alert-stream-broker/README.md
@@ -101,9 +101,9 @@ Alert transmission to community brokers
 | alert-stream-schema-registry.hostname | string | `"alert-schemas-int.lsst.cloud"` | Hostname for an ingress which sends traffic to the Schema Registry. |
 | alert-stream-schema-registry.name | string | `"alert-schema-registry"` | Name used by the registry, and by its users. |
 | alert-stream-schema-registry.port | int | `8081` | Port where the registry is listening. NOTE: Not actually configurable in strimzi-registry-operator, so this basically cannot be changed. |
-| alert-stream-schema-registry.schemaSync | object | `{"image":{"repository":"lsstdm/lsst_alert_packet","tag":"tickets-DM-32743"},"subject":"alert-packet"}` | Configuration for the Job which injects the most recent alert_packet schema into the Schema Registry |
+| alert-stream-schema-registry.schemaSync | object | `{"image":{"repository":"lsstdm/lsst_alert_packet","tag":"tickets-DM-40414"},"subject":"alert-packet"}` | Configuration for the Job which injects the most recent alert_packet schema into the Schema Registry |
 | alert-stream-schema-registry.schemaSync.image.repository | string | `"lsstdm/lsst_alert_packet"` | Repository of a container which has the alert_packet syncLatestSchemaToRegistry.py program |
-| alert-stream-schema-registry.schemaSync.image.tag | string | `"tickets-DM-32743"` | Version of the container to use |
+| alert-stream-schema-registry.schemaSync.image.tag | string | `"tickets-DM-40414"` | Version of the container to use |
 | alert-stream-schema-registry.schemaSync.subject | string | `"alert-packet"` | Subject name to use when inserting data into the Schema Registry |
 | alert-stream-schema-registry.schemaTopic | string | `"registry-schemas"` | Name of the topic used by the Schema Registry to store data. |
 | alert-stream-schema-registry.strimziAPIVersion | string | `"v1beta2"` | Version of the Strimzi Custom Resource API. The correct value depends on the deployed version of Strimzi. See [this blog post](https://strimzi.io/blog/2021/04/29/api-conversion/) for more. |

--- a/applications/alert-stream-broker/charts/alert-stream-broker/templates/kafka.yaml
+++ b/applications/alert-stream-broker/charts/alert-stream-broker/templates/kafka.yaml
@@ -106,6 +106,7 @@ spec:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
+      message.max.bytes: 4194304 # 8 Megabytes. For testing purposes only.
       log.message.format.version: {{ .Values.kafka.logMessageFormatVersion }}
       inter.broker.protocol.version: {{ .Values.kafka.interBrokerProtocolVersion }}
       ssl.client.auth: required

--- a/applications/alert-stream-broker/charts/alert-stream-schema-registry/README.md
+++ b/applications/alert-stream-broker/charts/alert-stream-schema-registry/README.md
@@ -10,9 +10,9 @@ Confluent Schema Registry for managing schema versions for the Alert Stream
 | hostname | string | `"alert-schemas-int.lsst.cloud"` | Hostname for an ingress which sends traffic to the Schema Registry. |
 | name | string | `"alert-schema-registry"` | Name used by the registry, and by its users. |
 | port | int | `8081` | Port where the registry is listening. NOTE: Not actually configurable in strimzi-registry-operator, so this basically cannot be changed. |
-| schemaSync | object | `{"image":{"repository":"lsstdm/lsst_alert_packet","tag":"tickets-DM-32743"},"subject":"alert-packet"}` | Configuration for the Job which injects the most recent alert_packet schema into the Schema Registry |
+| schemaSync | object | `{"image":{"repository":"lsstdm/lsst_alert_packet","tag":"tickets-DM-40414"},"subject":"alert-packet"}` | Configuration for the Job which injects the most recent alert_packet schema into the Schema Registry |
 | schemaSync.image.repository | string | `"lsstdm/lsst_alert_packet"` | Repository of a container which has the alert_packet syncLatestSchemaToRegistry.py program |
-| schemaSync.image.tag | string | `"tickets-DM-32743"` | Version of the container to use |
+| schemaSync.image.tag | string | `"tickets-DM-40414"` | Version of the container to use |
 | schemaSync.subject | string | `"alert-packet"` | Subject name to use when inserting data into the Schema Registry |
 | schemaTopic | string | `"registry-schemas"` | Name of the topic used by the Schema Registry to store data. |
 | strimziAPIVersion | string | `"v1beta2"` | Version of the Strimzi Custom Resource API. The correct value depends on the deployed version of Strimzi. See [this blog post](https://strimzi.io/blog/2021/04/29/api-conversion/) for more. |

--- a/applications/alert-stream-broker/charts/alert-stream-schema-registry/values.yaml
+++ b/applications/alert-stream-broker/charts/alert-stream-schema-registry/values.yaml
@@ -29,7 +29,7 @@ schemaSync:
     # syncLatestSchemaToRegistry.py program
     repository: lsstdm/lsst_alert_packet
     # -- Version of the container to use
-    tag: tickets-DM-32743
+    tag: tickets-DM-40414
 
   # -- Subject name to use when inserting data into the Schema Registry
   subject: alert-packet


### PR DESCRIPTION
Updates the alert stream schema registry to point to the new, updated schema image.