### PR TITLE
[DM-42596] Add secret to push Strimzi Kafka Connect images to ghcr.io

### DIFF
--- a/applications/sasquatch/secrets.yaml
+++ b/applications/sasquatch/secrets.yaml
@@ -67,5 +67,5 @@ ts-salkafka-password:
   if: strimzi-kafka.users.ts-salkafka.enabled
 connect-push-secret:
   description: >-
-    Write token for pushing generated kafka-connect image to GitHub container registry.
+    Write token for pushing generated Strimzi Kafka Connect image to GitHub Container Registry.
   if: strimzi-kafka.connect.enabled

--- a/applications/sasquatch/templates/vault-secrets.yaml
+++ b/applications/sasquatch/templates/vault-secrets.yaml
@@ -14,3 +14,17 @@ metadata:
 spec:
   path: "{{ .Values.global.vaultSecretsPath }}/pull-secret"
   type: kubernetes.io/dockerconfigjson
+---
+apiVersion: ricoberger.de/v1alpha1
+kind: VaultSecret
+metadata:
+  name: sasquatch-connect-push-secret
+  namespace: sasquatch
+spec:
+  path: "{{ .Values.global.vaultSecretsPath }}/sasquatch"
+  type: kubernetes.io/dockerconfigjson
+  keys:
+    - connect-push-secret
+  templates:
+    .dockerconfigjson: >-
+      {% index .Secrets "connect-push-secret" %}


### PR DESCRIPTION
- Strimzi requires a secret of type `kubernetes.io/dockerconfigjson` to push images to ghcr.io. Add a secret to sasquatch with the `.dockerconfigjson` key and a `VaultSecret` resource to create the `sasquatch-connect-push-secret` secret.