### PR TITLE
DM-43342: Fix mistakes in Argo CD documentation

### DIFF
--- a/docs/applications/argocd/bootstrap.rst
+++ b/docs/applications/argocd/bootstrap.rst
@@ -9,7 +9,7 @@ Authentication
 
 Initial installation of the Rubin Science Platform is done using Argo CD and a static password for the ``admin`` account.
 You can then log on to the ``admin`` account using that password to manage the resulting environment.
-The password is available as the ``admin.plaintext_password`` key in the static secrets for the ``argocd`` application, however those are managed for your environment.
+The password is available as the ``admin.plaintext_password`` key in Vault secret for the ``argocd`` application, and in the ``Secret`` resource named ``argocd-secret`` in the ``argocd`` namespace after installation of the environment.
 
 As part of bootstrapping a new environment, you should also configure per-user authentication.
 To do this, follow the instructions in :doc:`authentication`.

--- a/docs/applications/argocd/upgrade.rst
+++ b/docs/applications/argocd/upgrade.rst
@@ -32,7 +32,6 @@ Manual upgrade process
 Only use this process if the automatic upgrade failed or if there are documented serious problems with automatic upgrades.
 
 #. Determine the current version of Argo CD.
-
    The easiest way to do this is to go to the ``/argo-cd`` route and look at the version number in the top left sidebar.
    Ignore the hash after the ``+`` sign; the part before that is the version number.
 


### PR DESCRIPTION
The admin password is only in Vault, not in the static secrets store. Remove a spurious blank line from the upgrading instructions.