### PR TITLE
DM-42714: Document value injection

### DIFF
--- a/docs/applications/filestore-backup/index.rst
+++ b/docs/applications/filestore-backup/index.rst
@@ -1,10 +1,10 @@
 .. px-app:: filestore-backup
 
-##############################################################
-Filestore-backup — Create and purge Google filestore backups
-##############################################################
+############################################################
+filestore-backup — Create and purge Google filestore backups
+############################################################
 
-Filestore-backup manages backing up Google Filestore shares and purging old backups.
+filestore-backup manages backing up Google Filestore shares and purging old backups.
 
 .. jinja:: filestore-backup
    :file: applications/_summary.rst.jinja

--- a/docs/applications/filestore-backup/values.md
+++ b/docs/applications/filestore-backup/values.md
@@ -1,7 +1,7 @@
-```{px-app-values} giftless
+```{px-app-values} filestore-backup
 ```
 
-# Filestore-backup Helm values reference
+# filestore-backup Helm values reference
 
 Helm values reference table for the {px-app}`filestore-backup` application.
 

--- a/docs/developers/index.rst
+++ b/docs/developers/index.rst
@@ -47,3 +47,4 @@ Individual applications are documented in the :doc:`/applications/index` section
    :name: dev-reference-toc
 
    secrets-spec
+   injected-values

--- a/docs/developers/injected-values.rst
+++ b/docs/developers/injected-values.rst
@@ -1,0 +1,100 @@
+##########################
+Values injected by Argo CD
+##########################
+
+The behavior of a Helm chart is customized by _values_, which are settings injected from either files or command-line flags when Helm is invoked to create Kubernetes resources.
+For Phalanx applications, those values come from three sources, configured in the Argo CD ``Application`` resource for the application.
+Sources later on this list override values from earlier sources.
+
+#. The :file:`values.yaml` file for the application.
+#. The :file:`values-{environment}.yaml` file for that application and the current environment.
+#. Values injected by Argo CD directly from the ``Application`` resource.
+
+The ``Application`` resources are found in :file:`environments/templates`.
+Unlike the :file:`values.yaml` file for the application, they have access to environment-wide configuration set by the :file:`environments/values-{environment}.yaml` files.
+
+This page describes that third group of values injected by Argo CD.
+
+Always-injected values
+======================
+
+Injected values must be explicitly listed in the ``Application`` resource template for that application, and therefore a given application may not have any injected values.
+However, by convention and via :command:`phalanx application create`, Phalanx applications always get the following injected values, all of which provide information about the Phalanx environment in which the application is being deployed.
+
+``global.host``
+    The default hostname used by this Phalanx environment.
+    This corresponds to the hostname in the public URLs for the services in this environment.
+
+``global.baseUrl``
+    The base URL for applications deployed in this Phalanx environment.
+    This always uses the ``https://`` schema.
+
+``global.vaultSecretsPath``
+    The base path in Vault for secrets for this environment.
+    The Vault path for a secret for a given application can be formed by appending :samp:`/{application}` to this value.
+    The pull secret for the environment, if there is one, will be this value with ``/pull-secret`` appended.
+
+.. _dev-injected-optional:
+
+Optional injected values
+========================
+
+The following additional values are not normally injected by the default ``Application`` template but can be added if needed by adding a new entry to the ``spec.source.helm.parameters`` key of the ``Application`` resource template.
+
+``global.butlerRepositoryIndex``
+    The URI for the Butler index for this environment, used by services that connect directly to the Butler database without using the Butler server.
+
+``global.butlerServerRepositories``
+    A mapping from Butler repository labels to URIs that is used by applications that talk to the Butler server.
+    Since this is a complex data structure, it has to be injected as a base64-encoded value to prevent Helm from misinterpreting it:
+
+    .. code-block:: yaml
+
+       - name: "global.butlerServerRepositories"
+         value: {{ .Values.butlerServerRepositories | toJson | b64enc }}
+
+    When using this value in an application template, you will then need to undo the base64 encoding.
+    For example, here is a fragment of a template used to set an environment variable to the JSON encoding of this mapping:
+
+    .. code-block:: yaml
+
+       - name: "DAF_BUTLER_REPOSITORIES"
+         value: {{ .Values.global.butlerServerRepositories | b64dec | quote }}
+
+``global.controlSystem.*``
+    Settings that begin with ``global.controlSystem`` are specific to the telescope control system applications and correspond to the ``controlSystem.*`` settings in :file:`environments/values.yaml`.
+    These should only be used for the telescope control system, the details of which are outside of the scope of this documentation.
+
+If you use any of these optional injected values, do not forget to document them in the :file:`values.yaml` file for your application.
+
+Adding new injected values
+==========================
+
+In theory, any value that can be determined only from information present in the :file:`environments/values.yaml` and :file:`environments/values-{environment}.yaml` files can be injected into an application.
+However, if you add any values not present in the above list, you will have to change the source code for the :command:`phalanx` command-line tool to inject the same values when linting and templating charts.
+
+Use the following process when injecting new values:
+
+#. Make sure that you need to inject a new value.
+   Each new injected value adds additional complexity that Phalanx developers have to keep track of.
+   Only use injected values for information that is global to a given environment **and** is needed by multiple applications.
+
+#. Ensure that all the information that you are injecting is available from the environment configuration defined in :file:`environments/values.yaml`.
+   If it is not, you may have to extend the environment configuration by updating the model in :file:`src/phalanx/models/environments.py`.
+   New settings should be defined in `~phalanx.models.environments.EnvironmentBaseConfig`.
+   You will also need to regenerate the JSON schema for environments with :command:`phalanx environment schema`, replacing :file:`docs/extras/schemas/environment.json`.
+
+#. Add the new injected values to the ``Application`` resource template for the appropriate applications.
+   Injected values go through multiple layers of parsing and interpretation, so only string values will work reliably.
+   If you need to inject more complex information, you will have to JSON-encode and base64-encode the values and decode them again in the application template.
+
+#. Add the new injected values to the ``_build_injected_values`` method of `~phalanx.services.application.ApplicationService`.
+   This will make them available for :command:`phalanx application lint` and :command:`phalanx application template`.
+   If you did any encoding of the value in the ``Application`` resource templates, you will need to do the same encoding here.
+
+#. Document the injected values in the :file:`values.yaml` files of every application that uses them.
+
+#. Use the injected values in the templates of the applications that need them.
+   Often this will involve setting an environment variable for the application deployment to the injected value.
+
+#. Document the new injected values in this file, under :ref:`dev-injected-optional`.

--- a/docs/developers/write-a-helm-chart.rst
+++ b/docs/developers/write-a-helm-chart.rst
@@ -123,9 +123,12 @@ Write the Kubernetes resource templates
 =======================================
 
 Put all Kubernetes resource templates that should be created by your chart in the :file:`templates` subdirectory.
-See the `Helm chart template developer's guide <https://helm.sh/docs/chart_template_guide/>`__.
+See the `Helm chart template developer's guide <https://helm.sh/docs/chart_template_guide/>`__ for general instructions on how to write Helm templates.
 
