### PR TITLE
Fix broken links in documentation

### DIFF
--- a/docs/applications/vault/index.rst
+++ b/docs/applications/vault/index.rst
@@ -13,9 +13,8 @@ It is intended to run under Roundtable, and there should only be one production 
 
 The Vault Agent Injector is not enabled since we instead use the :doc:`Vault Secrets Operator <../vault-secrets-operator/index>`.
 
-Vault is configured in HA mode with a public API endpoint accessible at https://vault.lsst.cloud, or https://vault-dev.lsst.cloud for the development instance.
+Vault is configured in HA mode with a public API endpoint accessible at ``vault.lsst.cloud``, or ``vault-dev.lsst.cloud`` for the development instance.
 TLS termination is done at the nginx ingress layer using a Let's Encrypt server certificate.
-The UI is available at `vault.lsst.cloud <https://vault.lsst.cloud/ui>`__ for the production instance, and `vault-dev.lsst.cloud <https://vault-dev.lsst.cloud/ui>`__ for the development instance.
 
 To directly manipulate the secrets stored in this Vault instance, use `lsstvaultutils <https://github.com/lsst-sqre/lsstvaultutils>`__ .
 However, in normal operation, secrets will be managed via each application's ``secrets.yaml`` and manual interaction with Vault and its data will not be necessary.

--- a/docs/applications/vault/migration.rst
+++ b/docs/applications/vault/migration.rst
@@ -5,7 +5,7 @@ Vault Migration
 If you want to migrate a Vault deployment from one GCP project and Kubernetes cluster to another, do the following:
 
 #. Create the resources required for the new Vault server in the new GCP project.
-   If you are not using Terraform via `the IDF deployment terraform configuration <https://github.com/https://github.com/lsst/idf_deploy/tree/main/environment/deployments/roundtable>`__ consult that repository to understand what resources you will need and create them by hand.
+   If you are not using Terraform via `the IDF deployment terraform configuration <https://github.com/lsst/idf_deploy/tree/main/environment/deployments/roundtable>`__ consult that repository to understand what resources you will need and create them by hand.
 #. Grant the new service account access to the KMS keyring and key used for unsealing in the old GCP project.
    This is necessary to be able to do a seal migration later.
    See `this StackOverflow answer <https://stackoverflow.com/questions/49214127/can-you-share-google-cloud-kms-keys-across-projects-with-service-roles>`__ for how to grant access.

--- a/docs/applications/vault/upgrade.rst
+++ b/docs/applications/vault/upgrade.rst
@@ -23,7 +23,7 @@ When merging an update, Argo CD will get confused about the upgrade status of Va
 Fixing this will require the manual intervention explained below.
 It's good practice to check if Vault itself has an update each time the Vault Helm chart is updated.
 
-To upgrade Vault itself, first change the pinned version in the ``dependencies.version`` setting for Vault in `applications/vault/Chart.yaml <https://github.com/lsst-sqre/phalanx/blob/master/application/vault/Chart.yaml>`__.
+To upgrade Vault itself, first change the pinned version in the ``dependencies.version`` setting for Vault in `applications/vault/Chart.yaml <https://github.com/lsst-sqre/phalanx/blob/main/applications/vault/Chart.yaml>`__.
 Then, after that change is merged and you have synced Argo CD to apply the changes in Kubernetes, follow the `Vault upgrade instructions <https://developer.hashicorp.com/vault/docs/platform/k8s/helm/run#upgrading-vault-servers>`__.
 You can skip the ``helm upgrade`` step, since Argo CD has already made the equivalent change.
 Where those instructions say to delete a pod, deleting it through Argo CD works correctly.


### PR DESCRIPTION
Several of the links in the new Vault documentation were incorrect. Stop linking to the UI; we don't want anyone to use it.