### PR TITLE
DM-43246: Update to latest version of the Argo CD chart

### DIFF
--- a/applications/argocd/Chart.yaml
+++ b/applications/argocd/Chart.yaml
@@ -8,5 +8,5 @@ sources:
   - https://github.com/argoproj/argo-helm
 dependencies:
   - name: argo-cd
-    version: 5.55.0
+    version: 6.6.0
     repository: https://argoproj.github.io/argo-helm

--- a/applications/argocd/README.md
+++ b/applications/argocd/README.md
@@ -16,6 +16,7 @@ Kubernetes application manager
 | argo-cd.configs.cm."resource.compareoptions" | string | `"ignoreAggregatedRoles: true\n"` | Configure resource comparison |
 | argo-cd.configs.params."server.basehref" | string | `"/argo-cd"` | Base href for `index.html` when running under a reverse proxy |
 | argo-cd.configs.params."server.insecure" | bool | `true` | Do not use TLS (this is terminated at the ingress) |
+| argo-cd.configs.params."server.rootpath" | string | `"/argo-cd"` | Server root path when running under a reverse proxy |
 | argo-cd.configs.secret.createSecret | bool | `false` | Create the Argo CD secret (we manage this with Vault) |
 | argo-cd.controller.metrics.applicationLabels.enabled | bool | `true` | Enable adding additional labels to `argocd_app_labels` metric |
 | argo-cd.controller.metrics.applicationLabels.labels | list | `["name","instance"]` | Labels to add to `argocd_app_labels` metric |
@@ -27,7 +28,7 @@ Kubernetes application manager
 | argo-cd.server.ingress.annotations | object | Rewrite requests to remove `/argo-cd/` prefix | Additional annotations to add to the Argo CD ingress |
 | argo-cd.server.ingress.enabled | bool | `true` | Create an ingress for the Argo CD server |
 | argo-cd.server.ingress.ingressClassName | string | `"nginx"` | Ingress class to use for Argo CD ingress |
+| argo-cd.server.ingress.path | string | `"/argo-cd(/|$)(.*)"` | Paths to route to Argo CD |
 | argo-cd.server.ingress.pathType | string | `"ImplementationSpecific"` | Type of path expression for Argo CD ingress |
-| argo-cd.server.ingress.paths | list | `["/argo-cd(/|$)(.*)"]` | Paths to route to Argo CD |
 | argo-cd.server.metrics.enabled | bool | `true` | Enable server metrics service |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |

--- a/applications/argocd/values-base.yaml
+++ b/applications/argocd/values-base.yaml
@@ -1,9 +1,6 @@
 argo-cd:
-  server:
-    ingress:
-      hosts:
-        - "base-lsp.lsst.codes"
-    config:
+  configs:
+    cm:
       url: "https://base-lsp.lsst.codes/argo-cd"
       dex.config: |
         connectors:
@@ -18,8 +15,11 @@ argo-cd:
               clientSecret: $dex.clientSecret
               orgs:
                 - name: lsst-sqre
-
-    rbacConfig:
+    rbac:
       policy.csv: |
         g, lsst-sqre:friends, role:admin
         g, lsst-sqre:square, role:admin
+
+  server:
+    ingress:
+      hostname: "base-lsp.lsst.codes"

--- a/applications/argocd/values-ccin2p3.yaml
+++ b/applications/argocd/values-ccin2p3.yaml
@@ -1,10 +1,7 @@
 argo-cd:
-  server:
-    ingress:
-      hosts:
-        - "data-dev.lsst.eu"
-    config:
-      url: https://data-dev.lsst.eu/argo-cd
+  configs:
+    cm:
+      url: "https://data-dev.lsst.eu/argo-cd"
       dex.config: |
         connectors:
           # Auth using GitHub.
@@ -18,17 +15,10 @@ argo-cd:
               clientSecret: $dex.clientSecret
               orgs:
                 - name: rubin-lsst
-      # resource.customizations: |
-      #   networking.k8s.io/Ingress:
-      #     health.lua: |
-      #      hs = {}
-      #      hs.status = "Healthy"
-      #      return hs
-
-    rbacConfig:
+    rbac:
       policy.csv: |
         g, rubin-lsst:admin, role:admin
 
-  # configs:
-  #   secret:
-  #     createSecret: true
+  server:
+    ingress:
+      hostnmae: "data-dev.lsst.eu"

--- a/applications/argocd/values-idfdev.yaml
+++ b/applications/argocd/values-idfdev.yaml
@@ -1,10 +1,6 @@
 argo-cd:
-  server:
-    ingress:
-      hosts:
-        - "data-dev.lsst.cloud"
-
-    config:
+  configs:
+    cm:
       url: "https://data-dev.lsst.cloud/argo-cd"
       dex.config: |
         connectors:
@@ -19,8 +15,7 @@ argo-cd:
               hostedDomains:
                 - lsst.cloud
               redirectURI: https://data-dev.lsst.cloud/argo-cd/api/dex/callback
