### PR TITLE
DM-40823: Explore methods for calculating Prompt Processing preload timing

### DIFF
--- a/applications/prompt-proto-service-hsc/README.md
+++ b/applications/prompt-proto-service-hsc/README.md
@@ -38,3 +38,4 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.s3.disableBucketValidation | string | `"0"` | Set this to disable validation of S3 bucket names, allowing Ceph multi-tenant colon-separated names to be used. |
 | prompt-proto-service.s3.endpointUrl | string | None, must be set | S3 endpoint containing `imageBucket` |
 | prompt-proto-service.s3.imageBucket | string | None, must be set | Bucket containing the incoming raw images |
+| prompt-proto-service.sasquatch.endpointUrl | string | `""` | Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload. This is a preliminary implementation of Sasquatch support, and this parameter may be deprecated if we instead support `SasquatchDatastore` in the future. |

--- a/applications/prompt-proto-service-hsc/README.md
+++ b/applications/prompt-proto-service-hsc/README.md
@@ -38,4 +38,5 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.s3.disableBucketValidation | string | `"0"` | Set this to disable validation of S3 bucket names, allowing Ceph multi-tenant colon-separated names to be used. |
 | prompt-proto-service.s3.endpointUrl | string | None, must be set | S3 endpoint containing `imageBucket` |
 | prompt-proto-service.s3.imageBucket | string | None, must be set | Bucket containing the incoming raw images |
+| prompt-proto-service.sasquatch.auth_env | bool | `true` | If set, this application's Vault secret must contain a `sasquatch_token` key containing the authentication token for `sasquatch.endpointUrl`. Leave unset to attempt anonymous access. |
 | prompt-proto-service.sasquatch.endpointUrl | string | `""` | Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload. This is a preliminary implementation of Sasquatch support, and this parameter may be deprecated if we instead support `SasquatchDatastore` in the future. |

--- a/applications/prompt-proto-service-hsc/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-hsc/values-usdfdev-prompt-processing.yaml
@@ -29,5 +29,6 @@ prompt-proto-service:
 
   sasquatch:
     endpointUrl: https://usdf-rsp-dev.slac.stanford.edu/sasquatch-rest-proxy
+    auth_env: false
 
   fullnameOverride: "prompt-proto-service-hsc"

--- a/applications/prompt-proto-service-hsc/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-hsc/values-usdfdev-prompt-processing.yaml
@@ -27,4 +27,7 @@ prompt-proto-service:
   apdb:
     url: postgresql://rubin@usdf-prompt-processing-dev.slac.stanford.edu:5432/lsst-devl
 
+  sasquatch:
+    endpointUrl: https://usdf-rsp-dev.slac.stanford.edu/sasquatch-rest-proxy
+
   fullnameOverride: "prompt-proto-service-hsc"

--- a/applications/prompt-proto-service-hsc/values.yaml
+++ b/applications/prompt-proto-service-hsc/values.yaml
@@ -74,6 +74,12 @@ prompt-proto-service:
   # @default -- log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING.
   logLevel: ""
 
+  sasquatch:
+    # -- Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload.
+    # This is a preliminary implementation of Sasquatch support, and this parameter may be deprecated
+    # if we instead support `SasquatchDatastore` in the future.
+    endpointUrl: ""
+
   knative:
     # -- The storage space reserved for each container (mostly local Butler).
     ephemeralStorageRequest: "20Gi"

--- a/applications/prompt-proto-service-hsc/values.yaml
+++ b/applications/prompt-proto-service-hsc/values.yaml
@@ -72,7 +72,7 @@ prompt-proto-service:
 
   # -- Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level).
   # @default -- log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING.
-  logLevel: ""
+  logLevel: "timer.lsst.activator=DEBUG"
 
   sasquatch:
     # -- Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload.

