### PR TITLE
DM-42714: Move around secrets documentation

### DIFF
--- a/docs/about/secrets.rst
+++ b/docs/about/secrets.rst
@@ -31,8 +31,8 @@ While Kubernetes and Argo CD do not look beyond Vault, Vault is not the source o
 Secrets for external applications or which for whatever reason cannot be randomly regenerated when the environment is reinstalled are called *static secrets*.
 
 There are several ways that static secrets can be managed (see :ref:`admin-static-secrets`).
-SQuaRE uses 1Password for the static secrets for environments that we manage.
+SQuaRE uses 1Password for the static secrets for most environments that we manage.
 For more details on this secrets management approach, see :ref:`admin-secrets-onepassword`.
 
-For a step-by-step guide on adding a 1Password-based secret, see :ref:`dev-add-onepassword`.
-For updating an existing 1Password-based secret, see :doc:`/developers/update-a-onepassword-secret`.
+For a step-by-step guide on adding a 1Password-based secret, see :doc:`/admin/add-new-secret`.
+For updating an existing 1Password-based secret, see :doc:`/admin/update-a-secret`.

--- a/docs/admin/add-new-secret.rst
+++ b/docs/admin/add-new-secret.rst
@@ -1,0 +1,89 @@
+#######################
+Add a new static secret
+#######################
+
+Write access to the static secret store is generally limited to environment administrators.
+When a developer of an application wants to :doc:`add a new static secret for their application </developers/define-secrets>`, they provide those secrets to the environment administrator, who adds them to the underlying static secret store and ensures Vault is updated.
+
+How to do this depends on where static secrets are stored.
+
+Static secrets in a YAML file
+=============================
+
+If the environment stores static secrets in a secure YAML file, the environment administrator should update that file with the newly-required static secrets.
+It may be helpful to regenerate the template for that file (see :ref:`admin-secrets-yaml`) and then use :command:`diff` to see what changed.
+
+Then, sync the secrets into Vault following the instructions in :doc:`/admin/sync-secrets`.
+This must be done using a Phalanx configuration that includes your new application and the secret configuration for it that you created above.
+
+Static secrets stored directly in Vault
+=======================================
+
+If the environment stores static secrets directly in Vault, the environment administrator should add new Vault key/value pairs as needed.
+In this case, no sync step is required, since the secrets are used directly from Vault.
+
+In this case, you will need to be sure to store the secrets in the format expected by Phalanx (one secret per application, with keys and values for each Phalanx secret needed by that application).
+You will also have to manually set any generated or copied secrets, since you cannot use the normal sync tool.
+
+Static secrets stored in 1Password
+==================================
+
+For most SQuaRE-run Phalanx environments, static secrets for applications are stored in a 1Password vault before being automatically synced to the Vault service.
+Such secrets are things for external cloud services where we don't automatically provision accounts and password.
+When we manually create such a secret, we store it in 1Password.
+
+.. note::
+
+   This document only covers creating a 1Password-backed secret for the first time for an application.
+   If you want to update a secret, either by adding new 1Password secrets or by changing their secret values, you should follow the instructions in :doc:`/admin/update-a-secret`.
+
+1. Open the 1Password vault
+---------------------------
+
+In one password, access the **LSST IT** 1Password team and open the vault for the environment to which you're adding a secret.
+If your application will be deployed in multiple environments, you will need to repeat this process for each environment.
+
+The name of the 1Password vault for a given environment is configured in the ``onepassword.vaultTitle`` key in the :file:`values-{environment}.yaml` file in :file:`environments` for that environment.
+
+2. Create the new item
+----------------------
+
+Each application should have one entry in the 1Password vault.
+Each field in that entry is one Phalanx secret for that application.
+The value of the field is the value of the secret.
+
+For a new application, create a new 1Password item of type :guilabel:`Server`.
+Delete all of the pre-defined fields.
+
+Then, create a field for each static secret for that application, and set the value to the value of that secret in that environemnt.
+The field names should match the secret keys for the application.
+Change the field type to password so that the value isn't displayed any time someone opens the 1Password entry.
+
+Do not use sections.
+Phalanx requires all of the secret entries be top-level fields outside of any section.
+
+Newlines will be converted to spaces when pasting the secret value.
+If newlines need to be preserved, be sure to mark the secret with ``onepassword.encoded`` set to ``true`` in :file:`secrets.yaml`, and then encode the secret in base64 before pasting it into 1Password.
+To encode the secret, save it to a file with the correct newlines, and then use a command such as:
+
+.. tab-set::
+
+   .. tab-item:: Linux
+
+      .. prompt:: bash
+
+         base64 -w0 < /path/to/secret; echo ''
+
+   .. tab-item:: macOS
+
+      .. prompt:: bash
+
+         base64 -i /path/to/secret; echo ''
+
+This will generate a base64-encoded version of the secret on one line, suitable for cutting and pasting into the 1Password field.
+
+3. Sync 1Password items into Vault
+----------------------------------
+
+To sync the new 1Password items into Vault, follow the instructions in :doc:`/admin/sync-secrets`.
+This must be done using a Phalanx configuration that includes your new application and the secret configuration for it that you created above.