-
-    rbacConfig:
+    rbac:
       policy.csv: |
         g, adam@lsst.cloud, role:admin
         g, afausti@lsst.cloud, role:admin
@@ -36,3 +31,7 @@ argo-cd:
         g, dirving@lsst.cloud, role:admin
         g, jeremym@lsst.cloud, role:admin
       scopes: "[email]"
+
+  server:
+    ingress:
+      hostname: "data-dev.lsst.cloud"

--- a/applications/argocd/values-idfint.yaml
+++ b/applications/argocd/values-idfint.yaml
@@ -1,10 +1,6 @@
 argo-cd:
-  server:
-    ingress:
-      hosts:
-        - "data-int.lsst.cloud"
-
-    config:
+  configs:
+    cm:
       url: "https://data-int.lsst.cloud/argo-cd"
       dex.config: |
         connectors:
@@ -19,8 +15,7 @@ argo-cd:
               hostedDomains:
                 - lsst.cloud
               redirectURI: https://data-int.lsst.cloud/argo-cd/api/dex/callback
-
-    rbacConfig:
+    rbac:
       policy.csv: |
         g, adam@lsst.cloud, role:admin
         g, afausti@lsst.cloud, role:admin
@@ -38,3 +33,7 @@ argo-cd:
         g, dirving@lsst.cloud, role:admin
         g, jeremym@lsst.cloud, role:admin
       scopes: "[email]"
+
+  server:
+    ingress:
+      hostname: "data-int.lsst.cloud"

--- a/applications/argocd/values-idfprod.yaml
+++ b/applications/argocd/values-idfprod.yaml
@@ -1,10 +1,6 @@
 argo-cd:
-  server:
-    ingress:
-      hosts:
-        - "data.lsst.cloud"
-
-    config:
+  configs:
+    cm:
       url: "https://data.lsst.cloud/argo-cd"
       dex.config: |
         connectors:
@@ -19,8 +15,7 @@ argo-cd:
               hostedDomains:
                 - lsst.cloud
               redirectURI: https://data.lsst.cloud/argo-cd/api/dex/callback
-
-    rbacConfig:
+    rbac:
       policy.csv: |
         g, adam@lsst.cloud, role:admin
         g, afausti@lsst.cloud, role:admin
@@ -32,3 +27,7 @@ argo-cd:
         g, loi@lsst.cloud, role:admin
         g, roby@lsst.cloud, role:admin
       scopes: "[email]"
+
+  server:
+    ingress:
+      hostname: "data.lsst.cloud"

--- a/applications/argocd/values-minikube.yaml
+++ b/applications/argocd/values-minikube.yaml
@@ -1,9 +1,8 @@
 argo-cd:
-  controller:
-    args:
-      repoServerTimeoutSeconds: "180"
+  configs:
+    params:
+      controller.repo.server.timeout.seconds: 180
 
   server:
     ingress:
-      hosts:
-        - "minikube.lsst.codes"
+      hostname: "minikube.lsst.codes"

--- a/applications/argocd/values-roe.yaml
+++ b/applications/argocd/values-roe.yaml
@@ -1,12 +1,10 @@
 argo-cd:
-  server:
-    ingress:
-      hosts:
-        - "rsp.lsst.ac.uk"
-
-    config:
-      url: "https://rsp.lsst.ac.uk/argo-cd"
-
   configs:
+    cm:
+      url: "https://rsp.lsst.ac.uk/argo-cd"
     secret:
       createSecret: true
+
+  server:
+    ingress:
+      hostname: "rsp.lsst.ac.uk"

--- a/applications/argocd/values-roundtable-dev.yaml
+++ b/applications/argocd/values-roundtable-dev.yaml
@@ -1,16 +1,6 @@
 argo-cd:
-  server:
-    ingress:
-      hosts:
-        - "roundtable-dev.lsst.cloud"
-      tls:
-        - hosts:
-            - "roundtable-dev.lsst.cloud"
-          secretName: "argocd-tls"
-      annotations:
-        cert-manager.io/cluster-issuer: "letsencrypt-dns"
-
-    config:
+  configs:
+    cm:
       url: "https://roundtable-dev.lsst.cloud/argo-cd"
       dex.config: |
         connectors:
@@ -25,8 +15,7 @@ argo-cd:
               hostedDomains:
                 - lsst.cloud
               redirectURI: https://roundtable-dev.lsst.cloud/argo-cd/api/dex/callback
-
-    rbacConfig:
+    rbac:
       policy.csv: |
         g, adam@lsst.cloud, role:admin
         g, afausti@lsst.cloud, role:admin
@@ -35,3 +24,10 @@ argo-cd:
         g, jsick@lsst.cloud, role:admin
         g, rra@lsst.cloud, role:admin
       scopes: "[email]"
+
+  server:
+    ingress:
+      annotations:
+        cert-manager.io/cluster-issuer: "letsencrypt-dns"
+      hostname: "roundtable-dev.lsst.cloud"
+      tls: true

