### PR TITLE
DM-42877: Add unfurlbot application for Squarebot

### DIFF
--- a/applications/jira-data-proxy/values-roundtable-dev.yaml
+++ b/applications/jira-data-proxy/values-roundtable-dev.yaml
@@ -1,0 +1,4 @@
+image:
+  pullPolicy: Always
+config:
+  logLevel: "DEBUG"

--- a/applications/sasquatch/charts/square-events/templates/unfurlbot-user.yaml
+++ b/applications/sasquatch/charts/square-events/templates/unfurlbot-user.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaUser
+metadata:
+  name: unfurlbot
+  labels:
+    strimzi.io/cluster: {{ .Values.cluster.name }}
+spec:
+  template:
+      secret:
+        metadata:
+          annotations:
+            replicator.v1.mittwald.de/replication-allowed: "true"
+            replicator.v1.mittwald.de/replication-allowed-namespaces: "unfurlbot"
+  authentication:
+    type: tls
+  authorization:
+    type: simple
+    acls:
+      - resource:
+          type: group
+          name: "unfurlbot"
+          patternType: literal
+        operations:
+          - "Read"
+        host: "*"
+      - resource:
+          type: topic
+          name: "lsst.square-events.squarebot.slack.app.mention"
+          patternType: literal
+        type: allow
+        host: "*"
+        operations:
+          - "Read"
+          - "Describe"
+      - resource:
+          type: topic
+          name: "lsst.square-events.squarebot.slack.message.channels"
+          patternType: literal
+        type: allow
+        host: "*"
+        operations:
+          - "Read"
+          - "Describe"
+      - resource:
+          type: topic
+          name: "lsst.square-events.squarebot.slack.message.groups"
+          patternType: literal
+        type: allow
+        host: "*"
+        operations:
+          - "Read"
+          - "Describe"
+      - resource:
+          type: topic
+          name: "lsst.square-events.squarebot.slack.message.im"
+          patternType: literal
+        type: allow
+        host: "*"
+        operations:
+          - "Read"
+          - "Describe"
+      - resource:
+          type: topic
+          name: "lsst.square-events.squarebot.slack.message.mpim"
+          patternType: literal
+        type: allow
+        host: "*"
+        operations:
+          - "Read"
+          - "Describe"

--- a/applications/unfurlbot/.helmignore
+++ b/applications/unfurlbot/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/applications/unfurlbot/Chart.yaml
+++ b/applications/unfurlbot/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: tickets-DM-42877
+appVersion: "0.1.0"
 description: Squarebot backend that unfurls Jira issues.
 name: unfurlbot
 sources:

--- a/applications/unfurlbot/Chart.yaml
+++ b/applications/unfurlbot/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+appVersion: tickets-DM-42877
+description: Squarebot backend that unfurls Jira issues.
+name: unfurlbot
+sources:
+  - https://github.com/lsst-sqre/unfurlbot
+type: application
+version: 1.0.0