--- a/docs/admin/index.rst
+++ b/docs/admin/index.rst
@@ -21,6 +21,8 @@ Administrators operate infrastructure, manage secrets, and are involved in the d
 
    upgrade-windows
    sync-argo-cd
+   add-new-secret
+   update-a-secret
    sync-secrets
    audit-secrets
    update-pull-secret

--- a/docs/admin/migrating-secrets.rst
+++ b/docs/admin/migrating-secrets.rst
@@ -136,15 +136,8 @@ Update secrets
    This will create a YAML file listing all applications and their required static secrets, based on their configuration for your environment.
 
    Then, what you do depends on whether you are using 1Password as a source of static secrets or not.
-
-   - *If you are using 1Password*, add those static secrets to the 1Password vault for this environment.
-     See :ref:`dev-add-onepassword` for detailed instructions on how to add static secrets for an application.
-     You will need to do this for every application.
-     Don't forget to :ref:`add a pull secret <admin-onepassword-pull-secret>` if your environment needs one.
-
-   - *If you are not using 1Password*, edit :file:`static-secrets.yaml` and fill in the values of all of the static secrets.
-     Or, alternately, just put the static secrets directly into Vault via whatever mechanism works for you and do not supply a static secrets file.
-     In the second case, you will need to be sure to store the secrets in the format expected by Phalanx (one secret per application, with keys and values for each Phalanx secret needed by that application).
+   See :doc:`add-new-secret` for detailed instructions on how to add static secrets for an application.
+   You will need to do this for every application.
 
    To obtain the current values of static secrets, look either in the old ``RSP-Vault`` 1Password vault (for SQuaRE-managed environments) or use the :command:`vault kv get` command to read the current value of the static secret out of Vault (copied to the new path in the previous step).
 

--- a/docs/admin/update-a-secret.rst
+++ b/docs/admin/update-a-secret.rst
@@ -1,12 +1,27 @@
-#####################################
-Updating a secret stored in 1Password
-#####################################
+######################
+Update a static secret
+######################
 
-If you are adding a new secret, start by adding the new secret definition to :file:`secrets.yaml` or :file:`secrets-{environment}.yaml` in that application's chart.
-See :ref:`dev-secret-definition` for more details.
+The process for updating a static secret depends on how static secrets are stored for that environment.
+Since it requires write access to the underlying secret store, updates must be done by an enviroment administrator.
 
-For environments with static secrets stored in 1Password, updating them requires access to the 1Password Vault used by that enviroment.
-This may have to be done for you by an environment administrator.
+Static secrets in a YAML file
+=============================
+
+If the environment stores static secrets in a secure YAML file, the environment administrator should update that file with the newly-required static secrets.
+Then, sync the secrets into Vault following the instructions in :doc:`/admin/sync-secrets`.
+
+Static secrets stored directly in Vault
+=======================================
+
+If the environment stores static secrets directly in Vault, the environment administrator should change the static secret directly in Vault.
+Be aware that when multiple applications use the same static secret, one of them is defined as the "owner" and the other applications use ``copy`` directives in their :file:`secrets.yaml` files to copy the secret from the "owning" application.
+In this case, the static secret must be updated separately for every copy.
+
+When the static secrets are stored directly in Vault, no separate sync step is required.
+
+Static secrets stored in 1Password
+==================================
 
 #. Open the 1Password Vault for the environment whose secret you want to update.
    You can find the name of this vault in the ``onepassword.vaultTitle`` key in the :file:`environments/values-{environment}.yaml` file for your environment.