--- a/applications/prompt-proto-service-hsc/values.yaml
+++ b/applications/prompt-proto-service-hsc/values.yaml
@@ -79,6 +79,9 @@ prompt-proto-service:
     # This is a preliminary implementation of Sasquatch support, and this parameter may be deprecated
     # if we instead support `SasquatchDatastore` in the future.
     endpointUrl: ""
+    # -- If set, this application's Vault secret must contain a `sasquatch_token` key containing the authentication token for `sasquatch.endpointUrl`.
+    # Leave unset to attempt anonymous access.
+    auth_env: true
 
   knative:
     # -- The storage space reserved for each container (mostly local Butler).

--- a/applications/prompt-proto-service-latiss/README.md
+++ b/applications/prompt-proto-service-latiss/README.md
@@ -38,3 +38,4 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.s3.disableBucketValidation | string | `"0"` | Set this to disable validation of S3 bucket names, allowing Ceph multi-tenant colon-separated names to be used. |
 | prompt-proto-service.s3.endpointUrl | string | `""` |  |
 | prompt-proto-service.s3.imageBucket | string | None, must be set | Bucket containing the incoming raw images |
+| prompt-proto-service.sasquatch.endpointUrl | string | `""` | Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload. This is a preliminary implementation of Sasquatch support, and this parameter may be deprecated if we instead support `SasquatchDatastore` in the future. |

--- a/applications/prompt-proto-service-latiss/README.md
+++ b/applications/prompt-proto-service-latiss/README.md
@@ -38,4 +38,5 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.s3.disableBucketValidation | string | `"0"` | Set this to disable validation of S3 bucket names, allowing Ceph multi-tenant colon-separated names to be used. |
 | prompt-proto-service.s3.endpointUrl | string | `""` |  |
 | prompt-proto-service.s3.imageBucket | string | None, must be set | Bucket containing the incoming raw images |
+| prompt-proto-service.sasquatch.auth_env | bool | `true` | If set, this application's Vault secret must contain a `sasquatch_token` key containing the authentication token for `sasquatch.endpointUrl`. Leave unset to attempt anonymous access. |
 | prompt-proto-service.sasquatch.endpointUrl | string | `""` | Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload. This is a preliminary implementation of Sasquatch support, and this parameter may be deprecated if we instead support `SasquatchDatastore` in the future. |

--- a/applications/prompt-proto-service-latiss/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfdev-prompt-processing.yaml
@@ -29,4 +29,7 @@ prompt-proto-service:
   apdb:
     url: postgresql://rubin@usdf-prompt-processing-dev.slac.stanford.edu/lsst-devl
 
+  sasquatch:
+    endpointUrl: https://usdf-rsp-dev.slac.stanford.edu/sasquatch-rest-proxy
+
   fullnameOverride: "prompt-proto-service-latiss"

--- a/applications/prompt-proto-service-latiss/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfdev-prompt-processing.yaml
@@ -31,5 +31,6 @@ prompt-proto-service:
 
   sasquatch:
     endpointUrl: https://usdf-rsp-dev.slac.stanford.edu/sasquatch-rest-proxy
+    auth_env: false
 
   fullnameOverride: "prompt-proto-service-latiss"

--- a/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
@@ -43,7 +43,7 @@ prompt-proto-service:
   apdb:
     url: postgresql://rubin@usdf-prompt-processing.slac.stanford.edu:5432/lsst-devl
 
-  logLevel: lsst.resources=DEBUG
+  logLevel: timer.lsst.activator=DEBUG lsst.resources=DEBUG
 
   knative:
     ephemeralStorageRequest: "50Gi"

--- a/applications/prompt-proto-service-latiss/values.yaml
+++ b/applications/prompt-proto-service-latiss/values.yaml
@@ -74,6 +74,12 @@ prompt-proto-service:
   # @default -- log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING.
   logLevel: ""
 
