### PR TITLE
Avoid helm repo update on application template

### DIFF
--- a/src/phalanx/services/application.py
+++ b/src/phalanx/services/application.py
@@ -241,8 +241,8 @@ class ApplicationService:
         HelmFailedError
             Raised if Helm fails.
         """
-        self.add_helm_repositories([app_name], quiet=True)
-        self._helm.repo_update(quiet=True)
+        if self.add_helm_repositories([app_name], quiet=True):
+            self._helm.repo_update(quiet=True)
         self._helm.dependency_update(app_name, quiet=True)
         environment = self._config.load_environment(env_name)
         values = self._build_injected_values(app_name, environment)


### PR DESCRIPTION
If an application that is the target of a phalanx application template command has no dependency Helm repositories, avoid running a helm repo update. Since we added no repositories, helm repo update may fail if the user has no Helm repositories defined.