@@ -18,7 +33,7 @@ This may have to be done for you by an environment administrator.
 #. Replace the value of the secret with a new value.
 
 #. Sync secrets for that environment.
-   See :doc:`/admin/sync-secrets`.
+   See :doc:`sync-secrets`.
 
 If the same secret is used in multiple environments, these steps must be done for every environment.
 

--- a/docs/applications/onepassword-connect/add-new-connect-server.rst
+++ b/docs/applications/onepassword-connect/add-new-connect-server.rst
@@ -11,6 +11,11 @@ The one in the :px-env:`roundtable-dev` environment serves the vaults for develo
 When following these instructions, you will be creating a new `Secrets Automation workflow <https://developer.1password.com/docs/connect/get-started/>`__.
 You will need to have permissions to create that workflow for the vault for your environment.
 
+.. warning::
+
+   Currently, only rra has appropriate permissions in the SQuaRE 1Password vaults to set up new secrets automation workflows.
+   If someone else needs to follow these steps, you may first need to grant them additional permissions in 1Password.
+
 Create the workflow
 ===================
 
@@ -81,7 +86,7 @@ In the following steps, you'll deploy the new 1Password Connect server.
 
 #. If you are following this process, you are presumably using 1Password to manage your static secrets.
    Go to the 1Password vault for the environment where the 1Password Connect server will be running.
-   Create a new application secret item for the application ``onepassword-connect`` (see :ref:`dev-add-onepassword` for more details), and add a key named ``op-session`` whose value is the base64-encoded 1Password credentials.
+   Create a new application secret item for the application ``onepassword-connect`` (see :doc:`/admin/add-new-secret` for more details), and add a key named ``op-session`` whose value is the base64-encoded 1Password credentials.
 
 #. Synchronize secrets for that environment following the instructions in :doc:`/admin/sync-secrets`.
 

--- a/docs/applications/onepassword-connect/add-new-environment.rst
+++ b/docs/applications/onepassword-connect/add-new-environment.rst
@@ -73,4 +73,4 @@ Next steps
 You have now confirmed that 1Password is set up for your environment.
 
 - If you are migrating from the old secrets management system, perform the other steps now: :doc:`/admin/migrating-secrets`
-- If you are setting up a new environment, start populating the 1Password vault with static secrets for the applications running in that environment: :doc:`/developers/update-a-onepassword-secret`
+- If you are setting up a new environment, start populating the 1Password vault with static secrets for the applications running in that environment: :doc:`/admin/add-new-secret`

--- a/docs/developers/define-secrets.rst
+++ b/docs/developers/define-secrets.rst
@@ -168,74 +168,30 @@ See the `vault-secrets-operator documentation <https://github.com/ricoberger/vau
    The ``index`` function can retrieve secrets whose names are not valid identifiers (because, for instance, they contain a dash), and ``>-`` quoting avoids the conflict between two layers of quotes.
    This also works for other characters not allowed in identifiers, such as periods.
 
+.. _dev-inject-secrets:
+
+Inject the secrets into your application
+========================================
+
+Now that you have arranged for the creation of the ``Secret`` Kubernetes resource, you need to make those secrets available to your application.
+There are two main ways to give a ``Deployment``, ``StatefulSet``, ``CronJob``, or other pod-creating resource access to secrets:
+
+- `Set environment variables based on secrets <https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#define-container-environment-variables-using-secret-data>`__
+- `Mount the secrets as files in the container <https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#create-a-pod-that-has-access-to-the-secret-data-through-a-volume>`__
+
 See :doc:`write-a-helm-chart` for more details on creating a Helm chart for an application.
 
-.. _dev-add-onepassword:
+Add the new secrets
+===================
 
-Create static secrets in 1Password
-==================================
+Adding secrets for a new application must be done by the environment administrator, since it requires write access to the Vault and possibly the static secret store for the environment.
 
-For SQuaRE-run Phalanx environments, static secrets for applications are stored in a 1Password vault before being automatically synced to the Vault service.
-Such secrets are things for external cloud services where we don't automatically provision accounts and password.
-When we manually create such a secret, we store it in 1Password.
+Once you have defined the secrets for your new application, contact the administrator of that environment and provide the values of any static secrets that you are using.
+They will then use one or more of the following processes:
 
