### PR TITLE
DM-43288: Add more probes for Gafaelfawr

### DIFF
--- a/applications/gafaelfawr/Chart.yaml
+++ b/applications/gafaelfawr/Chart.yaml
@@ -1,16 +1,16 @@
 apiVersion: v2
 name: gafaelfawr
 version: 1.0.0
-description: Authentication and identity system
-home: https://gafaelfawr.lsst.io/
+description: "Authentication and identity system"
+home: "https://gafaelfawr.lsst.io/"
 sources:
-  - https://github.com/lsst-sqre/gafaelfawr
-appVersion: 10.0.1
+  - "https://github.com/lsst-sqre/gafaelfawr"
+appVersion: 10.1.0
 
 dependencies:
-  - name: redis
+  - name: "redis"
     version: 1.0.11
-    repository: https://lsst-sqre.github.io/charts/
+    repository: "https://lsst-sqre.github.io/charts/"
 
 annotations:
   phalanx.lsst.io/docs: |

--- a/applications/gafaelfawr/templates/deployment-operator.yaml
+++ b/applications/gafaelfawr/templates/deployment-operator.yaml
@@ -36,12 +36,23 @@ spec:
             {{- end }}
             - "kopf"
             - "run"
+            - "--liveness=http://0.0.0.0:8080/health"
             - "-A"
             - "--log-format=json"
             - "-m"
             - "gafaelfawr.operator"
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          livenessProbe:
+            httpGet:
+              path: "/health"
+              port: "http"
+            initialDelaySeconds: 60
+            periodSeconds: 60
+          ports:
+            - containerPort: 8080
+              name: "http"
+              protocol: "TCP"
           {{- with .Values.operator.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/applications/gafaelfawr/templates/deployment.yaml
+++ b/applications/gafaelfawr/templates/deployment.yaml
@@ -55,14 +55,27 @@ spec:
         - name: "gafaelfawr"
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          livenessProbe:
+            httpGet:
+              path: "/health"
+              port: "http"
+            periodSeconds: 60
           ports:
             - containerPort: 8080
               name: "http"
               protocol: "TCP"
+          {{- if (gt (int .Values.replicaCount) 1) }}
+          readinessProbe:
+            httpGet:
+              path: "/health"
+              port: "http"
+            periodSeconds: 60
+          {{- else }}
           readinessProbe:
             httpGet:
               path: "/"
               port: "http"
+          {{- end }}
           {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
Add a liveness problem for both the main Gafaelfawr deployment and the Kubernetes operator. The former uses the new /health endpoint, and the latter uses a newly-configured Kopf-provided /health endpoint. If there is more than one Gafaelfawr replica, switch the readiness probe for the main Gafaelfawr deployment to use the same health check as the liveness probe so that traffic will be routed away when it starts failing.