### PR TITLE
DM-42191: Support Butler client-server for vo-cutouts

### DIFF
--- a/applications/vo-cutouts/Chart.yaml
+++ b/applications/vo-cutouts/Chart.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 description: "Image cutout service complying with IVOA SODA"
 sources:
   - "https://github.com/lsst-sqre/vo-cutouts"
-appVersion: 1.0.0
+appVersion: 1.1.0
 
 dependencies:
   - name: redis

--- a/applications/vo-cutouts/README.md
+++ b/applications/vo-cutouts/README.md
@@ -21,6 +21,7 @@ Image cutout service complying with IVOA SODA
 | config.gcsBucketUrl | string | None, must be set | URL for the GCS bucket into which to store cutouts (must start with `s3`) |
 | config.lifetime | string | 2592000 (30 days) | Lifetime of job results in seconds (quote so that Helm doesn't turn it into a floating point number) |
 | config.loglevel | string | `"INFO"` | Choose from the text form of Python logging levels |
+| config.pathPrefix | string | `"/api/cutout"` | URL path prefix for the cutout API |
 | config.syncTimeout | int | 60 (1 minute) | Timeout for results from a sync cutout in seconds |
 | config.timeout | int | 600 (10 minutes) | Timeout for a single cutout job in seconds |
 | config.useButlerServer | bool | `true` | If true, use Butler in client/server mode instead of connecting directly to the Butler database |

--- a/applications/vo-cutouts/README.md
+++ b/applications/vo-cutouts/README.md
@@ -23,6 +23,7 @@ Image cutout service complying with IVOA SODA
 | config.loglevel | string | `"INFO"` | Choose from the text form of Python logging levels |
 | config.syncTimeout | int | 60 (1 minute) | Timeout for results from a sync cutout in seconds |
 | config.timeout | int | 600 (10 minutes) | Timeout for a single cutout job in seconds |
+| config.useButlerServer | bool | `true` | If true, use Butler in client/server mode instead of connecting directly to the Butler database |
 | cutoutWorker.affinity | object | `{}` | Affinity rules for the cutout worker pod |
 | cutoutWorker.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for cutout workers |
 | cutoutWorker.image.repository | string | `"ghcr.io/lsst-sqre/vo-cutouts-worker"` | Stack image to use for cutouts |
@@ -41,6 +42,7 @@ Image cutout service complying with IVOA SODA
 | fullnameOverride | string | `""` | Override the full name for resources (includes the release name) |
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.butlerRepositoryIndex | string | Set by Argo CD | URI to the Butler configuration of available repositories |
+| global.butlerServerRepositories | string | Set by Argo CD | Butler repositories accessible via Butler server |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the vo-cutouts image |

--- a/applications/vo-cutouts/README.md
+++ b/applications/vo-cutouts/README.md
@@ -16,6 +16,7 @@ Image cutout service complying with IVOA SODA
 | cloudsql.image.repository | string | `"gcr.io/cloudsql-docker/gce-proxy"` | Cloud SQL Auth Proxy image to use |
 | cloudsql.image.tag | string | `"1.33.16"` | Cloud SQL Auth Proxy tag to use |
 | cloudsql.instanceConnectionName | string | `""` | Instance connection name for a CloudSQL PostgreSQL instance |
+| cloudsql.resources | object | See `values.yaml` | Resource limits and requests for the Cloud SQL Proxy container |
 | cloudsql.serviceAccount | string | None, must be set | The Google service account that has an IAM binding to the `vo-cutouts` Kubernetes service accounts and has the `cloudsql.client` role, access to the GCS bucket, and ability to sign URLs as itself |
 | config.databaseUrl | string | None, must be set | URL for the PostgreSQL database |
 | config.gcsBucketUrl | string | None, must be set | URL for the GCS bucket into which to store cutouts (must start with `s3`) |
@@ -32,13 +33,13 @@ Image cutout service complying with IVOA SODA
 | cutoutWorker.nodeSelector | object | `{}` | Node selection rules for the cutout worker pod |
 | cutoutWorker.podAnnotations | object | `{}` | Annotations for the cutout worker pod |
 | cutoutWorker.replicaCount | int | `2` | Number of cutout worker pods to start |
-| cutoutWorker.resources | object | `{}` | Resource limits and requests for the cutout worker pod |
+| cutoutWorker.resources | object | See `values.yaml` | Resource limits and requests for the cutout worker pod |
 | cutoutWorker.tolerations | list | `[]` | Tolerations for the cutout worker pod |
 | databaseWorker.affinity | object | `{}` | Affinity rules for the database worker pod |
 | databaseWorker.nodeSelector | object | `{}` | Node selection rules for the database worker pod |
 | databaseWorker.podAnnotations | object | `{}` | Annotations for the database worker pod |
 | databaseWorker.replicaCount | int | `1` | Number of database worker pods to start |
-| databaseWorker.resources | object | `{}` | Resource limits and requests for the database worker pod |
+| databaseWorker.resources | object | See `values.yaml` | Resource limits and requests for the database worker pod |
 | databaseWorker.tolerations | list | `[]` | Tolerations for the database worker pod |
 | fullnameOverride | string | `""` | Override the full name for resources (includes the release name) |
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |
@@ -66,5 +67,5 @@ Image cutout service complying with IVOA SODA
 | redis.resources | object | See `values.yaml` | Resource limits and requests for the Redis pod |
 | redis.tolerations | list | `[]` | Tolerations for the Redis pod |
 | replicaCount | int | `1` | Number of web frontend pods to start |
-| resources | object | `{}` | Resource limits and requests for the vo-cutouts frontend pod |
+| resources | object | See `values.yaml` | Resource limits and requests for the vo-cutouts frontend pod |
 | tolerations | list | `[]` | Tolerations for the vo-cutouts frontend pod |

--- a/applications/vo-cutouts/templates/configmap.yaml
+++ b/applications/vo-cutouts/templates/configmap.yaml
@@ -6,11 +6,12 @@ metadata:
     {{- include "vo-cutouts.labels" . | nindent 4 }}
 data:
   CUTOUT_DATABASE_URL: {{ required "config.databaseUrl must be set" .Values.config.databaseUrl | quote }}
-  CUTOUT_SERVICE_ACCOUNT: {{ required "cloudsql.serviceAccount must be set" .Values.cloudsql.serviceAccount | quote }}
-  CUTOUT_STORAGE_URL: {{ required "config.gcsBucketUrl must be set" .Values.config.gcsBucketUrl | quote }}
-  CUTOUT_TIMEOUT: {{ .Values.config.timeout | quote }}
   CUTOUT_LIFETIME: {{ .Values.config.lifetime | quote }}
   CUTOUT_REDIS_HOST: "{{ template "vo-cutouts.fullname" . }}-redis.{{ .Release.Namespace }}"
+  CUTOUT_SERVICE_ACCOUNT: {{ required "cloudsql.serviceAccount must be set" .Values.cloudsql.serviceAccount | quote }}
+  CUTOUT_STORAGE_URL: {{ required "config.gcsBucketUrl must be set" .Values.config.gcsBucketUrl | quote }}
   CUTOUT_SYNC_TIMEOUT: {{ .Values.config.syncTimeout | quote }}
-  SAFIR_LOG_LEVEL: {{ .Values.config.loglevel | quote }}
-  SAFIR_PROFILE: "production"
+  CUTOUT_TIMEOUT: {{ .Values.config.timeout | quote }}
+  CUTOUT_LOG_LEVEL: {{ .Values.config.loglevel | quote }}
+  CUTOUT_PATH_PREFIX: {{ .Values.config.pathPrefix | quote }}
+  CUTOUT_PROFILE: "production"

--- a/applications/vo-cutouts/templates/deployment.yaml
+++ b/applications/vo-cutouts/templates/deployment.yaml
@@ -34,6 +34,18 @@ spec:
       containers:
         {{- if .Values.cloudsql.enabled }}
         - name: "cloud-sql-proxy"
+          command:
+            - "/cloud_sql_proxy"
+            - "-ip_address_types=PRIVATE"
+            - "-log_debug_stdout=true"
+            - "-structured_logs=true"
+            - "-instances={{ required "cloudsql.instanceConnectionName must be specified" .Values.cloudsql.instanceConnectionName }}=tcp:5432"
+          image: "{{ .Values.cloudsql.image.repository }}:{{ .Values.cloudsql.image.tag }}"
+          imagePullPolicy: {{ .Values.cloudsql.image.pullPolicy | quote }}
+          {{- with .Values.cloudsql.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -43,14 +55,6 @@ spec:
             runAsNonRoot: true
             runAsUser: 65532
             runAsGroup: 65532
-          image: "{{ .Values.cloudsql.image.repository }}:{{ .Values.cloudsql.image.tag }}"
-          imagePullPolicy: {{ .Values.cloudsql.image.pullPolicy | quote }}
-          command:
-            - "/cloud_sql_proxy"
-            - "-ip_address_types=PRIVATE"
-            - "-log_debug_stdout=true"
-            - "-structured_logs=true"
-            - "-instances={{ required "cloudsql.instanceConnectionName must be specified" .Values.cloudsql.instanceConnectionName }}=tcp:5432"
         {{- end }}
         - name: "vo-cutouts"
           securityContext:

--- a/applications/vo-cutouts/templates/ingress.yaml
+++ b/applications/vo-cutouts/templates/ingress.yaml
@@ -9,6 +9,13 @@ config:
   scopes:
     all:
       - "read:image"
+  # Request a delegated token to use for making calls to Butler server with the
+  # end-user's credentials.
+  delegate:
+    internal:
+      service: "vo-cutouts"
+      scopes:
+        - "read:image"
 template:
   metadata:
     name: {{ template "vo-cutouts.fullname" . }}

--- a/applications/vo-cutouts/templates/ingress.yaml
+++ b/applications/vo-cutouts/templates/ingress.yaml
@@ -28,7 +28,7 @@ template:
       - host: {{ required "global.host must be set" .Values.global.host | quote }}
         http:
           paths:
-            - path: "/api/cutout"
+            - path: {{ .Values.config.pathPrefix | quote }}
               pathType: "Prefix"
               backend:
                 service:

--- a/applications/vo-cutouts/templates/worker-deployment.yaml
+++ b/applications/vo-cutouts/templates/worker-deployment.yaml
@@ -94,7 +94,7 @@ spec:
 
             # lsst-resources writes temp files into the current working
             # directory unless you explicitly specify one.
-            - name: TMPDIR
+            - name: "TMPDIR"
               value: "/tmp"
           envFrom:
             - configMapRef:

--- a/applications/vo-cutouts/templates/worker-deployment.yaml
+++ b/applications/vo-cutouts/templates/worker-deployment.yaml
@@ -91,6 +91,11 @@ spec:
             # Temporary directory into which to stage cutouts before uploading.
             - name: "CUTOUT_TMPDIR"
               value: "/tmp/cutouts"
+
+            # lsst-resources writes temp files into the current working
+            # directory unless you explicitly specify one.
+            - name: TMPDIR
+              value: "/tmp"
           envFrom:
             - configMapRef:
                 name: {{ template "vo-cutouts.fullname" . }}-config

--- a/applications/vo-cutouts/templates/worker-deployment.yaml
+++ b/applications/vo-cutouts/templates/worker-deployment.yaml
@@ -65,8 +65,13 @@ spec:
             # and authenticate to its database.
             - name: "AWS_SHARED_CREDENTIALS_FILE"
               value: "/etc/vo-cutouts/secrets/aws-credentials"
+            {{- if .Values.config.useButlerServer }}
+            - name: "DAF_BUTLER_REPOSITORIES"
+              value: {{ .Values.global.butlerServerRepositories | b64dec | quote }}
+            {{- else }}
             - name: "DAF_BUTLER_REPOSITORY_INDEX"
               value: {{ .Values.global.butlerRepositoryIndex | quote }}
+            {{- end }}
             - name: "PGPASSFILE"
               value: "/etc/vo-cutouts/secrets/postgres-credentials"
             - name: "S3_ENDPOINT_URL"

--- a/applications/vo-cutouts/values.yaml
+++ b/applications/vo-cutouts/values.yaml
@@ -43,6 +43,9 @@ config:
   # -- Choose from the text form of Python logging levels
   loglevel: "INFO"
 
+  # -- URL path prefix for the cutout API
+  pathPrefix: "/api/cutout"
+
   # -- URL for the PostgreSQL database
   # @default -- None, must be set
   databaseUrl: ""

--- a/applications/vo-cutouts/values.yaml
+++ b/applications/vo-cutouts/values.yaml
@@ -25,7 +25,14 @@ ingress:
   annotations: {}
 
 # -- Resource limits and requests for the vo-cutouts frontend pod
-resources: {}
+# @default -- See `values.yaml`
+resources:
+  limits:
+    cpu: "0.5"
+    memory: "500Mi"
+  requests:
+    cpu: "0.1"
+    memory: "230Mi"
 
 # -- Annotations for the vo-cutouts frontend pod
 podAnnotations: {}
@@ -96,6 +103,16 @@ cloudsql:
   # @default -- None, must be set
   serviceAccount: ""
 
+  # -- Resource limits and requests for the Cloud SQL Proxy container
+  # @default -- See `values.yaml`
+  resources:
+    limits:
+      cpu: "100m"
+      memory: "20Mi"
+    requests:
+      cpu: "5m"
+      memory: "7Mi"
+
 cutoutWorker:
   # -- Number of cutout worker pods to start
   replicaCount: 2
@@ -112,7 +129,14 @@ cutoutWorker:
     pullPolicy: "IfNotPresent"
 
   # -- Resource limits and requests for the cutout worker pod
-  resources: {}
+  # @default -- See `values.yaml`
+  resources:
+    limits:
+      cpu: "1"
+      memory: "700Mi"
+    requests:
+      cpu: "0.1"
+      memory: "350Mi"
 
   # -- Annotations for the cutout worker pod
   podAnnotations: {}
@@ -131,7 +155,14 @@ databaseWorker:
   replicaCount: 1
 
   # -- Resource limits and requests for the database worker pod
-  resources: {}
+  # @default -- See `values.yaml`
+  resources:
+    limits:
+      cpu: "0.1"
+      memory: "200Mi"
+    requests:
+      cpu: "0.02"
+      memory: "85Mi"
 
   # -- Annotations for the database worker pod
   podAnnotations: {}
@@ -178,7 +209,11 @@ redis:
   # @default -- See `values.yaml`
   resources:
     limits:
-      cpu: "1"
+      cpu: "0.5"
+      memory: "10Mi"
+    requests:
+      cpu: "0.1"
+      memory: "5Mi"
 
   # -- Pod annotations for the Redis pod
   podAnnotations: {}

--- a/applications/vo-cutouts/values.yaml
+++ b/applications/vo-cutouts/values.yaml
@@ -65,6 +65,10 @@ config:
   # @default -- 60 (1 minute)
   syncTimeout: 60
 
+  # -- If true, use Butler in client/server mode instead of connecting
+  # directly to the Butler database
+  useButlerServer: true
+
 cloudsql:
   # -- Enable the Cloud SQL Auth Proxy sidecar, used with CloudSQL databases
   # on Google Cloud
@@ -195,6 +199,10 @@ global:
   # -- URI to the Butler configuration of available repositories
   # @default -- Set by Argo CD
   butlerRepositoryIndex: ""
+
+  # -- Butler repositories accessible via Butler server
+  # @default -- Set by Argo CD
+  butlerServerRepositories: ""
 
   # -- Host name for ingress
   # @default -- Set by Argo CD

--- a/environments/templates/vo-cutouts-application.yaml
+++ b/environments/templates/vo-cutouts-application.yaml
@@ -26,6 +26,8 @@ spec:
           value: "https://{{ .Values.fqdn }}"
         - name: "global.butlerRepositoryIndex"
           value: {{ .Values.butlerRepositoryIndex | quote }}
+        - name: "global.butlerServerRepositories"
+          value: {{ .Values.butlerServerRepositories | toJson | b64enc }}
         - name: "global.host"
           value: {{ .Values.fqdn | quote }}
         - name: "global.vaultSecretsPath"


### PR DESCRIPTION
Updated vo-cutouts to use Butler client/server instead of a direct postgres connection.  It now requests a delegated token from Gafaelfawr to pass to Butler server.