### PR TITLE
DM-42689: Update datalinker chart for 1.7.0 changes

### DIFF
--- a/applications/datalinker/README.md
+++ b/applications/datalinker/README.md
@@ -15,10 +15,14 @@ IVOA DataLink-based service and data discovery
 | autoscaling.maxReplicas | int | `100` | Maximum number of datalinker deployment pods |
 | autoscaling.minReplicas | int | `1` | Minimum number of datalinker deployment pods |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU utilization of datalinker deployment pods |
-| config.pgUser | string | `"rubin"` | User to use from the PGPASSFILE rubin is the default |
-| config.s3EndpointUrl | string | `"https://storage.googleapis.com"` | S3 Endpoint URL |
+| config.hipsPathPrefix | string | `"/api/hips"` | URL path prefix for the HiPS API (must match the configuration of the hips service) |
+| config.logLevel | string | `"INFO"` | Logging level |
+| config.pathPrefix | string | `"/api/datalink"` | URL path prefix for DataLink and related APIs |
+| config.pgUser | string | `"rubin"` | User to use from the PGPASSFILE if datalinker is using a direct Butler connection (`useButlerServer` is false) |
+| config.s3EndpointUrl | string | `"https://storage.googleapis.com"` | S3 endpoint URL (must be set if using S3) |
 | config.separateSecrets | bool | `false` | Whether to use the new secrets management scheme |
-| config.storageBackend | string | `"GCS"` | Storage backend to use: either GCS or S3 GCS is the default |
+| config.slackAlerts | bool | `false` | Whether to send certain serious alerts to Slack. If `true`, the `slack-webhook` secret must also be set. |
+| config.storageBackend | string | `"GCS"` | Storage backend to use (either `GCS` or `S3`) |
 | config.tapMetadataUrl | string | `"https://github.com/lsst/sdm_schemas/releases/download/1.2.0/datalink-columns.zip"` | URL containing TAP schema metadata used to construct queries |
 | config.useButlerServer | bool | `false` | If true, use Butler in client/server mode instead of connecting directly to the Butler database |
 | fullnameOverride | string | `""` | Override the full name for resources (includes the release name) |

--- a/applications/datalinker/README.md
+++ b/applications/datalinker/README.md
@@ -39,5 +39,5 @@ IVOA DataLink-based service and data discovery
 | nodeSelector | object | `{}` | Node selection rules for the datalinker deployment pod |
 | podAnnotations | object | `{}` | Annotations for the datalinker deployment pod |
 | replicaCount | int | `1` | Number of web deployment pods to start |
-| resources | object | `{}` | Resource limits and requests for the datalinker deployment pod |
+| resources | object | See `values.yaml` | Resource limits and requests for the datalinker deployment pod |
 | tolerations | list | `[]` | Tolerations for the datalinker deployment pod |

--- a/applications/datalinker/secrets.yaml
+++ b/applications/datalinker/secrets.yaml
@@ -18,3 +18,11 @@
   copy:
     application: nublado
     key: "postgres-credentials.txt"
+slack-webhook:
+  description: >-
+    Slack web hook used to report internal errors to Slack. This secret may be
+    changed at any time.
+  if: config.slackAlerts
+  copy:
+    application: mobu
+    key: app-alert-webhook

--- a/applications/datalinker/templates/deployment.yaml
+++ b/applications/datalinker/templates/deployment.yaml
@@ -20,14 +20,11 @@ spec:
       labels:
         {{- include "datalinker.selectorLabels" . | nindent 8 }}
     spec:
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       automountServiceAccountToken: false
-      imagePullSecrets:
-        - name: "pull-secret"
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
-        fsGroup: 1000
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -43,6 +40,23 @@ spec:
               value: "{{ .Values.global.baseUrl }}/api/cutout/sync"
             - name: "DATALINKER_HIPS_BASE_URL"
               value: "{{ .Values.global.baseUrl }}/api/hips"
