### PR TITLE
Increase STRIMZI_MAX_QUEUE_SIZE

### DIFF
--- a/applications/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
@@ -155,6 +155,11 @@ spec:
   entityOperator:
     topicOperator: {}
     userOperator: {}
+    template:
+      topicOperatorContainer:
+        env:
+        - name: STRIMZI_MAX_QUEUE_SIZE
+          value: "8192"
   {{- if .Values.kafkaExporter.enabled }}
   kafkaExporter:
     topicRegex: {{ .Values.kafkaExporter.topicRegex }}


### PR DESCRIPTION
- This addresses the error "Queue length 1024 exceeded, stopping operator. Please increase STRIMZI_MAX_QUEUE_SIZE environment variable." seen in Strimzi entity operator when upgrading to version 0.39.0