### PR TITLE
DM-43218: Add consdb KafkaUser

### DIFF
--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -435,6 +435,7 @@ Rubin Observatory's telemetry service.
 | strimzi-kafka.registry.ingress.hostname | string | `""` | Hostname for the Schema Registry. |
 | strimzi-kafka.registry.schemaTopic | string | `"registry-schemas"` | Name of the topic used by the Schema Registry |
 | strimzi-kafka.superusers | list | `["kafka-admin"]` | A list of usernames for users who should have global admin permissions. These users will be created, along with their credentials. |
+| strimzi-kafka.users.condsb.enabled | bool | `false` | Enable user consdb |
 | strimzi-kafka.users.kafdrop.enabled | bool | `false` | Enable user Kafdrop (deployed by parent Sasquatch chart). |
 | strimzi-kafka.users.kafkaConnectManager.enabled | bool | `false` | Enable user kafka-connect-manager |
 | strimzi-kafka.users.promptProcessing.enabled | bool | `false` | Enable user prompt-processing |

--- a/applications/sasquatch/charts/strimzi-kafka/README.md
+++ b/applications/sasquatch/charts/strimzi-kafka/README.md
@@ -56,6 +56,7 @@ A subchart to deploy Strimzi Kafka components for Sasquatch.
 | registry.ingress.hostname | string | `""` | Hostname for the Schema Registry. |
 | registry.schemaTopic | string | `"registry-schemas"` | Name of the topic used by the Schema Registry |
 | superusers | list | `["kafka-admin"]` | A list of usernames for users who should have global admin permissions. These users will be created, along with their credentials. |
+| users.condsb.enabled | bool | `false` | Enable user consdb |
 | users.kafdrop.enabled | bool | `false` | Enable user Kafdrop (deployed by parent Sasquatch chart). |
 | users.kafkaConnectManager.enabled | bool | `false` | Enable user kafka-connect-manager |
 | users.promptProcessing.enabled | bool | `false` | Enable user prompt-processing |

--- a/applications/sasquatch/charts/strimzi-kafka/templates/users.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/users.yaml
@@ -207,3 +207,35 @@ spec:
         host: "*"
         operation: Read
 {{- end }}
+{{- if .Values.users.consdb.enabled }}
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaUser
+metadata:
+  name: consdb
+  labels:
+    strimzi.io/cluster: {{ .Values.cluster.name }}
+spec:
+  authentication:
+    type: scram-sha-512
+    password:
+      valueFrom:
+        secretKeyRef:
+          name: sasquatch
+          key: consdb-password
+  authorization:
+    type: simple
+    acls:
+      - resource:
+          type: group
+          name: "*"
+          patternType: literal
+        operation: All
+      - resource:
+          type: topic
+          name: "*"
+          patternType: literal
+        type: allow
+        host: "*"
+        operation: All
+{{- end }}

--- a/applications/sasquatch/charts/strimzi-kafka/values.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/values.yaml
@@ -86,13 +86,13 @@ kafka:
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
-      - labelSelector:
-          matchExpressions:
-          - key: "app.kubernetes.io/name"
-            operator: In
-            values:
-            - kafka
-        topologyKey: "kubernetes.io/hostname"
+        - labelSelector:
+            matchExpressions:
+              - key: "app.kubernetes.io/name"
+                operator: In
+                values:
+                  - kafka
+          topologyKey: "kubernetes.io/hostname"
 
   # -- Tolerations for Kafka broker pod assignment.
   tolerations: []
@@ -128,13 +128,13 @@ zookeeper:
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
-      - labelSelector:
-          matchExpressions:
-          - key: "app.kubernetes.io/name"
-            operator: In
-            values:
-            - zookeeper
-        topologyKey: "kubernetes.io/hostname"
+        - labelSelector:
+            matchExpressions:
+              - key: "app.kubernetes.io/name"
+                operator: In
+                values:
+                  - zookeeper
+          topologyKey: "kubernetes.io/hostname"
 
   # -- Tolerations for Zookeeper pod assignment.
   tolerations: []
@@ -166,7 +166,7 @@ registry:
 # -- A list of usernames for users who should have global admin permissions.
 # These users will be created, along with their credentials.
 superusers:
-- kafka-admin
+  - kafka-admin
 
 users:
   replicator:
@@ -191,6 +191,10 @@ users:
 
   kafkaConnectManager:
     # -- Enable user kafka-connect-manager
+    enabled: false
+
+  condsb:
+    # -- Enable user consdb
     enabled: false
 
 mirrormaker2:

--- a/applications/sasquatch/secrets.yaml
+++ b/applications/sasquatch/secrets.yaml
@@ -12,6 +12,10 @@ TOKEN_SECRET:
     Chronograf token secret for OIDC authentication with Gafaelfawr.
   generate:
     type: password
+consdb-password:
+  description: >-
+    Consdb KafkaUser password.
+  if: strimzi-kafka.users.consdb.enabled
 influxdb-password:
   description: >-
     InfluxDB admin password.

--- a/applications/sasquatch/values-base.yaml
+++ b/applications/sasquatch/values-base.yaml
@@ -51,6 +51,8 @@ strimzi-kafka:
       enabled: true
     kafkaConnectManager:
       enabled: true
+    consdb:
+      enabled: true
 
 influxdb:
   persistence:
@@ -76,7 +78,6 @@ source-influxdb:
   ingress:
     enabled: true
     hostname: base-lsp.lsst.codes
-
 
 kafka-connect-manager:
   influxdbSink:

--- a/applications/sasquatch/values-summit.yaml
+++ b/applications/sasquatch/values-summit.yaml
@@ -29,6 +29,8 @@ strimzi-kafka:
       enabled: true
     kafkaConnectManager:
       enabled: true
+    consdb:
+      enabled: true
 
 influxdb:
   persistence:

--- a/applications/sasquatch/values-usdfdev.yaml
+++ b/applications/sasquatch/values-usdfdev.yaml
@@ -22,6 +22,8 @@ strimzi-kafka:
       enabled: true
     promptProcessing:
       enabled: true
+    consdb:
+      enabled: true
 
 influxdb:
   ingress:

--- a/applications/sasquatch/values-usdfint.yaml
+++ b/applications/sasquatch/values-usdfint.yaml
@@ -18,6 +18,8 @@ strimzi-kafka:
       enabled: true
     kafkaConnectManager:
       enabled: true
+    consdb:
+      enabled: true
 
 influxdb:
   ingress:

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -30,6 +30,8 @@ strimzi-kafka:
       enabled: true
     promptProcessing:
       enabled: true
+    consdb:
+      enabled: true
 
 influxdb:
   enabled: false


### PR DESCRIPTION
This user has broad permissions as a Kafka consumer.

The app can authenticate as user "consdb" and password corresponding to the consdb-password from the sasquatch secret / vault item.

The password is automatically provisioned in vault with Phalanx secrets.