### PR TITLE
DM-42660: Use Butler server for Datalinker on IDF

### DIFF
--- a/applications/butler/Chart.yaml
+++ b/applications/butler/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.0.2
+appVersion: w.2024.04
 description: Server for Butler data abstraction service
 name: butler
 sources:

--- a/applications/datalinker/Chart.yaml
+++ b/applications/datalinker/Chart.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 description: IVOA DataLink-based service and data discovery
 sources:
   - https://github.com/lsst-sqre/datalinker
-appVersion: 1.6.3
+appVersion: 1.7.0
 annotations:
   phalanx.lsst.io/docs: |
     - id: "DMTN-238"

--- a/applications/datalinker/README.md
+++ b/applications/datalinker/README.md
@@ -15,15 +15,16 @@ IVOA DataLink-based service and data discovery
 | autoscaling.maxReplicas | int | `100` | Maximum number of datalinker deployment pods |
 | autoscaling.minReplicas | int | `1` | Minimum number of datalinker deployment pods |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU utilization of datalinker deployment pods |
-| config.overrideButlerRepositoryIndex | string | Use the default configuration for the environment | URI to Butler repository index file, configuring which Butler repository labels are available. |
 | config.pgUser | string | `"rubin"` | User to use from the PGPASSFILE rubin is the default |
 | config.s3EndpointUrl | string | `"https://storage.googleapis.com"` | S3 Endpoint URL |
 | config.separateSecrets | bool | `false` | Whether to use the new secrets management scheme |
 | config.storageBackend | string | `"GCS"` | Storage backend to use: either GCS or S3 GCS is the default |
 | config.tapMetadataUrl | string | `"https://github.com/lsst/sdm_schemas/releases/download/1.2.0/datalink-columns.zip"` | URL containing TAP schema metadata used to construct queries |
+| config.useButlerServer | bool | `false` | If true, use Butler in client/server mode instead of connecting directly to the Butler database |
 | fullnameOverride | string | `""` | Override the full name for resources (includes the release name) |
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.butlerRepositoryIndex | string | Set by Argo CD | URI to the Butler configuration of available repositories |
+| global.butlerServerRepositories | string | Set by Argo CD | Butler repositories accessible via Butler server |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the datalinker image |

--- a/applications/datalinker/README.md
+++ b/applications/datalinker/README.md
@@ -15,6 +15,7 @@ IVOA DataLink-based service and data discovery
 | autoscaling.maxReplicas | int | `100` | Maximum number of datalinker deployment pods |
 | autoscaling.minReplicas | int | `1` | Minimum number of datalinker deployment pods |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU utilization of datalinker deployment pods |
+| config.overrideButlerRepositoryIndex | string | Use the default configuration for the environment | URI to Butler repository index file, configuring which Butler repository labels are available. |
 | config.pgUser | string | `"rubin"` | User to use from the PGPASSFILE rubin is the default |
 | config.s3EndpointUrl | string | `"https://storage.googleapis.com"` | S3 Endpoint URL |
 | config.separateSecrets | bool | `false` | Whether to use the new secrets management scheme |

--- a/applications/datalinker/templates/deployment.yaml
+++ b/applications/datalinker/templates/deployment.yaml
@@ -58,10 +58,11 @@ spec:
             # and authenticate to its database.
             - name: "AWS_SHARED_CREDENTIALS_FILE"
               value: "/tmp/secrets/aws-credentials.ini"
-            - name: "DAF_BUTLER_REPOSITORY_INDEX"
-            {{- if .Values.config.overrideButlerRepositoryIndex }}
-              value: {{ .Values.config.overrideButlerRepositoryIndex | quote }}
+            {{- if .Values.config.useButlerServer }}
+            - name: "DAF_BUTLER_REPOSITORIES"
+              value: {{ .Values.global.butlerServerRepositories | b64dec | quote }}
             {{- else }}
+            - name: "DAF_BUTLER_REPOSITORY_INDEX"
               value: {{ .Values.global.butlerRepositoryIndex | quote }}
             {{- end }}
             - name: "PGUSER"

--- a/applications/datalinker/templates/deployment.yaml
+++ b/applications/datalinker/templates/deployment.yaml
@@ -59,7 +59,11 @@ spec:
             - name: "AWS_SHARED_CREDENTIALS_FILE"
               value: "/tmp/secrets/aws-credentials.ini"
             - name: "DAF_BUTLER_REPOSITORY_INDEX"
+            {{- if .Values.config.overrideButlerRepositoryIndex }}
+              value: {{ .Values.config.overrideButlerRepositoryIndex | quote }}
+            {{- else }}
               value: {{ .Values.global.butlerRepositoryIndex | quote }}
+            {{- end }}
             - name: "PGUSER"
               value: {{ .Values.config.pgUser }}
             - name: "PGPASSFILE"