+  sasquatch:
+    # -- Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload.
+    # This is a preliminary implementation of Sasquatch support, and this parameter may be deprecated
+    # if we instead support `SasquatchDatastore` in the future.
+    endpointUrl: ""
+
   knative:
     # -- The storage space reserved for each container (mostly local Butler).
     ephemeralStorageRequest: "20Gi"

--- a/applications/prompt-proto-service-latiss/values.yaml
+++ b/applications/prompt-proto-service-latiss/values.yaml
@@ -72,7 +72,7 @@ prompt-proto-service:
 
   # -- Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level).
   # @default -- log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING.
-  logLevel: ""
+  logLevel: "timer.lsst.activator=DEBUG"
 
   sasquatch:
     # -- Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload.

--- a/applications/prompt-proto-service-latiss/values.yaml
+++ b/applications/prompt-proto-service-latiss/values.yaml
@@ -79,6 +79,9 @@ prompt-proto-service:
     # This is a preliminary implementation of Sasquatch support, and this parameter may be deprecated
     # if we instead support `SasquatchDatastore` in the future.
     endpointUrl: ""
+    # -- If set, this application's Vault secret must contain a `sasquatch_token` key containing the authentication token for `sasquatch.endpointUrl`.
+    # Leave unset to attempt anonymous access.
+    auth_env: true
 
   knative:
     # -- The storage space reserved for each container (mostly local Butler).

--- a/applications/prompt-proto-service-lsstcam/README.md
+++ b/applications/prompt-proto-service-lsstcam/README.md
@@ -38,3 +38,4 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.s3.disableBucketValidation | string | `"0"` | Set this to disable validation of S3 bucket names, allowing Ceph multi-tenant colon-separated names to be used. |
 | prompt-proto-service.s3.endpointUrl | string | None, must be set | S3 endpoint containing `imageBucket` |
 | prompt-proto-service.s3.imageBucket | string | None, must be set | Bucket containing the incoming raw images |
+| prompt-proto-service.sasquatch.endpointUrl | string | `""` | Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload. This is a preliminary implementation of Sasquatch support, and this parameter may be deprecated if we instead support `SasquatchDatastore` in the future. |

--- a/applications/prompt-proto-service-lsstcam/README.md
+++ b/applications/prompt-proto-service-lsstcam/README.md
@@ -38,4 +38,5 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.s3.disableBucketValidation | string | `"0"` | Set this to disable validation of S3 bucket names, allowing Ceph multi-tenant colon-separated names to be used. |
 | prompt-proto-service.s3.endpointUrl | string | None, must be set | S3 endpoint containing `imageBucket` |
 | prompt-proto-service.s3.imageBucket | string | None, must be set | Bucket containing the incoming raw images |
+| prompt-proto-service.sasquatch.auth_env | bool | `true` | If set, this application's Vault secret must contain a `sasquatch_token` key containing the authentication token for `sasquatch.endpointUrl`. Leave unset to attempt anonymous access. |
 | prompt-proto-service.sasquatch.endpointUrl | string | `""` | Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload. This is a preliminary implementation of Sasquatch support, and this parameter may be deprecated if we instead support `SasquatchDatastore` in the future. |

--- a/applications/prompt-proto-service-lsstcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcam/values.yaml
@@ -74,6 +74,12 @@ prompt-proto-service:
   # @default -- log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING.
   logLevel: ""
 
+  sasquatch:
+    # -- Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload.
+    # This is a preliminary implementation of Sasquatch support, and this parameter may be deprecated
+    # if we instead support `SasquatchDatastore` in the future.
+    endpointUrl: ""
+
   knative:
     # -- The storage space reserved for each container (mostly local Butler).
     ephemeralStorageRequest: "20Gi"

--- a/applications/prompt-proto-service-lsstcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcam/values.yaml
@@ -79,6 +79,9 @@ prompt-proto-service:
     # This is a preliminary implementation of Sasquatch support, and this parameter may be deprecated
     # if we instead support `SasquatchDatastore` in the future.
     endpointUrl: ""
