### PR TITLE
Disable argo-workflows on data-dev

### DIFF
--- a/environments/values-idfdev.yaml
+++ b/environments/values-idfdev.yaml
@@ -13,7 +13,6 @@ onepassword:
 vaultPathPrefix: "secret/phalanx/idfdev"
 
 applications:
-  argo-workflows: true
   butler: true
   datalinker: true
   filestore-backup: true


### PR DESCRIPTION
We don't use this package there (it's only for T&S sites), so stop installing it and thus having to upgrade it.