### PR TITLE
Revert "Update sdm_schemas to 2.5.0 release"

### DIFF
--- a/charts/cadc-tap/README.md
+++ b/charts/cadc-tap/README.md
@@ -14,7 +14,7 @@ IVOA TAP service
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules for the TAP pod |
 | config.backend | string | None, must be set to `pg` or `qserv` | What type of backend are we connecting to? |
-| config.datalinkPayloadUrl | string | `"https://github.com/lsst/sdm_schemas/releases/download/2.5.0/datalink-snippets.zip"` | Datalink payload URL |
+| config.datalinkPayloadUrl | string | `"https://github.com/lsst/sdm_schemas/releases/download/2.4.0/datalink-snippets.zip"` | Datalink payload URL |
 | config.gcsBucket | string | `"async-results.lsst.codes"` | Name of GCS bucket in which to store results |
 | config.gcsBucketType | string | `"GCS"` | GCS bucket type (GCS or S3) |
 | config.gcsBucketUrl | string | `"https://tap-files.lsst.codes"` | Base URL for results stored in GCS bucket |
@@ -56,7 +56,7 @@ IVOA TAP service
 | tapSchema.affinity | object | `{}` | Affinity rules for the TAP schema database pod |
 | tapSchema.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the TAP schema image |
 | tapSchema.image.repository | string | `"lsstsqre/tap-schema-mock"` | TAP schema image to ue. This must be overridden by each environment with the TAP schema for that environment. |
-| tapSchema.image.tag | string | `"2.5.0"` | Tag of TAP schema image |
+| tapSchema.image.tag | string | `"2.4.0"` | Tag of TAP schema image |
 | tapSchema.nodeSelector | object | `{}` | Node selection rules for the TAP schema database pod |
 | tapSchema.podAnnotations | object | `{}` | Annotations for the TAP schema database pod |
 | tapSchema.resources | object | `{}` | Resource limits and requests for the TAP schema database pod |

--- a/charts/cadc-tap/values.yaml
+++ b/charts/cadc-tap/values.yaml
@@ -92,7 +92,7 @@ config:
   tapSchemaAddress: "cadc-tap-schema-db:3306"
 
   # -- Datalink payload URL
-  datalinkPayloadUrl: "https://github.com/lsst/sdm_schemas/releases/download/2.5.0/datalink-snippets.zip"
+  datalinkPayloadUrl: "https://github.com/lsst/sdm_schemas/releases/download/2.4.0/datalink-snippets.zip"
 
   # -- Name of GCS bucket in which to store results
   gcsBucket: "async-results.lsst.codes"
@@ -155,7 +155,7 @@ tapSchema:
     pullPolicy: "IfNotPresent"
 
     # -- Tag of TAP schema image
-    tag: "2.5.0"
+    tag: "2.4.0"
 
   # -- Resource limits and requests for the TAP schema database pod
   resources: {}


### PR DESCRIPTION
Reverts lsst-sqre/phalanx#3056

There is a bug in Firefly that needs to be fixed, having to do with `null` units when a column has a `time.epoch` UCD.

Rolling back the change to TAP_SCHEMA that tripped the bug.  Next week we will modify sdm_schemas itself to avoid triggering the bug until a bug-fixed version of Firefly can be deployed to production -- which might be the new-UI version of Firefly, not a patch on 2023.3.x.