+    # -- If set, this application's Vault secret must contain a `sasquatch_token` key containing the authentication token for `sasquatch.endpointUrl`.
+    # Leave unset to attempt anonymous access.
+    auth_env: true
 
   knative:
     # -- The storage space reserved for each container (mostly local Butler).

--- a/applications/prompt-proto-service-lsstcomcam/README.md
+++ b/applications/prompt-proto-service-lsstcomcam/README.md
@@ -37,4 +37,5 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.s3.disableBucketValidation | string | `"0"` | Set this to disable validation of S3 bucket names, allowing Ceph multi-tenant colon-separated names to be used. |
 | prompt-proto-service.s3.endpointUrl | string | None, must be set | S3 endpoint containing `imageBucket` |
 | prompt-proto-service.s3.imageBucket | string | None, must be set | Bucket containing the incoming raw images |
+| prompt-proto-service.sasquatch.auth_env | bool | `true` | If set, this application's Vault secret must contain a `sasquatch_token` key containing the authentication token for `sasquatch.endpointUrl`. Leave unset to attempt anonymous access. |
 | prompt-proto-service.sasquatch.endpointUrl | string | `""` | Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload. This is a preliminary implementation of Sasquatch support, and this parameter may be deprecated if we instead support `SasquatchDatastore` in the future. |

--- a/applications/prompt-proto-service-lsstcomcam/README.md
+++ b/applications/prompt-proto-service-lsstcomcam/README.md
@@ -37,3 +37,4 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.s3.disableBucketValidation | string | `"0"` | Set this to disable validation of S3 bucket names, allowing Ceph multi-tenant colon-separated names to be used. |
 | prompt-proto-service.s3.endpointUrl | string | None, must be set | S3 endpoint containing `imageBucket` |
 | prompt-proto-service.s3.imageBucket | string | None, must be set | Bucket containing the incoming raw images |
+| prompt-proto-service.sasquatch.endpointUrl | string | `""` | Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload. This is a preliminary implementation of Sasquatch support, and this parameter may be deprecated if we instead support `SasquatchDatastore` in the future. |

--- a/applications/prompt-proto-service-lsstcomcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/values.yaml
@@ -74,6 +74,12 @@ prompt-proto-service:
   # @default -- log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING.
   logLevel: ""
 
+  sasquatch:
+    # -- Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload.
+    # This is a preliminary implementation of Sasquatch support, and this parameter may be deprecated
+    # if we instead support `SasquatchDatastore` in the future.
+    endpointUrl: ""
+
   knative:
     # -- The storage space reserved for each container (mostly local Butler).
     ephemeralStorageRequest: "20Gi"

--- a/applications/prompt-proto-service-lsstcomcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/values.yaml
@@ -79,6 +79,9 @@ prompt-proto-service:
     # This is a preliminary implementation of Sasquatch support, and this parameter may be deprecated
     # if we instead support `SasquatchDatastore` in the future.
     endpointUrl: ""
+    # -- If set, this application's Vault secret must contain a `sasquatch_token` key containing the authentication token for `sasquatch.endpointUrl`.
+    # Leave unset to attempt anonymous access.
+    auth_env: true
 
   knative:
     # -- The storage space reserved for each container (mostly local Butler).

--- a/charts/prompt-proto-service/README.md
+++ b/charts/prompt-proto-service/README.md
@@ -43,5 +43,6 @@ Event-driven processing of camera images
 | s3.disableBucketValidation | string | `"0"` | Set this to disable validation of S3 bucket names, allowing Ceph multi-tenant colon-separated names to be used. |
 | s3.endpointUrl | string | None, must be set | S3 endpoint containing `imageBucket` |
 | s3.imageBucket | string | None, must be set | Bucket containing the incoming raw images |
