### PR TITLE
DM-43342: Update Argo CD boostrap documentation

### DIFF
--- a/docs/applications/argocd/authentication.rst
+++ b/docs/applications/argocd/authentication.rst
@@ -9,11 +9,13 @@ Argo CD documentation recommends disabling the ``admin`` account once user acces
 We've chosen to ignore that advice in favor of having an easy and reliable emergency access mechanism that doesn't rely on any other service, and have instead created strong, randomized ``admin`` passwords.
 Still, normal Argo CD access should be done via SSO, both to minimize use of the ``admin`` password and for attribution of actions taken via the web UI.
 
-On :abbr:`IDF (Interim Data Facility)` installations, Argo CD is configured to use Google OAuth for SSO using the same Google Cloud Identity domain as is used for other IDF operations.
+In SQuaRE-run environments hosted on Google Kubernetes Engine, Argo CD is configured to use Google OAuth for SSO using the same Google Cloud Identity domain (``lsst.cloud``) as is used for other Google operations.
 On all other installations, Argo CD is configured to use GitHub.
 
-We do not use :doc:`Gafaelfawr <../gafaelfawr/index>` to protect Argo CD even though it would be capable of doing so because we want access to the cluster management UI to be independent of anything else running in the cluster.
-Argo CD is how we prefer to fix Gafaelfawr if it is broken, so it is configured to authenticate users directly and independently.
+.. note::
+
+   We do not use :doc:`Gafaelfawr <../gafaelfawr/index>` to protect Argo CD even though it would be capable of doing so because we want access to the cluster management UI to be independent of anything else running in the cluster.
+   Argo CD is how we prefer to fix Gafaelfawr if it is broken, so it is configured to authenticate users directly and independently.
 
 Configuring Google SSO
 ======================
@@ -52,23 +54,14 @@ To set up Google SSO authentication to Argo CD in a new cluster, take the follow
 #. Click on :guilabel:`Create`.
    This will pop up a dialog with the client ID and secret for the newly-created OAuth client.
 
-#. For SQuaRE-run enviroments, go to the RSP-Vault 1Password vault and create a new Login item with a name like "Argo CD Google OAuth - data-int.lsst.cloud" (replacing the last part with the FQDN of the environment).
-   In this secret, put the client ID in the username field.
-   Put the secret in the password field.
-   Create a field labeled ``generate_secrets_key`` with value ``argocd dex.clientSecret``.
-   Create a field labeled ``environment`` with value ``data-int.lsst.cloud`` (replace with the FQDN of the environment).
-   Save this 1Password secret.
+#. Store this secret as the ``dex.clientSecret`` key in the secret for the ``argocd`` application in your :ref:`static secrets store <admin-static-secrets>`, however those secrets are stored for your environment.
+   Then, sync secrets for your environment.
 
-#. If the environment already exists, get a Vault write token for the environment (or the Vault admin token) and set the ``dex.clientSecret`` key in the ``argocd`` secret in the Vault path for that environment (something like ``secret/k8s_operator/data-int.lsst.cloud``, replacing the last part with the FQDN of the environment).
-   This will add the value to the Argo CD secret once vault-secrets-operator notices the change.
-   You can delete ``argocd-secret`` to immediately recreate it to speed up the propagation.
-
-#. In the Phalanx repository, under ``applications/argocd``, edit the ``values-*.yaml`` file for the relevant environment.
-   In ``argo-cd.server.config``, at the same level as ``helm.repositories``, add the following, modifying the URLs and ``hostedDomains`` for the environment and changing the ``clientID`` to the value from the pop-up:
+#. In the Phalanx repository, under :file:`applications/argocd`, edit the :file:`values-{environment}.yaml` file for the relevant environment.
+   In ``argo-cd.configs.cm``, at the same level as ``url``, add the following, modifying the URLs and ``hostedDomains`` for the environment and changing the ``clientID`` to the value from the pop-up:
 
    .. code-block:: yaml
 
-      url: https://data-int.lsst.cloud/argo-cd
       dex.config: |
         connectors:
           # Auth using Google.
@@ -85,11 +78,11 @@ To set up Google SSO authentication to Argo CD in a new cluster, take the follow
 
    The value for ``clientSecret`` should literally be ``$dex.clientSecret``, which tells Argo CD to get it from the Argo CD configuration secret.
 
-#. In the same file, add a new ``argo-cd.server.rbacConfig`` key as follows:
+#. In the same file, add a new ``argo-cd.configs.rbac.`` key as follows:
 
    .. code-block:: yaml
 
-      rbacConfig:
+      rbac:
         policy.csv: |
           g, adam@lsst.cloud, role:admin
           g, afausti@lsst.cloud, role:admin