-Two aspects of writing a Helm chart are specific to Phalanx:
+Three aspects of writing a Helm chart are specific to Phalanx:
+
+- Some values will be automatically injected by Argo CD in the ``global.*`` namespace.
+  See :doc:`injected-values` for more information.
 
 - All secrets must come from ``VaultSecret`` resources, not Kubernetes ``Secret`` resources.
   You should use the value of the ``global.vaultSecretsPath`` configuration option followed by a slash and the name of your application.
@@ -234,11 +237,14 @@ If something is the same in every Phalanx environment, it can be hard-coded into
 Injected values
 ---------------
 
-Three values will be injected by Argo CD into your application automatically as globals, and therefore do not need to be set for each environment.
+Three values will always be injected by Argo CD into your application automatically as globals, and therefore do not need to be set for each environment.
 These are ``global.baseUrl``, ``global.host``, and ``global.vaultSecretsPath`` and are taken from the global settings for each environment.
 
 These should be mentioned for documentation purposes at the bottom of your :file:`values.yaml` file with empty defaults.
 This is done automatically for you by the :ref:`chart starters <dev-chart-starters>`.
+
+It is possible to inject other values from the environment configuration.
+For more details, see :doc:`injected-values`.
 
 .. _dev-helm-docs:
 

--- a/docs/documenteer.toml
+++ b/docs/documenteer.toml
@@ -30,6 +30,8 @@ nitpick_ignore = [
     ["py:class", "pydantic.networks.AnyHttpUrl"],
     ["py:class", "pydantic.types.SecretStr"],
     ["py:class", "pydantic.utils.Representation"],
+    ["py:obj", "ComputedFieldInfo"],
+    ["py:obj", "pydantic.BaseModel.model_dict"],
 ]
 nitpick_ignore_regex = [
     # Bug in Sphinx

--- a/docs/extras/schemas/secrets.json
+++ b/docs/extras/schemas/secrets.json
@@ -169,7 +169,7 @@
           "title": "Condition"
         },
         "source": {
-          "description": "Key of secret on which this secret is based. This may only be set by secrets of type `bcrypt-password-hash` or `mtime`.",
+          "description": "Key of secret on which this secret is based. This may only be set by secrets of type ``bcrypt-password-hash`` or ``mtime``.",
           "title": "Source key",
           "type": "string"
         },

--- a/src/phalanx/models/environments.py
+++ b/src/phalanx/models/environments.py
@@ -149,7 +149,9 @@ class ControlSystemConfig(CamelCaseModel):
 
 
 class EnvironmentBaseConfig(CamelCaseModel):
-    """Configuration common to `EnviromentConfig` and `Environment`."""
+    """Configuration common to `~phalanx.models.environments.EnvironmentConfig`
+    and `~phalanx.models.environments.Environment`.
+    """
 
     name: str = Field(..., title="Name", description="Name of the environment")
 
@@ -406,9 +408,9 @@ class EnvironmentDetails(EnvironmentBaseConfig):
     """Full details about an environment, including auth and Argo CD.
 
     Used primarily for documentation generation, which needs details from the
-    Argo CD and Gafaelfawr configurations for that environment.  Use
-    `EnvironmentConfig` instead when only the basic environment configuration
-    is needed.
+    Argo CD and Gafaelfawr configurations for that environment. Use
+    `~phalanx.models.environments.EnvironmentConfig` instead when only the
+    basic environment configuration is needed.
     """
 
     applications: list[Application]

--- a/src/phalanx/models/secrets.py
+++ b/src/phalanx/models/secrets.py
@@ -146,7 +146,7 @@ class SourceSecretGenerateRules(BaseModel):
         title="Source key",
         description=(
             "Key of secret on which this secret is based. This may only be"
-            " set by secrets of type `bcrypt-password-hash` or `mtime`."
+            " set by secrets of type ``bcrypt-password-hash`` or ``mtime``."
         ),
     )
 


### PR DESCRIPTION
Add documentation for Argo CD injection of values into the application and describe the default injected values. Include documentation for how to add new ones.

Fix various problems with the documentation build and incorrect capitalization of filestore-backup.