### PR TITLE
DM-43287: HSC GPU Application

### DIFF
--- a/applications/prompt-proto-service-hsc-gpu/Chart.yaml
+++ b/applications/prompt-proto-service-hsc-gpu/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: prompt-proto-service-hsc-gpu
+version: 1.0.0
+description: >-
+  Prompt Proto Service is an event driven service for processing camera
+  images. This instance of the service handles HSC images with GPU.
+home: https://github.com/lsst-dm/prompt_processing/blob/main/doc/playbook.rst
+sources:
+  - https://github.com/lsst-dm/prompt_processing
+annotations:
+  phalanx.lsst.io/docs: |
+    - id: "DMTN-219"
+      title: "Proposal and Prototype for Prompt Processing"
+      url: "https://dmtn-219.lsst.io/"
+    - id: "DMTN-260"
+      title: "Failure Modes and Error Handling for Prompt Processing"
+      url: "https://dmtn-260.lsst.io/"
+dependencies:
+  - name: prompt-proto-service
+    version: 1.0.0
+    repository: "file://../../charts/prompt-proto-service"

--- a/applications/prompt-proto-service-hsc-gpu/README.md
+++ b/applications/prompt-proto-service-hsc-gpu/README.md
@@ -1,6 +1,6 @@
-# prompt-proto-service-hsc
+# prompt-proto-service-hsc-gpu
 
-Prompt Proto Service is an event driven service for processing camera images. This instance of the service handles HSC images.
+Prompt Proto Service is an event driven service for processing camera images. This instance of the service handles HSC images with GPU.
 
 **Homepage:** <https://github.com/lsst-dm/prompt_processing/blob/main/doc/playbook.rst>
 
@@ -30,8 +30,8 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.knative.cpuRequest | string | `"1"` | The cpu cores requested. |
 | prompt-proto-service.knative.ephemeralStorageLimit | string | `"20Gi"` | The maximum storage space allowed for each container (mostly local Butler). |
 | prompt-proto-service.knative.ephemeralStorageRequest | string | `"20Gi"` | The storage space reserved for each container (mostly local Butler). |
-| prompt-proto-service.knative.gpu | bool | `false` | GPUs enabled. |
-| prompt-proto-service.knative.gpuRequest | string | `"0"` | The number of GPUs to request. |
+| prompt-proto-service.knative.gpu | bool | `true` | GPUs enabled. |
+| prompt-proto-service.knative.gpuRequest | string | `"1"` | The number of GPUs to request. |
 | prompt-proto-service.knative.idleTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service (seconds). |
 | prompt-proto-service.knative.memoryLimit | string | `"8Gi"` | The maximum memory limit. |
 | prompt-proto-service.knative.memoryRequest | string | `"2Gi"` | The minimum memory to request. |

--- a/applications/prompt-proto-service-hsc-gpu/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-hsc-gpu/values-usdfdev-prompt-processing.yaml
@@ -1,0 +1,33 @@
+prompt-proto-service:
+
+  podAnnotations:
+    # Update this field if using latest or static image tag in dev
+    revision: "1"
+
+  image:
+    repository: ghcr.io/lsst-dm/prompt-service
+    pullPolicy: Always
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: latest
+
+  instrument:
+    pipelines: (survey="SURVEY")=[${PROMPT_PROCESSING_DIR}/pipelines/HSC/ApPipe.yaml]
+    calibRepo: s3://rubin-pp-dev-users/central_repo/
+    calibRepoPguser: hsc_prompt
+
+  s3:
+    imageBucket: rubin-pp-dev
+    endpointUrl: https://s3dfrgw.slac.stanford.edu
+
+  imageNotifications:
+    kafkaClusterAddress: prompt-processing-kafka-bootstrap.kafka:9092
+    topic: prompt-processing-dev
+
+  apdb:
+    url: postgresql://rubin@usdf-prompt-processing-dev.slac.stanford.edu:5432/lsst-devl
+
+  sasquatch:
+    endpointUrl: https://usdf-rsp-dev.slac.stanford.edu/sasquatch-rest-proxy
+    auth_env: false
+
+  fullnameOverride: "prompt-proto-service-hsc-gpu"

