### PR TITLE
DM-43288: Use recreate strategy for Gafaelfawr operator

### DIFF
--- a/applications/gafaelfawr/templates/deployment-operator.yaml
+++ b/applications/gafaelfawr/templates/deployment-operator.yaml
@@ -10,6 +10,8 @@ spec:
     matchLabels:
       {{- include "gafaelfawr.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: "operator"
+  strategy:
+    type: "Recreate"
   template:
     metadata:
       annotations:


### PR DESCRIPTION
Only one Gafaelfawr Kubernetes operator should be running at a time, so use the recreate strategy to ensure that the running pod is terminated before a new one is started.