### PR TITLE
DM-42419 hotfix: Treat pipeline as tag in Sasquatch metrics.

### DIFF
--- a/applications/sasquatch/values-usdfdev.yaml
+++ b/applications/sasquatch/values-usdfdev.yaml
@@ -124,7 +124,7 @@ kafka-connect-manager:
         timestamp: "timestamp"
         connectInfluxDb: "lsst.verify"
         topicsRegex: "lsst.verify.*"
-        tags: dataset_tag,band,instrument,skymap,detector,physical_filter,tract,exposure,patch,visit,run
+        tags: dataset_tag,band,instrument,skymap,detector,physical_filter,tract,exposure,patch,visit,run,pipeline
       lsstlf:
         enabled: true
         timestamp: "timestamp"

--- a/applications/sasquatch/values-usdfint.yaml
+++ b/applications/sasquatch/values-usdfint.yaml
@@ -120,7 +120,7 @@ kafka-connect-manager:
         timestamp: "timestamp"
         connectInfluxDb: "lsst.verify"
         topicsRegex: "lsst.verify.*"
-        tags: dataset_tag,band,instrument,skymap,detector,physical_filter,tract,exposure,patch,visit,run
+        tags: dataset_tag,band,instrument,skymap,detector,physical_filter,tract,exposure,patch,visit,run,pipeline
       lsstlf:
         enabled: true
         timestamp: "timestamp"


### PR DESCRIPTION
This PR registers `pipeline` as a Sasquatch tag in the `lsst.verify` namespace in both the `-dev` and `-int` environments. This PR should have been merged alongside lsst-dm/jenkins-dm-jobs#976, which added `pipeline` to upload metadata.