### PR TITLE
DM-43322: Update Jira URL to atlassian cloud for Jira Data Proxy

### DIFF
--- a/applications/jira-data-proxy/README.md
+++ b/applications/jira-data-proxy/README.md
@@ -15,7 +15,7 @@ Jira API read-only proxy for Times Square users.
 | autoscaling.maxReplicas | int | `100` | Maximum number of jira-data-proxy deployment pods |
 | autoscaling.minReplicas | int | `1` | Minimum number of jira-data-proxy deployment pods |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU utilization of jira-data-proxy deployment pods |
-| config.jiraUrl | string | `"https://jira.lsstcorp.org/"` | Jira base URL |
+| config.jiraUrl | string | `"https://rubinobs.atlassian.net/"` | Jira base URL |
 | config.logLevel | string | `"info"` | Logging level |
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |

--- a/applications/jira-data-proxy/values.yaml
+++ b/applications/jira-data-proxy/values.yaml
@@ -7,7 +7,7 @@ config:
   logLevel: "info"
 
   # -- Jira base URL
-  jiraUrl: "https://jira.lsstcorp.org/"
+  jiraUrl: "https://rubinobs.atlassian.net/"
 
 # -- Number of web deployment pods to start
 replicaCount: 2


### PR DESCRIPTION
This points Jira Data Proxy to rubinobs.atlassian.net in usdf-rsp-dev, idfdev, roundtable-dev, and roundtable-prod.