### PR TITLE
DM-42714: Document mounting a writable /tmp

### DIFF
--- a/docs/_rst_epilog.rst
+++ b/docs/_rst_epilog.rst
@@ -29,6 +29,7 @@
 .. _Namespace: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
 .. _`lsst-sqre/phalanx`:
 .. _ObsTAP: https://www.ivoa.net/documents/ObsCore/
+.. _persistent volume: https://kubernetes.io/docs/concepts/storage/persistent-volumes/
 .. _Phalanx repository: https://github.com/lsst-sqre/phalanx
 .. _Pods:
 .. _Pod: https://kubernetes.io/docs/concepts/workloads/pods/

--- a/docs/developers/write-a-helm-chart.rst
+++ b/docs/developers/write-a-helm-chart.rst
@@ -139,6 +139,40 @@ Two aspects of writing a Helm chart are specific to Phalanx:
   You will also need to customize the path under which your application should be served.
   See the `Gafaelfawr documentation <https://gafaelfawr.lsst.io/user-guide/gafaelfawringress.html>`__ for more details.
 
+/tmp
+----
+
+The ``web-service`` starter creates a deployment with an entirely read-only file system.
+This is ideal for security, since it denies an attacker the ability to create new local files, which makes some attacks harder.
+
+Some applications, however, need working scratch space.
+For those applications, you may need to mount a writable :file:`/tmp` file system.
+Here is how to do that:
+
+#. Add a ``volumes`` section to the ``spec`` part of the Deployment_ (or add a new element one is not already there) that creates a volume for temporary files:
+
+   .. code-block:: yaml
+
+      volumes:
+        - name: "tmp"
+          emptyDir: {}
+
+#. Mount that volume by adding a ``volumeMounts`` section to the main container in the Deployment_ (or add it to the volume mounts if there already are others):
+
+   .. code-block:: yaml
+
+      volumeMounts:
+        - name: "tmp"
+          mountPath: "/tmp"
+
+.. warning::
+
+   Files written to this temporary directory are stored in `node ephemeral storage <https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#configurations-for-local-ephemeral-storage>`__, which is shared between all pods running on that node.
+   Writing excessive amounts of data to this directory may exhaust node resources and cause problems for other applications in the cluster.
+
+   This type of temporary directory should therefore only be used for small files.
+   Applications that need large amounts of temporary space should allocate and mount a `persistent volume`_ instead.
+
 Pull secrets
 ------------
 


### PR DESCRIPTION
Our default starter does not provide any writable file systems for the application. Document how to mount a writable /tmp, and caution against using it for large files.