-This step may have to be done for you by a Phalanx environment administrator depending on how permissions in Vault and any underlying secrets store are handled for your environment.
-
-.. note::
-
-   This document only covers creating a 1Password-backed secret for the first time for an application.
-   If you want to update a secret, either by adding new 1Password secrets or by changing their secret values, you should follow the instructions in :doc:`/developers/update-a-onepassword-secret`.
-
-1. Open the 1Password vault
----------------------------
-
-In one password, access the **LSST IT** 1Password team and open the vault for the environment to which you're adding a secret.
-If your application will be deployed in multiple environments, you will need to repeat this process for each environment.
-
-The name of the 1Password vault for a given environment is configured in the ``onepassword.vaultTitle`` key in the :file:`values-{environment}.yaml` file in :file:`environments` for that environment.
-
-2. Create the new item
-----------------------
-
-Each application should have one entry in the 1Password vault.
-Each field in that entry is one Phalanx secret for that application.
-The value of the field is the value of the secret.
-
-For a new application, create a new 1Password item of type :guilabel:`Server`.
-Delete all of the pre-defined fields.
-
-Then, create a field for each static secret for that application, and set the value to the value of that secret in that environemnt.
-The field names should match the secret keys for the application.
-Change the field type to password so that the value isn't displayed any time someone opens the 1Password entry.
-
-Do not use sections.
-Phalanx requires all of the secret entries be top-level fields outside of any section.
-
-Newlines will be converted to spaces when pasting the secret value.
-If newlines need to be preserved, be sure to mark the secret with ``onepassword.encoded`` set to ``true`` in :file:`secrets.yaml`, and then encode the secret in base64 before pasting it into 1Password.
-To encode the secret, save it to a file with the correct newlines, and then use a command such as:
-
-.. tab-set::
-
-   .. tab-item:: Linux
-
-      .. prompt:: bash
-
-         base64 -w0 < /path/to/secret; echo ''
-
-   .. tab-item:: macOS
-
-      .. prompt:: bash
-
-         base64 -i /path/to/secret; echo ''
-
-This will generate a base64-encoded version of the secret on one line, suitable for cutting and pasting into the 1Password field.
-
-3. Sync 1Password items into Vault
-----------------------------------
-
-To sync the new 1Password items into Vault, follow the instructions in :doc:`/admin/sync-secrets`.
-This must be done using a Phalanx configuration that includes your new application and the secret configuration for it that you created above.
+- :doc:`/admin/add-new-secret`
+- :doc:`/admin/update-a-secret`
+- :doc:`/admin/sync-secrets`
 
 Next steps
 ==========

--- a/docs/developers/index.rst
+++ b/docs/developers/index.rst
@@ -36,7 +36,7 @@ Individual applications are documented in the :doc:`/applications/index` section
 
    get-application-logs
    upgrade
-   update-a-onepassword-secret
+   update-a-secret
    deploy-from-a-branch
    local-development
 

--- a/docs/developers/update-a-secret.rst
+++ b/docs/developers/update-a-secret.rst
@@ -1,0 +1,22 @@
+######################
+Add or update a secret
+######################
+
+Adding or updating a secret for your application requires changing Vault, which must be done by the environment administrator.
+However, there are some steps that you, as the application developer, should take first:
+
+#. If you are adding a new secret, update :file:`secrets.yaml` or :file:`secrets-{environment}.yaml` for that application with the details of the new secret.
+   See :doc:`secrets-spec` for details about the format of that file.
+
+#. If necessary, update the application templates to pass in the new secrets to your application.
+   See :ref:`dev-inject-secrets`.
+
+#. Determine the values of any new static secrets for every environment in which your application is deployed that will need the new secret.
+
+Once you have done those steps on a PR branch, contact the environment administrator for each Phalanx environment where a secret needs to be added or updated.
+Provide them with the new static secret values and ask them to create or update the secrets.
+
+The environment administrator will then follow the instructions in either:
+
+- :doc:`/admin/add-new-secret`
+- :doc:`/admin/update-a-secret`

