### PR TITLE
Redo documentation for shared cadc-tap chart

### DIFF
--- a/charts/cadc-tap/README.md
+++ b/charts/cadc-tap/README.md
@@ -13,22 +13,22 @@ IVOA TAP service
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules for the TAP pod |
-| config.backend | string | None, must be set to "pg" or "qserv" | What type of backend are we connecting to? |
+| config.backend | string | None, must be set to `pg` or `qserv` | What type of backend are we connecting to? |
 | config.datalinkPayloadUrl | string | `"https://github.com/lsst/sdm_schemas/releases/download/2.4.0/datalink-snippets.zip"` | Datalink payload URL |
-| config.gcsBucket | string | The common GCS bucket | Name of GCS bucket in which to store results |
-| config.gcsBucketType | string | GCS | GCS bucket type (GCS or S3) |
-| config.gcsBucketUrl | string | The common GCS bucket | Base URL for results stored in GCS bucket |
+| config.gcsBucket | string | `"async-results.lsst.codes"` | Name of GCS bucket in which to store results |
+| config.gcsBucketType | string | `"GCS"` | GCS bucket type (GCS or S3) |
+| config.gcsBucketUrl | string | `"https://tap-files.lsst.codes"` | Base URL for results stored in GCS bucket |
 | config.jvmMaxHeapSize | string | `"31G"` | Java heap size, which will set the maximum size of the heap. Otherwise Java would determine it based on how much memory is available and black maths. |
-| config.pg.database | string | None, must be set if backend is pg | Database to connect to |
-| config.pg.host | string | None, must be set if backend is pg | Host to connect to |
-| config.pg.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the tap image |
-| config.pg.image.repository | string | `"ghcr.io/lsst-sqre/tap-postgres-service"` | tap image to use |
-| config.pg.image.tag | string | Latest release | Tag of tap image to use |
-| config.pg.username | string | None, must be set if backend is pg | Username to connect with |
+| config.pg.database | string | None, must be set if backend is `pg` | Database to connect to |
+| config.pg.host | string | None, must be set if backend is `pg` | Host to connect to |
+| config.pg.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the TAP image |
+| config.pg.image.repository | string | `"ghcr.io/lsst-sqre/tap-postgres-service"` | TAP image to use |
+| config.pg.image.tag | string | `"1.15.0"` | Tag of TAP image to use |
+| config.pg.username | string | None, must be set if backend is `pg` | Username to connect with |
 | config.qserv.host | string | `"mock-db:3306"` (the mock QServ) | QServ hostname:port to connect to |
-| config.qserv.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the tap image |
-| config.qserv.image.repository | string | `"ghcr.io/lsst-sqre/lsst-tap-service"` | tap image to use |
-| config.qserv.image.tag | string | Latest release | Tag of tap image to use |
+| config.qserv.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the TAP image |
+| config.qserv.image.repository | string | `"ghcr.io/lsst-sqre/lsst-tap-service"` | TAP image to use |
+| config.qserv.image.tag | string | `"2.2.0"` | Tag of TAP image to use |
 | config.tapSchemaAddress | string | `"cadc-tap-schema-db:3306"` | Address to a MySQL database containing TAP schema data |
 | config.vaultSecretName | string | `""` | Vault secret name, this is appended to the global path to find the vault secrets associated with this deployment. |
 | fullnameOverride | string | `"cadc-tap"` | Override the full name for resources (includes the release name) |
@@ -37,7 +37,7 @@ IVOA TAP service
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | ingress.anonymousAnnotations | object | `{}` | Additional annotations to use for endpoints that allow anonymous access, such as `/capabilities` and `/availability` |
 | ingress.authenticatedAnnotations | object | `{}` | Additional annotations to use for endpoints that are authenticated, such as `/sync`, `/async`, and `/tables` |
-| ingress.path | string | `""` | External path to the tap service, the path eventually gets rewritten by tomcat. |
+| ingress.path | string | `""` | External path to the TAP service, the path eventually gets rewritten by tomcat. |
 | mockdb.affinity | object | `{}` | Affinity rules for the mock db pod |
 | mockdb.enabled | bool | `false` | Spin up a container to pretend to be the database. |
 | mockdb.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the mock database image |
@@ -52,7 +52,7 @@ IVOA TAP service
 | nodeSelector | object | `{}` | Node selector rules for the TAP pod |
 | podAnnotations | object | `{}` | Annotations for the TAP pod |
 | replicaCount | int | `1` | Number of pods to start |
-| resources | object | `{"limits":{"cpu":8,"memory":"32Gi"},"requests":{"cpu":2,"memory":"2Gi"}}` | Resource limits and requests for the TAP pod |
+| resources | object | See `values.yaml` | Resource limits and requests for the TAP pod |
 | tapSchema.affinity | object | `{}` | Affinity rules for the TAP schema database pod |
 | tapSchema.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the TAP schema image |
 | tapSchema.image.repository | string | `"lsstsqre/tap-schema-mock"` | TAP schema image to ue. This must be overridden by each environment with the TAP schema for that environment. |
