### PR TITLE
DM-43148: Remove obsolete users

### DIFF
--- a/applications/argocd/values-idfdev.yaml
+++ b/applications/argocd/values-idfdev.yaml
@@ -24,11 +24,9 @@ argo-cd:
       policy.csv: |
         g, adam@lsst.cloud, role:admin
         g, afausti@lsst.cloud, role:admin
-        g, christine@lsst.cloud, role:admin
         g, dspeck@lsst.cloud, role:admin
         g, frossie@lsst.cloud, role:admin
         g, jsick@lsst.cloud, role:admin
-        g, krughoff@lsst.cloud, role:admin
         g, rra@lsst.cloud, role:admin
         g, gpdf@lsst.cloud, role:admin
         g, loi@lsst.cloud, role:admin

--- a/applications/argocd/values-idfint.yaml
+++ b/applications/argocd/values-idfint.yaml
@@ -24,11 +24,9 @@ argo-cd:
       policy.csv: |
         g, adam@lsst.cloud, role:admin
         g, afausti@lsst.cloud, role:admin
-        g, christine@lsst.cloud, role:admin
         g, dspeck@lsst.cloud, role:admin
         g, frossie@lsst.cloud, role:admin
         g, jsick@lsst.cloud, role:admin
-        g, krughoff@lsst.cloud, role:admin
         g, rra@lsst.cloud, role:admin
         g, ctslater@lsst.cloud, role:admin
         g, gpdf@lsst.cloud, role:admin

--- a/applications/argocd/values-idfprod.yaml
+++ b/applications/argocd/values-idfprod.yaml
@@ -24,11 +24,9 @@ argo-cd:
       policy.csv: |
         g, adam@lsst.cloud, role:admin
         g, afausti@lsst.cloud, role:admin
-        g, christine@lsst.cloud, role:admin
         g, dspeck@lsst.cloud, role:admin
         g, frossie@lsst.cloud, role:admin
         g, jsick@lsst.cloud, role:admin
-        g, krughoff@lsst.cloud, role:admin
         g, rra@lsst.cloud, role:admin
         g, gpdf@lsst.cloud, role:admin
         g, loi@lsst.cloud, role:admin

--- a/applications/argocd/values-roundtable-dev.yaml
+++ b/applications/argocd/values-roundtable-dev.yaml
@@ -30,7 +30,6 @@ argo-cd:
       policy.csv: |
         g, adam@lsst.cloud, role:admin
         g, afausti@lsst.cloud, role:admin
-        g, christine@lsst.cloud, role:admin
         g, dspeck@lsst.cloud, role:admin
         g, frossie@lsst.cloud, role:admin
         g, jsick@lsst.cloud, role:admin

--- a/applications/argocd/values-roundtable-prod.yaml
+++ b/applications/argocd/values-roundtable-prod.yaml
@@ -30,7 +30,6 @@ argo-cd:
       policy.csv: |
         g, adam@lsst.cloud, role:admin
         g, afausti@lsst.cloud, role:admin
-        g, christine@lsst.cloud, role:admin
         g, dspeck@lsst.cloud, role:admin
         g, frossie@lsst.cloud, role:admin
         g, jsick@lsst.cloud, role:admin

--- a/applications/argocd/values-usdf-tel-rsp.yaml
+++ b/applications/argocd/values-usdf-tel-rsp.yaml
@@ -44,7 +44,6 @@ argo-cd:
         g, dspeck@slac.stanford.edu, role:admin
         g, afausti@slac.stanford.edu, role:admin
         g, mfl@slac.stanford.edu, role:admin
-        g, cbanek@slac.stanford.edu, role:admin
         g, frossie@slac.stanford.edu, role:admin
         g, hchiang2@slac.stanford.edu, role:admin
         g, athor@slac.stanford.edu, role:admin

--- a/applications/argocd/values-usdfdev.yaml
+++ b/applications/argocd/values-usdfdev.yaml
@@ -44,7 +44,6 @@ argo-cd:
         g, dspeck@slac.stanford.edu, role:admin
         g, afausti@slac.stanford.edu, role:admin
         g, mfl@slac.stanford.edu, role:admin
-        g, cbanek@slac.stanford.edu, role:admin
         g, frossie@slac.stanford.edu, role:admin
         g, hchiang2@slac.stanford.edu, role:admin
         g, athor@slac.stanford.edu, role:admin

