### PR TITLE
DM-43342: Require Argo CD projects when making applications

### DIFF
--- a/docs/applications/index.rst
+++ b/docs/applications/index.rst
@@ -6,99 +6,19 @@ Applications are individual *atomic* services that are configured and deployed t
 Each environment can opt whether to deploy an application, and also customize the configuration of the application.
 This section of the documentation describes each Phalanx application.
 
+Applications are divided into several Argo CD projects by type of application.
+These groupings are used for access control in some Phalanx environments.
+When creating a new Phalanx application, you will choose which of these groupings the application fits best into.
+
 To learn how to develop applications for Phalanx, see the :doc:`/developers/index` section.
 
 .. toctree::
-   :maxdepth: 1
-   :caption: Cluster infrastructure
+   :maxdepth: 2
 
-   argocd/index
-   cert-manager/index
-   ingress-nginx/index
-   gafaelfawr/index
-   postgres/index
-   vault-secrets-operator/index
-
-.. toctree::
-   :maxdepth: 1
-   :caption: Rubin Science Platform
-
-   butler/index
-   datalinker/index
-   filestore-backup/index
-   hips/index
-   livetap/index
-   mobu/index
-   noteburst/index
-   nublado/index
-   portal/index
-   semaphore/index
-   siav2/index
-   sqlproxy-cross-project/index
-   squareone/index
-   ssotap/index
-   tap/index
-   times-square/index
-   vo-cutouts/index
-   consdb/index
-
-.. toctree::
-   :maxdepth: 1
-   :caption: RSP+
-
-   argo-workflows/index
-   alert-stream-broker/index
-   exposurelog/index
-   jira-data-proxy/index
-   narrativelog/index
-   obsloctap/index
-   plot-navigator/index
-   production-tools/index
-   rubintv/index
-   sasquatch/index
-   schedview-prenight/index
-   schedview-snapshot/index
-   strimzi/index
-   strimzi-access-operator/index
-   telegraf/index
-   telegraf-ds/index
-
-.. toctree::
-   :maxdepth: 1
-   :caption: Roundtable
-
-   checkerboard/index
-   giftless/index
-   kubernetes-replicator/index
-   monitoring/index
-   onepassword-connect/index
-   ook/index
-   sqrbot-sr/index
-   squarebot/index
-   unfurlbot/index
-   vault/index
-
-.. toctree::
-   :maxdepth: 1
-   :caption: Prompt Processing
-
-   next-visit-fan-out/index
-   prompt-proto-service-hsc/index
-   prompt-proto-service-hsc-gpu/index
-   prompt-proto-service-latiss/index
-   prompt-proto-service-lsstcam/index
-   prompt-proto-service-lsstcomcam/index
-   prompt-proto-service-lsstcomcamsim/index
-
-.. toctree::
-   :maxdepth: 1
-   :caption: Rubin Observatory Control System
-
-   auxtel/index
-   calsys/index
-   control-system-test/index
-   eas/index
-   love/index
-   obssys/index
-   simonyitel/index
-   uws/index
+   infrastructure
+   rsp
+   rubin
+   roundtable
+   monitoring
+   prompt
+   telescope

--- a/docs/applications/infrastructure.rst
+++ b/docs/applications/infrastructure.rst
@@ -1,0 +1,18 @@
+######################
+Cluster infrastructure
+######################
+
+These applications provide the core functionality of a Phalanx environment.
+Access to write operations on these Argo CD applications is often restricted only to environment administrators.
+
+Argo CD project: ``infrastructure``
+
+.. toctree::
+   :maxdepth: 1
+
+   argocd/index
+   cert-manager/index
+   ingress-nginx/index
+   gafaelfawr/index
+   postgres/index
+   vault-secrets-operator/index

--- a/docs/applications/infrastructure.rst
+++ b/docs/applications/infrastructure.rst
@@ -14,5 +14,8 @@ Argo CD project: ``infrastructure``
    cert-manager/index
    ingress-nginx/index
    gafaelfawr/index
+   mobu/index
    postgres/index
+   strimzi/index
+   strimzi-access-operator/index
    vault-secrets-operator/index