+            - name: "DATALINKER_LOG_LEVEL"
+              value: {{ .Values.config.logLevel | quote }}
+            - name: "DATALINKER_PATH_PREFIX"
+              value: {{ .Values.config.pathPrefix | quote }}
+            - name: "DATALINKER_HIPS_PATH_PREFIX"
+              value: {{ .Values.config.hipsPathPrefix | quote }}
+            - name: "DATALINKER_STORAGE_BACKEND"
+              value: {{ .Values.config.storageBackend | quote }}
+            - name: "DATALINKER_S3_ENDPOINT_URL"
+              value: {{ .Values.config.s3EndpointUrl | quote }}
+            {{- if .Values.config.slackAlerts }}
+            - name: "DATALINKER_SLACK_WEBHOOK"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "datalinker.fullname" . }}
+                  key: "slack-webhook"
+            {{- end }}
             {{- if .Values.config.tapMetadataUrl }}
             - name: "DATALINKER_TAP_METADATA_DIR"
               value: "/tmp/tap-metadata"
@@ -69,24 +83,20 @@ spec:
               value: {{ .Values.config.pgUser }}
             - name: "PGPASSFILE"
               value: "/tmp/secrets/postgres-credentials.txt"
-            - name: "STORAGE_BACKEND"
-              value: {{ .Values.config.storageBackend }}
-            - name: "S3_ENDPOINT_URL"
-              value: {{ .Values.config.s3EndpointUrl }}
             - name: "GOOGLE_APPLICATION_CREDENTIALS"
               value: "/tmp/secrets/butler-gcs-idf-creds.json"
           ports:
-            - name: http
+            - name: "http"
               containerPort: 8080
-              protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /
-              port: http
+              protocol: "TCP"
           readinessProbe:
             httpGet:
-              path: /
-              port: http
+              path: "/"
+              port: "http"
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
@@ -98,10 +108,11 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/applications/datalinker/templates/ingress-anonymous.yaml
+++ b/applications/datalinker/templates/ingress-anonymous.yaml
@@ -20,7 +20,7 @@ template:
       - host: {{ required "global.host must be set" .Values.global.host | quote }}
         http:
           paths:
-            - path: "/api/hips/list"
+            - path: "{{ .Values.config.hipsPathPrefix }}/list"
               pathType: "Exact"
               backend:
                 service:

--- a/applications/datalinker/templates/ingress-image.yaml
+++ b/applications/datalinker/templates/ingress-image.yaml
@@ -28,7 +28,7 @@ template:
       - host: {{ required "global.host must be set" .Values.global.host | quote }}
         http:
           paths:
-            - path: "/api/datalink/links"
+            - path: "{{ .Values.config.pathPrefix }}/links"
               pathType: "Exact"
               backend:
                 service:

--- a/applications/datalinker/templates/ingress-tap.yaml
+++ b/applications/datalinker/templates/ingress-tap.yaml
@@ -21,7 +21,7 @@ template:
       - host: {{ required "global.host must be set" .Values.global.host | quote }}
         http:
           paths:
-            - path: "/api/datalink"
+            - path: {{ .Values.config.pathPrefix | quote }}
               pathType: "Prefix"
               backend:
                 service:

--- a/applications/datalinker/values-idfdev.yaml
+++ b/applications/datalinker/values-idfdev.yaml
@@ -1,3 +1,4 @@
 config:
   separateSecrets: true
   useButlerServer: true
+  slackAlerts: true

--- a/applications/datalinker/values-idfint.yaml
+++ b/applications/datalinker/values-idfint.yaml
@@ -1,3 +1,4 @@
 config:
   separateSecrets: true
   useButlerServer: true
+  slackAlerts: true

--- a/applications/datalinker/values-idfprod.yaml
+++ b/applications/datalinker/values-idfprod.yaml
@@ -1,3 +1,4 @@
 config:
   separateSecrets: true
   useButlerServer: true
+  slackAlerts: true