--- a/docs/developers/write-a-helm-chart.rst
+++ b/docs/developers/write-a-helm-chart.rst
@@ -182,7 +182,7 @@ Pull secrets
 If your application image resides at a Docker repository which requires authentication (either to pull the image at all or to raise the pull rate limit), then you must tell any pods deployed by your application to use a pull secret named ``pull-secret``, and you must create a ``VaultSecret`` resource for that pull secret.
 
 If your container image is built through GitHub Actions and stored at ghcr.io (the recommended approach), there is no rate limiting (as long as your container image is built from a public repository, which it should be).
-There is therefore no need for a pull secret.
+There is therefore no need for a pull secret and you can skip the rest of this section.
 
 If your container image is stored at Docker Hub, you should use a pull secret, because we have been (and will no doubt continue to be) rate-limited at Docker Hub.
 Strongly consider moving your container image to the GitHub Container Registry (ghcr.io) instead.

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -10,16 +10,14 @@
 # Testing
 coverage[toml]
 mypy
-pre-commit
 pytest
 pytest-cov
-pytest-pretty
-ruff
+pytest-sugar
 types-PyYAML
 
 # Documentation
 autodoc_pydantic
-documenteer[guide]>=1.0.0a7
+documenteer[guide]>1
 sphinx-click
 sphinx-diagrams
 sphinx-jinja

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -29,10 +29,6 @@ certifi==2024.2.2 \
     --hash=sha256:0569859f95fc761b18b45ef421b1290a0f65f147e92a1e5eb3e635f9a5e4e66f \
     --hash=sha256:dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1
     # via requests
-cfgv==3.4.0 \
-    --hash=sha256:b7265b1f29fd3316bfcd2b330d63d024f2bfd8bcb8b0272f8e19a504856c48f9 \
-    --hash=sha256:e52591d4c5f5dead8e0f673fb16db7949d2cfb3f7da4582893288f0ded8fe560
-    # via pre-commit
 charset-normalizer==3.3.2 \
     --hash=sha256:06435b539f889b1f6f4ac1758871aae42dc3a8c0e24ac9e60c2384973ad73027 \
     --hash=sha256:06a81e93cd441c56a9b65d8e1d043daeb97a3d0856d177d5c90ba85acb3db087 \
@@ -189,10 +185,6 @@ diagrams==0.23.4 \
     --hash=sha256:1ba69d98fcf8d768dbddf07d2c77aba6cc95c2e6f90f37146c04c96bc6765450 \
     --hash=sha256:b7ada0b119b5189dd021b1dc1467fad3704737452bb18b1e06d05e4d1fa48ed7
     # via sphinx-diagrams
-distlib==0.3.8 \
-    --hash=sha256:034db59a0b96f8ca18035f36290806a9a6e6bd9d1ff91e45a7f172eb17e51784 \
-    --hash=sha256:1530ea13e350031b6312d8580ddb6b27a104275a31106523b8f123787f494f64
-    # via virtualenv
 documenteer==1.1.1 \
     --hash=sha256:398b7aec72dbc5a073b8b83e632384ecbba3dccc3f373ff15a98459f95aa7396 \
     --hash=sha256:547232b01111de8b88afa6347e376b524b08b93c7ef4b4364b09ecd7ab118c8f
@@ -209,10 +201,6 @@ docutils==0.20.1 \
     #   sphinx-jinja
     #   sphinx-prompt
     #   sphinxcontrib-bibtex
-filelock==3.13.1 \
-    --hash=sha256:521f5f56c50f8426f5e03ad3b281b490a87ef15bc6c526f168290f0c7148d44e \
-    --hash=sha256:57dbda9b35157b05fb3e58ee91448612eb674172fab98ee235ccb0b5bee19a1c
-    # via virtualenv
 gitdb==4.0.11 \
     --hash=sha256:81a3407ddd2ee8df444cbacea00e2d038e40150acfa3001696fe0dcf1d3adfa4 \
     --hash=sha256:bf5421126136d6d0af55bc1e7c1af1c397a34f5b7bd79e776cd3e89785c2b04b
@@ -225,10 +213,6 @@ graphviz==0.20.1 \
     --hash=sha256:587c58a223b51611c0cf461132da386edd896a029524ca61a1462b880bf97977 \
     --hash=sha256:8c58f14adaa3b947daf26c19bc1e98c4e0702cdc31cf99153e6f06904d492bf8
     # via diagrams
