### PR TITLE
DM-43124: Add Redis to Unfurlbot

### DIFF
--- a/applications/unfurlbot/Chart.yaml
+++ b/applications/unfurlbot/Chart.yaml
@@ -1,8 +1,13 @@
 apiVersion: v2
-appVersion: "0.1.0"
+appVersion: "tickets-DM-43124"
 description: Squarebot backend that unfurls Jira issues.
 name: unfurlbot
 sources:
   - https://github.com/lsst-sqre/unfurlbot
 type: application
 version: 1.0.0
+
+dependencies:
+  - name: redis
+    version: 1.0.11
+    repository: https://lsst-sqre.github.io/charts/

--- a/applications/unfurlbot/Chart.yaml
+++ b/applications/unfurlbot/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "tickets-DM-43124"
+appVersion: "0.2.0"
 description: Squarebot backend that unfurls Jira issues.
 name: unfurlbot
 sources:

--- a/applications/unfurlbot/README.md
+++ b/applications/unfurlbot/README.md
@@ -17,6 +17,7 @@ Squarebot backend that unfurls Jira issues.
 | autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU utilization of unfurlbot deployment pods |
 | config.jiraProjects | string | `"ADMIN, CCB, CAP, COMCAM, COMT, DM, EPO, FRACAS, IAM, IHS, IT, ITRFC, LOVE, LASD, LIT, LOPS, LVV, M1M3V, OPSIM, PHOSIM, PST, PSV, PUB, RFC, RM, SAFE, SIM, SPP, SBTT, SE, TSAIV, TCT, SECMVERIF, TMDC, TPC, TSEIA, TAS, TELV, TSSAL, TSS, TSSPP, WMP, PREOPS, OBS, SITCOM, BLOCK\n"` | Names of Jira projects to unfurl (comma-separated) |
 | config.logLevel | string | `"INFO"` | Logging level: "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL" |
+| config.redisUrl | string | `"redis://unfurlbot-redis:6379/0"` | URL to the local redis instance |
 | config.topics.slackAppMention | string | `"lsst.square-events.squarebot.slack.app.mention"` | Kafka topic name for the Slack `app_mention` events |
 | config.topics.slackMessageChannels | string | `"lsst.square-events.squarebot.slack.message.channels"` | Kafka topic name for the Slack `message.channels` events (public channels) |
 | config.topics.slackMessageGroups | string | `"lsst.square-events.squarebot.slack.message.groups"` | Kafka topic name for the Slack `message.groups` events (private channels) |

--- a/applications/unfurlbot/templates/configmap.yaml
+++ b/applications/unfurlbot/templates/configmap.yaml
@@ -14,3 +14,4 @@ data:
   UNFURLBOT_TOPIC_MESSAGE_IM: {{ .Values.config.topics.slackMessageIm | quote }}
   UNFURLBOT_TOPIC_MESSAGE_MPIM: {{ .Values.config.topics.slackMessageMpim | quote }}
   UNFURLBOT_JIRA_PROJECTS: {{ .Values.config.jiraProjects | quote }}
+  UNFURLBOT_REDIS_URL: {{ .Values.config.redisUrl | quote }}

--- a/applications/unfurlbot/templates/deployment.yaml
+++ b/applications/unfurlbot/templates/deployment.yaml
@@ -22,6 +22,7 @@ spec:
         {{- end }}
       labels:
         {{- include "unfurlbot.selectorLabels" . | nindent 8 }}
+        unfurlbot-redis-client: "true"
         app.kubernetes.io/component: "server"
         app.kubernetes.io/part-of: "unfurlbot"
     spec:

--- a/applications/unfurlbot/values.yaml
+++ b/applications/unfurlbot/values.yaml
@@ -19,6 +19,9 @@ config:
   # -- Logging level: "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"
   logLevel: "INFO"
 
+  # -- URL to the local redis instance
+  redisUrl: "redis://unfurlbot-redis:6379/0"
+
   topics:
     # -- Kafka topic name for the Slack `app_mention` events
     slackAppMention: "lsst.square-events.squarebot.slack.app.mention"

--- a/environments/values-roundtable-prod.yaml
+++ b/environments/values-roundtable-prod.yaml
@@ -22,5 +22,5 @@ applications:
   strimzi: true
   strimzi-access-operator: true
   squarebot: true
-  unfurlbot: false
+  unfurlbot: true
   vault: true


### PR DESCRIPTION
This redis instance is used to maintain a memory of issues already unfurled per channel or thread.