--- a/applications/prompt-proto-service-hsc-gpu/values.yaml
+++ b/applications/prompt-proto-service-hsc-gpu/values.yaml
@@ -3,8 +3,8 @@ prompt-proto-service:
   # -- Annotations for the prompt-proto-service pod
   # @default -- See the `values.yaml` file.
   podAnnotations:
-    autoscaling.knative.dev/min-scale: "3"
-    autoscaling.knative.dev/max-scale: "30"
+    autoscaling.knative.dev/min-scale: "0"
+    autoscaling.knative.dev/max-scale: "100"
     autoscaling.knative.dev/target-utilization-percentage: "60"
     autoscaling.knative.dev/target-burst-capacity: "-1"
     queue.sidecar.serving.knative.dev/cpu-resource-request: "1"
@@ -27,13 +27,13 @@ prompt-proto-service:
 
   instrument:
     # -- The "short" name of the instrument
-    name: ""
+    name: HSC
     # -- Machine-readable string describing which pipeline(s) should be run for which visits.
     # Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples.
     # @default -- None, must be set
     pipelines: ""
     # -- Skymap to use with the instrument
-    skymap: ""
+    skymap: hsc_rings_v1
     # -- URI to the shared repo used for calibrations, templates, and pipeline outputs.
     # If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself.
     # @default -- None, must be set
@@ -70,7 +70,7 @@ prompt-proto-service:
     # @default -- None, must be set
     url: ""
     # -- Database namespace for the APDB
-    namespace: pp_apdb_lsstcomcam
+    namespace: pp_apdb_hsc
 
   registry:
     # -- If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted.
@@ -78,7 +78,7 @@ prompt-proto-service:
 
   # -- Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level).
   # @default -- log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING.
-  logLevel: ""
+  logLevel: "timer.lsst.activator=DEBUG"
 
   sasquatch:
     # -- Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload.
@@ -99,9 +99,9 @@ prompt-proto-service:
     # -- The maximum storage space allowed for each container (mostly local Butler).
     ephemeralStorageLimit: "20Gi"
     # -- GPUs enabled.
-    gpu: false
+    gpu: true
     # -- The number of GPUs to request.
-    gpuRequest: "0"
+    gpuRequest: "1"
     # -- The minimum memory to request.
     memoryRequest: "2Gi"
     # -- The maximum memory limit.
@@ -112,3 +112,7 @@ prompt-proto-service:
     idleTimeout: 900
     # -- Maximum time that a container can send nothing to the fanout service after initial submission (seconds).
     responseStartTimeout: 900
+
+  # -- Kubernetes YAML configs for extra container volume(s).
+  # Any volumes required by other config options are automatically handled by the Helm chart.
+  additionalVolumeMounts: []

--- a/applications/prompt-proto-service-hsc/values.yaml
+++ b/applications/prompt-proto-service-hsc/values.yaml
@@ -98,6 +98,10 @@ prompt-proto-service:
     ephemeralStorageRequest: "20Gi"
     # -- The maximum storage space allowed for each container (mostly local Butler).
     ephemeralStorageLimit: "20Gi"
+    # -- GPUs enabled.
+    gpu: false
+    # -- The number of GPUs to request.
+    gpuRequest: "0"
     # -- The minimum memory to request.
     memoryRequest: "2Gi"
     # -- The maximum memory limit.

--- a/applications/prompt-proto-service-latiss/README.md
+++ b/applications/prompt-proto-service-latiss/README.md
@@ -30,6 +30,8 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.knative.cpuRequest | string | `"1"` | The cpu cores requested. |
 | prompt-proto-service.knative.ephemeralStorageLimit | string | `"20Gi"` | The maximum storage space allowed for each container (mostly local Butler). |
 | prompt-proto-service.knative.ephemeralStorageRequest | string | `"20Gi"` | The storage space reserved for each container (mostly local Butler). |
+| prompt-proto-service.knative.gpu | bool | `false` | GPUs enabled. |
+| prompt-proto-service.knative.gpuRequest | string | `"0"` | The number of GPUs to request. |
 | prompt-proto-service.knative.idleTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service (seconds). |
 | prompt-proto-service.knative.memoryLimit | string | `"8Gi"` | The maximum memory limit. |
 | prompt-proto-service.knative.memoryRequest | string | `"2Gi"` | The minimum memory to request. |