--- a/applications/argocd/values-usdfint.yaml
+++ b/applications/argocd/values-usdfint.yaml
@@ -44,7 +44,6 @@ argo-cd:
         g, dspeck@slac.stanford.edu, role:admin
         g, afausti@slac.stanford.edu, role:admin
         g, mfl@slac.stanford.edu, role:admin
-        g, cbanek@slac.stanford.edu, role:admin
         g, frossie@slac.stanford.edu, role:admin
         g, hchiang2@slac.stanford.edu, role:admin
         g, athor@slac.stanford.edu, role:admin

--- a/applications/argocd/values-usdfprod.yaml
+++ b/applications/argocd/values-usdfprod.yaml
@@ -44,7 +44,6 @@ argo-cd:
         g, dspeck@slac.stanford.edu, role:admin
         g, afausti@slac.stanford.edu, role:admin
         g, mfl@slac.stanford.edu, role:admin
-        g, cbanek@slac.stanford.edu, role:admin
         g, frossie@slac.stanford.edu, role:admin
         g, hchiang2@slac.stanford.edu, role:admin
         g, athor@slac.stanford.edu, role:admin

--- a/applications/gafaelfawr/values-base.yaml
+++ b/applications/gafaelfawr/values-base.yaml
@@ -53,7 +53,6 @@ config:
   initialAdmins:
     - "afausti"
     - "athornton"
-    - "cbanek"
     - "frossie"
     - "jonathansick"
     - "rra"

--- a/applications/gafaelfawr/values-idfdev.yaml
+++ b/applications/gafaelfawr/values-idfdev.yaml
@@ -61,7 +61,6 @@ config:
   initialAdmins:
     - "adam"
     - "afausti"
-    - "cbanek"
     - "frossie"
     - "jsick"
     - "rra"

--- a/applications/gafaelfawr/values-idfint.yaml
+++ b/applications/gafaelfawr/values-idfint.yaml
@@ -63,7 +63,6 @@ config:
   initialAdmins:
     - "adam"
     - "afausti"
-    - "cbanek"
     - "frossie"
     - "jsick"
     - "rra"

--- a/applications/gafaelfawr/values-idfprod.yaml
+++ b/applications/gafaelfawr/values-idfprod.yaml
@@ -53,7 +53,6 @@ config:
   initialAdmins:
     - "afausti"
     - "athornton"
-    - "cbanek"
     - "frossie"
     - "jonathansick"
     - "rra"

--- a/applications/gafaelfawr/values-minikube.yaml
+++ b/applications/gafaelfawr/values-minikube.yaml
@@ -48,7 +48,6 @@ config:
   initialAdmins:
     - "afausti"
     - "athornton"
-    - "cbanek"
     - "frossie"
     - "jonathansick"
     - "rra"

--- a/applications/gafaelfawr/values-roundtable-dev.yaml
+++ b/applications/gafaelfawr/values-roundtable-dev.yaml
@@ -47,7 +47,6 @@ config:
   initialAdmins:
     - "afausti"
     - "athornton"
-    - "cbanek"
     - "frossie"
     - "jonathansick"
     - "rra"

--- a/applications/gafaelfawr/values-roundtable-prod.yaml
+++ b/applications/gafaelfawr/values-roundtable-prod.yaml
@@ -48,7 +48,6 @@ config:
   initialAdmins:
     - "afausti"
     - "athornton"
-    - "cbanek"
     - "frossie"
     - "jonathansick"
     - "rra"

--- a/applications/gafaelfawr/values-summit.yaml
+++ b/applications/gafaelfawr/values-summit.yaml
@@ -97,7 +97,6 @@ config:
   initialAdmins:
     - "afausti"
     - "athornton"
-    - "cbanek"
     - "frossie"
     - "jonathansick"
     - "rra"

--- a/applications/gafaelfawr/values-tucson-teststand.yaml
+++ b/applications/gafaelfawr/values-tucson-teststand.yaml
@@ -87,7 +87,6 @@ config:
   initialAdmins:
     - "afausti"
     - "athornton"
-    - "cbanek"
     - "frossie"
     - "jonathansick"
     - "rra"

--- a/applications/gafaelfawr/values-usdf-tel-rsp.yaml
+++ b/applications/gafaelfawr/values-usdf-tel-rsp.yaml
@@ -182,7 +182,6 @@ config:
   initialAdmins:
     - "afausti"
     - "athor"
