### PR TITLE
Fix incorrect settings for T&S Nublado

### DIFF
--- a/applications/nublado/values-base.yaml
+++ b/applications/nublado/values-base.yaml
@@ -5,11 +5,11 @@ controller:
         type: "docker"
         registry: "ts-dockerhub.lsst.org"
         repository: "sal-sciplat-lab"
-      num_releases: 0
-      num_weeklies: 3
-      num_dailies: 2
+      numReleases: 0
+      numWeeklies: 3
+      numDailies: 2
       cycle: 35
-      recommended_tag: "recommended_c0035"
+      recommendedTag: "recommended_c0035"
     lab:
       extraAnnotations:
         k8s.v1.cni.cncf.io/networks: "kube-system/dds"

--- a/applications/nublado/values-summit.yaml
+++ b/applications/nublado/values-summit.yaml
@@ -5,11 +5,11 @@ controller:
         type: "docker"
         registry: "ts-dockerhub.lsst.org"
         repository: "sal-sciplat-lab"
-      num_releases: 0
-      num_weeklies: 3
-      num_dailies: 2
+      numReleases: 0
+      numWeeklies: 3
+      numDailies: 2
       cycle: 34
-      recommended_tag: "recommended_c0034"
+      recommendedTag: "recommended_c0034"
     lab:
       extraAnnotations:
         k8s.v1.cni.cncf.io/networks: "kube-system/dds"

--- a/applications/nublado/values-tucson-teststand.yaml
+++ b/applications/nublado/values-tucson-teststand.yaml
@@ -5,11 +5,11 @@ controller:
         type: "docker"
         registry: "ts-dockerhub.lsst.org"
         repository: "sal-sciplat-lab"
-      num_releases: 0
-      num_weeklies: 3
-      num_dailies: 2
+      numReleases: 0
+      numWeeklies: 3
+      numDailies: 2
       cycle: null
-      recommended_tag: "recommended_k0001"
+      recommendedTag: "recommended_k0001"
     lab:
       extraAnnotations:
         k8s.v1.cni.cncf.io/networks: "kube-system/dds"


### PR DESCRIPTION
The image configuration was specified with underscores instead of camel-case, which hasn't been valid for a while.