--- a/applications/prompt-proto-service-latiss/values.yaml
+++ b/applications/prompt-proto-service-latiss/values.yaml
@@ -98,6 +98,10 @@ prompt-proto-service:
     ephemeralStorageRequest: "20Gi"
     # -- The maximum storage space allowed for each container (mostly local Butler).
     ephemeralStorageLimit: "20Gi"
+    # -- GPUs enabled.
+    gpu: false
+    # -- The number of GPUs to request.
+    gpuRequest: "0"
     # -- The minimum memory to request.
     memoryRequest: "2Gi"
     # -- The maximum memory limit.

--- a/applications/prompt-proto-service-lsstcam/README.md
+++ b/applications/prompt-proto-service-lsstcam/README.md
@@ -30,6 +30,8 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.knative.cpuRequest | string | `"1"` | The cpu cores requested. |
 | prompt-proto-service.knative.ephemeralStorageLimit | string | `"20Gi"` | The maximum storage space allowed for each container (mostly local Butler). |
 | prompt-proto-service.knative.ephemeralStorageRequest | string | `"20Gi"` | The storage space reserved for each container (mostly local Butler). |
+| prompt-proto-service.knative.gpu | bool | `false` | GPUs enabled. |
+| prompt-proto-service.knative.gpuRequest | string | `"0"` | The number of GPUs to request. |
 | prompt-proto-service.knative.idleTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service (seconds). |
 | prompt-proto-service.knative.memoryLimit | string | `"8Gi"` | The maximum memory limit. |
 | prompt-proto-service.knative.memoryRequest | string | `"2Gi"` | The minimum memory to request. |

--- a/applications/prompt-proto-service-lsstcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcam/values.yaml
@@ -98,6 +98,10 @@ prompt-proto-service:
     ephemeralStorageRequest: "20Gi"
     # -- The maximum storage space allowed for each container (mostly local Butler).
     ephemeralStorageLimit: "20Gi"
+    # -- GPUs enabled.
+    gpu: false
+    # -- The number of GPUs to request.
+    gpuRequest: "0"
     # -- The minimum memory to request.
     memoryRequest: "2Gi"
     # -- The maximum memory limit.

--- a/applications/prompt-proto-service-lsstcomcam/README.md
+++ b/applications/prompt-proto-service-lsstcomcam/README.md
@@ -29,6 +29,8 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.knative.cpuRequest | string | `"1"` | The cpu cores requested. |
 | prompt-proto-service.knative.ephemeralStorageLimit | string | `"20Gi"` | The maximum storage space allowed for each container (mostly local Butler). |
 | prompt-proto-service.knative.ephemeralStorageRequest | string | `"20Gi"` | The storage space reserved for each container (mostly local Butler). |
+| prompt-proto-service.knative.gpu | bool | `false` | GPUs enabled. |
+| prompt-proto-service.knative.gpuRequest | string | `"0"` | The number of GPUs to request. |
 | prompt-proto-service.knative.idleTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service (seconds). |
 | prompt-proto-service.knative.memoryLimit | string | `"8Gi"` | The maximum memory limit. |
 | prompt-proto-service.knative.memoryRequest | string | `"2Gi"` | The minimum memory to request. |

--- a/applications/prompt-proto-service-lsstcomcamsim/README.md
+++ b/applications/prompt-proto-service-lsstcomcamsim/README.md
@@ -30,6 +30,8 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.knative.cpuRequest | string | `"1"` | The cpu cores requested. |
 | prompt-proto-service.knative.ephemeralStorageLimit | string | `"20Gi"` | The maximum storage space allowed for each container (mostly local Butler). |
 | prompt-proto-service.knative.ephemeralStorageRequest | string | `"20Gi"` | The storage space reserved for each container (mostly local Butler). |
+| prompt-proto-service.knative.gpu | bool | `false` | GPUs enabled. |
+| prompt-proto-service.knative.gpuRequest | string | `"0"` | The number of GPUs to request. |
 | prompt-proto-service.knative.idleTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service (seconds). |
 | prompt-proto-service.knative.memoryLimit | string | `"8Gi"` | The maximum memory limit. |
 | prompt-proto-service.knative.memoryRequest | string | `"2Gi"` | The minimum memory to request. |

