### PR TITLE
DM-42714: Add documentation for editing on GitHub

### DIFF
--- a/docs/about/contributing-docs.rst
+++ b/docs/about/contributing-docs.rst
@@ -2,14 +2,14 @@
 Contributing to the documentation
 #################################
 
-This documentation is a Sphinx_ project hosted out of the :file:`docs` directory of the `phalanx repository`_ on GitHub.
+This documentation is a Sphinx_ project hosted out of the :file:`docs` directory of the `Phalanx repository`_ on GitHub.
 You can contribute to this documentation by editing the source files in a clone of this repository and submitting a pull request on GitHub.
 This page provides the basic steps.
 
 Set up for documentation development
 ====================================
 
-Follow the steps at :ref:`about-dev-setup` to set up a Phalanx development environment.
+Follow the steps at :doc:`local-environment-setup` to set up a Phalanx development environment.
 This installs tox_, the tooling for builds with isolated Python environments, and pre-commit_, a tool for linting and formatting files.
 
 Compiling the documentation
@@ -17,7 +17,7 @@ Compiling the documentation
 
 Use the tox_ ``docs`` environment for compiling the documentation:
 
-.. code-block:: bash
+.. prompt:: bash
 
    tox run -e docs
 
@@ -25,7 +25,7 @@ The built documentation is located in the ``docs/_build/html`` directory.
 
 Sphinx caches build products and in some cases you may need to delete the build to get a consistent result:
 
-.. code-block:: bash
+.. prompt:: bash
 
    make clean
 
@@ -34,18 +34,19 @@ Checking links
 
 Links in the documentation are validated in the GitHub Actions workflow, but you can also run this validation on your local clone:
 
-.. code-block:: bash
+.. prompt:: bash
 
    tox run -e docs-linkcheck
 
 Submitting a pull request and sharing documentation drafts
 ==========================================================
 
-Members of the `lsst-sqre/phalanx`_ repository should submit pull requests following the `Data Management workflow guide`_.
-Note that GitHub Actions builds the documentation and uploads a draft edition of the documentation to the web.
+Members of the https://github.com/lsst-sqre/phalanx repository should submit pull requests following the `Data Management workflow guide`_.
+GitHub Actions builds the documentation for any pull requests and uploads a draft edition of the documentation to the web.
 You can find your branch's development edition at `the list of available versions <https://phalanx.lsst.io/v/index.html>`__.
 
 If you are submitting a GitHub pull request from a fork, the documentation will build as a check, but the draft won't upload for public staging.
+If you will regularly be making Phalanx contributions, please contact SQuaRE so that we can add you as a collaborator on the Phalanx repository.
 
 More information on writing documentation
 =========================================

--- a/docs/about/edit-on-github.rst
+++ b/docs/about/edit-on-github.rst
@@ -1,0 +1,31 @@
+#########################
+Editing Phalanx on GitHub
+#########################
+
+The Phalanx repository is hosted on GitHub at https://github.com/lsst-sqre/phalanx.
+Some types of small changes can be made directly there without having to set up a local development environment.
+Other changes, however, require a development environment to make correctly.
+
+Changes that are safe to make on GitHub
+=======================================
+
+If you wish, you can make the following classes of changes using the edit button on GitHub:
+
+- Changing the applications settings in :file:`values-{environment}.yaml` for a specific environment (**not** :file:`values.yaml`).
+- Updating the ``appVersion`` of an application in :file:`Chart.yaml`.
+- Disabling or re-enabling an application for an environment in :file:`environments/values-{environment}.yaml` when the application is already configured for that environment.
+- Small documentation changes where there is little risk of introducing a syntax error.
+
+For any other changes, please set up a :doc:`local development environment <local-environment-setup>` and use it to create your PR.
+
+Creating a PR
+=============
+
+All changes to Phalanx must be done via a pull request.
+Direct changes to the ``main`` branch, even for trivial changes, are not allowed.
+
+When you try to commit a change made on GitHub, GitHub will recognize this and prompt you to create a branch and a PR.
+Before submitting, edit the proposed branch name to follow the conventions in the `LSST DM developer guide <https://developer.lsst.io/work/flow.html#git-branching>`__.
+
+For small changes of this type, and as long as you are the developer responsible for the application whose configuration you are changing, you may merge the change without further review using the :guilabel:`Merge when ready` button on the resulting PR.
+Changes will only be merged once they pass automated GitHub Actions tests.

--- a/docs/about/index.rst
+++ b/docs/about/index.rst
@@ -18,6 +18,7 @@ After you have reviewed this documentation, see the :doc:`/developers/index` sec
    :maxdepth: 1
    :caption: Contributing
 
+   edit-on-github
    local-environment-setup
    pre-commit-and-testing
    contributing-docs

--- a/docs/about/local-environment-setup.rst
+++ b/docs/about/local-environment-setup.rst
@@ -1,5 +1,3 @@
-.. _about-dev-setup:
-
 ############################################
 Setting up a Phalanx development environment
 ############################################

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ allowlist_externals =
     rm
 commands =
     rm -rf docs/internals/api/
-    sphinx-build --keep-going -n -T -b html -d {envtmpdir}/doctrees docs docs/_build/html
+    sphinx-build -W --keep-going -n -T -b html -d {envtmpdir}/doctrees docs docs/_build/html
 
 [testenv:docs-linkcheck]
 description = Check links in the documentation.


### PR DESCRIPTION
Also re-enable documentation build failures on syntax errors, and change some code blocks to prompt blocks for better formatting.