--- a/applications/unfurlbot/README.md
+++ b/applications/unfurlbot/README.md
@@ -1,0 +1,35 @@
+# unfurlbot
+
+Squarebot backend that unfurls Jira issues.
+
+## Source Code
+
+* <https://github.com/lsst-sqre/unfurlbot>
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Affinity rules for the unfurlbot deployment pod |
+| autoscaling.enabled | bool | `false` | Enable autoscaling of unfurlbot deployment |
+| autoscaling.maxReplicas | int | `100` | Maximum number of unfurlbot deployment pods |
+| autoscaling.minReplicas | int | `1` | Minimum number of unfurlbot deployment pods |
+| autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU utilization of unfurlbot deployment pods |
+| config.logLevel | string | `"INFO"` | Logging level: "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL" |
+| config.topics.slackAppMention | string | `"lsst.square-events.squarebot.slack.app.mention"` | Kafka topic name for the Slack `app_mention` events |
+| config.topics.slackMessageChannels | string | `"lsst.square-events.squarebot.slack.message.channels"` | Kafka topic name for the Slack `message.channels` events (public channels) |
+| config.topics.slackMessageGroups | string | `"lsst.square-events.squarebot.slack.message.groups"` | Kafka topic name for the Slack `message.groups` events (private channels) |
+| config.topics.slackMessageIm | string | `"lsst.square-events.squarebot.slack.message.im"` | Kafka topic name for the Slack `message.im` events (direct message channels) |
+| config.topics.slackMessageMpim | string | `"lsst.square-events.squarebot.slack.message.mpim"` | Kafka topic name for the Slack `message.mpim` events (multi-person direct messages) |
+| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
+| global.host | string | Set by Argo CD | Host name for ingress |
+| global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
+| image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the unfurlbot image |
+| image.repository | string | `"ghcr.io/lsst-sqre/unfurlbot"` | Image to use in the unfurlbot deployment |
+| image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
+| ingress.annotations | object | `{}` | Additional annotations for the ingress rule |
+| nodeSelector | object | `{}` | Node selection rules for the unfurlbot deployment pod |
+| podAnnotations | object | `{}` | Annotations for the unfurlbot deployment pod |
+| replicaCount | int | `1` | Number of web deployment pods to start |
+| resources | object | `{}` | Resource limits and requests for the unfurlbot deployment pod |
+| tolerations | list | `[]` | Tolerations for the unfurlbot deployment pod |

--- a/applications/unfurlbot/README.md
+++ b/applications/unfurlbot/README.md
@@ -15,6 +15,7 @@ Squarebot backend that unfurls Jira issues.
 | autoscaling.maxReplicas | int | `100` | Maximum number of unfurlbot deployment pods |
 | autoscaling.minReplicas | int | `1` | Minimum number of unfurlbot deployment pods |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU utilization of unfurlbot deployment pods |
+| config.jiraProjects | string | `"ADMIN, CCB, CAP, COMCAM, COMT, DM, EPO, FRACAS, IAM, IHS, IT, ITRFC, LOVE, LASD, LIT, LOPS, LVV, M1M3V, OPSIM, PHOSIM, PST, PSV, PUB, RFC, RM, SAFE, SIM, SPP, SBTT, SE, TSAIV, TCT, SECMVERIF, TMDC, TPC, TSEIA, TAS, TELV, TSSAL, TSS, TSSPP, WMP, PREOPS, OBS, SITCOM, BLOCK\n"` | Names of Jira projects to unfurl (comma-separated) |
 | config.logLevel | string | `"INFO"` | Logging level: "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL" |
 | config.topics.slackAppMention | string | `"lsst.square-events.squarebot.slack.app.mention"` | Kafka topic name for the Slack `app_mention` events |
 | config.topics.slackMessageChannels | string | `"lsst.square-events.squarebot.slack.message.channels"` | Kafka topic name for the Slack `message.channels` events (public channels) |

--- a/applications/unfurlbot/secrets.yaml
+++ b/applications/unfurlbot/secrets.yaml
@@ -1,0 +1,36 @@
+UNFURLBOT_GITHUB_APP_ID:
+  description: >-
+    The ID of the GitHub App shared by all Squarebot services.
+  copy:
+    application: squarebot
+    key: SQUAREBOT_GITHUB_APP_ID
+UNFURLBOT_GITHUB_APP_PRIVATE_KEY:
+  description: >-
+    The private key for the GitHub App shared by all Squarebot services.
+  onepassword:
+    encoded: true
+  copy:
+    application: squarebot
+    key: SQUAREBOT_GITHUB_APP_PRIVATE_KEY
+UNFURLBOT_SLACK_APP_ID:
+  description: >-
+    The ID of the Slack App shared by all Squarebot services.
+  copy:
+    application: squarebot
+    key: SQUAREBOT_SLACK_APP_ID
+UNFURLBOT_SLACK_TOKEN:
+  description: >-
+    The Slack bot user oauth token for the Slack App shared by all Squarebot services.
+  copy:
+    application: squarebot
+    key: SQUAREBOT_SLACK_TOKEN
+ca.crt:
+  description: >-
+    The cluster CA certificate for the Kubernetes cluster. This is available
+    on the Kafka resource in the sasquatch application under the
+    ``status.listeners[].certificate`` field.
+  onepassword:
+    encoded: true
+  copy:
+    application: squarebot
+    key: ca.crt

