### PR TITLE
DM-42714: Reject application names containing underscore

### DIFF
--- a/src/phalanx/cli.py
+++ b/src/phalanx/cli.py
@@ -162,10 +162,15 @@ def application_create(
     """
     if not config:
         config = _find_config()
+    if not re.match("[a-z]", name):
+        raise click.BadParameter("Name must start with a lowercase letter")
+    if not re.match("[a-z0-9-]+$", name):
+        msg = "Name must be only lowercase letters, digits, and hyphens"
+        raise click.BadParameter(msg)
     if len(name) + 3 + len(description) > 80:
-        raise click.UsageError("Name plus description is too long")
+        raise click.BadParameter("Name plus description is too long")
     if not re.match("[A-Z0-9]", description):
-        raise click.UsageError("Description must start with capital letter")
+        raise click.BadParameter("Description must start with capital letter")
     factory = Factory(config)
     application_service = factory.create_application_service()
     application_service.create(name, HelmStarter(starter), description)

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -31,6 +31,14 @@ def all_charts(
         yield candidate
 
 
+def test_application_names() -> None:
+    """All applications must have valid names."""
+    for application in all_charts("applications"):
+        assert re.match(
+            "[a-z][a-z0-9-]+$", application.name
+        ), f"Application {application.name} has invalid name"
+
+
 def test_application_version() -> None:
     """All application charts should have version 1.0.0."""
     for application in all_charts("applications"):

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -11,12 +11,7 @@ import yaml
 
 from phalanx.factory import Factory
 
-_ALLOW_NO_SECRETS = (
-    "giftless",
-    "linters",
-    "monitoring",
-    "next-visit-fan-out",
-)
+_ALLOW_NO_SECRETS = ("linters", "monitoring", "next-visit-fan-out")
 """Temporary whitelist of applications that haven't added secrets.yaml."""
 
 


### PR DESCRIPTION
Enforce restrictions on application names. They must start with a lowercase character and consist only of lowercase characters, digits, and hyphen. Enforce this in phalanx application create and with a separate test.