--- a/applications/argocd/values-roundtable-prod.yaml
+++ b/applications/argocd/values-roundtable-prod.yaml
@@ -1,16 +1,6 @@
 argo-cd:
-  server:
-    ingress:
-      hosts:
-        - "roundtable.lsst.cloud"
-      tls:
-        - hosts:
-            - "roundtable.lsst.cloud"
-          secretName: "argocd-tls"
-      annotations:
-        cert-manager.io/cluster-issuer: "letsencrypt-dns"
-
-    config:
+  configs:
+    cm:
       url: "https://roundtable.lsst.cloud/argo-cd"
       dex.config: |
         connectors:
@@ -25,8 +15,7 @@ argo-cd:
               hostedDomains:
                 - lsst.cloud
               redirectURI: https://roundtable.lsst.cloud/argo-cd/api/dex/callback
-
-    rbacConfig:
+    rbac:
       policy.csv: |
         g, adam@lsst.cloud, role:admin
         g, afausti@lsst.cloud, role:admin
@@ -35,3 +24,10 @@ argo-cd:
         g, jsick@lsst.cloud, role:admin
         g, rra@lsst.cloud, role:admin
       scopes: "[email]"
+
+  server:
+    ingress:
+      annotations:
+        cert-manager.io/cluster-issuer: "letsencrypt-dns"
+      hostname: "roundtable.lsst.cloud"
+      tls: true

--- a/applications/argocd/values-summit.yaml
+++ b/applications/argocd/values-summit.yaml
@@ -1,10 +1,6 @@
 argo-cd:
-  server:
-    ingress:
-      hosts:
-        - "summit-lsp.lsst.codes"
-
-    config:
+  configs:
+    cm:
       url: "https://summit-lsp.lsst.codes/argo-cd"
       dex.config: |
         connectors:
@@ -19,7 +15,11 @@ argo-cd:
               clientSecret: $dex.clientSecret
               orgs:
                 - name: lsst-sqre
-    rbacConfig:
+    rbac:
       policy.csv: |
         g, lsst-sqre:friends, role:admin
         g, lsst-sqre:square, role:admin
+
+  server:
+    ingress:
+      hostname: "summit-lsp.lsst.codes"

--- a/applications/argocd/values-tucson-teststand.yaml
+++ b/applications/argocd/values-tucson-teststand.yaml
@@ -1,10 +1,6 @@
 argo-cd:
-  server:
-    ingress:
-      hosts:
-        - "tucson-teststand.lsst.codes"
-
-    config:
+  configs:
+    cm:
       url: "https://tucson-teststand.lsst.codes/argo-cd"
       dex.config: |
         connectors:
@@ -19,7 +15,11 @@ argo-cd:
               clientSecret: $dex.clientSecret
               orgs:
                 - name: lsst-sqre
-    rbacConfig:
+    rbac:
       policy.csv: |
         g, lsst-sqre:friends, role:admin
         g, lsst-sqre:square, role:admin
+
+  server:
+    ingress:
+      hostname: "tucson-teststand.lsst.codes"

--- a/applications/argocd/values-usdf-tel-rsp.yaml
+++ b/applications/argocd/values-usdf-tel-rsp.yaml
@@ -1,42 +1,27 @@
 argo-cd:
-  redis:
-    enabled: true
-
-  server:
-    ingress:
-      enabled: true
-      hosts:
-        - "usdf-tel-rsp.slac.stanford.edu"
-      annotations:
-        kubernetes.io/ingress.class: nginx
-        nginx.ingress.kubernetes.io/rewrite-target: "/$2"
-      paths:
-        - /argo-cd(/|$)(.*)
-
-    extraArgs:
-      - "--basehref=/argo-cd"
-      - "--insecure=true"
-
+  global:
     env:
-      - name: HTTP_PROXY
-        value: http://squid.slac.stanford.edu:3128
-      - name: HTTPS_PROXY
-        value: http://squid.slac.stanford.edu:3128
-      - name: NO_PROXY
-        value: 127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.cluster.local,argocd-repo-server
+      - name: "HTTP_PROXY"
+        value: "http://squid.slac.stanford.edu:3128"
+      - name: "HTTPS_PROXY"
+        value: "http://squid.slac.stanford.edu:3128"
+      - name: "NO_PROXY"
+        value: "127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.cluster.local,argocd-repo-server"
 
-    config:
-      url: https://usdf-tel-rsp.slac.stanford.edu/argo-cd
+  configs:
+    cm:
+      url: "https://usdf-tel-rsp.slac.stanford.edu/argo-cd"
       oidc.config: |
         name: SLAC
         issuer: https://dex.slac.stanford.edu
         clientID: vcluster--usdf-tel-rsp
         clientSecret: $dex.clientSecret
