### PR TITLE
DM-43264: Update Times Square with Slack error reporting

### DIFF
--- a/applications/times-square/Chart.yaml
+++ b/applications/times-square/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 type: application
 
 # The default version tag of the times-square docker image
-appVersion: "0.9.2"
+appVersion: "0.10.0"
 
 dependencies:
   - name: redis

--- a/applications/times-square/README.md
+++ b/applications/times-square/README.md
@@ -30,6 +30,7 @@ An API service for managing and rendering parameterized Jupyter notebooks.
 | config.profile | string | `"production"` | Run profile: "production" or "development" |
 | config.redisCacheUrl | string | Points to embedded Redis | URL for Redis html / noteburst job cache database |
 | config.redisQueueUrl | string | Points to embedded Redis | URL for Redis arq queue database |
+| config.worker.enableLivenessCheck | bool | `true` | Enable liveness checks for the arq queue |
 | fullnameOverride | string | `""` | Override the full name for resources (includes the release name) |
 | global.baseUrl | string | Set by times-square Argo CD Application | Base URL for the environment |
 | global.host | string | Set by times-square Argo CD Application | Host name for ingress |

--- a/applications/times-square/secrets.yaml
+++ b/applications/times-square/secrets.yaml
@@ -9,3 +9,7 @@ TS_GITHUB_APP_PRIVATE_KEY:
 TS_GITHUB_WEBHOOK_SECRET:
   description: >-
     Secret for the GitHub webhook.
+TS_SLACK_WEBHOOK_URL:
+  description: >-
+    Slack webhook URL for Times Square.
+    This is used to send messages to the Times Square Slack status channel.

--- a/applications/times-square/templates/deployment.yaml
+++ b/applications/times-square/templates/deployment.yaml
@@ -112,6 +112,11 @@ spec:
                 secretKeyRef:
                   name: {{ template "times-square.fullname" . }}-secret
                   key: "TS_GITHUB_APP_PRIVATE_KEY"
+            - name: "TS_SLACK_WEBHOOK_URL"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "times-square.fullname" . }}-secret
+                  key: "TS_SLACK_WEBHOOK_URL"
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/applications/times-square/templates/worker-deployment.yaml
+++ b/applications/times-square/templates/worker-deployment.yaml
@@ -105,6 +105,11 @@ spec:
                 secretKeyRef:
                   name: {{ template "times-square.fullname" . }}-secret
                   key: "TS_GITHUB_APP_PRIVATE_KEY"
+            - name: "TS_SLACK_WEBHOOK_URL"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "times-square.fullname" . }}-secret
+                  key: "TS_SLACK_WEBHOOK_URL"
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/applications/times-square/values-usdfdev.yaml
+++ b/applications/times-square/values-usdfdev.yaml
@@ -5,6 +5,8 @@ config:
   databaseUrl: "postgresql://timessquare@postgres.postgres/timessquare"
   githubAppId: "327289"
   enableGitHubApp: "True"
+  worker:
+    enableLivenessCheck: false # not compatible with USDF
 cloudsql:
   enabled: false
 redis:

--- a/applications/times-square/values.yaml
+++ b/applications/times-square/values.yaml
@@ -116,6 +116,10 @@ config:
   # -- GitHub organizations that can sync repos to Times Square (comma-separated).
   githubOrgs: "lsst,lsst-sqre,lsst-dm,lsst-ts,lsst-sitcom,lsst-pst"
 
+  worker:
+    # -- Enable liveness checks for the arq queue
+    enableLivenessCheck: true
+
 cloudsql:
   # -- Enable the Cloud SQL Auth Proxy sidecar, used with Cloud SQL databases
   # on Google Cloud


### PR DESCRIPTION
Deploys Times Square 0.10.0: https://github.com/lsst-sqre/phalanx/pull/3051

We've discovered that the arq liveness check is not compatible with the USDF (it runs fine on GKE/IDF). So we're disable it to avoid restarting the workers every 6 minutes.