### PR TITLE
DM-42660: Bump Butler version

### DIFF
--- a/applications/butler/Chart.yaml
+++ b/applications/butler/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: w.2024.04
+appVersion: server-1.0.2
 description: Server for Butler data abstraction service
 name: butler
 sources:


### PR DESCRIPTION
Upgrade Butler to server-1.0.2, which supports the chained datastore configuration on idfprod.