-    - "cbanek"
     - "frossie"
     - "jonathansick"
     - "rra"

--- a/applications/gafaelfawr/values-usdfdev.yaml
+++ b/applications/gafaelfawr/values-usdfdev.yaml
@@ -225,7 +225,6 @@ config:
   initialAdmins:
     - "afausti"
     - "athor"
-    - "cbanek"
     - "frossie"
     - "jonathansick"
     - "rra"

--- a/applications/gafaelfawr/values-usdfint.yaml
+++ b/applications/gafaelfawr/values-usdfint.yaml
@@ -218,10 +218,8 @@ config:
   initialAdmins:
     - "afausti"
     - "athor"
-    - "cbanek"
     - "frossie"
     - "jonathansick"
     - "rra"
-    - "simonkrughoff"
     - "ytl"
     - "ppascual"

--- a/applications/gafaelfawr/values-usdfprod.yaml
+++ b/applications/gafaelfawr/values-usdfprod.yaml
@@ -218,7 +218,6 @@ config:
   initialAdmins:
     - "afausti"
     - "athor"
-    - "cbanek"
     - "frossie"
     - "jonathansick"
     - "rra"

--- a/docs/applications/argocd/authentication.rst
+++ b/docs/applications/argocd/authentication.rst
@@ -93,10 +93,8 @@ To set up Google SSO authentication to Argo CD in a new cluster, take the follow
         policy.csv: |
           g, adam@lsst.cloud, role:admin
           g, afausti@lsst.cloud, role:admin
-          g, christine@lsst.cloud, role:admin
           g, frossie@lsst.cloud, role:admin
           g, jsick@lsst.cloud, role:admin
-          g, krughoff@lsst.cloud, role:admin
           g, rra@lsst.cloud, role:admin
         scopes: "[email]"
 

--- a/tests/data/input/applications/argocd/values-idfdev.yaml
+++ b/tests/data/input/applications/argocd/values-idfdev.yaml
@@ -47,11 +47,9 @@ argo-cd:
       policy.csv: |
         g, adam@lsst.cloud, role:admin
         g, afausti@lsst.cloud, role:admin
-        g, christine@lsst.cloud, role:admin
         g, dspeck@lsst.cloud, role:admin
         g, frossie@lsst.cloud, role:admin
         g, jsick@lsst.cloud, role:admin
-        g, krughoff@lsst.cloud, role:admin
         g, rra@lsst.cloud, role:admin
         g, gpdf@lsst.cloud, role:admin
         g, loi@lsst.cloud, role:admin

--- a/tests/data/input/applications/gafaelfawr/values-idfdev.yaml
+++ b/tests/data/input/applications/gafaelfawr/values-idfdev.yaml
@@ -60,11 +60,9 @@ config:
   initialAdmins:
     - "adam"
     - "afausti"
-    - "cbanek"
     - "frossie"
     - "jsick"
     - "rra"
-    - "simonkrughoff"
 
 cloudsql:
   enabled: true

--- a/tests/data/input/applications/gafaelfawr/values-minikube.yaml
+++ b/tests/data/input/applications/gafaelfawr/values-minikube.yaml
@@ -47,8 +47,6 @@ config:
   initialAdmins:
     - "afausti"
     - "athornton"
-    - "cbanek"
     - "frossie"
     - "jonathansick"
     - "rra"
-    - "simonkrughoff"

--- a/tests/data/output/idfdev/argocd-rbac-rst
+++ b/tests/data/output/idfdev/argocd-rbac-rst
@@ -1,10 +1,8 @@
 ``g``,``adam@lsst.cloud``,``role:admin``
 ``g``,``afausti@lsst.cloud``,``role:admin``
-``g``,``christine@lsst.cloud``,``role:admin``
 ``g``,``dspeck@lsst.cloud``,``role:admin``
 ``g``,``frossie@lsst.cloud``,``role:admin``
 ``g``,``jsick@lsst.cloud``,``role:admin``
-``g``,``krughoff@lsst.cloud``,``role:admin``
 ``g``,``rra@lsst.cloud``,``role:admin``
 ``g``,``gpdf@lsst.cloud``,``role:admin``
 ``g``,``loi@lsst.cloud``,``role:admin``


### PR DESCRIPTION
Remove obsolete users from Argo CD RBAC and Gafaelfawr's list of initial administrators.