@@ -101,7 +94,6 @@ To set up Google SSO authentication to Argo CD in a new cluster, take the follow
    Change the list of users to the email addresses of the users who should have admin access to this environment.
 
 #. If the environment already exists, create a PR with the above changes, merge it, and then sync Argo CD.
-   Ensure that both the ``argocd-server`` and ``argocd-dex-server`` deployments are restarted (in case the Argo CD Helm chart doesn't ensure this).
 
 #. Go to the ``/argo-cd`` route on the environment.
    Log out if you're logged in with the admin password.
@@ -114,7 +106,7 @@ Configuring GitHub SSO
 
 To set up Google SSO authentication to Argo CD in a new cluster, take the following steps:
 
-#. From the GitHub page of the organization in which you want to create the OAuth application (such as `lsst-sqre <https://github.com/lsst-sqre>`__), go to :guilabel:`Settings → Developer Settings → OAuth Apps`.
+#. From the GitHub page of the organization in which you want to create the OAuth application (such as `lsst-sqre <https://github.com/lsst-sqre>`__), go to :menuselection:`Settings --> Developer Settings --> OAuth Apps`.
 
 #. Click :guilabel:`New OAuth App`.
 
@@ -127,24 +119,14 @@ To set up Google SSO authentication to Argo CD in a new cluster, take the follow
 
 #. Click :guilabel:`Generate a new client secret`.
 
-#. For SQuaRE-run enviroments, go to the RSP-Vault 1Password vault and create a new Login item with a name like "Argo CD GitHub OAuth - data-int.lsst.cloud" (replacing the last part with the FQDN of the environment).
-   In this secret, put the client ID in the username field.
-   Put the client secret in the password field.
-   Create a field labeled ``generate_secrets_key`` with value ``argocd dex.clientSecret``.
-   Create a field labeled ``environment`` with value ``data-int.lsst.cloud`` (replace with the FQDN of the environment).
-   Save this 1Password secret.
+#. Store this secret as the ``dex.clientSecret`` key in the secret for the ``argocd`` application in your :ref:`static secrets store <admin-static-secrets>`, however those secrets are stored for your environment.
+   Then, sync secrets for your environment.
 
-#. If the environment already exists, get a Vault write token for the environment (or the Vault admin token) and set the ``dex.clientSecret`` key in the ``argocd`` secret in the Vault path for that environment (something like ``secret/k8s_operator/data-int.lsst.cloud``, replacing the last part with the FQDN of the environment).
-   Be sure to use ``vault kv patch`` to add the key to the existing secret.
-   This will add the value to the Argo CD secret once vault-secrets-operator notices the change.
-   You can delete ``argocd-secret`` to immediately recreate it to speed up the propagation.
-
-#. In the Phalanx repository, under ``applications/argocd``, edit the ``values-*.yaml`` file for the relevant environment.
-   In ``argo-cd.server.config``, at the same level as ``helm.repositories``, add the following, modifying the URL for the environment and changing the ``clientID`` to the value from GitHub:
+#. In the Phalanx repository, under :file:`applications/argocd`, edit the :file:`values-{environment}.yaml` file for the relevant environment.
+   In ``argo-cd.configs.cm``, at the same level as ``url``, add the following, modifying the URL for the environment and changing the ``clientID`` to the value from GitHub:
 
    .. code-block:: yaml
 
-      url: https://data-int.lsst.cloud/argo-cd
       dex.config: |
         connectors:
           # Auth using GitHub.
@@ -162,7 +144,7 @@ To set up Google SSO authentication to Argo CD in a new cluster, take the follow
    The value for ``clientSecret`` should literally be ``$dex.clientSecret``, which tells Argo CD to get it from the Argo CD configuration secret.
    Adjust the ``orgs`` list if needed to allow access to different GitHub organizations.
 
-#. In the same file, add a new ``argo-cd.server.rbacConfig`` key as follows:
+#. In the same file, add a new ``argo-cd.configs.cm.rbac`` key as follows:
 
    .. code-block:: yaml
 
@@ -174,10 +156,9 @@ To set up Google SSO authentication to Argo CD in a new cluster, take the follow
    Be aware that this uses the human-readable name of the team (with capital letters and spaces if applicable), not the slug.
 
 #. If the environment already exists, create a PR with the above changes, merge it, and then sync Argo CD.
-   Ensure that both the ``argocd-server`` and ``argocd-dex-server`` deployments are restarted (in case the Argo CD Helm chart doesn't ensure this).
 
 #. Go to the ``/argo-cd`` route on the environment.
    Log out if you're logged in with the admin password.
    You should see a login in with Google option appear.
    Click on it and you should be able to authenticate with Google.
-   Anyone in the same hosted domain can authenticate, but if you aren't one of the listed users, you should not see any applications.
+   Anyone in the same GitHub organization can authenticate, but if you aren't in one of the listed teams, you should not see any applications.

--- a/docs/applications/argocd/bootstrap.rst
+++ b/docs/applications/argocd/bootstrap.rst
@@ -4,14 +4,68 @@
 Bootstrapping Argo CD
 #####################
 
+Authentication
+==============
+
 Initial installation of the Rubin Science Platform is done using Argo CD and a static password for the ``admin`` account.
 You can then log on to the ``admin`` account using that password to manage the resulting environment.
-No special bootstrapping is required.
+The password is available as the ``admin.plaintext_password`` key in the static secrets for the ``argocd`` application, however those are managed for your environment.
 
-That said, using the ``admin`` account for longer than necessary is not recommended.
-Instead, you should configure single sign-on for Argo CD as soon as possible and prefer that for day-to-day operations to minimize the chances of leaking the ``admin`` password.
+As part of bootstrapping a new environment, you should also configure per-user authentication.
+To do this, follow the instructions in :doc:`authentication`.
 
-To do that, follow the instructions in :doc:`authentication`.
+Once the environment has been installed, switch to using per-user authentication for all routine operations, and save the ``admin`` account only for emergency situations, such as some problem that breaks per-user authentication.
 
-You may want to do this during your initial bootstrapping process, or very shortly afterwards.
-The execution of the installer script itself will use the ``admin`` account and password regardless, but if Argo CD SSO is set up in advance, you can then immediately switch to using it for management of the environment.
+Access control
+==============
+
+When you followed the instructions in :doc:`authentication`, you set up ``role:admin`` access to Argo CD for a group or list of users.
+
+If the only people who need to manage applications in the environment are those administrators, you don't need to do any further configuration.
+If other people need to view or modify some Argo CD applications, you will need to configure up Argo CD RBAC (role-based access control).
+
+Built-in roles
+--------------
+
+Argo CD supports two built-in roles, the first of which you configured when following the steps in :doc:`authentication`:
+
+``role:admin``
+    Full read/write access to everything managed by Argo CD.
+
+``role:readonly``
+    Read-only access to everything, but no write access.
+
+You can add additional users or groups to these roles using ``g`` lines in the ``argo-cd.configs.cm.rbac."policy.csv"`` key in :file:`values-{environment}.yaml`.
+
+Custom roles
+------------
+
+If you want to give some users access to change some Argo CD applications but not others, you will need to define a custom role and then assign it to users or groups.
+
+All applications in Argo CD are assigned to a project.
+The list of projects are the top-level divisions in :doc:`/applications/index`.
+The primary purpose of these projects is for access control.
+The ``infrastructure`` project, in particular, holds the critical Phalanx infrastructure that application developers should not need to change and that runs the highest risk of breaking the environment in a way that would require Kubernetes-level intervention.
+
+A common RBAC pattern is therefore to set up a ``role:developer`` role that has write access to all applications except those in the ``infrastructure`` project.
+To create this role, add the following lines to the top of the ``policy.csv`` in :file:`values-{environment}.yaml` for your environment::
+
+   p, role:developer, applications, *, */*, allow
+   p, role:developer, applications, get, infrastructure/*, allow
+   p, role:developer, applications, create, infrastructure/*, deny
+   p, role:developer, applications, update, infrastructure/*, deny
+   p, role:developer, applications, delete, infrastructure/*, deny
+   p, role:developer, applications, sync, infrastructure/*, deny
+   p, role:developer, applications, override, infrastructure/*, deny
+   p, role:developer, applications, action/*, infrastructure/*, deny
+
+You can then assign ``role:developer`` to users or groups in exactly the same way as the built-in ``role:admin`` and ``role:readonly`` roles.
+
+This same approach can be used to restrict access to other Argo CD projects (such as ``telescope``).
+Or, alternately, you can grant a role write access to only one Argo CD project and read access to everything else with a role definition like::
+
+   p, role:rsp, applications, get, */*, allow
+   p, role:rsp, applications, *, rsp/*, allow
+
+More complicated rules are possible.
+See the `Argo CD RBAC documentation <https://argo-cd.readthedocs.io/en/stable/operator-manual/rbac/>`__ for the details.


### PR DESCRIPTION
Rework the documentation for configuring Argo CD authentication to reflect the new secrets management system and the new layout of Helm chart parameters. Add documentation for setting up Argo CD RBAC.