### PR TITLE
DM-42714: Warn against using the Argo CD client

### DIFF
--- a/docs/admin/installation.rst
+++ b/docs/admin/installation.rst
@@ -5,8 +5,8 @@ Installing a Phalanx environment
 Each separate installation of Phalanx is called an environment.
 An environment has a hostname, Vault server and path to its secrets, and a set of Phalanx applications that should be installed in that environment.
 
-Before starting this process, you should set up the required secrets for your new environment.
-See :doc:`secrets-setup` for details.
+Before starting this process, ensure that you have met the :doc:`requirements to run Phalanx <requirements>`.
+Then, set up the required secrets for your new environment as documented in :doc:`secrets-setup`.
 
 If you are setting up an environment that will be running a 1Password Connect server for itself, you will need to take special bootstrapping steps.
 See :px-app-bootstrap:`onepassword-connect` for more information.

--- a/docs/admin/requirements.rst
+++ b/docs/admin/requirements.rst
@@ -32,8 +32,8 @@ Phalanx can only be installed in environments that meet the following requiremen
 - An external managed PostgreSQL-compatible database server is not strictly required but is strongly recommended.
   Phalanx can deploy an in-cluster PostgreSQL server for test and development environments, but that server is not backed up and is not intended for production use.
 
-Using a Kubernetes networking layer that enforces ``NetworkPolicy`` objects is not required, but is strongly recommended.
-Without such an enforcement layer, all users and applications in the Phalanx cluster are trusted and will be able to impersonate arbitrary users to other services.
+- Using a Kubernetes networking layer that enforces ``NetworkPolicy`` objects is not required, but is strongly recommended.
+  Without such an enforcement layer, all users and applications in the Phalanx cluster are trusted and will be able to impersonate arbitrary users to other services.
 
 You will also need to manage TLS certificates for the public hostname or hostnames of your Phalanx environment, although Phalanx may be able to automate this for you.
 See :doc:`hostnames` for more information.
@@ -51,6 +51,11 @@ For installing an environment, you will also need the following tools:
 - Argo CD's command-line tool.
   It may be necessary to update this regularly to match the version of Argo CD that Phalanx, since Argo CD tends to break backward compatibility for its command-line API.
   To see the version of the client that is currently tested, search for ``argocd-linux`` in `.github/workflows/ci.yaml <https://github.com/lsst-sqre/phalanx/blob/main/.github/workflows/ci.yaml>`__.
+
+  .. warning::
+
+     Although the Argo CD command-line client must be installed to use the Phalanx installer, do not use it to create applications.
+     All Argo CD applications should be managed through Phalanx and the ``science-platform`` app of apps.
 
 - The Vault command-line client.
   Any recent version of the client should work.

--- a/docs/developers/add-application.rst
+++ b/docs/developers/add-application.rst
@@ -9,6 +9,12 @@ Some of the integration will be done for you by the :command:`phalanx applicatio
 
 For background on building an application, see the :ref:`dev-build-toc` documentation.
 
+.. warning::
+
+   Although Phalanx uses Argo CD to manage applications, do not use the Argo CD command-line client to add new applications to a Phalanx environment.
+   All Phalanx applications are managed inside Git and created through the Phalanx tooling.
+   Applications created by the Argo CD command-line client will not be properly managed by Phalanx.
+
 Add documentation
 =================
 


### PR DESCRIPTION
Tell people not to use the Argo CD command-line client to create applications. Some folks have attempted to do this and gotten into trouble.