### PR TITLE
DM-43342: Add new infrastructure Argo CD project

### DIFF
--- a/applications/argocd/values-idfdev.yaml
+++ b/applications/argocd/values-idfdev.yaml
@@ -17,19 +17,29 @@ argo-cd:
               redirectURI: https://data-dev.lsst.cloud/argo-cd/api/dex/callback
     rbac:
       policy.csv: |
+        p, role:developer, applications, *, */*, allow
+        p, role:developer, applications, get, infrastructure/*, allow
+        p, role:developer, applications, create, infrastructure/*, deny
+        p, role:developer, applications, update, infrastructure/*, deny
+        p, role:developer, applications, delete, infrastructure/*, deny
+        p, role:developer, applications, sync, infrastructure/*, deny
+        p, role:developer, applications, override, infrastructure/*, deny
+        p, role:developer, applications, action/*, infrastructure/*, deny
+
         g, adam@lsst.cloud, role:admin
         g, afausti@lsst.cloud, role:admin
         g, dspeck@lsst.cloud, role:admin
         g, frossie@lsst.cloud, role:admin
         g, jsick@lsst.cloud, role:admin
         g, rra@lsst.cloud, role:admin
-        g, gpdf@lsst.cloud, role:admin
-        g, loi@lsst.cloud, role:admin
-        g, roby@lsst.cloud, role:admin
-        g, kkoehler@lsst.cloud, role:admin
-        g, fritzm@lsst.cloud, role:admin
-        g, dirving@lsst.cloud, role:admin
-        g, jeremym@lsst.cloud, role:admin
+
+        g, dirving@lsst.cloud, role:developer
+        g, fritzm@lsst.cloud, role:developer
+        g, gpdf@lsst.cloud, role:developer
+        g, jeremym@lsst.cloud, role:developer
+        g, kkoehler@lsst.cloud, role:developer
+        g, loi@lsst.cloud, role:developer
+        g, roby@lsst.cloud, role:developer
       scopes: "[email]"
 
   server:

--- a/environments/templates/argocd-application.yaml
+++ b/environments/templates/argocd-application.yaml
@@ -9,7 +9,7 @@ spec:
   destination:
     namespace: "argocd"
     server: "https://kubernetes.default.svc"
-  project: "default"
+  project: "infrastructure"
   source:
     path: "applications/argocd"
     repoURL: {{ .Values.repoUrl | quote }}

--- a/environments/templates/cert-manager-application.yaml
+++ b/environments/templates/cert-manager-application.yaml
@@ -15,7 +15,7 @@ spec:
   destination:
     namespace: "cert-manager"
     server: "https://kubernetes.default.svc"
-  project: "default"
+  project: "infrastructure"
   source:
     path: "applications/cert-manager"
     repoURL: {{ .Values.repoUrl | quote }}

--- a/environments/templates/gafaelfawr-application.yaml
+++ b/environments/templates/gafaelfawr-application.yaml
@@ -15,7 +15,7 @@ spec:
   destination:
     namespace: "gafaelfawr"
     server: "https://kubernetes.default.svc"
-  project: "default"
+  project: "infrastructure"
   source:
     path: "applications/gafaelfawr"
     repoURL: {{ .Values.repoUrl | quote }}

--- a/environments/templates/ingress-nginx-application.yaml
+++ b/environments/templates/ingress-nginx-application.yaml
@@ -15,7 +15,7 @@ spec:
   destination:
     namespace: "ingress-nginx"
     server: "https://kubernetes.default.svc"
-  project: "default"
+  project: "infrastructure"
   source:
     path: "applications/ingress-nginx"
     repoURL: {{ .Values.repoUrl | quote }}

--- a/environments/templates/mobu-application.yaml
+++ b/environments/templates/mobu-application.yaml
@@ -15,7 +15,7 @@ spec:
   destination:
     namespace: "mobu"
     server: "https://kubernetes.default.svc"
-  project: "default"
+  project: "infrastructure"
   source:
     path: "applications/mobu"
     repoURL: {{ .Values.repoUrl | quote }}

--- a/environments/templates/postgres-application.yaml
+++ b/environments/templates/postgres-application.yaml
@@ -15,7 +15,7 @@ spec:
   destination:
     namespace: "postgres"
     server: "https://kubernetes.default.svc"
-  project: "default"
+  project: "infrastructure"
   source:
     path: "applications/postgres"
     repoURL: {{ .Values.repoUrl | quote }}

--- a/environments/templates/projects/infrastructure.yaml
+++ b/environments/templates/projects/infrastructure.yaml
@@ -1,0 +1,17 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: "infrastructure"
+  namespace: "argocd"
+spec:
+  clusterResourceWhitelist:
+    - group: "*"
+      kind: "*"
+  destinations:
+    - namespace: "*"
+      server: "*"
+  namespaceResourceWhitelist:
+    - group: "*"
+      kind: "*"
+  sourceRepos:
+    - "*"

--- a/environments/templates/strimzi-access-operator-application.yaml
+++ b/environments/templates/strimzi-access-operator-application.yaml
@@ -15,7 +15,7 @@ spec:
   destination:
     namespace: "strimzi-access-operator"
     server: "https://kubernetes.default.svc"
-  project: "default"
+  project: "infrastructure"
   source:
     path: "applications/strimzi-access-operator"
     repoURL: {{ .Values.repoUrl | quote }}

--- a/environments/templates/strimzi-application.yaml
+++ b/environments/templates/strimzi-application.yaml
@@ -15,7 +15,7 @@ spec:
   destination:
     namespace: "strimzi"
     server: "https://kubernetes.default.svc"
-  project: "default"
+  project: "infrastructure"
   source:
     path: "applications/strimzi"
     repoURL: {{ .Values.repoUrl | quote }}

--- a/environments/templates/vault-secrets-operator-application.yaml
+++ b/environments/templates/vault-secrets-operator-application.yaml
@@ -15,7 +15,7 @@ spec:
   destination:
     namespace: "vault-secrets-operator"
     server: "https://kubernetes.default.svc"
-  project: "default"
+  project: "infrastructure"
   source:
     path: "applications/vault-secrets-operator"
     repoURL: {{ .Values.repoUrl | quote }}

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -243,6 +243,11 @@ argocd app sync science-platform \
   --port-forward-namespace argocd \
   --timeout 30
 
+echo "Moving the top-level Argo CD application into infrastructure..."
+argocd app set science-platform --project infrastructure \
+  --port-forward \
+  --port-forward-namespace argocd
+
 echo "Syncing Argo CD..."
 timeout 30 argocd app sync argocd \
   --port-forward \


### PR DESCRIPTION
Create an Argo CD project named infrastructure and put the core Phalanx infrastructure applications in it. Use this to write new RBAC rules for idfdev that divide users into admins and developers and block write access to infrastructure applications by developers.