### PR TITLE
DM-43246: Further simplify Argo CD configuration

### DIFF
--- a/applications/argocd/README.md
+++ b/applications/argocd/README.md
@@ -25,10 +25,8 @@ Kubernetes application manager
 | argo-cd.notifications.metrics.enabled | bool | `true` | Enable notifications metrics service |
 | argo-cd.redis.metrics.enabled | bool | `true` | Enable Redis metrics service |
 | argo-cd.repoServer.metrics.enabled | bool | `true` | Enable repo server metrics service |
-| argo-cd.server.ingress.annotations | object | Rewrite requests to remove `/argo-cd/` prefix | Additional annotations to add to the Argo CD ingress |
 | argo-cd.server.ingress.enabled | bool | `true` | Create an ingress for the Argo CD server |
 | argo-cd.server.ingress.ingressClassName | string | `"nginx"` | Ingress class to use for Argo CD ingress |
-| argo-cd.server.ingress.path | string | `"/argo-cd(/|$)(.*)"` | Paths to route to Argo CD |
-| argo-cd.server.ingress.pathType | string | `"ImplementationSpecific"` | Type of path expression for Argo CD ingress |
+| argo-cd.server.ingress.path | string | `"/argo-cd"` | Paths to route to Argo CD |
 | argo-cd.server.metrics.enabled | bool | `true` | Enable server metrics service |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |

--- a/applications/argocd/values-usdfdev-alert-stream-broker.yaml
+++ b/applications/argocd/values-usdfdev-alert-stream-broker.yaml
@@ -36,4 +36,4 @@ argo-cd:
   server:
     ingress:
       hostname: "k8s.slac.stanford.edu"
-      path: "/usdf-alert-stream-broker-dev/argo-cd(/|$)(.*)"
+      path: "/usdf-alert-stream-broker-dev/argo-cd"

--- a/applications/argocd/values-usdfdev-prompt-processing.yaml
+++ b/applications/argocd/values-usdfdev-prompt-processing.yaml
@@ -38,4 +38,4 @@ argo-cd:
   server:
     ingress:
       hostname: "k8s.slac.stanford.edu"
-      path: "/usdf-prompt-processing-dev/argo-cd(/|$)(.*)"
+      path: "/usdf-prompt-processing-dev/argo-cd"

--- a/applications/argocd/values-usdfprod-prompt-processing.yaml
+++ b/applications/argocd/values-usdfprod-prompt-processing.yaml
@@ -38,4 +38,4 @@ argo-cd:
   server:
     ingress:
       hostname: "k8s.slac.stanford.edu"
-      path: "/usdf-prompt-processing/argo-cd(/|$)(.*)"
+      path: "/usdf-prompt-processing/argo-cd"

--- a/applications/argocd/values.yaml
+++ b/applications/argocd/values.yaml
@@ -43,20 +43,11 @@ argo-cd:
       # -- Create an ingress for the Argo CD server
       enabled: true
 
-      # -- Additional annotations to add to the Argo CD ingress
-      # @default -- Rewrite requests to remove `/argo-cd/` prefix
-      annotations:
-        nginx.ingress.kubernetes.io/rewrite-target: "/$2"
-        nginx.ingress.kubernetes.io/use-regex: "true"
-
       # -- Ingress class to use for Argo CD ingress
       ingressClassName: "nginx"
 
       # -- Paths to route to Argo CD
-      path: "/argo-cd(/|$)(.*)"
-
-      # -- Type of path expression for Argo CD ingress
-      pathType: "ImplementationSpecific"
+      path: "/argo-cd"
 
   configs:
     cm:


### PR DESCRIPTION
We can now set the root path for the server and avoid having to do a rewrite in the ingress, so go ahead and do that. This also means we don't have to use a regex for the ingress path.