--- a/applications/prompt-proto-service-lsstcomcamsim/values.yaml
+++ b/applications/prompt-proto-service-lsstcomcamsim/values.yaml
@@ -98,6 +98,10 @@ prompt-proto-service:
     ephemeralStorageRequest: "20Gi"
     # -- The maximum storage space allowed for each container (mostly local Butler).
     ephemeralStorageLimit: "20Gi"
+    # -- GPUs enabled.
+    gpu: false
+    # -- The number of GPUs to request.
+    gpuRequest: "0"
     # -- The minimum memory to request.
     memoryRequest: "2Gi"
     # -- The maximum memory limit.

--- a/charts/prompt-proto-service/README.md
+++ b/charts/prompt-proto-service/README.md
@@ -34,6 +34,8 @@ Event-driven processing of camera images
 | knative.cpuRequest | string | `"1"` | The cpu cores requested. |
 | knative.ephemeralStorageLimit | string | `"20Gi"` | The maximum storage space allowed for each container (mostly local Butler). |
 | knative.ephemeralStorageRequest | string | `"20Gi"` | The storage space reserved for each container (mostly local Butler). |
+| knative.gpu | bool | `false` | GPUs enabled. |
+| knative.gpuRequest | string | `"0"` | The number of GPUs to request. |
 | knative.idleTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service (seconds). |
 | knative.memoryLimit | string | `"8Gi"` | The maximum memory limit. |
 | knative.memoryRequest | string | `"2Gi"` | The minimum memory to request. |

--- a/charts/prompt-proto-service/templates/prompt-proto-service.yaml
+++ b/charts/prompt-proto-service/templates/prompt-proto-service.yaml
@@ -118,6 +118,9 @@ spec:
             cpu: {{ .Values.knative.cpuLimit }}
             ephemeral-storage: {{ .Values.knative.ephemeralStorageLimit }}
             memory: {{ .Values.knative.memoryLimit }}
+            {{- if .Values.knative.gpu }}
+            nvidia.com/gpu: {{ .Values.knative.gpuRequest }}
+            {{- end }}
       volumes:
       - name: ephemeral
         emptyDir:
@@ -146,6 +149,11 @@ spec:
           items:
           - key: central_repo_file
             path: butler.yaml
+      {{- end }}
+      {{- if .Values.knative.gpu }}
+      tolerations:
+      - effect: NoSchedule
+        key: nvidia.com/gpu
       {{- end }}
       enableServiceLinks: false
       timeoutSeconds: {{ .Values.knative.timeout }}

--- a/charts/prompt-proto-service/values.yaml
+++ b/charts/prompt-proto-service/values.yaml
@@ -97,6 +97,10 @@ knative:
   ephemeralStorageRequest: "20Gi"
   # -- The maximum storage space allowed for each container (mostly local Butler).
   ephemeralStorageLimit: "20Gi"
+  # -- GPUs enabled.
+  gpu: false
+  # -- The number of GPUs to request.
+  gpuRequest: "0"
   # -- The minimum memory to request.
   memoryRequest: "2Gi"
   # -- The maximum memory limit.

--- a/docs/applications/index.rst
+++ b/docs/applications/index.rst
@@ -84,6 +84,7 @@ To learn how to develop applications for Phalanx, see the :doc:`/developers/inde
 
    next-visit-fan-out/index
    prompt-proto-service-hsc/index
+   prompt-proto-service-hsc-gpu/index
    prompt-proto-service-latiss/index
    prompt-proto-service-lsstcam/index
    prompt-proto-service-lsstcomcam/index

--- a/docs/applications/prompt-proto-service-hsc-gpu/index.rst
+++ b/docs/applications/prompt-proto-service-hsc-gpu/index.rst
@@ -1,0 +1,21 @@
+.. px-app:: prompt-proto-service-hsc-gpu
+
+########################################################################
+prompt-proto-service-hsc-gpu — Prompt processing for HSC images with GPU
+########################################################################
+
+Prompt Proto Service is an event driven service for processing camera images.
+This instance of the service handles HSC images.
+
+This and all of the other instances of the Prompt Proto Service use a shared chart in `charts/prompt-proto-service <https://github.com/lsst-sqre/phalanx/tree/main/charts/prompt-proto-service>`__.
+
+.. jinja:: prompt-proto-service-hsc-gpu
+   :file: applications/_summary.rst.jinja
+
+Guides
+======
+
+.. toctree::
+   :maxdepth: 2
+
+   values