--- a/applications/unfurlbot/templates/_helpers.tpl
+++ b/applications/unfurlbot/templates/_helpers.tpl
@@ -1,0 +1,26 @@
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "unfurlbot.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "unfurlbot.labels" -}}
+helm.sh/chart: {{ include "unfurlbot.chart" . }}
+{{ include "unfurlbot.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "unfurlbot.selectorLabels" -}}
+app.kubernetes.io/name: "unfurlbot"
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/applications/unfurlbot/templates/configmap.yaml
+++ b/applications/unfurlbot/templates/configmap.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: unfurlbot
+  labels:
+    {{- include "unfurlbot.labels" . | nindent 4 }}
+data:
+  UNFURLBOT_LOG_LEVEL: {{ .Values.config.logLevel | quote }}
+  UNFURLBOT_PATH_PREFIX: {{ .Values.ingress.path | quote }}
+  UNFURLBOT_ENVIRONMENT_URL: {{ .Values.global.baseUrl | quote }}
+  UNFURLBOT_PROFILE: "production"
+  UNFURLBOT_TOPIC_APP_MENTION: {{ .Values.config.topics.slackAppMention | quote }}
+  UNFURLBOT_TOPIC_MESSAGE_CHANNELS: {{ .Values.config.topics.slackMessageChannels | quote }}
+  UNFURLBOT_TOPIC_MESSAGE_GROUPS: {{ .Values.config.topics.slackMessageGroups | quote }}
+  UNFURLBOT_TOPIC_MESSAGE_IM: {{ .Values.config.topics.slackMessageIm | quote }}
+  UNFURLBOT_TOPIC_MESSAGE_MPIM: {{ .Values.config.topics.slackMessageMpim | quote }}

--- a/applications/unfurlbot/templates/configmap.yaml
+++ b/applications/unfurlbot/templates/configmap.yaml
@@ -6,7 +6,6 @@ metadata:
     {{- include "unfurlbot.labels" . | nindent 4 }}
 data:
   UNFURLBOT_LOG_LEVEL: {{ .Values.config.logLevel | quote }}
-  UNFURLBOT_PATH_PREFIX: {{ .Values.ingress.path | quote }}
   UNFURLBOT_ENVIRONMENT_URL: {{ .Values.global.baseUrl | quote }}
   UNFURLBOT_PROFILE: "production"
   UNFURLBOT_TOPIC_APP_MENTION: {{ .Values.config.topics.slackAppMention | quote }}

--- a/applications/unfurlbot/templates/configmap.yaml
+++ b/applications/unfurlbot/templates/configmap.yaml
@@ -14,3 +14,4 @@ data:
   UNFURLBOT_TOPIC_MESSAGE_GROUPS: {{ .Values.config.topics.slackMessageGroups | quote }}
   UNFURLBOT_TOPIC_MESSAGE_IM: {{ .Values.config.topics.slackMessageIm | quote }}
   UNFURLBOT_TOPIC_MESSAGE_MPIM: {{ .Values.config.topics.slackMessageMpim | quote }}
+  UNFURLBOT_JIRA_PROJECTS: {{ .Values.config.jiraProjects | quote }}

--- a/applications/unfurlbot/templates/deployment.yaml
+++ b/applications/unfurlbot/templates/deployment.yaml
@@ -54,6 +54,11 @@ spec:
             - configMapRef:
                 name: unfurlbot
           env:
+            - name: "UNFURLBOT_GAFAELFAWR_TOKEN"
+              valueFrom:
+                secretKeyRef:
+                  name: unfurlbot-gafaelfawr-token
+                  key: "token"
             # Writeable directory for concatenating certs. See "tmp" volume.
             - name: "KAFKA_CERT_TEMP_DIR"
               value: "/tmp/kafka_certs"

--- a/applications/unfurlbot/templates/deployment.yaml
+++ b/applications/unfurlbot/templates/deployment.yaml
@@ -1,0 +1,127 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "unfurlbot"
+  labels:
+    {{- include "unfurlbot.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
+    app.kubernetes.io/part-of: "unfurlbot"
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "unfurlbot.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "unfurlbot.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: "server"
+        app.kubernetes.io/part-of: "unfurlbot"
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+            readOnlyRootFilesystem: true
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: "http"
+              containerPort: 8080
+              protocol: "TCP"
+          readinessProbe:
+            httpGet:
+              path: "/"
+              port: "http"
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          envFrom:
+            - configMapRef:
+                name: unfurlbot
+          env:
+            # Writeable directory for concatenating certs. See "tmp" volume.
+            - name: "KAFKA_CERT_TEMP_DIR"
+              value: "/tmp/kafka_certs"
+            # From KafkaAccess
+            - name: "KAFKA_BOOTSTRAP_SERVERS"
+              valueFrom:
+                secretKeyRef:
+                  name: unfurlbot-kafka
+                  key: "bootstrapServers"
+            - name: "KAFKA_SECURITY_PROTOCOL"
+              value: "SSL"
+            # From replicated KafkaUser secret
+            - name: "KAFKA_CLUSTER_CA_PATH"
+              value: "/etc/kafkacluster/ca.crt"
+            - name: "KAFKA_CLIENT_CA_PATH"
+              value: "/etc/kafkauser/ca.crt"
+            - name: "KAFKA_CLIENT_CERT_PATH"
+              value: "/etc/kafkauser/user.crt"
+            - name: "KAFKA_CLIENT_KEY_PATH"
+              value: "/etc/kafkauser/user.key"
+            # From Vault secrets
+            - name: "UNFURLBOT_SLACK_APP_ID"
+              valueFrom:
+                secretKeyRef:
+                  name: "unfurlbot"
+                  key: "UNFURLBOT_SLACK_APP_ID"
+            - name: "UNFURLBOT_SLACK_TOKEN"
+              valueFrom:
+                secretKeyRef:
+                  name: "unfurlbot"
+                  key: "UNFURLBOT_SLACK_TOKEN"
+          volumeMounts:
+            - name: "unfurlbot"
+              mountPath: "/etc/kafkacluster/ca.crt"
+              subPath: "ca.crt"
+            - name: "kafka-user"
+              mountPath: "/etc/kafkauser/ca.crt"
+              subPath: "ca.crt"
+            - name: "kafka-user"
+              mountPath: "/etc/kafkauser/user.crt"
+              subPath: "user.crt"
+            - name: "kafka-user"
+              mountPath: "/etc/kafkauser/user.key"
+              subPath: "user.key"
+            - name: "tmp"
+              mountPath: "/tmp/kafka_certs"
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: "kafka-user"
+          secret:
+            secretName: unfurlbot-kafka-user
+        - name: "unfurlbot"
+          secret:
+            secretName: "unfurlbot"
+        - name: "tmp"
+          emptyDir: {}

--- a/applications/unfurlbot/templates/gafaelfawrtoken.yaml
+++ b/applications/unfurlbot/templates/gafaelfawrtoken.yaml
@@ -1,0 +1,11 @@
+
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrServiceToken
+metadata:
+  name: unfurlbot-gafaelfawr-token
+  labels:
+    {{- include "unfurlbot.labels" . | nindent 4 }}
+spec:
+  service: "bot-unfurlbot"
+  scopes:
+    - "exec:notebook"

--- a/applications/unfurlbot/templates/hpa.yaml
+++ b/applications/unfurlbot/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: "unfurlbot"
+  labels:
+    {{- include "unfurlbot.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: "unfurlbot"
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: "cpu"
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: "memory"
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/applications/unfurlbot/templates/kafkaaccess.yaml
+++ b/applications/unfurlbot/templates/kafkaaccess.yaml
@@ -1,0 +1,14 @@
+apiVersion: access.strimzi.io/v1alpha1
+kind: KafkaAccess
+metadata:
+  name: unfurlbot-kafka
+spec:
+  kafka:
+    name: sasquatch
+    namespace: sasquatch
+    listener: tls
+  user:
+    kind: KafkaUser
+    apiGroup: kafka.strimzi.io
+    name: unfurlbot
+    namespace: sasquatch

--- a/applications/unfurlbot/templates/kafkauser-secret.yaml
+++ b/applications/unfurlbot/templates/kafkauser-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: unfurlbot-kafka-user
+  annotations:
+    replicator.v1.mittwald.de/replicate-from: sasquatch/unfurlbot
+    replicator.v1.mittwald.de/strip-labels: "true"
+data: {}

--- a/applications/unfurlbot/templates/networkpolicy.yaml
+++ b/applications/unfurlbot/templates/networkpolicy.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: "unfurlbot"
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "unfurlbot.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    # Allow inbound access from pods (in any namespace) labeled
+    # gafaelfawr.lsst.io/ingress: true.
+    - from:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              gafaelfawr.lsst.io/ingress: "true"
+      ports:
+        - protocol: "TCP"
+          port: 8080

--- a/applications/unfurlbot/templates/service.yaml
+++ b/applications/unfurlbot/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "unfurlbot"
+  labels:
+    {{- include "unfurlbot.labels" . | nindent 4 }}
+spec:
+  type: "ClusterIP"
+  ports:
+    - port: 8080
+      targetPort: "http"
+      protocol: "TCP"
+      name: "http"
+  selector:
+    {{- include "unfurlbot.selectorLabels" . | nindent 4 }}

--- a/applications/unfurlbot/templates/vaultsecret.yaml
+++ b/applications/unfurlbot/templates/vaultsecret.yaml
@@ -1,0 +1,9 @@
+apiVersion: ricoberger.de/v1alpha1
+kind: VaultSecret
+metadata:
+  name: unfurlbot
+  labels:
+    {{- include "unfurlbot.labels" . | nindent 4 }}
+spec:
+  path: "{{ .Values.global.vaultSecretsPath }}/unfurlbot"
+  type: Opaque

--- a/applications/unfurlbot/values-roundtable-dev.yaml
+++ b/applications/unfurlbot/values-roundtable-dev.yaml
@@ -1,0 +1,5 @@
+image:
+  pullPolicy: Always
+
+config:
+  logLevel: "DEBUG"

--- a/applications/unfurlbot/values.yaml
+++ b/applications/unfurlbot/values.yaml
@@ -35,6 +35,55 @@ config:
     # -- Kafka topic name for the Slack `message.mpim` events (multi-person direct messages)
     slackMessageMpim: "lsst.square-events.squarebot.slack.message.mpim"
 
+  # -- Names of Jira projects to unfurl (comma-separated)
+  jiraProjects: >
+    ADMIN,
+    CCB,
+    CAP,
+    COMCAM,
+    COMT,
+    DM,
+    EPO,
+    FRACAS,
+    IAM,
+    IHS,
+    IT,
+    ITRFC,
+    LOVE,
+    LASD,
+    LIT,
+    LOPS,
+    LVV,
+    M1M3V,
+    OPSIM,
+    PHOSIM,
+    PST,
+    PSV,
+    PUB,
+    RFC,
+    RM,
+    SAFE,
+    SIM,
+    SPP,
+    SBTT,
+    SE,
+    TSAIV,
+    TCT,
+    SECMVERIF,
+    TMDC,
+    TPC,
+    TSEIA,
+    TAS,
+    TELV,
+    TSSAL,
+    TSS,
+    TSSPP,
+    WMP,
+    PREOPS,
+    OBS,
+    SITCOM,
+    BLOCK
+
 ingress:
   # -- Additional annotations for the ingress rule
   annotations: {}

--- a/applications/unfurlbot/values.yaml
+++ b/applications/unfurlbot/values.yaml
@@ -1,0 +1,84 @@
+# Default values for unfurlbot.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# -- Number of web deployment pods to start
+replicaCount: 1
+
+image:
+  # -- Image to use in the unfurlbot deployment
+  repository: "ghcr.io/lsst-sqre/unfurlbot"
+
+  # -- Pull policy for the unfurlbot image
+  pullPolicy: "IfNotPresent"
+
+  # -- Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+config:
+  # -- Logging level: "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"
+  logLevel: "INFO"
+
+  topics:
+    # -- Kafka topic name for the Slack `app_mention` events
+    slackAppMention: "lsst.square-events.squarebot.slack.app.mention"
+
+    # -- Kafka topic name for the Slack `message.channels` events (public channels)
+    slackMessageChannels: "lsst.square-events.squarebot.slack.message.channels"
+
+    # -- Kafka topic name for the Slack `message.groups` events (private channels)
+    slackMessageGroups: "lsst.square-events.squarebot.slack.message.groups"
+
+    # -- Kafka topic name for the Slack `message.im` events (direct message channels)
+    slackMessageIm: "lsst.square-events.squarebot.slack.message.im"
+
+    # -- Kafka topic name for the Slack `message.mpim` events (multi-person direct messages)
+    slackMessageMpim: "lsst.square-events.squarebot.slack.message.mpim"
+
+ingress:
+  # -- Additional annotations for the ingress rule
+  annotations: {}
+
+autoscaling:
+  # -- Enable autoscaling of unfurlbot deployment
+  enabled: false
+
+  # -- Minimum number of unfurlbot deployment pods
+  minReplicas: 1
+
+  # -- Maximum number of unfurlbot deployment pods
+  maxReplicas: 100
+
+  # -- Target CPU utilization of unfurlbot deployment pods
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+# -- Annotations for the unfurlbot deployment pod
+podAnnotations: {}
+
+# -- Resource limits and requests for the unfurlbot deployment pod
+resources: {}
+
+# -- Node selection rules for the unfurlbot deployment pod
+nodeSelector: {}
+
+# -- Tolerations for the unfurlbot deployment pod
+tolerations: []
+
+# -- Affinity rules for the unfurlbot deployment pod
+affinity: {}
+
+# The following will be set by parameters injected by Argo CD and should not
+# be set in the individual environment values files.
+global:
+  # -- Base URL for the environment
+  # @default -- Set by Argo CD
+  baseUrl: ""
+
+  # -- Host name for ingress
+  # @default -- Set by Argo CD
+  host: ""
+
+  # -- Base path for Vault secrets
+  # @default -- Set by Argo CD
+  vaultSecretsPath: ""

--- a/docs/applications/index.rst
+++ b/docs/applications/index.rst
@@ -76,6 +76,7 @@ To learn how to develop applications for Phalanx, see the :doc:`/developers/inde
    ook/index
    sqrbot-sr/index
    squarebot/index
+   unfurlbot/index
 
 .. toctree::
    :maxdepth: 1

--- a/docs/applications/unfurlbot/index.rst
+++ b/docs/applications/unfurlbot/index.rst
@@ -1,0 +1,16 @@
+.. px-app:: unfurlbot
+
+#######################################################
+unfurlbot — Squarebot backend that unfurls Jira issues.
+#######################################################
+
+.. jinja:: unfurlbot
+   :file: applications/_summary.rst.jinja
+
+Guides
+======
+
+.. toctree::
+   :maxdepth: 1
+
+   values

--- a/docs/applications/unfurlbot/values.md
+++ b/docs/applications/unfurlbot/values.md
@@ -1,0 +1,12 @@
+```{px-app-values} unfurlbot
+```
+
+# unfurlbot Helm values reference
+
+Helm values reference table for the {px-app}`unfurlbot` application.
+
+```{include} ../../../applications/unfurlbot/README.md
+---
+start-after: "## Values"
+---
+```

--- a/environments/README.md
+++ b/environments/README.md
@@ -63,6 +63,7 @@
 | applications.telegraf | bool | `false` | Enable the telegraf application |
 | applications.telegraf-ds | bool | `false` | Enable the telegraf-ds application |
 | applications.times-square | bool | `false` | Enable the times-square application |
+| applications.unfurlbot | bool | `false` | Enable the unfurlbot application |
 | applications.uws | bool | `false` | Enable the uws application. This includes the dmocps control system application. |
 | applications.vault-secrets-operator | bool | `true` | Enable the vault-secrets-operator application. This is required for all environments. |
 | applications.vo-cutouts | bool | `false` | Enable the vo-cutouts application |

--- a/environments/templates/unfurlbot-application.yaml
+++ b/environments/templates/unfurlbot-application.yaml
@@ -1,0 +1,34 @@
+{{- if (index .Values "applications" "unfurlbot") -}}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "unfurlbot"
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: "unfurlbot"
+  namespace: "argocd"
+  finalizers:
+    - "resources-finalizer.argocd.argoproj.io"
+spec:
+  destination:
+    namespace: "unfurlbot"
+    server: "https://kubernetes.default.svc"
+  project: "default"
+  source:
+    path: "applications/unfurlbot"
+    repoURL: {{ .Values.repoUrl | quote }}
+    targetRevision: {{ .Values.targetRevision | quote }}
+    helm:
+      parameters:
+        - name: "global.host"
+          value: {{ .Values.fqdn | quote }}
+        - name: "global.baseUrl"
+          value: "https://{{ .Values.fqdn }}"
+        - name: "global.vaultSecretsPath"
+          value: {{ .Values.vaultPathPrefix | quote }}
+      valueFiles:
+        - "values.yaml"
+        - "values-{{ .Values.name }}.yaml"
+{{- end -}}

--- a/environments/values-roundtable-dev.yaml
+++ b/environments/values-roundtable-dev.yaml
@@ -12,6 +12,7 @@ vaultPathPrefix: "secret/phalanx/roundtable-dev"
 applications:
   checkerboard: false
   giftless: true
+  jira-data-proxy: true
   kubernetes-replicator: true
   monitoring: true
   onepassword-connect: true

--- a/environments/values-roundtable-dev.yaml
+++ b/environments/values-roundtable-dev.yaml
@@ -22,3 +22,4 @@ applications:
   squareone: true
   strimzi: true
   strimzi-access-operator: true
+  unfurlbot: true

--- a/environments/values-roundtable-prod.yaml
+++ b/environments/values-roundtable-prod.yaml
@@ -21,3 +21,4 @@ applications:
   strimzi: true
   strimzi-access-operator: true
   squarebot: true
+  unfurlbot: true

--- a/environments/values-roundtable-prod.yaml
+++ b/environments/values-roundtable-prod.yaml
@@ -12,6 +12,7 @@ vaultPathPrefix: "secret/phalanx/roundtable-prod"
 applications:
   checkerboard: true
   giftless: true
+  jira-data-proxy: true
   kubernetes-replicator: true
   onepassword-connect: true
   ook: true

--- a/environments/values-roundtable-prod.yaml
+++ b/environments/values-roundtable-prod.yaml
@@ -22,4 +22,4 @@ applications:
   strimzi: true
   strimzi-access-operator: true
   squarebot: true
-  unfurlbot: true
+  unfurlbot: false

--- a/environments/values.yaml
+++ b/environments/values.yaml
@@ -217,6 +217,9 @@ applications:
   # -- Enable the times-square application
   times-square: false
 
+  # -- Enable the unfurlbot application
+  unfurlbot: false
+
   # -- Enable the uws application. This includes the dmocps control system
   # application.
   uws: false


### PR DESCRIPTION
This app consumes from Sasquatch/Kafka topics produced by Squarebot for Slack traffic. Currently the app doesn't expose an external endpoint, it's only a Kafka consumer.