--- a/docs/applications/monitoring.rst
+++ b/docs/applications/monitoring.rst
@@ -1,0 +1,14 @@
+##########
+Monitoring
+##########
+
+This collection of Argo CD applications provides monitoring and metrics collection services to Phalanx environments.
+
+Argo CD project: ``monitoring``
+
+.. toctree::
+   :maxdepth: 1
+
+   sasquatch/index
+   telegraf/index
+   telegraf-ds/index

--- a/docs/applications/prompt.rst
+++ b/docs/applications/prompt.rst
@@ -1,0 +1,18 @@
+#################
+Prompt processing
+#################
+
+These Argo CD applications constitute the Rubin Observatory Prompt Processing framework.
+
+Argo CD project: ``prompt``
+
+.. toctree::
+   :maxdepth: 1
+
+   next-visit-fan-out/index
+   prompt-proto-service-hsc/index
+   prompt-proto-service-hsc-gpu/index
+   prompt-proto-service-latiss/index
+   prompt-proto-service-lsstcam/index
+   prompt-proto-service-lsstcomcam/index
+   prompt-proto-service-lsstcomcamsim/index

--- a/docs/applications/roundtable.rst
+++ b/docs/applications/roundtable.rst
@@ -1,0 +1,25 @@
+##########
+Roundtable
+##########
+
+Roundtable is a collection of services maintained by the Rubin Observatory SQuaRE team that are unrelated to the Rubin Science Platform.
+They are deployed in the :px-env:`roundtable-prod` environment.
+This environment also provides the Vault and 1Password Connect services for SQuaRE-maintained Phalanx clusters.
+
+Argo CD project: ``roundtable``
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Roundtable
+
+   checkerboard/index
+   giftless/index
+   kubernetes-replicator/index
+   monitoring/index
+   onepassword-connect/index
+   ook/index
+   sqrbot-sr/index
+   squarebot/index
+   unfurlbot/index
+   vault/index
+

--- a/docs/applications/rsp.rst
+++ b/docs/applications/rsp.rst
@@ -13,8 +13,8 @@ Argo CD project: ``rsp``
    datalinker/index
    filestore-backup/index
    hips/index
+   jira-data-proxy/index
    livetap/index
-   mobu/index
    noteburst/index
    nublado/index
    portal/index
@@ -26,4 +26,3 @@ Argo CD project: ``rsp``
    tap/index
    times-square/index
    vo-cutouts/index
-   consdb/index

--- a/docs/applications/rsp.rst
+++ b/docs/applications/rsp.rst
@@ -1,0 +1,29 @@
+######################
+Rubin Science Platform
+######################
+
+These applications constitute the Rubin Science Platform, which provides a portal, user notebooks, and IVOA-compatible APIs for astronomers.
+
+Argo CD project: ``rsp``
+
+.. toctree::
+   :maxdepth: 1
+
+   butler/index
+   datalinker/index
+   filestore-backup/index
+   hips/index
+   livetap/index
+   mobu/index
+   noteburst/index
+   nublado/index
+   portal/index
+   semaphore/index
+   siav2/index
+   sqlproxy-cross-project/index
+   squareone/index
+   ssotap/index
+   tap/index
+   times-square/index
+   vo-cutouts/index
+   consdb/index

--- a/docs/applications/rubin.rst
+++ b/docs/applications/rubin.rst
@@ -9,10 +9,9 @@ Argo CD project: ``rubin``
 .. toctree::
    :maxdepth: 1
 
-   argo-workflows/index
    alert-stream-broker/index
+   consdb/index
    exposurelog/index
-   jira-data-proxy/index
    narrativelog/index
    obsloctap/index
    plot-navigator/index
@@ -20,5 +19,3 @@ Argo CD project: ``rubin``
    rubintv/index
    schedview-prenight/index
    schedview-snapshot/index
-   strimzi/index
-   strimzi-access-operator/index

--- a/docs/applications/rubin.rst
+++ b/docs/applications/rubin.rst
@@ -1,0 +1,24 @@
+#########################
+Additional Rubin services
+#########################
+
+These are additional Rubin-specific services that are outside the scope of the Rubin Science Platform itself but support Rubin observatory operations in other ways.
+
+Argo CD project: ``rubin``
+
+.. toctree::
+   :maxdepth: 1
+
+   argo-workflows/index
+   alert-stream-broker/index
+   exposurelog/index
+   jira-data-proxy/index
+   narrativelog/index
+   obsloctap/index
+   plot-navigator/index
+   production-tools/index
+   rubintv/index
+   schedview-prenight/index
+   schedview-snapshot/index
+   strimzi/index
+   strimzi-access-operator/index

