### PR TITLE
DM-42714: Document testing development versions

### DIFF
--- a/docs/developers/add-application.rst
+++ b/docs/developers/add-application.rst
@@ -48,3 +48,8 @@ Finally, you need to tell Argo CD to deploy your application in some environment
    This environment will be the first place your application is deployed.
 
    You almost certainly want to start in a development or integration environment and enable your new application in production environments only after it has been smoke-tested in less critical environments.
+
+Next steps
+==========
+
+- Test your application by deploying it from a branch: :doc:`deploy-from-a-branch`

--- a/docs/developers/deploy-from-a-branch.rst
+++ b/docs/developers/deploy-from-a-branch.rst
@@ -13,7 +13,7 @@ Through this process it is possible to develop an application in a fairly tight 
 
 .. seealso::
 
-   This page focuses on using a development environment to iteratively develop and test changes to an application, ultimately yielding a applicatino upgrade in Phalanx.
+   This page focuses on using a development environment to iteratively develop and test changes to an application, ultimately yielding a application upgrade in Phalanx.
    You can achieve the same result without the iterative deployment testing by following the steps in :doc:`upgrade`.
 
 .. _deploy-branch-prep:
@@ -34,7 +34,7 @@ Throughout this process, you can continue to commit changes and push updates to 
 
 .. tip::
 
-   In a development environment it's useful to force Kubernetes to pull the application's Docker images every time a Pod_ starts up.
+   When testing development versions of a service, it's useful to force Kubernetes to pull the application's Docker images every time a Pod_ starts up.
    This way you can push edits to the Docker images with a specific development tag [1]_ and then have your test deployment use those updated images.
    This setting is controlled by the ``imagePullPolicy`` key in Deployment_ resources (and specifically their Pods_).
    In typical application Helm charts the image pull policy is accessible from Helm values.
@@ -48,7 +48,7 @@ Throughout this process, you can continue to commit changes and push updates to 
 
    Consult the Helm values documentation for your application for details.
 
-   .. [1] SQuaRE Docker images are tagged with the Git branch or tag they are built from, with a typical branch build being tagged as ``tickets-DM-00000``.
+   .. [1] SQuaRE Docker images are tagged with the Git branch or tag they are built from, with a typical branch build for a ticket branch being tagged as :samp:`tickets-DM-NNNNN`.
 
 Switching the Argo CD Application to sync the branch
 ====================================================

--- a/docs/developers/upgrade.rst
+++ b/docs/developers/upgrade.rst
@@ -15,5 +15,10 @@ Then, update Phalanx to install the new version of the application.
 - If it is a complex application such as ``sasquatch`` that bundles first- and third-party applications, you may need to do both, including making updates to ``appVersion`` or dependency versions in the :file:`charts` subdirectory.
   Tricky cases such as these may require some study before deciding on the best course of action.
 
+- If you only want to test a new version of the application in a specific environment, edit the :file:`values-{environment}.yaml` file for that environment and override the ``image.tag`` setting to point to the new test version.
+  This can be either a new tag or (more commonly) the name of an image built from a branch, such as :samp:`tickets-DM-{NNNNN}`.
+  In this case, you will also want to set ``image.pullPolicy`` to ``Always`` so that you can restart the deployment to pick up new test versions.
+  ``image.tag`` and ``image.pullPolicy`` are the normal names for these settings but, depending on the application, the specific configuration setting may be different.
+
 Once you have updated the application, Argo CD will notice that the change is pending, but no changes will be applied automatically.
 To apply the changes in a given environment, see :doc:`/admin/sync-argo-cd`.

--- a/docs/developers/write-a-helm-chart.rst
+++ b/docs/developers/write-a-helm-chart.rst
@@ -28,6 +28,7 @@ Then, create the files for the new application, including the start of a Helm ch
    phalanx application create <application>
 
 Replace ``<application>`` with the name of your new application, which will double as the name of the Helm chart.
+The application name must start with a lowercase letter and consist of lowercase letters, numbers, and hyphen (``-``).
 
 By default, this will create a Helm chart for a FastAPI web service.
 Use the ``--starter`` flag to specify a different Helm chart starter.
@@ -214,6 +215,8 @@ Phalanx uses helm-docs_ to automate generating documentation for the :file:`valu
 
 For this to work correctly, each setting must be immediately preceded by a comment that starts with :literal:`# --\ ` and is followed by documentation for that setting in Markdown.
 This documentation may be wrapped to multiple lines.
+
+Add a blank line between settings, before the helm-docs comment for the next setting.
 
 The default value is included in the documentation.
 The documentation of the default value can be overridden with a comment starting with :literal:`# @default --\ `.


### PR DESCRIPTION
Add some more explicit documentation for how to test development versions of an application, and reference pullPolicy in that documentation.

Add explicit documentation of the restrictions on application names, and mention blank lines between settings in values.yaml.