### PR TITLE
[DM-42691] Add Pod Disruption Budgets for meta and data pods

### DIFF
--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -117,6 +117,7 @@ Rubin Observatory's telemetry service.
 | influxdb-enterprise.data.ingress.hostname | string | `""` |  |
 | influxdb-enterprise.data.ingress.path | string | `"/influxdb-enterprise-data(/|$)(.*)"` |  |
 | influxdb-enterprise.data.persistence.enabled | bool | `false` |  |
+| influxdb-enterprise.data.podDisruptionBudget.minAvailable | int | `1` |  |
 | influxdb-enterprise.data.replicas | int | `1` |  |
 | influxdb-enterprise.data.resources | object | `{}` |  |
 | influxdb-enterprise.data.service.type | string | `"ClusterIP"` |  |

--- a/applications/sasquatch/charts/influxdb-enterprise/README.md
+++ b/applications/sasquatch/charts/influxdb-enterprise/README.md
@@ -39,6 +39,7 @@ Run InfluxDB Enterprise on Kubernetes
 | data.ingress.hostname | string | `""` |  |
 | data.ingress.path | string | `"/influxdb-enterprise-data(/|$)(.*)"` |  |
 | data.persistence.enabled | bool | `false` |  |
+| data.podDisruptionBudget.minAvailable | int | `1` |  |
 | data.replicas | int | `1` |  |
 | data.resources | object | `{}` |  |
 | data.service.type | string | `"ClusterIP"` |  |

--- a/applications/sasquatch/charts/influxdb-enterprise/templates/data-pdb.yaml
+++ b/applications/sasquatch/charts/influxdb-enterprise/templates/data-pdb.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: data-pdb
+spec:
+  minAvailable: {{ .Values.data.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      influxdb.influxdata.com/component: data

--- a/applications/sasquatch/charts/influxdb-enterprise/templates/meta-pdb.yaml
+++ b/applications/sasquatch/charts/influxdb-enterprise/templates/meta-pdb.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: meta-pdb
+spec:
+  minAvailable: {{ .Values.meta.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      influxdb.influxdata.com/component: meta

--- a/applications/sasquatch/charts/influxdb-enterprise/values.yaml
+++ b/applications/sasquatch/charts/influxdb-enterprise/values.yaml
@@ -155,7 +155,7 @@ meta:
     # size: 8Gi
   podDisruptionBudget:
     minAvailable: 2
-  ## Additional data container environment variables.
+  ## Additional meta container environment variables.
   env: {}
   resources: {}
 

--- a/applications/sasquatch/charts/influxdb-enterprise/values.yaml
+++ b/applications/sasquatch/charts/influxdb-enterprise/values.yaml
@@ -153,9 +153,7 @@ meta:
     # annotations:
     # accessMode: ReadWriteOnce
     # size: 8Gi
-  # Pick one
   podDisruptionBudget:
-    # maxUnavailable: 2
     minAvailable: 2
   ## Additional data container environment variables.
   env: {}
@@ -267,6 +265,8 @@ data:
       enabled: false
     logging:
       level: "debug"
+  podDisruptionBudget:
+    minAvailable: 1
   ## Additional data container environment variables e.g.:
   ##   INFLUXDB_HTTP_FLUX_ENABLED: "true"
   env: {}


### PR DESCRIPTION
- Add Pod Disruption Budgets to InfluxDB Enterprise meta and data pods to help protect against some voluntary disruptions, e.g. `kubectl drain`
