### PR TITLE
tickets/DM-42303: add gitlfs monitoring for roundtable

### DIFF
--- a/applications/mobu/templates/deployment.yaml
+++ b/applications/mobu/templates/deployment.yaml
@@ -44,7 +44,12 @@ spec:
                   key: "token"
             - name: "MOBU_PATH_PREFIX"
               value: {{ .Values.config.pathPrefix | quote }}
-            {{- if (not .Values.config.debug) }}
+            {{- if (.Values.config.debug) }}
+            - name: "MOBU_LOGGING_PROFILE"
+              value: "development"
+            - name: "MOBU_LOG_LEVEL"
+              value: "debug"
+            {{- else }}
             - name: "MOBU_LOGGING_PROFILE"
               value: "production"
             {{- end }}

--- a/applications/mobu/values-roundtable-dev.yaml
+++ b/applications/mobu/values-roundtable-dev.yaml
@@ -1,5 +1,4 @@
 config:
-  debug: true
   autostart:
     - name: "gitlfs"
       count: 1
@@ -13,6 +12,3 @@ config:
           lfs_read_url: "https://git-lfs-dev.lsst.cloud/mobu/git-lfs-test"
           lfs_write_url: "https://git-lfs-dev-rw.lsst.cloud/mobu/git-lfs-test"
         restart: true
-image:
-  tag: "tickets-DM-43203"
-  pullPolicy: "Always"

--- a/applications/mobu/values-roundtable-dev.yaml
+++ b/applications/mobu/values-roundtable-dev.yaml
@@ -1,0 +1,18 @@
+config:
+  debug: true
+  autostart:
+    - name: "gitlfs"
+      count: 1
+      users:
+        - username: "bot-mobu-gitlfs"
+      scopes:
+        - "write:git-lfs"
+      business:
+        type: "GitLFS"
+        options:
+          lfs_read_url: "https://git-lfs-dev.lsst.cloud/mobu/git-lfs-test"
+          lfs_write_url: "https://git-lfs-dev-rw.lsst.cloud/mobu/git-lfs-test"
+        restart: true
+image:
+  tag: "tickets-DM-43203"
+  pullPolicy: "Always"

--- a/environments/values-roundtable-dev.yaml
+++ b/environments/values-roundtable-dev.yaml
@@ -14,6 +14,7 @@ applications:
   giftless: true
   jira-data-proxy: true
   kubernetes-replicator: true
+  mobu: true
   monitoring: true
   onepassword-connect: true
   ook: true

--- a/environments/values-roundtable-prod.yaml
+++ b/environments/values-roundtable-prod.yaml
@@ -14,6 +14,7 @@ applications:
   giftless: true
   jira-data-proxy: true
   kubernetes-replicator: true
+  mobu: true
   onepassword-connect: true
   ook: true
   sasquatch: true


### PR DESCRIPTION
Turn on mobu for roundtable-*, with gitlfs monkey enabled.  Requires that https://github.com/lsst-sqre/mobu/pull/339 be merged so we have a gitlfs monkey to enable.