### PR TITLE
DM-42997: Separate APDBs for different instruments in Prompt Processing

### DIFF
--- a/applications/prompt-proto-service-hsc/README.md
+++ b/applications/prompt-proto-service-hsc/README.md
@@ -13,7 +13,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | prompt-proto-service.additionalVolumeMounts | list | `[]` | Kubernetes YAML configs for extra container volume(s). Any volumes required by other config options are automatically handled by the Helm chart. |
-| prompt-proto-service.apdb.namespace | string | `"pp_apdb"` | Database namespace for the APDB |
+| prompt-proto-service.apdb.namespace | string | `"pp_apdb_hsc"` | Database namespace for the APDB |
 | prompt-proto-service.apdb.url | string | None, must be set | URL to the APDB, in any form recognized by SQLAlchemy |
 | prompt-proto-service.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
 | prompt-proto-service.image.repository | string | `"ghcr.io/lsst-dm/prompt-service"` | Image to use in the PP deployment |

--- a/applications/prompt-proto-service-hsc/values.yaml
+++ b/applications/prompt-proto-service-hsc/values.yaml
@@ -64,7 +64,7 @@ prompt-proto-service:
     # @default -- None, must be set
     url: ""
     # -- Database namespace for the APDB
-    namespace: pp_apdb
+    namespace: pp_apdb_hsc
 
   registry:
     # -- If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted.

--- a/applications/prompt-proto-service-latiss/README.md
+++ b/applications/prompt-proto-service-latiss/README.md
@@ -13,7 +13,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | prompt-proto-service.additionalVolumeMounts | list | `[]` | Kubernetes YAML configs for extra container volume(s). Any volumes required by other config options are automatically handled by the Helm chart. |
-| prompt-proto-service.apdb.namespace | string | `"pp_apdb"` | Database namespace for the APDB |
+| prompt-proto-service.apdb.namespace | string | `"pp_apdb_latiss"` | Database namespace for the APDB |
 | prompt-proto-service.apdb.url | string | None, must be set | URL to the APDB, in any form recognized by SQLAlchemy |
 | prompt-proto-service.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
 | prompt-proto-service.image.repository | string | `"ghcr.io/lsst-dm/prompt-service"` | Image to use in the PP deployment |

--- a/applications/prompt-proto-service-latiss/values.yaml
+++ b/applications/prompt-proto-service-latiss/values.yaml
@@ -64,7 +64,7 @@ prompt-proto-service:
     # @default -- None, must be set
     url: ""
     # -- Database namespace for the APDB
-    namespace: pp_apdb
+    namespace: pp_apdb_latiss
 
   registry:
     # -- If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted.

--- a/applications/prompt-proto-service-lsstcam/README.md
+++ b/applications/prompt-proto-service-lsstcam/README.md
@@ -13,7 +13,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | prompt-proto-service.additionalVolumeMounts | list | `[]` | Kubernetes YAML configs for extra container volume(s). Any volumes required by other config options are automatically handled by the Helm chart. |
-| prompt-proto-service.apdb.namespace | string | `"pp_apdb"` | Database namespace for the APDB |
+| prompt-proto-service.apdb.namespace | string | `"pp_apdb_lsstcam"` | Database namespace for the APDB |
 | prompt-proto-service.apdb.url | string | None, must be set | URL to the APDB, in any form recognized by SQLAlchemy |
 | prompt-proto-service.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
 | prompt-proto-service.image.repository | string | `"ghcr.io/lsst-dm/prompt-service"` | Image to use in the PP deployment |

--- a/applications/prompt-proto-service-lsstcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcam/values.yaml
@@ -64,7 +64,7 @@ prompt-proto-service:
     # @default -- None, must be set
     url: ""
     # -- Database namespace for the APDB
-    namespace: pp_apdb
+    namespace: pp_apdb_lsstcam
 
   registry:
     # -- If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted.

--- a/applications/prompt-proto-service-lsstcomcam/README.md
+++ b/applications/prompt-proto-service-lsstcomcam/README.md
@@ -12,7 +12,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| prompt-proto-service.apdb.namespace | string | `"pp_apdb"` | Database namespace for the APDB |
+| prompt-proto-service.apdb.namespace | string | `"pp_apdb_lsstcomcam"` | Database namespace for the APDB |
 | prompt-proto-service.apdb.url | string | None, must be set | URL to the APDB, in any form recognized by SQLAlchemy |
 | prompt-proto-service.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
 | prompt-proto-service.image.repository | string | `"ghcr.io/lsst-dm/prompt-service"` | Image to use in the PP deployment |

--- a/applications/prompt-proto-service-lsstcomcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/values.yaml
@@ -64,7 +64,7 @@ prompt-proto-service:
     # @default -- None, must be set
     url: ""
     # -- Database namespace for the APDB
-    namespace: pp_apdb
+    namespace: pp_apdb_lsstcomcam
 
   registry:
     # -- If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted.

--- a/charts/prompt-proto-service/README.md
+++ b/charts/prompt-proto-service/README.md
@@ -14,7 +14,7 @@ Event-driven processing of camera images
 |-----|------|---------|-------------|
 | additionalVolumeMounts | list | `[]` | Kubernetes YAML configs for extra container volume(s). Any volumes required by other config options are automatically handled by the Helm chart. |
 | affinity | object | `{}` |  |
-| apdb.namespace | string | `""` | Database namespace for the APDB |
+| apdb.namespace | string | None, must be set | Database namespace for the APDB |
 | apdb.url | string | None, must be set | URL to the APDB, in any form recognized by SQLAlchemy |
 | containerConcurrency | int | `1` |  |
 | fullnameOverride | string | `"prompt-proto-service"` | Override the full name for resources (includes the release name) |

--- a/charts/prompt-proto-service/values.yaml
+++ b/charts/prompt-proto-service/values.yaml
@@ -62,6 +62,7 @@ apdb:
   # @default -- None, must be set
   url: ""
   # -- Database namespace for the APDB
+  # @default -- None, must be set
   namespace: ""
 
 registry:


### PR DESCRIPTION
This PR gives each service an instrument-specific namespace (one of the few cases where our config depends on the instrument and not the environment 🙂).

The instrument-specific namespaces are already available on `-dev` (alongside the old one), so this update can be deployed there at any time. On `-prod`, we will need to coordinate deployment carefully with a schema rename in the APDB, so as to not interfere with active observing (aiming for midday PST on Monday).