-        # Optional set of OIDC scopes to request. If omitted, defaults to: ["openid", "profile", "email", "groups"]
+        # Optional set of OIDC scopes to request. If omitted, defaults to:
+        # ["openid", "profile", "email", "groups"]
         requestedScopes: ["openid", "profile", "email", "groups"]
         # Optional set of OIDC claims to request on the ID token.
         requestedIDTokenClaims: {"groups": {"essential": true}}
-    rbacConfig:
+    rbac:
       policy.csv: |
         g, ytl@slac.stanford.edu, role:admin
         g, ppascual@slac.stanford.edu, role:admin
@@ -53,32 +38,6 @@ argo-cd:
         g, mreuter@slac.stanford.edu, role:admin
       scopes: "[email]"
 
-      helm.repositories: |
-        - url: https://lsst-sqre.github.io/charts/
-          name: lsst-sqre
-        - url: https://charts.helm.sh/stable
-          name: stable
-
-  repoServer:
-
-    env:
-      - name: HTTP_PROXY
-        value: http://squid.slac.stanford.edu:3128
-      - name: HTTPS_PROXY
-        value: http://squid.slac.stanford.edu:3128
-      - name: NO_PROXY
-        value: 127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.cluster.local,argocd-repo-server
-
-  controller:
-
-    env:
-      - name: HTTP_PROXY
-        value: http://squid.slac.stanford.edu:3128
-      - name: HTTPS_PROXY
-        value: http://squid.slac.stanford.edu:3128
-      - name: NO_PROXY
-        value: 127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.cluster.local,argocd-repo-server
-
-  configs:
-    secret:
-      createSecret: false
+  server:
+    ingress:
+      hostname: "usdf-tel-rsp.slac.stanford.edu"

--- a/applications/argocd/values-usdfdev-alert-stream-broker.yaml
+++ b/applications/argocd/values-usdfdev-alert-stream-broker.yaml
@@ -1,33 +1,15 @@
 argo-cd:
-  configs:
-
-    params:
-      # -- Base href for `index.html` when running under a reverse proxy
-      server.basehref: "/"
-
-  server:
-    ingress:
-      enabled: true
-      hosts:
-        - "k8s.slac.stanford.edu"
-      annotations:
-        kubernetes.io/ingress.class: nginx
-        nginx.ingress.kubernetes.io/rewrite-target: "/$2"
-      paths:
-        - /usdf-alert-stream-broker-dev/argo-cd(/|$)(.*)
-    extraArgs:
-      - "--basehref=/usdf-alert-stream-broker-dev/argo-cd"
-      - "--insecure=true"
-
+  global:
     env:
-      - name: HTTP_PROXY
-        value: http://squid.slac.stanford.edu:3128
-      - name: HTTPS_PROXY
-        value: http://squid.slac.stanford.edu:3128
-      - name: NO_PROXY
-        value: 127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.cluster.local,argocd-repo-server
+      - name: "HTTP_PROXY"
+        value: "http://squid.slac.stanford.edu:3128"
+      - name: "HTTPS_PROXY"
+        value: "http://squid.slac.stanford.edu:3128"
+      - name: "NO_PROXY"
+        value: "127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.cluster.local,argocd-repo-server"
 
-    config:
+  configs:
+    cm:
       url: "https://k8s.slac.stanford.edu/usdf-alert-stream-broker-dev/argo-cd"
       oidc.config: |
         name: SLAC
@@ -38,8 +20,10 @@ argo-cd:
         requestedScopes: ["openid", "profile", "email", "groups"]
         # Optional set of OIDC claims to request on the ID token.
         requestedIDTokenClaims: {"groups": {"essential": true}}
-
-    rbacConfig:
+    params:
+      server.basehref: "/usdf-alert-stream-broker-dev/argo-cd"
+      server.rootpath: "/usdf-alert-stream-broker-dev/argo-cd"
+    rbac:
       policy.csv: |
         g, ytl@slac.stanford.edu, role:admin
         g, ppascual@slac.stanford.edu, role:admin
@@ -49,33 +33,7 @@ argo-cd:
         g, smart@slac.stanford.edu, role:admin
       scopes: "[email]"
 
-    helm.repositories: |
-      - url: https://lsst-sqre.github.io/charts/
-        name: lsst-sqre
-      - url: https://charts.helm.sh/stable
-        name: stable
-    repoServer:
-
-  env:
-    - name: HTTP_PROXY
-      value: http://sdfproxy.sdf.slac.stanford.edu:3128
-    - name: HTTPS_PROXY
-      value: http://sdfproxy.sdf.slac.stanford.edu:3128
-    - name: NO_PROXY
-      value: 127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.cluster.local,argocd-repo-server
-
-controller:
-
-  env:
-    - name: HTTP_PROXY
-      value: http://sdfproxy.sdf.slac.stanford.edu:3128
-    - name: HTTPS_PROXY
-      value: http://sdfproxy.sdf.slac.stanford.edu:3128
-    - name: NO_PROXY
-      value: 127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.cluster.local,argocd-repo-server
-
-  configs:
-    secret:
-      createSecret: false
-
-vaultSecretsPath: "secret/rubin/usdf-alert-stream-broker-dev/"
+  server:
+    ingress:
+      hostname: "k8s.slac.stanford.edu"
+      path: "/usdf-alert-stream-broker-dev/argo-cd(/|$)(.*)"

