### PR TITLE
DM-42190: Add delegated token for datalinker links

### DIFF
--- a/applications/datalinker/templates/ingress-image.yaml
+++ b/applications/datalinker/templates/ingress-image.yaml
@@ -9,6 +9,13 @@ config:
   scopes:
     all:
       - "read:image"
+  # Request a delegated token to use for making calls to Butler server with the
+  # end-user's credentials.
+  delegate:
+    internal:
+      service: "datalinker"
+      scopes:
+        - "read:image"
 template:
   metadata:
     name: {{ include "datalinker.fullname" . }}-image


### PR DESCRIPTION
In order to work with Butler client/server, Datalinker will need to get a delegated token for making a request to the Butler server on behalf of the caller.