-identify==2.5.35 \
-    --hash=sha256:10a7ca245cfcd756a554a7288159f72ff105ad233c7c4b9c6f0f4d108f5f6791 \
-    --hash=sha256:c4de0081837b211594f8e877a6b4fad7ca32bbfc1a9307fdd61c28bfe923f13e
-    # via pre-commit
 idna==3.6 \
     --hash=sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca \
     --hash=sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f
@@ -273,7 +257,6 @@ markdown-it-py==3.0.0 \
     #   documenteer
     #   mdit-py-plugins
     #   myst-parser
-    #   rich
 markupsafe==2.1.5 \
     --hash=sha256:00e046b6dd71aa03a41079792f8473dc494d564611a8f89bbbd7cb93295ebdcf \
     --hash=sha256:075202fa5b72c86ad32dc7d0b56024ebdbcf2048c0ba09f1cde31bfdd57bcfff \
@@ -380,28 +363,18 @@ myst-parser==2.0.0 \
     --hash=sha256:7c36344ae39c8e740dad7fdabf5aa6fc4897a813083c6cc9990044eb93656b14 \
     --hash=sha256:ea929a67a6a0b1683cdbe19b8d2e724cd7643f8aa3e7bb18dd65beac3483bead
     # via documenteer
-nodeenv==1.8.0 \
-    --hash=sha256:d51e0c37e64fbf47d017feac3145cdbb58836d7eee8c6f6d3b6880c5456227d2 \
-    --hash=sha256:df865724bb3c3adc86b3876fa209771517b0cfe596beff01a92700e0e8be4cec
-    # via pre-commit
 packaging==23.2 \
     --hash=sha256:048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5 \
     --hash=sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7
     # via
     #   pydata-sphinx-theme
     #   pytest
+    #   pytest-sugar
     #   sphinx
-platformdirs==4.2.0 \
-    --hash=sha256:0614df2a2f37e1a662acbd8e2b25b92ccf8632929bc6d43467e17fe89c75e068 \
-    --hash=sha256:ef0cc731df711022c174543cb70a9b5bd22e5a9337c8624ef2c2ceb8ddad8768
-    # via virtualenv
 pluggy==1.4.0 \
     --hash=sha256:7db9f7b503d67d1c5b95f59773ebb58a8c1c288129a88665838012cfb07b8981 \
     --hash=sha256:8c85c2876142a764e5b7548e7d9a0e0ddb46f5185161049a79b7e974454223be
     # via pytest
-pre-commit==3.6.2 \
-    --hash=sha256:ba637c2d7a670c10daedc059f5c49b5bd0aadbccfcd7ec15592cf9665117532c \
-    --hash=sha256:c3ef34f463045c88658c5b99f38c1e297abdcc0ff13f98d3370055fbbfabc67e
 pybtex==0.24.0 \
     --hash=sha256:818eae35b61733e5c007c3fcd2cfb75ed1bc8b4173c1f70b56cc4c0802d34755 \
     --hash=sha256:e1e0c8c69998452fea90e9179aa2a98ab103f3eed894405b7264e517cc2fcc0f
@@ -412,9 +385,9 @@ pybtex-docutils==1.0.3 \
     --hash=sha256:3a7ebdf92b593e00e8c1c538aa9a20bca5d92d84231124715acc964d51d93c6b \
     --hash=sha256:8fd290d2ae48e32fcb54d86b0efb8d573198653c7e2447d5bec5847095f430b9
     # via sphinxcontrib-bibtex
-pydantic==2.6.2 \
-    --hash=sha256:37a5432e54b12fecaa1049c5195f3d860a10e01bdfd24f1840ef14bd0d3aeab3 \
-    --hash=sha256:a09be1c3d28f3abe37f8a78af58284b236a92ce520105ddc91a6d29ea1176ba7
+pydantic==2.6.3 \
+    --hash=sha256:72c6034df47f46ccdf81869fddb81aade68056003900a8724a4f160700016a2a \
+    --hash=sha256:e07805c4c7f5c6826e33a1d4c9d47950d7eaf34868e2690f8594d2e30241f11f
     # via
     #   autodoc-pydantic
     #   documenteer
@@ -513,7 +486,6 @@ pygments==2.17.2 \
     --hash=sha256:da46cec9fd2de5be3a8a784f434e4c4ab670b4ff54d605c4c2717e9d49c4c367
     # via
     #   pydata-sphinx-theme
