### PR TITLE
DM-42875: Deploy Squarebot 0.8.0

### DIFF
--- a/applications/squarebot/Chart.yaml
+++ b/applications/squarebot/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: squarebot
 version: 1.0.0
-appVersion: "0.7.0"
-description: Squarebot feeds events from services like Slack and GitHub into the SQuaRE Events Kafka message bus running on Roundtable. Backend apps like Templatebot can subscribe to these events and take domain-specific action.
+appVersion: "0.8.0"
+description: Squarebot feeds events from services like Slack and GitHub into the SQuaRE Events Kafka message bus running on Roundtable. Backend apps like Templatebot and Unfurlbot can subscribe to these events and take domain-specific action.
 type: application
 home: https://squarebot.lsst.io/
 sources:

--- a/applications/squarebot/README.md
+++ b/applications/squarebot/README.md
@@ -18,9 +18,6 @@ Squarebot feeds events from services like Slack and GitHub into the SQuaRE Event
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
 | config.logLevel | string | `"INFO"` | Logging level: "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL" |
-| config.registryUrl | string | `"http://sasquatch-schema-registry.sasquatch:8081"` | Cluster URL for the Confluent Schema Registry |
-| config.subjectCompatibility | string | `"FORWARD"` | Schema subject compatibility. |
-| config.subjectSuffix | string | `""` | Schema subject suffix. Should be empty for production but can be set to a value to create unique subjects in the Confluent Schema Registry for testing. |
 | config.topics.slackAppMention | string | `"lsst.square-events.squarebot.slack.app.mention"` | Kafka topic name for the Slack `app_mention` events |
 | config.topics.slackInteraction | string | `"lsst.square-events.squarebot.slack.interaction"` | Kafka topic for Slack interaction events |
 | config.topics.slackMessageChannels | string | `"lsst.square-events.squarebot.slack.message.channels"` | Kafka topic name for the Slack `message.channels` events (public channels) |

--- a/applications/squarebot/README.md
+++ b/applications/squarebot/README.md
@@ -1,6 +1,6 @@
 # squarebot
 
-Squarebot feeds events from services like Slack and GitHub into the SQuaRE Events Kafka message bus running on Roundtable. Backend apps like Templatebot can subscribe to these events and take domain-specific action.
+Squarebot feeds events from services like Slack and GitHub into the SQuaRE Events Kafka message bus running on Roundtable. Backend apps like Templatebot and Unfurlbot can subscribe to these events and take domain-specific action.
 
 **Homepage:** <https://squarebot.lsst.io/>
 

--- a/applications/squarebot/templates/configmap.yaml
+++ b/applications/squarebot/templates/configmap.yaml
@@ -5,16 +5,13 @@ metadata:
   labels:
     {{- include "squarebot.labels" . | nindent 4 }}
 data:
-  SAFIR_LOG_LEVEL: {{ .Values.config.logLevel | quote }}
-  SAFIR_PATH_PREFIX: {{ .Values.ingress.path | quote }}
-  SAFIR_ENVIRONMENT_URL: {{ .Values.global.baseUrl | quote }}
-  SAFIR_PROFILE: "production"
-  SQUAREBOT_REGISTRY_URL: {{ .Values.config.registryUrl | quote }}
-  SQUAREBOT_SUBJECT_SUFFIX: {{ .Values.config.subjectSuffix | quote }}
-  SQUAREBOT_SUBJECT_COMPATIBILITY: {{ .Values.config.subjectCompatibility | quote }}
+  SQUAREBOT_LOG_LEVEL: {{ .Values.config.logLevel | quote }}
+  SQUAREBOT_PATH_PREFIX: {{ .Values.ingress.path | quote }}
+  SQUAREBOT_ENVIRONMENT_URL: {{ .Values.global.baseUrl | quote }}
+  SQUAREBOT_PROFILE: "production"
   SQUAREBOT_TOPIC_APP_MENTION: {{ .Values.config.topics.slackAppMention | quote }}
   SQUAREBOT_TOPIC_MESSAGE_CHANNELS: {{ .Values.config.topics.slackMessageChannels | quote }}
   SQUAREBOT_TOPIC_MESSAGE_GROUPS: {{ .Values.config.topics.slackMessageGroups | quote }}
   SQUAREBOT_TOPIC_MESSAGE_IM: {{ .Values.config.topics.slackMessageIm | quote }}
   SQUAREBOT_TOPIC_MESSAGE_MPIM: {{ .Values.config.topics.slackMessageMpim | quote }}
-  SQUAREBOT_TOPIC_MESSAGE_INTERACTION: {{ .Values.config.topics.slackInteraction | quote }}
+  SQUAREBOT_TOPIC_INTERACTION: {{ .Values.config.topics.slackInteraction | quote }}

--- a/applications/squarebot/templates/deployment.yaml
+++ b/applications/squarebot/templates/deployment.yaml
@@ -67,18 +67,14 @@ spec:
                   key: "bootstrapServers"
             - name: "KAFKA_SECURITY_PROTOCOL"
               value: "SSL"
-              # valueFrom:
-              #   secretKeyRef:
-              #     name: {{ template "squarebot.fullname" . }}-kafka
-              #     key: "securityProtocol"
             # From replicated KafkaUser secret
-            - name: "KAFKA_SSL_CLUSTER_CAFILE"
+            - name: "KAFKA_CLUSTER_CA_PATH"
               value: "/etc/kafkacluster/ca.crt"
-            - name: "KAFKA_SSL_CLIENT_CAFILE"
+            - name: "KAFKA_CLIENT_CA_PATH"
               value: "/etc/kafkauser/ca.crt"
-            - name: "KAFKA_SSL_CLIENT_CERTFILE"
+            - name: "KAFKA_CLIENT_CERT_PATH"
               value: "/etc/kafkauser/user.crt"
-            - name: "KAFKA_SSL_CLIENT_KEYFILE"
+            - name: "KAFKA_CLIENT_KEY_PATH"
               value: "/etc/kafkauser/user.key"
             # From Vault secrets
             - name: "SQUAREBOT_SLACK_APP_ID"

--- a/applications/squarebot/values-roundtable-prod.yaml
+++ b/applications/squarebot/values-roundtable-prod.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/applications/squarebot/values.yaml
+++ b/applications/squarebot/values.yaml
@@ -94,17 +94,6 @@ config:
   # -- Logging level: "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"
   logLevel: "INFO"
 
-  # -- Cluster URL for the Confluent Schema Registry
-  registryUrl: "http://sasquatch-schema-registry.sasquatch:8081"
-
-  # -- Schema subject suffix. Should be empty for production but can be set
-  # to a value to create unique subjects in the Confluent Schema Registry
-  # for testing.
-  subjectSuffix: ""
-
-  # -- Schema subject compatibility.
-  subjectCompatibility: "FORWARD"
-
   topics:
     # -- Kafka topic name for the Slack `app_mention` events
     slackAppMention: "lsst.square-events.squarebot.slack.app.mention"


### PR DESCRIPTION
See https://github.com/lsst-sqre/squarebot/pull/28

Squarebot 0.8 no longer uses the schema registry. Some environment variables also changed names with the use of autoprefixing in pydantic-settings.

Merge before #2950