### PR TITLE
DM-43264: Drop Times Square arq liveness probe

### DIFF
--- a/applications/times-square/templates/worker-deployment.yaml
+++ b/applications/times-square/templates/worker-deployment.yaml
@@ -71,14 +71,6 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["arq"]
           args: ["timessquare.worker.main.WorkerSettings"]
-          livenessProbe:
-            exec:
-              command:
-                - "arq"
-                - "--check"
-                - "timessquare.worker.main.WorkerSettings"
-            initialDelaySeconds: 360
-            periodSeconds: 15
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           envFrom:

--- a/applications/times-square/values-usdfdev.yaml
+++ b/applications/times-square/values-usdfdev.yaml
@@ -5,8 +5,6 @@ config:
   databaseUrl: "postgresql://timessquare@postgres.postgres/timessquare"
   githubAppId: "327289"
   enableGitHubApp: "True"
-  worker:
-    enableLivenessCheck: false # not compatible with USDF
 cloudsql:
   enabled: false
 redis:


### PR DESCRIPTION
The arq --check command consistently fails on USDF (but no on Google
Cloud). We'll drop this check for now until we can investigate fully.