### PR TITLE
DM-42705: Update ook to 0.9.1

### DIFF
--- a/applications/ook/Chart.yaml
+++ b/applications/ook/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v2
 name: ook
 version: 1.0.0
-appVersion: "0.9.0"
+appVersion: "0.9.1"
 description: >
   Ook is the librarian service for Rubin Observatory. Ook indexes
   documentation content into the Algolia search engine that powers the Rubin
-  Observatory documentation portal, lsst.io.
+  Observatory documentation portal, www.lsst.io.
 type: application
 home: https://ook.lsst.io/
 sources:

--- a/applications/ook/README.md
+++ b/applications/ook/README.md
@@ -1,6 +1,6 @@
 # ook
 
-Ook is the librarian service for Rubin Observatory. Ook indexes documentation content into the Algolia search engine that powers the Rubin Observatory documentation portal, lsst.io.
+Ook is the librarian service for Rubin Observatory. Ook indexes documentation content into the Algolia search engine that powers the Rubin Observatory documentation portal, www.lsst.io.
 
 **Homepage:** <https://ook.lsst.io/>
 


### PR DESCRIPTION
This update deals with technotes that are missing update date metadata.