### PR TITLE
Bump limits for gafaelfawr-operator pod

### DIFF
--- a/applications/gafaelfawr/README.md
+++ b/applications/gafaelfawr/README.md
@@ -97,7 +97,7 @@ Authentication and identity system
 | operator.affinity | object | `{}` | Affinity rules for the token management pod |
 | operator.nodeSelector | object | `{}` | Node selection rules for the token management pod |
 | operator.podAnnotations | object | `{}` | Annotations for the token management pod |
-| operator.resources | object | See `values.yaml` | Resource limits and requests for the Gafaelfawr Kubernetes operator |
+| operator.resources | object | See `values.yaml` | Resource limits and requests for the Gafaelfawr Kubernetes operator. The limits are artificially higher since the operator pod is also where we manually run `gafaelfawr audit --fix`, which requires more CPU and memory. |
 | operator.tolerations | list | `[]` | Tolerations for the token management pod |
 | podAnnotations | object | `{}` | Annotations for the Gafaelfawr frontend pod |
 | redis.affinity | object | `{}` | Affinity rules for the Redis pod |

--- a/applications/gafaelfawr/values.yaml
+++ b/applications/gafaelfawr/values.yaml
@@ -390,12 +390,14 @@ maintenance:
   affinity: {}
 
 operator:
-  # -- Resource limits and requests for the Gafaelfawr Kubernetes operator
+  # -- Resource limits and requests for the Gafaelfawr Kubernetes operator.
+  # The limits are artificially higher since the operator pod is also where we
+  # manually run `gafaelfawr audit --fix`, which requires more CPU and memory.
   # @default -- See `values.yaml`
   resources:
     limits:
-      cpu: "100m"
-      memory: "300Mi"
+      cpu: "500m"
+      memory: "500Mi"
     requests:
       cpu: "10m"
       memory: "150Mi"


### PR DESCRIPTION
The limits were too tight to run gafaelfawr audit --fix.