--- a/applications/datalinker/values-idfdev.yaml
+++ b/applications/datalinker/values-idfdev.yaml
@@ -1,3 +1,3 @@
 config:
   separateSecrets: true
-  overrideButlerRepositoryIndex: "s3://butler-us-central1-repo-locations/data-dev-repos-remote.yaml"
+  useButlerServer: true

--- a/applications/datalinker/values-idfdev.yaml
+++ b/applications/datalinker/values-idfdev.yaml
@@ -1,2 +1,3 @@
 config:
   separateSecrets: true
+  overrideButlerRepositoryIndex: "s3://butler-us-central1-repo-locations/data-dev-repos-remote.yaml"

--- a/applications/datalinker/values-idfint.yaml
+++ b/applications/datalinker/values-idfint.yaml
@@ -1,3 +1,3 @@
 config:
   separateSecrets: true
-  overrideButlerRepositoryIndex: "s3://butler-us-central1-repo-locations/data-int-repos-remote.yaml"
+  useButlerServer: true

--- a/applications/datalinker/values-idfint.yaml
+++ b/applications/datalinker/values-idfint.yaml
@@ -1,2 +1,3 @@
 config:
   separateSecrets: true
+  overrideButlerRepositoryIndex: "s3://butler-us-central1-repo-locations/data-int-repos-remote.yaml"

--- a/applications/datalinker/values-idfprod.yaml
+++ b/applications/datalinker/values-idfprod.yaml
@@ -1,2 +1,3 @@
 config:
   separateSecrets: true
+  overrideButlerRepositoryIndex: "s3://butler-us-central1-repo-locations/data-repos-remote.yaml"

--- a/applications/datalinker/values-idfprod.yaml
+++ b/applications/datalinker/values-idfprod.yaml
@@ -1,3 +1,3 @@
 config:
   separateSecrets: true
-  overrideButlerRepositoryIndex: "s3://butler-us-central1-repo-locations/data-repos-remote.yaml"
+  useButlerServer: true

--- a/applications/datalinker/values.yaml
+++ b/applications/datalinker/values.yaml
@@ -51,15 +51,15 @@ config:
   # rubin is the default
   pgUser: "rubin"
 
-  # -- URI to Butler repository index file, configuring which Butler repository labels are available.
-  # @default -- Use the default configuration for the environment
-  overrideButlerRepositoryIndex: ""
-
   # -- S3 Endpoint URL
   s3EndpointUrl: "https://storage.googleapis.com"
 
   # -- Whether to use the new secrets management scheme
   separateSecrets: false
+
+  # -- If true, use Butler in client/server mode instead of connecting
+  # directly to the Butler database
+  useButlerServer: false
 
 # -- Annotations for the datalinker deployment pod
 podAnnotations: {}
@@ -86,6 +86,10 @@ global:
   # -- URI to the Butler configuration of available repositories
   # @default -- Set by Argo CD
   butlerRepositoryIndex: ""
+
+  # -- Butler repositories accessible via Butler server
+  # @default -- Set by Argo CD
+  butlerServerRepositories: ""
 
   # -- Host name for ingress
   # @default -- Set by Argo CD

--- a/applications/datalinker/values.yaml
+++ b/applications/datalinker/values.yaml
@@ -51,6 +51,10 @@ config:
   # rubin is the default
   pgUser: "rubin"
 
+  # -- URI to Butler repository index file, configuring which Butler repository labels are available.
+  # @default -- Use the default configuration for the environment
+  overrideButlerRepositoryIndex: ""
+
   # -- S3 Endpoint URL
   s3EndpointUrl: "https://storage.googleapis.com"
 

--- a/docs/extras/schemas/environment.json
+++ b/docs/extras/schemas/environment.json
@@ -189,6 +189,24 @@
       "description": "URL to Butler repository index",
       "title": "Butler repository index URL"
     },
