### PR TITLE
DM-43327: Update Times Square to 0.11.0

### DIFF
--- a/applications/times-square/Chart.yaml
+++ b/applications/times-square/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 type: application
 
 # The default version tag of the times-square docker image
-appVersion: "0.10.0"
+appVersion: "0.11.0"
 
 dependencies:
   - name: redis


### PR DESCRIPTION
Add HTML cache busting for page renders. See https://github.com/lsst-sqre/times-square/releases/tag/0.11.0