+| sasquatch.auth_env | bool | `true` | If set, this application's Vault secret must contain a `sasquatch_token` key containing the authentication token for `sasquatch.endpointUrl`. Leave unset to attempt anonymous access. |
 | sasquatch.endpointUrl | string | `""` | Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload. This is a preliminary implementation of Sasquatch support, and this parameter may be deprecated if we instead support `SasquatchDatastore` in the future. |
 | tolerations | list | `[]` |  |

--- a/charts/prompt-proto-service/README.md
+++ b/charts/prompt-proto-service/README.md
@@ -43,4 +43,5 @@ Event-driven processing of camera images
 | s3.disableBucketValidation | string | `"0"` | Set this to disable validation of S3 bucket names, allowing Ceph multi-tenant colon-separated names to be used. |
 | s3.endpointUrl | string | None, must be set | S3 endpoint containing `imageBucket` |
 | s3.imageBucket | string | None, must be set | Bucket containing the incoming raw images |
+| sasquatch.endpointUrl | string | `""` | Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload. This is a preliminary implementation of Sasquatch support, and this parameter may be deprecated if we instead support `SasquatchDatastore` in the future. |
 | tolerations | list | `[]` |  |

--- a/charts/prompt-proto-service/templates/prompt-proto-service.yaml
+++ b/charts/prompt-proto-service/templates/prompt-proto-service.yaml
@@ -67,6 +67,13 @@ spec:
           value: {{ .Values.imageNotifications.kafkaClusterAddress }}
         - name: SASQUATCH_URL
           value: {{ .Values.sasquatch.endpointUrl }}
+        {{- if and .Values.sasquatch.endpointUrl .Values.sasquatch.auth_env }}
+        - name: SASQUATCH_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "prompt-proto-service.fullname" . }}-secret
+              key: sasquatch_token
+        {{- end }}
         - name: S3_ENDPOINT_URL
           value: {{ .Values.s3.endpointUrl }}
         {{- if .Values.s3.auth_env }}

--- a/charts/prompt-proto-service/templates/prompt-proto-service.yaml
+++ b/charts/prompt-proto-service/templates/prompt-proto-service.yaml
@@ -65,6 +65,8 @@ spec:
           value: {{ .Values.apdb.namespace }}
         - name: KAFKA_CLUSTER
           value: {{ .Values.imageNotifications.kafkaClusterAddress }}
+        - name: SASQUATCH_URL
+          value: {{ .Values.sasquatch.endpointUrl }}
         - name: S3_ENDPOINT_URL
           value: {{ .Values.s3.endpointUrl }}
         {{- if .Values.s3.auth_env }}

--- a/charts/prompt-proto-service/values.yaml
+++ b/charts/prompt-proto-service/values.yaml
@@ -72,6 +72,12 @@ registry:
 # @default -- log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING.
 logLevel: ""
 
+sasquatch:
+  # -- Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload.
+  # This is a preliminary implementation of Sasquatch support, and this parameter may be deprecated
+  # if we instead support `SasquatchDatastore` in the future.
+  endpointUrl: ""
+
 knative:
     # -- The storage space reserved for each container (mostly local Butler).
   ephemeralStorageRequest: "20Gi"

--- a/charts/prompt-proto-service/values.yaml
+++ b/charts/prompt-proto-service/values.yaml
@@ -77,6 +77,9 @@ sasquatch:
   # This is a preliminary implementation of Sasquatch support, and this parameter may be deprecated
   # if we instead support `SasquatchDatastore` in the future.
   endpointUrl: ""
+  # -- If set, this application's Vault secret must contain a `sasquatch_token` key containing the authentication token for `sasquatch.endpointUrl`.
+  # Leave unset to attempt anonymous access.
+  auth_env: true
 
 knative:
     # -- The storage space reserved for each container (mostly local Butler).


### PR DESCRIPTION
This PR adds configurable Sasquatch support to the Prompt Processing service. At present, it's only possible to upload to Sasquatch on `usdfdev`, not `usdfprod`.

This PR must be merged after lsst-dm/prompt_processing#107.