### PR TITLE
DM-43288: Add Kubernetes resource limits for Cloud SQL

### DIFF
--- a/applications/gafaelfawr/templates/deployment.yaml
+++ b/applications/gafaelfawr/templates/deployment.yaml
@@ -38,6 +38,10 @@ spec:
             - "-instances={{ required "cloudsql.instanceConnectionName must be specified" .Values.cloudsql.instanceConnectionName }}=tcp:5432"
           image: "{{ .Values.cloudsql.image.repository }}:{{ .Values.cloudsql.image.tag }}"
           imagePullPolicy: {{ .Values.cloudsql.image.pullPolicy | quote }}
+          {{- with .Values.cloudsql.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
The Cloud SQL Auth Proxy sidecar containers didn't have resource limits defined. Use the same limits as are used for the standalone Cloud SQL Auth Proxy deployment.