--- a/applications/argocd/values-usdfdev-prompt-processing.yaml
+++ b/applications/argocd/values-usdfdev-prompt-processing.yaml
@@ -1,44 +1,30 @@
 argo-cd:
-  configs:
-
-    params:
-      # -- Base href for `index.html` when running under a reverse proxy
-      server.basehref: "/"
-
-  server:
-    ingress:
-      enabled: true
-      hosts:
-        - "k8s.slac.stanford.edu"
-      annotations:
-        nginx.ingress.kubernetes.io/rewrite-target: "/$2"
-      paths:
-        - /usdf-prompt-processing-dev/argo-cd(/|$)(.*)
-    extraArgs:
-      - "--basehref=/usdf-prompt-processing-dev/argo-cd"
-      - "--insecure=true"
-
+  global:
     env:
-      - name: HTTP_PROXY
-        value: http://squid.slac.stanford.edu:3128
-      - name: HTTPS_PROXY
-        value: http://squid.slac.stanford.edu:3128
-      - name: NO_PROXY
-        value: 127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.cluster.local,argocd-repo-server
+      - name: "HTTP_PROXY"
+        value: "http://squid.slac.stanford.edu:3128"
+      - name: "HTTPS_PROXY"
+        value: "http://squid.slac.stanford.edu:3128"
+      - name: "NO_PROXY"
+        value: "127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.cluster.local,argocd-repo-server"
 
-    config:
+  configs:
+    cm:
       url: "https://k8s.slac.stanford.edu/usdf-prompt-processing-dev/argo-cd"
       oidc.config: |
         name: SLAC
         issuer: https://dex.slac.stanford.edu
         clientID: vcluster--usdf-prompt-processing-dev
         clientSecret: $dex.clientSecret
-        # Optional set of OIDC scopes to request. If omitted, defaults to: ["openid", "profile", "email", "groups"]
+        # Optional set of OIDC scopes to request. If omitted, defaults to:
+        # ["openid", "profile", "email", "groups"]
         requestedScopes: ["openid", "profile", "email", "groups"]
         # Optional set of OIDC claims to request on the ID token.
         requestedIDTokenClaims: {"groups": {"essential": true}}
-
-    rbacConfig:
+    params:
+      server.basehref: "/usdf-prompt-processing-dev/argo-cd"
+      server.rootpath: "/usdf-prompt-processing-dev/argo-cd"
+    rbac:
       policy.csv: |
         g, ytl@slac.stanford.edu, role:admin
         g, ppascual@slac.stanford.edu, role:admin
@@ -49,33 +35,7 @@ argo-cd:
         g, hchiang2@slac.stanford.edu, role:admin
       scopes: "[email]"
 
-    helm.repositories: |
-      - url: https://lsst-sqre.github.io/charts/
-        name: lsst-sqre
-      - url: https://charts.helm.sh/stable
-        name: stable
-    repoServer:
-
-  env:
-    - name: HTTP_PROXY
-      value: http://sdfproxy.sdf.slac.stanford.edu:3128
-    - name: HTTPS_PROXY
-      value: http://sdfproxy.sdf.slac.stanford.edu:3128
-    - name: NO_PROXY
-      value: 127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.cluster.local,argocd-repo-server
-
-controller:
-
-  env:
-    - name: HTTP_PROXY
-      value: http://sdfproxy.sdf.slac.stanford.edu:3128
-    - name: HTTPS_PROXY
-      value: http://sdfproxy.sdf.slac.stanford.edu:3128
-    - name: NO_PROXY
-      value: 127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.cluster.local,argocd-repo-server
-
-  configs:
-    secret:
-      createSecret: false
-
-vaultSecretsPath: "secret/rubin/usdf-prompt-processing-dev/"
+  server:
+    ingress:
+      hostname: "k8s.slac.stanford.edu"
+      path: "/usdf-prompt-processing-dev/argo-cd(/|$)(.*)"

--- a/applications/argocd/values-usdfdev.yaml
+++ b/applications/argocd/values-usdfdev.yaml
@@ -1,42 +1,27 @@
 argo-cd:
-  redis:
-    enabled: true
-
-  server:
-    ingress:
-      enabled: true
-      hosts:
-        - "usdf-rsp-dev.slac.stanford.edu"
-      annotations:
-        kubernetes.io/ingress.class: nginx
-        nginx.ingress.kubernetes.io/rewrite-target: "/$2"
-      paths:
-        - /argo-cd(/|$)(.*)
-
-    extraArgs:
-      - "--basehref=/argo-cd"
-      - "--insecure=true"
-
+  global:
     env:
