### PR TITLE
DM-43205: Calibs fail to locally certify in Prompt Processing

### DIFF
--- a/applications/prompt-proto-service-hsc/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-hsc/values-usdfdev-prompt-processing.yaml
@@ -30,4 +30,7 @@ prompt-proto-service:
     endpointUrl: https://usdf-rsp-dev.slac.stanford.edu/sasquatch-rest-proxy
     auth_env: false
 
+  # A cache efficiency workaround breaks on RC2 tests; see DM-43205.
+  cacheCalibs: false
+
   fullnameOverride: "prompt-proto-service-hsc"

--- a/charts/prompt-proto-service/README.md
+++ b/charts/prompt-proto-service/README.md
@@ -16,6 +16,7 @@ Event-driven processing of camera images
 | affinity | object | `{}` |  |
 | apdb.namespace | string | None, must be set | Database namespace for the APDB |
 | apdb.url | string | None, must be set | URL to the APDB, in any form recognized by SQLAlchemy |
+| cacheCalibs | bool | `true` | Whether or not calibs should be cached between runs of a pod. This is a temporary flag that should only be unset in specific circumstances, and only in the development environment. |
 | containerConcurrency | int | `1` |  |
 | fullnameOverride | string | `"prompt-proto-service"` | Override the full name for resources (includes the release name) |
 | image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |

--- a/charts/prompt-proto-service/README.md
+++ b/charts/prompt-proto-service/README.md
@@ -17,7 +17,7 @@ Event-driven processing of camera images
 | apdb.namespace | string | None, must be set | Database namespace for the APDB |
 | apdb.url | string | None, must be set | URL to the APDB, in any form recognized by SQLAlchemy |
 | cacheCalibs | bool | `true` | Whether or not calibs should be cached between runs of a pod. This is a temporary flag that should only be unset in specific circumstances, and only in the development environment. |
-| containerConcurrency | int | `1` |  |
+| containerConcurrency | int | `1` | The number of Knative requests that can be handled simultaneously by one container |
 | fullnameOverride | string | `"prompt-proto-service"` | Override the full name for resources (includes the release name) |
 | image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
 | image.repository | string | `"ghcr.io/lsst-dm/prompt-service"` | Image to use in the PP deployment |

--- a/charts/prompt-proto-service/templates/prompt-proto-service.yaml
+++ b/charts/prompt-proto-service/templates/prompt-proto-service.yaml
@@ -13,27 +13,15 @@ spec:
     spec:
       containerConcurrency: {{ .Values.containerConcurrency }}
       initContainers:
-      - name: init-copy-pgpass
-        # Make a copy of the read-only secret so we can change owner
+      - name: init-pgpass
+        # Make a copy of the read-only secret that's owned by lsst
+        # lsst account is created by main image with id 1000
         image: busybox
-        command: ["sh", "-c", "cp -L /app/pg-mount/.pgpass /app/pgsql/"]
+        command: ["sh", "-c", "cp -L /app/pg-mount/.pgpass /app/pgsql/ && chown 1000:1000 /app/pgsql/.pgpass && chmod u=r,go-rwx /app/pgsql/.pgpass"]
         volumeMounts:
         - mountPath: /app/pg-mount
           name: pgpass-mount
           readOnly: true
-        - mountPath: /app/pgsql
-          name: pgpass-credentials-file
-      - name: init-chown-pgpass
-        image: busybox
-        command: ["sh", "-c", "chown 1000:1000 /app/pgsql/.pgpass"]  # lsst account created by main image
-        volumeMounts:
-        - mountPath: /app/pgsql
-          name: pgpass-credentials-file
-      - name: init-chmod-pgpass
-        image: busybox
-        # PostgreSQL refuses to read group- or world-readable files
-        command: ["sh", "-c", "chmod u=r,go-rwx /app/pgsql/.pgpass"]
-        volumeMounts:
         - mountPath: /app/pgsql
           name: pgpass-credentials-file
       containers:

--- a/charts/prompt-proto-service/templates/prompt-proto-service.yaml
+++ b/charts/prompt-proto-service/templates/prompt-proto-service.yaml
@@ -98,6 +98,8 @@ spec:
           value: "/tmp-butler"
         - name: SERVICE_LOG_LEVELS
           value: {{ .Values.logLevel }}
+        - name: DEBUG_CACHE_CALIBS
+          value: {{ if .Values.cacheCalibs }}'1'{{ else }}'0'{{ end }}
         volumeMounts:
         - mountPath: /tmp-butler
           name: ephemeral

--- a/charts/prompt-proto-service/values.yaml
+++ b/charts/prompt-proto-service/values.yaml
@@ -114,7 +114,7 @@ nameOverride: ""
 # -- Override the full name for resources (includes the release name)
 fullnameOverride: "prompt-proto-service"
 
-# The number of Knative requests that can be handled simultaneously by one container
+# -- The number of Knative requests that can be handled simultaneously by one container
 containerConcurrency: 1
 
 # -- Whether or not calibs should be cached between runs of a pod.

--- a/charts/prompt-proto-service/values.yaml
+++ b/charts/prompt-proto-service/values.yaml
@@ -117,6 +117,10 @@ fullnameOverride: "prompt-proto-service"
 # The number of Knative requests that can be handled simultaneously by one container
 containerConcurrency: 1
 
+# -- Whether or not calibs should be cached between runs of a pod.
+# This is a temporary flag that should only be unset in specific circumstances, and only in the development environment.
+cacheCalibs: true
+
 # -- Kubernetes YAML configs for extra container volume(s).
 # Any volumes required by other config options are automatically handled by the Helm chart.
 additionalVolumeMounts: []


### PR DESCRIPTION
This PR adds a flag to the Prompt Processing service that toggles caching calibs. While this is a useful feature, it causes the DM-41915 workaround to break in certain development environments. The flag is kept out of the published API as much as possible to make it easy to remove once calib handling is properly fixed.