### PR TITLE
DM-43342: Update development docs for RBAC

### DIFF
--- a/docs/developers/deploy-from-a-branch.rst
+++ b/docs/developers/deploy-from-a-branch.rst
@@ -186,8 +186,6 @@ Once your branch is merged, remember to reset your application's Argo CD ``Appli
 
 #. In the application's page in Argo CD, click on the :guilabel:`Sync` button to redeploy the application from the default branch.
 
-Alternatively, you can find the application in the ``science-platform`` Argo CD application and sync it from there to reset the default branch and any other settings you changed.
-
 Next steps
 ==========
 

--- a/docs/developers/switch-environment-to-branch.rst
+++ b/docs/developers/switch-environment-to-branch.rst
@@ -8,6 +8,14 @@ This is documented in :doc:`deploy-from-a-branch`.
 If the application is not already deployed to a given environment, the Argo CD application for it will not exist and that process will not work.
 In this case, deploying your application from a branch requires the additional step of switching the Argo CD "app of apps" application to your branch first.
 
+.. note::
+
+   In Phalanx environments that are using role-based access control for Argo CD, regular developers will normally not have access to do this.
+   You will need to ask an environment administrator to take these steps for you.
+
+Process
+=======
+
 First, add your application to an environment on a Phalanx PR branch and push that branch to https://github.com/lsst-sqre/phalanx.
 Do not use a GitHub fork; the steps below require that your change be on a branch in that repository.
 


### PR DESCRIPTION
Remove the suggestion to restore an application to the main branch by syncing science-platform, since people will normally not have access. Document that switching science-platform to a branch may have to be done by the environment administrator.