### PR TITLE
DM-42677: Don't forward visits with instrument=""

### DIFF
--- a/applications/next-visit-fan-out/values-usdfdev-prompt-processing.yaml
+++ b/applications/next-visit-fan-out/values-usdfdev-prompt-processing.yaml
@@ -14,4 +14,4 @@ image:
   repository: ghcr.io/lsst-dm/next_visit_fan_out
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: v1.0.2
+  tag: v1.0.4

--- a/applications/next-visit-fan-out/values-usdfprod-prompt-processing.yaml
+++ b/applications/next-visit-fan-out/values-usdfprod-prompt-processing.yaml
@@ -13,4 +13,4 @@ image:
   repository: ghcr.io/lsst-dm/next_visit_fan_out
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: v1.0.2
+  tag: v1.0.4


### PR DESCRIPTION
This PR updates `next-visit-fan-out` with bug fixes ahead of the January 29 -- February 2 AuxTel run.