--- a/docs/applications/telescope.rst
+++ b/docs/applications/telescope.rst
@@ -1,0 +1,19 @@
+##########################################
+Rubin Observatory telescope control system
+##########################################
+
+These applications constitute the telescope control system for Rubin Observatory.
+
+Argo CD project: ``telescope``
+
+.. toctree::
+   :maxdepth: 1
+
+   auxtel/index
+   calsys/index
+   control-system-test/index
+   eas/index
+   love/index
+   obssys/index
+   simonyitel/index
+   uws/index

--- a/docs/applications/telescope.rst
+++ b/docs/applications/telescope.rst
@@ -2,13 +2,14 @@
 Rubin Observatory telescope control system
 ##########################################
 
-These applications constitute the telescope control system for Rubin Observatory.
+These applications constitute the telescope control system for Rubin Observatory, plus some closely-related services and support infrastructure.
 
 Argo CD project: ``telescope``
 
 .. toctree::
    :maxdepth: 1
 
+   argo-workflows/index
    auxtel/index
    calsys/index
    control-system-test/index

--- a/docs/developers/helm-chart/add-application.rst
+++ b/docs/developers/helm-chart/add-application.rst
@@ -26,8 +26,8 @@ This should explain the purpose of the application and which environments should
 
 The :file:`values.md` file generally does not need to be modified.
 
-Add the new application to `docs/applications/index.rst <https://github.com/lsst-sqre/phalanx/blob/main/docs/applications/index.rst>`__ in the appropriate section.
-Please maintain the alphabetical sorting of each section.
+Add the new application to the appropriate :file:`docs/applications/{project}.rst` file, where *project* is the Argo CD project of your application (the value that you passed to ``--project`` when creating the application originally).
+Please maintain the alphabetical sorting of the applications.
 
 Configure other Phalanx applications
 ====================================

--- a/docs/developers/helm-chart/create-new-chart.rst
+++ b/docs/developers/helm-chart/create-new-chart.rst
@@ -10,10 +10,13 @@ Then, create the files for the new application, including the start of a Helm ch
 
 .. prompt:: bash
 
-   phalanx application create <application>
+   phalanx application create <application> --project <project>
 
 Replace ``<application>`` with the name of your new application, which will double as the name of the Helm chart.
 The application name must start with a lowercase letter and consist of lowercase letters, numbers, and hyphen (``-``).
+
+Replace ``<project>`` with the all-lowercase name of the Argo CD project that should contain the application.
+This must be chosen from the list of projects shown at :doc:`/applications/index`.
 
 By default, this will create a Helm chart for a FastAPI web service.
 Use the ``--starter`` flag to specify a different Helm chart starter.
@@ -29,6 +32,7 @@ empty
 
 You will be prompted for a short description of the application.
 Keep it succinct, ideally just a few words, and do not add a period at the end.
+The description must begin with a capital letter.
 
 Next steps
 ==========

--- a/docs/developers/helm-chart/create-new-chart.rst
+++ b/docs/developers/helm-chart/create-new-chart.rst
@@ -10,13 +10,10 @@ Then, create the files for the new application, including the start of a Helm ch
 
 .. prompt:: bash
 
-   phalanx application create <application> --project <project>
+   phalanx application create <application>
 
 Replace ``<application>`` with the name of your new application, which will double as the name of the Helm chart.
 The application name must start with a lowercase letter and consist of lowercase letters, numbers, and hyphen (``-``).
-
-Replace ``<project>`` with the all-lowercase name of the Argo CD project that should contain the application.
-This must be chosen from the list of projects shown at :doc:`/applications/index`.
 
 By default, this will create a Helm chart for a FastAPI web service.
 Use the ``--starter`` flag to specify a different Helm chart starter.
@@ -33,6 +30,10 @@ empty
 You will be prompted for a short description of the application.
 Keep it succinct, ideally just a few words, and do not add a period at the end.
 The description must begin with a capital letter.