@@ -65,9 +65,8 @@ IVOA TAP service
 | uws.affinity | object | `{}` | Affinity rules for the UWS database pod |
 | uws.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the UWS database image |
 | uws.image.repository | string | `"ghcr.io/lsst-sqre/lsst-tap-uws-db"` | UWS database image to use |
-| uws.image.tag | string | Version of QServ TAP image | Tag of UWS database image to use |
+| uws.image.tag | string | `"2.2.0"` | Tag of UWS database image to use |
 | uws.nodeSelector | object | `{}` | Node selection rules for the UWS database pod |
 | uws.podAnnotations | object | `{}` | Annotations for the UWS databse pod |
-| uws.resources | object | `{"limits":{"cpu":2,"memory":"4Gi"},"requests":{"cpu":0.25,"memory":"1Gi"}}` | Resource limits and requests for the UWS database pod |
+| uws.resources | object | See `values.yaml` | Resource limits and requests for the UWS database pod |
 | uws.tolerations | list | `[]` | Tolerations for the UWS database pod |
-| vaultSecretsPath | string | None, must be set | Path to the Vault secret (`secret/k8s_operator/<host>/tap`, for example) |

--- a/charts/cadc-tap/values.yaml
+++ b/charts/cadc-tap/values.yaml
@@ -1,6 +1,4 @@
 # Default values for cadc-tap.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
 
 # -- Override the base name for resources
 nameOverride: ""
@@ -21,11 +19,12 @@ ingress:
   # such as `/sync`, `/async`, and `/tables`
   authenticatedAnnotations: {}
 
-  # -- External path to the tap service, the path eventually gets rewritten
+  # -- External path to the TAP service, the path eventually gets rewritten
   # by tomcat.
   path: ""
 
 # -- Resource limits and requests for the TAP pod
+# @default -- See `values.yaml`
 resources:
   requests:
     cpu: 2.0
@@ -46,37 +45,32 @@ tolerations: []
 # -- Affinity rules for the TAP pod
 affinity: {}
 
-# -- Path to the Vault secret (`secret/k8s_operator/<host>/tap`, for example)
-# @default -- None, must be set
-vaultSecretsPath: ""
-
 config:
   # -- What type of backend are we connecting to?
-  # @default -- None, must be set to "pg" or "qserv"
+  # @default -- None, must be set to `pg` or `qserv`
   backend: ""
 
   pg:
     # -- Host to connect to
-    # @default -- None, must be set if backend is pg
+    # @default -- None, must be set if backend is `pg`
     host: ""
 
     # -- Database to connect to
-    # @default -- None, must be set if backend is pg
+    # @default -- None, must be set if backend is `pg`
     database: ""
 
     # -- Username to connect with
-    # @default -- None, must be set if backend is pg
+    # @default -- None, must be set if backend is `pg`
     username: ""
 
     image:
-      # -- tap image to use
+      # -- TAP image to use
       repository: "ghcr.io/lsst-sqre/tap-postgres-service"
 
-      # -- Pull policy for the tap image
+      # -- Pull policy for the TAP image
       pullPolicy: "IfNotPresent"
 
-      # -- Tag of tap image to use
-      # @default -- Latest release
+      # -- Tag of TAP image to use
       tag: "1.15.0"
 
   qserv:
@@ -85,14 +79,13 @@ config:
     host: "mock-db:3306"
 
     image:
-      # -- tap image to use
+      # -- TAP image to use
       repository: "ghcr.io/lsst-sqre/lsst-tap-service"
 
-      # -- Pull policy for the tap image
+      # -- Pull policy for the TAP image
       pullPolicy: "IfNotPresent"
 
-      # -- Tag of tap image to use
-      # @default -- Latest release
+      # -- Tag of TAP image to use
       tag: "2.2.0"
 
   # -- Address to a MySQL database containing TAP schema data
@@ -102,15 +95,12 @@ config:
   datalinkPayloadUrl: "https://github.com/lsst/sdm_schemas/releases/download/2.4.0/datalink-snippets.zip"
 
   # -- Name of GCS bucket in which to store results
-  # @default -- The common GCS bucket
   gcsBucket: "async-results.lsst.codes"
 
   # -- Base URL for results stored in GCS bucket
-  # @default -- The common GCS bucket
   gcsBucketUrl: "https://tap-files.lsst.codes"
 
   # -- GCS bucket type (GCS or S3)
-  # @default -- GCS
   gcsBucketType: "GCS"
 
   # -- Java heap size, which will set the maximum size of the heap. Otherwise
@@ -191,10 +181,10 @@ uws:
     pullPolicy: "IfNotPresent"
 
     # -- Tag of UWS database image to use
-    # @default -- Version of QServ TAP image
     tag: "2.2.0"
 
   # -- Resource limits and requests for the UWS database pod
+  # @default -- See `values.yaml`
   resources:
     requests:
       cpu: 0.25


### PR DESCRIPTION
Stop hiding the version numbers of components from the generated documentation. Fix some capitalization and markup issues, and remove a stray Vault secrets path setting that isn't used.