--- a/docs/applications/prompt-proto-service-hsc-gpu/values.md
+++ b/docs/applications/prompt-proto-service-hsc-gpu/values.md
@@ -1,0 +1,12 @@
+```{px-app-values} prompt-proto-service-hsc-gpu
+```
+
+# Prompt Proto Service HSC Helm values reference
+
+Helm values reference table for the {px-app}`prompt-proto-service-hsc-gpu` application.
+
+```{include} ../../../applications/prompt-proto-service-hsc-gpu/README.md
+---
+start-after: "## Values"
+---
+```

--- a/environments/README.md
+++ b/environments/README.md
@@ -40,6 +40,7 @@
 | applications.postgres | bool | `false` | Enable the in-cluster PostgreSQL server. Use of this server is discouraged in favor of using infrastructure SQL, but will remain supported for use cases such as minikube test deployments. |
 | applications.production-tools | bool | `false` | Enable the production-tools application |
 | applications.prompt-proto-service-hsc | bool | `false` | Enable the prompt-proto-service-hsc application |
+| applications.prompt-proto-service-hsc-gpu | bool | `false` | Enable the prompt-proto-service-hsc-gpu application |
 | applications.prompt-proto-service-latiss | bool | `false` | Enable the prompt-proto-service-latiss application |
 | applications.prompt-proto-service-lsstcam | bool | `false` | Enable the prompt-proto-service-lsstcam application |
 | applications.prompt-proto-service-lsstcomcam | bool | `false` | Enable the prompt-proto-service-lsstcomcam application |

--- a/environments/templates/prompt-proto-service-hsc-gpu-application.yaml
+++ b/environments/templates/prompt-proto-service-hsc-gpu-application.yaml
@@ -1,0 +1,41 @@
+{{- if (index .Values "applications"  "prompt-proto-service-hsc-gpu") -}}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: prompt-proto-service-hsc-gpu
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  syncPolicy:
+    managedNamespaceMetadata:
+      labels:
+        argocd.argoproj.io/managed-by: argocd
+    syncOptions:
+    - CreateNamespace=true
+  destination:
+    namespace: prompt-proto-service-hsc-gpu
+    server: https://kubernetes.default.svc
+  ignoreDifferences:
+  - group: serving.knative.dev
+    kind: Service
+    jqPathExpressions:
+    - .spec.template.spec.containers[].resources.requests
+    - .spec.template.spec.containers[].resources.limits
+  project: default
+  source:
+    path: applications/prompt-proto-service-hsc-gpu
+    repoURL: {{ .Values.repoURL }}
+    targetRevision: {{ .Values.targetRevision }}
+    helm:
+      parameters:
+        - name: "global.host"
+          value: {{ .Values.fqdn | quote }}
+        - name: "global.baseUrl"
+          value: "https://{{ .Values.fqdn }}"
+        - name: "global.vaultSecretsPath"
+          value: {{ .Values.vaultPathPrefix | quote }}
+      valueFiles:
+        - "values.yaml"
+        - "values-{{ .Values.name }}.yaml"
+{{- end -}}

--- a/environments/values-usdfdev-prompt-processing.yaml
+++ b/environments/values-usdfdev-prompt-processing.yaml
@@ -9,6 +9,7 @@ applications:
   ingress-nginx: false
   next-visit-fan-out: true
   prompt-proto-service-hsc: true
+  prompt-proto-service-hsc-gpu: true
   prompt-proto-service-latiss: true
   prompt-proto-service-lsstcam: true
   prompt-proto-service-lsstcomcam: true

--- a/environments/values.yaml
+++ b/environments/values.yaml
@@ -172,6 +172,9 @@ applications:
   # -- Enable the prompt-proto-service-hsc application
   prompt-proto-service-hsc: false
 
+  # -- Enable the prompt-proto-service-hsc-gpu application
+  prompt-proto-service-hsc-gpu: false
+
   # -- Enable the prompt-proto-service-latiss application
   prompt-proto-service-latiss: false
 


### PR DESCRIPTION
Add prompt processing GPU application for HSC to perform testing.  Enables GPU support in disabled state on all other prompt processing applications.