-      - name: HTTP_PROXY
-        value: http://squid.slac.stanford.edu:3128
-      - name: HTTPS_PROXY
-        value: http://squid.slac.stanford.edu:3128
-      - name: NO_PROXY
-        value: 127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.cluster.local,argocd-repo-server
+      - name: "HTTP_PROXY"
+        value: "http://squid.slac.stanford.edu:3128"
+      - name: "HTTPS_PROXY"
+        value: "http://squid.slac.stanford.edu:3128"
+      - name: "NO_PROXY"
+        value: "127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.cluster.local,argocd-repo-server"
 
-    config:
-      url: https://usdf-rsp-dev.slac.stanford.edu/argo-cd
+  configs:
+    cm:
+      url: "https://usdf-rsp-dev.slac.stanford.edu/argo-cd"
       oidc.config: |
         name: SLAC
         issuer: https://dex.slac.stanford.edu
         clientID: usdf-rsp-dev-argocd
         clientSecret: $dex.clientSecret
-        # Optional set of OIDC scopes to request. If omitted, defaults to: ["openid", "profile", "email", "groups"]
+        # Optional set of OIDC scopes to request. If omitted, defaults to:
+        # ["openid", "profile", "email", "groups"]
         requestedScopes: ["openid", "profile", "email", "groups"]
         # Optional set of OIDC claims to request on the ID token.
         requestedIDTokenClaims: {"groups": {"essential": true}}
-    rbacConfig:
+    rbac:
       policy.csv: |
         g, ytl@slac.stanford.edu, role:admin
         g, ppascual@slac.stanford.edu, role:admin
@@ -61,31 +46,6 @@ argo-cd:
         g, jeremym@slac.stanford.edu, role:admin
       scopes: "[email]"
 
-      helm.repositories: |
-        - url: https://lsst-sqre.github.io/charts/
-          name: lsst-sqre
-        - url: https://charts.helm.sh/stable
-          name: stable
-  repoServer:
-
-    env:
-      - name: HTTP_PROXY
-        value: http://sdfproxy.sdf.slac.stanford.edu:3128
-      - name: HTTPS_PROXY
-        value: http://sdfproxy.sdf.slac.stanford.edu:3128
-      - name: NO_PROXY
-        value: 127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.cluster.local,argocd-repo-server
-
-  controller:
-
-    env:
-      - name: HTTP_PROXY
-        value: http://sdfproxy.sdf.slac.stanford.edu:3128
-      - name: HTTPS_PROXY
-        value: http://sdfproxy.sdf.slac.stanford.edu:3128
-      - name: NO_PROXY
-        value: 127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.cluster.local,argocd-repo-server
-
-  configs:
-    secret:
-      createSecret: false
+  server:
+    ingress:
+      hostname: "usdf-rsp-dev.slac.stanford.edu"

--- a/applications/argocd/values-usdfint.yaml
+++ b/applications/argocd/values-usdfint.yaml
@@ -1,42 +1,27 @@
 argo-cd:
-  redis:
-    enabled: true
-
-  server:
-    ingress:
-      enabled: true
-      hosts:
-        - "usdf-rsp-int.slac.stanford.edu"
-      annotations:
-        kubernetes.io/ingress.class: nginx
-        nginx.ingress.kubernetes.io/rewrite-target: "/$2"
-      paths:
-        - /argo-cd(/|$)(.*)
-
-    extraArgs:
-      - "--basehref=/argo-cd"
-      - "--insecure=true"
-
+  global:
     env:
-      - name: HTTP_PROXY
-        value: http://squid.slac.stanford.edu:3128
-      - name: HTTPS_PROXY
-        value: http://squid.slac.stanford.edu:3128
-      - name: NO_PROXY
-        value: 127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.cluster.local,argocd-repo-server
+      - name: "HTTP_PROXY"
+        value: "http://squid.slac.stanford.edu:3128"
+      - name: "HTTPS_PROXY"
+        value: "http://squid.slac.stanford.edu:3128"
+      - name: "NO_PROXY"
+        value: "127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.cluster.local,argocd-repo-server"
 
-    config:
-      url: https://usdf-rsp-int.slac.stanford.edu/argo-cd
+  configs:
+    cm:
+      url: "https://usdf-rsp-int.slac.stanford.edu/argo-cd"
       oidc.config: |
         name: SLAC
         issuer: https://dex.slac.stanford.edu
         clientID: "vcluster--usdf-rsp-int"
         clientSecret: $dex.clientSecret
-        # Optional set of OIDC scopes to request. If omitted, defaults to: ["openid", "profile", "email", "groups"]
+        # Optional set of OIDC scopes to request. If omitted, defaults to:
+        # ["openid", "profile", "email", "groups"]
         requestedScopes: ["openid", "profile", "email", "groups"]
         # Optional set of OIDC claims to request on the ID token.
         requestedIDTokenClaims: {"groups": {"essential": true}}