+    "butlerServerRepositories": {
+      "anyOf": [
+        {
+          "additionalProperties": {
+            "format": "uri",
+            "minLength": 1,
+            "type": "string"
+          },
+          "type": "object"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "A mapping from label to repository URI for Butler repositoriesserved by Butler server in this environment.",
+      "title": "Butler repositories accessible via Butler server"
+    },
     "gcp": {
       "anyOf": [
         {

--- a/environments/README.md
+++ b/environments/README.md
@@ -64,7 +64,8 @@
 | applications.uws | bool | `false` | Enable the uws application. This includes the dmocps control system application. |
 | applications.vault-secrets-operator | bool | `true` | Enable the vault-secrets-operator application. This is required for all environments. |
 | applications.vo-cutouts | bool | `false` | Enable the vo-cutouts application |
-| butlerRepositoryIndex | string | None, must be set | Butler repository index to use for this environment |
+| butlerRepositoryIndex | string | None, must be set | Butler repository index URI to use for this environment, for services that connect directly to the Butler database. |
+| butlerServerRepositories | object | None, must be set | Butler repositories that can be accessed via Butler server, as a dictionary from repository label to URI. |
 | controlSystem.appNamespace | string | None, must be set | Application namespacce for the control system deployment |
 | controlSystem.imageTag | string | None, must be set | Image tag for the control system deployment |
 | controlSystem.kafkaBrokerAddress | string | `"sasquatch-kafka-brokers.sasquatch:9092"` | Kafka broker address for the control system deployment |

--- a/environments/templates/datalinker-application.yaml
+++ b/environments/templates/datalinker-application.yaml
@@ -26,6 +26,8 @@ spec:
           value: "https://{{ .Values.fqdn }}"
         - name: "global.butlerRepositoryIndex"
           value: {{ .Values.butlerRepositoryIndex | quote }}
+        - name: "global.butlerServerRepositories"
+          value: {{ .Values.butlerServerRepositories | toJson | b64enc }}
         - name: "global.host"
           value: {{ .Values.fqdn | quote }}
         - name: "global.vaultSecretsPath"

--- a/environments/values-idfdev.yaml
+++ b/environments/values-idfdev.yaml
@@ -1,6 +1,8 @@
 name: "idfdev"
 fqdn: "data-dev.lsst.cloud"
 butlerRepositoryIndex: "s3://butler-us-central1-repo-locations/data-dev-repos.yaml"
+butlerServerRepositories:
+  dp02: "https://data-dev.lsst.cloud/api/butler/repo/dp02/butler.yaml"
 gcp:
   projectId: "science-platform-dev-7696"
   region: "us-central1"

--- a/environments/values-idfint.yaml
+++ b/environments/values-idfint.yaml
@@ -1,6 +1,8 @@
 name: "idfint"
 fqdn: "data-int.lsst.cloud"
 butlerRepositoryIndex: "s3://butler-us-central1-repo-locations/data-int-repos.yaml"
+butlerServerRepositories:
+  dp02: "https://data-int.lsst.cloud/api/butler/repo/dp02/butler.yaml"
 gcp:
   projectId: "science-platform-int-dc5d"
   region: "us-central1"

--- a/environments/values-idfprod.yaml
+++ b/environments/values-idfprod.yaml
@@ -1,6 +1,9 @@
 name: "idfprod"
 fqdn: "data.lsst.cloud"
 butlerRepositoryIndex: "s3://butler-us-central1-repo-locations/data-repos.yaml"
+butlerServerRepositories:
+  dp01: "https://data.lsst.cloud/api/butler/repo/dp01/butler.yaml"
+  dp02: "https://data.lsst.cloud/api/butler/repo/dp02/butler.yaml"
 gcp:
   projectId: "science-platform-stable-6994"
   region: "us-central1"

--- a/environments/values-idfprod.yaml
+++ b/environments/values-idfprod.yaml
@@ -11,6 +11,7 @@ onepassword:
 vaultPathPrefix: "secret/phalanx/idfprod"
 
 applications:
+  butler: true
   datalinker: true
   hips: true
   mobu: true

--- a/environments/values.yaml
+++ b/environments/values.yaml
@@ -1,8 +1,14 @@
 # These four settings should be set in each environment values-*.yaml file.
 
-# -- Butler repository index to use for this environment
+# -- Butler repository index URI to use for this environment, for services that
+# connect directly to the Butler database.
 # @default -- None, must be set
 butlerRepositoryIndex: ""
+
+# -- Butler repositories that can be accessed via Butler server, as a
+# dictionary from repository label to URI.
+# @default -- None, must be set
+butlerServerRepositories: {}
 
 # -- Name of the environment
 # @default -- None, must be set

--- a/src/phalanx/models/environments.py
+++ b/src/phalanx/models/environments.py
@@ -6,6 +6,7 @@ from enum import Enum
 
 from pydantic import (
     AnyHttpUrl,
+    AnyUrl,
     BaseModel,
     ConfigDict,
     Field,
@@ -164,6 +165,15 @@ class EnvironmentBaseConfig(CamelCaseModel):
         None,
         title="Butler repository index URL",
         description="URL to Butler repository index",
+    )
+
+    butler_server_repositories: dict[str, AnyUrl] | None = Field(
+        None,
+        title="Butler repositories accessible via Butler server",
+        description=(
+            "A mapping from label to repository URI for Butler repositories"
+            "served by Butler server in this environment."
+        ),
     )
 
     gcp: GCPMetadata | None = Field(


### PR DESCRIPTION
Upgraded datalinker and Butler server to versions that are able to work with each other.  Configured datalinker deployments in all IDF environments to use Butler server instead of connecting directly to the Butler database.  Enabled Butler server on idfprod.

Butler repositories for services using Butler server are now configured by putting the list of repositories in an environment variable, instead of a URI pointing to a file containing the list of repositories.  The file is currently hosted on S3, which services will no longer have credentials for in the near future.