--- a/applications/datalinker/values-usdfdev.yaml
+++ b/applications/datalinker/values-usdfdev.yaml
@@ -1,4 +1,3 @@
 config:
-  # -- USDF uses an on prem S3 storage backend
   storageBackend: "S3"
   s3EndpointUrl: "https://s3dfrgw.slac.stanford.edu"

--- a/applications/datalinker/values-usdfprod.yaml
+++ b/applications/datalinker/values-usdfprod.yaml
@@ -1,4 +1,3 @@
 config:
-  # -- USDF uses an on prem S3 storage backend
   storageBackend: "S3"
   s3EndpointUrl: "https://s3dfrgw.slac.stanford.edu"

--- a/applications/datalinker/values.yaml
+++ b/applications/datalinker/values.yaml
@@ -37,21 +37,25 @@ autoscaling:
 
   # -- Target CPU utilization of datalinker deployment pods
   targetCPUUtilizationPercentage: 80
-  # targetMemoryUtilizationPercentage: 80
 
 config:
+  # -- Logging level
+  logLevel: "INFO"
+
+  # -- URL path prefix for DataLink and related APIs
+  pathPrefix: "/api/datalink"
+
+  # -- URL path prefix for the HiPS API (must match the configuration of the
+  # hips service)
+  hipsPathPrefix: "/api/hips"
+
   # -- URL containing TAP schema metadata used to construct queries
   tapMetadataUrl: "https://github.com/lsst/sdm_schemas/releases/download/1.2.0/datalink-columns.zip"
 
-  # -- Storage backend to use: either GCS or S3
-  # GCS is the default
+  # -- Storage backend to use (either `GCS` or `S3`)
   storageBackend: "GCS"
 
-  # -- User to use from the PGPASSFILE
-  # rubin is the default
-  pgUser: "rubin"
-
-  # -- S3 Endpoint URL
+  # -- S3 endpoint URL (must be set if using S3)
   s3EndpointUrl: "https://storage.googleapis.com"
 
   # -- Whether to use the new secrets management scheme
@@ -60,6 +64,14 @@ config:
   # -- If true, use Butler in client/server mode instead of connecting
   # directly to the Butler database
   useButlerServer: false
+
+  # -- User to use from the PGPASSFILE if datalinker is using a direct Butler
+  # connection (`useButlerServer` is false)
+  pgUser: "rubin"
+
+  # -- Whether to send certain serious alerts to Slack. If `true`, the
+  # `slack-webhook` secret must also be set.
+  slackAlerts: false
 
 # -- Annotations for the datalinker deployment pod
 podAnnotations: {}

--- a/applications/datalinker/values.yaml
+++ b/applications/datalinker/values.yaml
@@ -77,7 +77,14 @@ config:
 podAnnotations: {}
 
 # -- Resource limits and requests for the datalinker deployment pod
-resources: {}
+# @default -- See `values.yaml`
+resources:
+  limits:
+    cpu: "1"
+    memory: "200Mi"
+  requests:
+    cpu: "50m"
+    memory: "150Mi"
 
 # -- Node selection rules for the datalinker deployment pod
 nodeSelector: {}

--- a/applications/nublado/templates/controller-deployment.yaml
+++ b/applications/nublado/templates/controller-deployment.yaml
@@ -53,9 +53,9 @@ spec:
             httpGet:
               path: "/"
               port: "http"
-          {{- with .Values.resources }}
+          {{- with .Values.controller.resources }}
           resources:
-            {{- toYaml .Values.controller.resources | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
             - name: "config"


### PR DESCRIPTION
Update the names of the environment variables in preparation for the new release. Add pathPrefix, hipsPathPrefix, and logLevel settings that are passed through to the application. Add support for configuring Slack alerts for uncaught exceptions and enable them in the environments where we normally enable them.

Set resource requests and limits for datalinker based on its current production usage.

Fix setting of Nublado controller resources, noticed when looking at it as a template for datalinker.