### PR TITLE
DM-43177: Reconfigure the summit authentication

### DIFF
--- a/applications/gafaelfawr/values-summit.yaml
+++ b/applications/gafaelfawr/values-summit.yaml
@@ -6,8 +6,24 @@ config:
   slackAlerts: true
   databaseUrl: "postgresql://gafaelfawr@postgresdb01.cp.lsst.org/gafaelfawr"
 
-  github:
-    clientId: "220d64cbf46f9d2b7873"
+  oidc:
+    clientId: "rsp-summit"
+    audience: "rsp-summit"
+    loginUrl: "https://keycloak.cp.lsst.org/realms/master/protocol/openid-connect/auth"
+    tokenUrl: "https://keycloak.cp.lsst.org/realms/master/protocol/openid-connect/token"
+    issuer: "https://keycloak.cp.lsst.org/realms/master"
+    scopes:
+      - "openid"
+    usernameClaim: "preferred_username"
+
+  ldap:
+    url: "ldap://ipa1.cp.lsst.org"
+    userDn: "uid=svc_rsp,cn=users,cn=accounts,dc=lsst,dc=cloud"
+    userBaseDn: "cn=users,cn=accounts,dc=lsst,dc=cloud"
+    uidAttr: "uidNumber"
+    gidAttr: "gidNumber"
+    groupBaseDn: "cn=groups,cn=accounts,dc=lsst,dc=cloud"
+    groupSearchByDn: true
 
   # Support OpenID Connect clients like Chronograf.
   oidcServer:
@@ -16,83 +32,22 @@ config:
   # Allow access by GitHub team.
   groupMapping:
     "admin:jupyterlab":
-      - github:
-          organization: "lsst-sqre"
-          team: "square"
+      - "sqre"
     "exec:admin":
-      - github:
-          organization: "lsst-sqre"
-          team: "square"
-      - "lsst-sqre-square"
+      - "k8s-yagan-admin"
+      - "sqre"
     "exec:internal-tools":
-      - github:
-          organization: "lsst-sqre"
-          team: "square"
-      - github:
-          organization: "lsst-sqre"
-          team: "friends"
-      - github:
-          organization: "lsst-ts"
-          team: "summit-access"
-      - github:
-          organization: "rubin-summit"
-          team: "rsp-access"
+      - "rsp-summit"
     "exec:notebook":
-      - github:
-          organization: "lsst-sqre"
-          team: "square"
-      - github:
-          organization: "lsst-sqre"
-          team: "friends"
-      - github:
-          organization: "lsst-ts"
-          team: "summit-access"
-      - github:
-          organization: "rubin-summit"
-          team: "rsp-access"
+      - "rsp-summit"
     "exec:portal":
-      - github:
-          organization: "lsst-sqre"
-          team: "square"
-      - github:
-          organization: "lsst-sqre"
-          team: "friends"
-      - github:
-          organization: "lsst-ts"
-          team: "summit-access"
-      - github:
-          organization: "rubin-summit"
-          team: "rsp-access"
+      - "rsp-summit"
     "read:image":
-      - github:
-          organization: "lsst-sqre"
-          team: "square"
-      - github:
-          organization: "lsst-sqre"
-          team: "friends"
-      - github:
-          organization: "lsst-ts"
-          team: "summit-access"
-      - github:
-          organization: "rubin-summit"
-          team: "rsp-access"
+      - "rsp-summit"
     "read:tap":
-      - github:
-          organization: "lsst-sqre"
-          team: "square"
-      - github:
-          organization: "lsst-sqre"
-          team: "friends"
-      - github:
-          organization: "lsst-ts"
-          team: "summit-access"
-      - github:
-          organization: "rubin-summit"
-          team: "rsp-access"
+      - "rsp-summit"
     "write:sasquatch":
-      - github:
-          organization: "lsst-sqre"
-          team: "square"
+      - "sqre"
 
   initialAdmins:
     - "afausti"

--- a/applications/nublado/values-summit.yaml
+++ b/applications/nublado/values-summit.yaml
@@ -37,8 +37,8 @@ controller:
         - name: "home"
           source:
             type: "nfs"
-            serverPath: "/jhome"
-            server: "nfs1.cp.lsst.org"
+            serverPath: "/rsphome"
+            server: "nfs-rsphome.cp.lsst.org"
         - name: "project"
           source:
             type: "nfs"


### PR DESCRIPTION
Configure the summit for IPA authentication instead of GitHub. Switch to the new home directory NFS server and path, which will have the user files under the new usernames.