-    rbacConfig:
+    rbac:
       policy.csv: |
         g, ytl@slac.stanford.edu, role:admin
         g, ppascual@slac.stanford.edu, role:admin
@@ -56,31 +41,6 @@ argo-cd:
         g, jeremym@slac.stanford.edu, role:admin
       scopes: "[email]"
 
-      helm.repositories: |
-        - url: https://lsst-sqre.github.io/charts/
-          name: lsst-sqre
-        - url: https://charts.helm.sh/stable
-          name: stable
-  repoServer:
-
-    env:
-      - name: HTTP_PROXY
-        value: http://sdfproxy.sdf.slac.stanford.edu:3128
-      - name: HTTPS_PROXY
-        value: http://sdfproxy.sdf.slac.stanford.edu:3128
-      - name: NO_PROXY
-        value: 127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.cluster.local,argocd-repo-server
-
-  controller:
-
-    env:
-      - name: HTTP_PROXY
-        value: http://sdfproxy.sdf.slac.stanford.edu:3128
-      - name: HTTPS_PROXY
-        value: http://sdfproxy.sdf.slac.stanford.edu:3128
-      - name: NO_PROXY
-        value: 127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.cluster.local,argocd-repo-server
-
-  configs:
-    secret:
-      createSecret: false
+  server:
+    ingress:
+      hostname: "usdf-rsp-int.slac.stanford.edu"

--- a/applications/argocd/values-usdfprod-prompt-processing.yaml
+++ b/applications/argocd/values-usdfprod-prompt-processing.yaml
@@ -1,44 +1,30 @@
 argo-cd:
-  configs:
-
-    params:
-      # -- Base href for `index.html` when running under a reverse proxy
-      server.basehref: "/"
-
-  server:
-    ingress:
-      enabled: true
-      hosts:
-        - "k8s.slac.stanford.edu"
-      annotations:
-        nginx.ingress.kubernetes.io/rewrite-target: "/$2"
-      paths:
-        - /usdf-prompt-processing/argo-cd(/|$)(.*)
-    extraArgs:
-      - "--basehref=/usdf-prompt-processing/argo-cd"
-      - "--insecure=true"
-
+  global:
     env:
-      - name: HTTP_PROXY
-        value: http://squid.slac.stanford.edu:3128
-      - name: HTTPS_PROXY
-        value: http://squid.slac.stanford.edu:3128
-      - name: NO_PROXY
-        value: 127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.cluster.local,argocd-repo-server
+      - name: "HTTP_PROXY"
+        value: "http://squid.slac.stanford.edu:3128"
+      - name: "HTTPS_PROXY"
+        value: "http://squid.slac.stanford.edu:3128"
+      - name: "NO_PROXY"
+        value: "127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.cluster.local,argocd-repo-server"
 
-    config:
+  configs:
+    cm:
       url: "https://k8s.slac.stanford.edu/usdf-prompt-processing/argo-cd"
       oidc.config: |
         name: SLAC
         issuer: https://dex.slac.stanford.edu
         clientID: vcluster--usdf-prompt-processing
         clientSecret: $dex.clientSecret
-        # Optional set of OIDC scopes to request. If omitted, defaults to: ["openid", "profile", "email", "groups"]
+        # Optional set of OIDC scopes to request. If omitted, defaults to:
+        # ["openid", "profile", "email", "groups"]
         requestedScopes: ["openid", "profile", "email", "groups"]
         # Optional set of OIDC claims to request on the ID token.
         requestedIDTokenClaims: {"groups": {"essential": true}}
-
-    rbacConfig:
+    params:
+      server.basehref: "/usdf-prompt-processing/argo-cd"
+      server.rootpath: "/usdf-prompt-processing/argo-cd"
+    rbac:
       policy.csv: |
         g, ytl@slac.stanford.edu, role:admin
         g, ppascual@slac.stanford.edu, role:admin
@@ -49,33 +35,7 @@ argo-cd:
         g, hchiang2@slac.stanford.edu, role:admin
       scopes: "[email]"
 
-    helm.repositories: |
-      - url: https://lsst-sqre.github.io/charts/
-        name: lsst-sqre
-      - url: https://charts.helm.sh/stable
-        name: stable
-    repoServer:
-
-  env:
-    - name: HTTP_PROXY
-      value: http://sdfproxy.sdf.slac.stanford.edu:3128
-    - name: HTTPS_PROXY
-      value: http://sdfproxy.sdf.slac.stanford.edu:3128
-    - name: NO_PROXY
-      value: 127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.cluster.local,argocd-repo-server
-
-controller:
-
-  env:
-    - name: HTTP_PROXY
-      value: http://sdfproxy.sdf.slac.stanford.edu:3128
-    - name: HTTPS_PROXY
-      value: http://sdfproxy.sdf.slac.stanford.edu:3128
-    - name: NO_PROXY
-      value: 127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.cluster.local,argocd-repo-server
-
-  configs:
-    secret:
-      createSecret: false
-
-#vaultSecretsPath: "secret/rubin/usdf-prompt-processing-prod/"
+  server:
+    ingress:
+      hostname: "k8s.slac.stanford.edu"
+      path: "/usdf-prompt-processing/argo-cd(/|$)(.*)"