-    #   rich
     #   sphinx
     #   sphinx-prompt
 pylatexenc==2.10 \
@@ -524,13 +496,13 @@ pytest==8.0.2 \
     --hash=sha256:edfaaef32ce5172d5466b5127b42e0d6d35ebbe4453f0e3505d96afd93f6b096
     # via
     #   pytest-cov
-    #   pytest-pretty
+    #   pytest-sugar
 pytest-cov==4.1.0 \
     --hash=sha256:3904b13dfbfec47f003b8e77fd5b589cd11904a21ddf1ab38a64f204d6a10ef6 \
     --hash=sha256:6ba70b9e97e69fcc3fb45bfeab2d0a138fb65c4d0d6a41ef33983ad114be8c3a
-pytest-pretty==1.2.0 \
-    --hash=sha256:105a355f128e392860ad2c478ae173ff96d2f03044692f9818ff3d49205d3a60 \
-    --hash=sha256:6f79122bf53864ae2951b6c9e94d7a06a87ef753476acd4588aeac018f062036
+pytest-sugar==1.0.0 \
+    --hash=sha256:6422e83258f5b0c04ce7c632176c7732cab5fdb909cb39cca5c9139f81276c0a \
+    --hash=sha256:70ebcd8fc5795dc457ff8b69d266a4e2e8a74ae0c3edc749381c64b5246c8dfd
 python-dotenv==1.0.1 \
     --hash=sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca \
     --hash=sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a
@@ -590,7 +562,6 @@ pyyaml==6.0.1 \
     # via
     #   documenteer
     #   myst-parser
-    #   pre-commit
     #   pybtex
     #   sphinxcontrib-redoc
 referencing==0.33.0 \
@@ -605,10 +576,6 @@ requests==2.31.0 \
     # via
     #   documenteer
     #   sphinx
-rich==13.7.0 \
-    --hash=sha256:5cb5123b5cf9ee70584244246816e9114227e0b98ad9176eede6ad54bf5403fa \
-    --hash=sha256:6da14c108c4866ee9520bbffa71f6fe3962e193b7da68720583850cd4548e235
-    # via pytest-pretty
 rpds-py==0.18.0 \
     --hash=sha256:01e36a39af54a30f28b73096dd39b6802eddd04c90dbe161c1b8dbe22353189f \
     --hash=sha256:044a3e61a7c2dafacae99d1e722cc2d4c05280790ec5a05031b3876809d89a5c \
@@ -712,30 +679,10 @@ rpds-py==0.18.0 \
     # via
     #   jsonschema
     #   referencing
-ruff==0.2.2 \
-    --hash=sha256:0a9efb032855ffb3c21f6405751d5e147b0c6b631e3ca3f6b20f917572b97eb6 \
-    --hash=sha256:0c126da55c38dd917621552ab430213bdb3273bb10ddb67bc4b761989210eb6e \
-    --hash=sha256:1695700d1e25a99d28f7a1636d85bafcc5030bba9d0578c0781ba1790dbcf51c \
-    --hash=sha256:1ec49be4fe6ddac0503833f3ed8930528e26d1e60ad35c2446da372d16651ce9 \
-    --hash=sha256:3b65494f7e4bed2e74110dac1f0d17dc8e1f42faaa784e7c58a98e335ec83d7e \
-    --hash=sha256:5e1439c8f407e4f356470e54cdecdca1bd5439a0673792dbe34a2b0a551a2fe3 \
-    --hash=sha256:5e22676a5b875bd72acd3d11d5fa9075d3a5f53b877fe7b4793e4673499318ba \
-    --hash=sha256:6a61ea0ff048e06de273b2e45bd72629f470f5da8f71daf09fe481278b175001 \
-    --hash=sha256:940de32dc8853eba0f67f7198b3e79bc6ba95c2edbfdfac2144c8235114d6726 \
-    --hash=sha256:b0c232af3d0bd8f521806223723456ffebf8e323bd1e4e82b0befb20ba18388e \
-    --hash=sha256:c9d15fc41e6054bfc7200478720570078f0b41c9ae4f010bcc16bd6f4d1aacdd \
-    --hash=sha256:cc9a91ae137d687f43a44c900e5d95e9617cb37d4c989e462980ba27039d239d \
-    --hash=sha256:d450b7fbff85913f866a5384d8912710936e2b96da74541c82c1b458472ddb39 \
-    --hash=sha256:d920499b576f6c68295bc04e7b17b6544d9d05f196bb3aac4358792ef6f34325 \
-    --hash=sha256:e62ed7f36b3068a30ba39193a14274cd706bc486fad521276458022f7bccb31d \
-    --hash=sha256:ecd46e3106850a5c26aee114e562c329f9a1fbe9e4821b008c4404f64ff9ce73 \
-    --hash=sha256:f63d96494eeec2fc70d909393bcd76c69f35334cdbd9e20d089fb3f0640216ca
 setuptools==69.1.1 \
     --hash=sha256:02fa291a0471b3a18b2b2481ed902af520c69e8ae0919c13da936542754b4c56 \
     --hash=sha256:5c0806c7d9af348e6dd3777b4f4dbb42c7ad85b190104837488eab9a7c945cf8
