### PR TITLE
DM-43177: Switch base cluster to named LDAP server

### DIFF
--- a/applications/gafaelfawr/values-base.yaml
+++ b/applications/gafaelfawr/values-base.yaml
@@ -18,7 +18,7 @@ config:
     usernameClaim: "preferred_username"
 
   ldap:
-    url: "ldap://ipa.lsst.org"
+    url: "ldap://ipa1.ls.lsst.org"
     userDn: "uid=svc_rsp,cn=users,cn=accounts,dc=lsst,dc=cloud"
     userBaseDn: "cn=users,cn=accounts,dc=lsst,dc=cloud"
     uidAttr: "uidNumber"


### PR DESCRIPTION
Rather than using the DNS round-robin, which a running Gafaelfawr doesn't honor properly anyway, point directly to the main replica at the base cluster. This more closely parallels the configuration that we'll use for the summit.