+
+You will also be prompted for the Argo CD project to use for your application.
+This must be chosen from the list of projects at :doc:`/applications/index`.
+See the page for each project for a short description of what it should contain.
 
 Next steps
 ==========

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,9 @@ exclude = [
     "installer/**",
 ]
 line-length = 79
+target-version = "py312"
+
+[tool.ruff.lint]
 ignore = [
     "ANN101",  # self should not have a type annotation
     "ANN102",  # cls should not have a type annotation
@@ -185,9 +188,8 @@ ignore = [
     "ISC002",
 ]
 select = ["ALL"]
-target-version = "py312"
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "src/phalanx/**" = [
     "T201",    # print makes sense to use because Phalanx is interactive
 ]
@@ -199,22 +201,13 @@ target-version = "py312"
     "SLF001",  # tests are allowed to access private members
 ]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-first-party = ["phalanx", "tests"]
 split-on-trailing-comma = false
 
-[tool.ruff.flake8-bugbear]
-extend-immutable-calls = [
-    "fastapi.Form",
-    "fastapi.Header",
-    "fastapi.Depends",
-    "fastapi.Path",
-    "fastapi.Query",
-]
-
 # These are too useful as attributes or methods to allow the conflict with the
 # built-in to rule out their use.
-[tool.ruff.flake8-builtins]
+[tool.ruff.lint.flake8-builtins]
 builtins-ignorelist = [
     "all",
     "any",
@@ -224,9 +217,9 @@ builtins-ignorelist = [
     "type",
 ]
 
-[tool.ruff.flake8-pytest-style]
+[tool.ruff.lint.flake8-pytest-style]
 fixture-parentheses = false
 mark-parentheses = false
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 convention = "numpy"

--- a/src/phalanx/cli.py
+++ b/src/phalanx/cli.py
@@ -14,6 +14,7 @@ from safir.click import display_help
 
 from .constants import VAULT_WRITE_TOKEN_LIFETIME
 from .factory import Factory
+from .models.applications import Project
 from .models.environments import EnvironmentConfig
 from .models.helm import HelmStarter
 from .models.secrets import ConditionalSecretConfig, StaticSecrets
@@ -144,6 +145,14 @@ def application_add_helm_repos(
     ),
 )
 @click.option(
+    "-p",
+    "--project",
+    type=click.Choice([p.value for p in Project]),
+    prompt="Argo CD project",
+    show_choices=False,
+    help="Argo CD project for the application.",
+)
+@click.option(
     "-s",
     "--starter",
     type=click.Choice([s.value for s in HelmStarter]),
@@ -151,7 +160,12 @@ def application_add_helm_repos(
     help="Helm starter to use as the basis for the chart.",
 )
 def application_create(
-    name: str, *, starter: str, config: Path | None, description: str
+    name: str,
+    *,
+    config: Path | None,
+    description: str,
+    project: str,
+    starter: str,
 ) -> None:
     """Create a new application from a starter template.
 
@@ -173,7 +187,12 @@ def application_create(
         raise click.BadParameter("Description must start with capital letter")
     factory = Factory(config)
     application_service = factory.create_application_service()
-    application_service.create(name, HelmStarter(starter), description)
+    application_service.create(
+        name,
+        starter=HelmStarter(starter),
+        project=Project(project),
+        description=description,
+    )
 
 
 @application.command("lint")

--- a/src/phalanx/cli.py
+++ b/src/phalanx/cli.py
@@ -148,7 +148,11 @@ def application_add_helm_repos(
     "-p",
     "--project",
     type=click.Choice([p.value for p in Project]),
-    prompt="Argo CD project",
+    prompt=(
+        "Possible Argo CD projects are\n  "
+        + "\n  ".join(p.value for p in Project)
+        + "\nArgo CD project"
+    ),
     show_choices=False,
     help="Argo CD project for the application.",
 )

--- a/src/phalanx/data/application-template.yaml.jinja
+++ b/src/phalanx/data/application-template.yaml.jinja
@@ -15,7 +15,7 @@ spec:
   destination:
     namespace: "[[ name ]]"
     server: "https://kubernetes.default.svc"
-  project: "default"
+  project: "[[ project ]]"
   source:
     path: "applications/[[ name ]]"
     repoURL: {{ .Values.repoUrl | quote }}

--- a/src/phalanx/models/applications.py
+++ b/src/phalanx/models/applications.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from enum import Enum
 from typing import Any
 
 from pydantic import BaseModel, Field
@@ -13,6 +14,7 @@ __all__ = [
     "ApplicationConfig",
     "ApplicationInstance",
     "DocLink",
+    "Project",
 ]
 
 
@@ -38,6 +40,22 @@ class DocLink(BaseModel):
         return f"`{label} <{self.url}>`__"
 
 
+class Project(Enum):
+    """Valid choices for the Argo CD project of an application."""
+
+    infrastructure = "infrastructure"
+    rsp = "rsp"
+    rubin = "rubin"
+    roundtable = "roundtable"
+    monitoring = "monitoring"
+    prompt = "prompt"
+    telescope = "telescope"
+
+    # Temporarily permissible while the migration is happening, but will be
+    # removed in the future.
+    default = "default"
+
+
 class ApplicationConfig(BaseModel):
     """Configuration for a Phalanx application."""
 
@@ -47,7 +65,7 @@ class ApplicationConfig(BaseModel):
     namespace: str
     """Namespace to which the application is deployed."""
 
-    project: str
+    project: Project
     """Argo CD project to which this application belongs."""
 
     chart: dict[str, Any]
@@ -94,6 +112,9 @@ class ApplicationInstance(BaseModel):
 
     environment: str
     """Name of the environment for which the application is configured."""
+
+    project: Project
+    """Argo CD project to which this application belongs."""
 
     chart: dict[str, Any]
     """Parsed Helm :file:`Chart.yaml` file."""

--- a/src/phalanx/models/applications.py
+++ b/src/phalanx/models/applications.py
@@ -51,10 +51,6 @@ class Project(Enum):
     prompt = "prompt"
     telescope = "telescope"
 
-    # Temporarily permissible while the migration is happening, but will be
-    # removed in the future.
-    default = "default"
-
 
 class ApplicationConfig(BaseModel):
     """Configuration for a Phalanx application."""

--- a/tests/cli/application_test.py
+++ b/tests/cli/application_test.py
@@ -229,7 +229,9 @@ def test_create_prompt(tmp_path: Path) -> None:
     )
     assert result.output == (
         "Short description: Some application\n"
-        "Argo CD project: infrastructure\n"
+        "Possible Argo CD projects are\n  "
+        + "\n  ".join(p.value for p in Project)
+        + "\nArgo CD project: infrastructure\n"
     )
     assert result.exit_code == 0
 

--- a/tests/cli/application_test.py
+++ b/tests/cli/application_test.py
@@ -12,6 +12,7 @@ from git.repo import Repo
 from git.util import Actor
 
 from phalanx.factory import Factory
+from phalanx.models.applications import Project
 
 from ..support.cli import run_cli
 from ..support.data import (
@@ -63,6 +64,8 @@ def test_create(tmp_path: Path) -> None:
         "aaa-new-app",
         "--starter",
         "empty",
+        "--project",
+        "infrastructure",
         "--description",
         "First new app",
         "--config",
@@ -75,6 +78,8 @@ def test_create(tmp_path: Path) -> None:
         "application",
         "create",
         "hips",
+        "--project",
+        "rsp",
         "--description",
         "Some HiPS service",
         "--config",
@@ -89,6 +94,8 @@ def test_create(tmp_path: Path) -> None:
         "zzz-other-app",
         "--starter",
         "empty",
+        "--project",
+        "telescope",
         "--description",
         "Last new app",
         "--config",
@@ -131,6 +138,12 @@ def test_create(tmp_path: Path) -> None:
     assert "aaa-new-app" in environment.applications
     assert "hips" in environment.applications
     assert "zzz-other-app" in environment.applications
+    for app, project in (
+        ("aaa-new-app", Project.infrastructure),
+        ("hips", Project.rsp),
+        ("zzz-other-app", Project.telescope),
+    ):
+        assert environment.applications[app].project == project
     for app, expected in (
         ("aaa-new-app", "First new app"),
         ("hips", "Some HiPS service"),
@@ -157,6 +170,8 @@ def test_create_errors(tmp_path: Path) -> None:
         "application",
         "create",
         "some-really-long-app-name-please-do-not-do-this",
+        "--project",
+        "infrastructure",
         "--description",
         "Some really long description on top of the app name",
         "--config",
@@ -169,6 +184,8 @@ def test_create_errors(tmp_path: Path) -> None:
         "application",
         "create",
         "app",
+        "--project",
+        "infrastructure",
         "--description",
         "lowercase description",
         "--config",
@@ -176,6 +193,20 @@ def test_create_errors(tmp_path: Path) -> None:
         needs_config=False,
     )
     assert "Description must start with capital letter" in result.output
+    assert result.exit_code == 2
+    result = run_cli(
+        "application",
+        "create",
+        "app",
+        "--description",
+        "Description",
+        "--project",
+        "foo",
+        "--config",
+        str(config_path),
+        needs_config=False,
+    )
+    assert "'foo' is not one of" in result.output
     assert result.exit_code == 2
 
 
@@ -194,9 +225,12 @@ def test_create_prompt(tmp_path: Path) -> None:
         "--config",
         str(config_path),
         needs_config=False,
-        stdin="Some application\n",
+        stdin="Some application\ninfrastructure\n",
     )
-    assert result.output == "Short description: Some application\n"
+    assert result.output == (
+        "Short description: Some application\n"
+        "Argo CD project: infrastructure\n"
+    )
     assert result.exit_code == 0
 
     app_path = config_path / "applications" / "aaa-new-app"

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -52,7 +52,7 @@ def test_application_version() -> None:
 
 def test_enviroments() -> None:
     """Ensure applications don't have configs for unknown environments."""
-    factory = Factory(Path.cwd())
+    factory = Factory(Path(__file__).parent.parent)
     config_storage = factory.create_config_storage()
     environments = set(config_storage.list_environments())
     for app_name in config_storage.list_applications():

--- a/tests/data/input/environments/templates/nublado-application.yaml
+++ b/tests/data/input/environments/templates/nublado-application.yaml
@@ -15,7 +15,7 @@ spec:
   destination:
     namespace: "nublado"
     server: "https://kubernetes.default.svc"
-  project: "default"
+  project: "rsp"
   source:
     path: "applications/nublado"
     repoURL: {{ .Values.repoUrl | quote }}

--- a/tests/data/input/environments/templates/portal-application.yaml
+++ b/tests/data/input/environments/templates/portal-application.yaml
@@ -15,7 +15,7 @@ spec:
   destination:
     namespace: "portal"
     server: "https://kubernetes.default.svc"
-  project: "default"
+  project: "rsp"
   source:
     path: "applications/portal"
     repoURL: {{ .Values.repoUrl | quote }}

--- a/tests/data/input/environments/templates/tap-application.yaml
+++ b/tests/data/input/environments/templates/tap-application.yaml
@@ -15,7 +15,7 @@ spec:
   destination:
     namespace: "tap"
     server: "https://kubernetes.default.svc"
-  project: "default"
+  project: "rsp"
   source:
     path: "applications/tap"
     repoURL: {{ .Values.repoUrl | quote }}

--- a/tests/docs/applications_test.py
+++ b/tests/docs/applications_test.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+from phalanx.models.applications import Project
+
 
 def test_descriptions() -> None:
     """Ensure all application pages have proper short descriptions."""
@@ -29,10 +31,13 @@ def test_applications_index() -> None:
     """Ensure all applications are mentioned in the index."""
     doc_root = Path(__file__).parent.parent.parent / "docs" / "applications"
     seen = set()
-    with (doc_root / "index.rst").open() as fh:
-        for line in fh:
-            if m := re.match("^   ([^/]+)/index$", line):
-                seen.add(m.group(1))
+    for project in Project:
+        if project == Project.default:
+            continue
+        with (doc_root / (project.value + ".rst")).open() as fh:
+            for line in fh:
+                if m := re.match("^   ([^/]+)/index$", line):
+                    seen.add(m.group(1))
     root_path = Path(__file__).parent.parent.parent / "applications"
     for application in root_path.iterdir():
         if not application.is_dir():


### PR DESCRIPTION
When creating a new application, require an Argo CD project be provided. Break up the list of applications into separate files by project, and tell people to add their new application to the appropriate project. Check that each application is linked in the appropriate place for its project.

Sort all of the projects into the appropriate place in the documentation so that we can look at the resulting documentation build. The Argo CD applications were assigned to projects and the Argo CD projects were added in a separate, mechanical PR.