--- a/applications/argocd/values-usdfprod.yaml
+++ b/applications/argocd/values-usdfprod.yaml
@@ -1,42 +1,27 @@
 argo-cd:
-  redis:
-    enabled: true
-
-  server:
-    ingress:
-      enabled: true
-      hosts:
-        - "usdf-rsp.slac.stanford.edu"
-      annotations:
-        kubernetes.io/ingress.class: nginx
-        nginx.ingress.kubernetes.io/rewrite-target: "/$2"
-      paths:
-        - /argo-cd(/|$)(.*)
-
-    extraArgs:
-      - "--basehref=/argo-cd"
-      - "--insecure=true"
-
+  global:
     env:
-      - name: HTTP_PROXY
-        value: http://squid.slac.stanford.edu:3128
-      - name: HTTPS_PROXY
-        value: http://squid.slac.stanford.edu:3128
-      - name: NO_PROXY
-        value: 127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.cluster.local,argocd-repo-server
+      - name: "HTTP_PROXY"
+        value: "http://squid.slac.stanford.edu:3128"
+      - name: "HTTPS_PROXY"
+        value: "http://squid.slac.stanford.edu:3128"
+      - name: "NO_PROXY"
+        value: "127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.cluster.local,argocd-repo-server"
 
-    config:
-      url: https://usdf-rsp.slac.stanford.edu/argo-cd
+  configs:
+    cm:
+      url: "https://usdf-rsp.slac.stanford.edu/argo-cd"
       oidc.config: |
         name: SLAC
         issuer: https://dex.slac.stanford.edu
         clientID: usdf-rsp-argocd
         clientSecret: $dex.clientSecret
-        # Optional set of OIDC scopes to request. If omitted, defaults to: ["openid", "profile", "email", "groups"]
+        # Optional set of OIDC scopes to request. If omitted, defaults to:
+        # ["openid", "profile", "email", "groups"]
         requestedScopes: ["openid", "profile", "email", "groups"]
         # Optional set of OIDC claims to request on the ID token.
         requestedIDTokenClaims: {"groups": {"essential": true}}
-    rbacConfig:
+    rbac:
       policy.csv: |
         g, ytl@slac.stanford.edu, role:admin
         g, ppascual@slac.stanford.edu, role:admin
@@ -56,32 +41,6 @@ argo-cd:
         g, cslater@slac.stanford.edu, role:admin
       scopes: "[email]"
 
-      helm.repositories: |
-        - url: https://lsst-sqre.github.io/charts/
-          name: lsst-sqre
-        - url: https://charts.helm.sh/stable
-          name: stable
-
-  repoServer:
-
-    env:
-      - name: HTTP_PROXY
-        value: http://squid.slac.stanford.edu:3128
-      - name: HTTPS_PROXY
-        value: http://squid.slac.stanford.edu:3128
-      - name: NO_PROXY
-        value: 127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.cluster.local,argocd-repo-server
-
-  controller:
-
-    env:
-      - name: HTTP_PROXY
-        value: http://squid.slac.stanford.edu:3128
-      - name: HTTPS_PROXY
-        value: http://squid.slac.stanford.edu:3128
-      - name: NO_PROXY
-        value: 127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.cluster.local,argocd-repo-server
-
-  configs:
-    secret:
-      createSecret: false
+  server:
+    ingress:
+      hostname: "usdf-rsp.slac.stanford.edu"

--- a/applications/argocd/values.yaml
+++ b/applications/argocd/values.yaml
@@ -47,13 +47,13 @@ argo-cd:
       # @default -- Rewrite requests to remove `/argo-cd/` prefix
       annotations:
         nginx.ingress.kubernetes.io/rewrite-target: "/$2"
+        nginx.ingress.kubernetes.io/use-regex: "true"
 
       # -- Ingress class to use for Argo CD ingress
       ingressClassName: "nginx"
 
       # -- Paths to route to Argo CD
-      paths:
-        - "/argo-cd(/|$)(.*)"
+      path: "/argo-cd(/|$)(.*)"
 
       # -- Type of path expression for Argo CD ingress
       pathType: "ImplementationSpecific"
@@ -70,6 +70,9 @@ argo-cd:
 
       # -- Base href for `index.html` when running under a reverse proxy
       server.basehref: "/argo-cd"
+
+      # -- Server root path when running under a reverse proxy
+      server.rootpath: "/argo-cd"
 
     secret:
       # -- Create the Argo CD secret (we manage this with Vault)


### PR DESCRIPTION
Restructure the Argo CD configuration for the latest major revision of the Helm chart, which drops a lot of backward compatibility. Clean up the USDF Argo CD configurations by deleting a bunch of unnecessary settings and moving the proxy environment variable settings into the new global.env setting.