-    # via
-    #   documenteer
-    #   nodeenv
+    # via documenteer
 six==1.16.0 \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
@@ -852,9 +799,13 @@ sphinxext-rediraffe==0.2.7 \
     --hash=sha256:651dcbfae5ffda9ffd534dfb8025f36120e5efb6ea1a33f5420023862b9f725d \
     --hash=sha256:9e430a52d4403847f4ffb3a8dd6dfc34a9fe43525305131f52ed899743a5fd8c
     # via documenteer
-tomlkit==0.12.3 \
-    --hash=sha256:75baf5012d06501f07bee5bf8e801b9f343e7aac5a92581f20f80ce632e6b5a4 \
-    --hash=sha256:b0a645a9156dc7cb5d3a1f0d4bab66db287fcb8e0430bdd4664a095ea16414ba
+termcolor==2.4.0 \
+    --hash=sha256:9297c0df9c99445c2412e832e882a7884038a25617c60cea2ad69488d4040d63 \
+    --hash=sha256:aab9e56047c8ac41ed798fa36d892a37aca6b3e9159f3e0c24bc64a9b3ac7b7a
+    # via pytest-sugar
+tomlkit==0.12.4 \
+    --hash=sha256:5cd82d48a3dd89dee1f9d64420aa20ae65cfbd00668d6f094d7578a78efbb77b \
+    --hash=sha256:7ca1cfc12232806517a8515047ba66a19369e71edf2439d0f5824f91032b6cc3
     # via documenteer
 typed-ast==1.5.5 \
     --hash=sha256:042eb665ff6bf020dd2243307d11ed626306b82812aba21836096d229fdc6a10 \
@@ -919,7 +870,3 @@ urllib3==2.2.1 \
     # via
     #   documenteer
     #   requests
-virtualenv==20.25.1 \
-    --hash=sha256:961c026ac520bac5f69acb8ea063e8a4f071bcc9457b9c1f28f6b085c511583a \
-    --hash=sha256:e08e13ecdca7a0bd53798f356d5831434afa5b07b93f0abdf0797b7a06ffe197
-    # via pre-commit

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -342,9 +342,9 @@ pycparser==2.21 \
     --hash=sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9 \
     --hash=sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206
     # via cffi
-pydantic==2.6.2 \
-    --hash=sha256:37a5432e54b12fecaa1049c5195f3d860a10e01bdfd24f1840ef14bd0d3aeab3 \
-    --hash=sha256:a09be1c3d28f3abe37f8a78af58284b236a92ce520105ddc91a6d29ea1176ba7
+pydantic==2.6.3 \
+    --hash=sha256:72c6034df47f46ccdf81869fddb81aade68056003900a8724a4f160700016a2a \
+    --hash=sha256:e07805c4c7f5c6826e33a1d4c9d47950d7eaf34868e2690f8594d2e30241f11f
     # via
     #   fastapi
     #   safir


### PR DESCRIPTION
Several documentation pages about updating secrets were in the developer section, but secrets can generally only be updated by admins. Move the documentation into the appropriate place and tell developers to ask their platform administrators about secrets.

Break down the documentation in a hopefully simpler way with separate pages for adding and updating secrets for administrators to follow.

Note that currently I'm the only person with access to create new 1Password integrations.