### PR TITLE
DM-43409: Fix 1Password documentation, add tucson-teststand

### DIFF
--- a/applications/argocd/secrets.yaml
+++ b/applications/argocd/secrets.yaml
@@ -1,10 +1,10 @@
 "admin.plaintext_password":
   description: >-
     Admin password for Argo CD. This password is normally not used because
-    Argo CD is configured to use Google or GitHub authentication, but it is
-    used by the installer (which cannot use external authentication) and is
-    useful as a fallback if external authentication is not working for some
-    reason. This secret can be changed at any time.
+    Argo CD is configured to use Keycloak, Google, or GitHub authentication,
+    but it is used by the installer (which cannot use external authentication)
+    and is useful as a fallback if external authentication is not working for
+    some reason. This secret can be changed at any time.
   generate:
     type: password
 "admin.password":
@@ -22,9 +22,9 @@
     source: admin.plaintext_password
 "dex.clientSecret":
   description: >-
-    OAuth 2 or OpenID Connect client secret, used to authenticate to GitHub or
-    Google as part of the authentication flow. This secret can be changed at
-    any time.
+    OAuth 2 or OpenID Connect client secret, used to authenticate to Keycloak,
+    GitHub, or Google as part of the authentication flow. This secret can be
+    changed at any time.
 "server.secretkey":
   description: >-
     Key used to validate user session cookies. Argo CD will generate this

--- a/applications/consdb/secrets.yaml
+++ b/applications/consdb/secrets.yaml
@@ -1,9 +1,12 @@
-"oods-password":
-  description: >-
-    PostgreSQL password  for the OODS user Butler database.
-"lfa-password":
-  description: >-
-    LFA password
-"consdb-password":
+consdb-password:
   description: >-
     Kafka password for consdb user
+  copy:
+    application: sasquatch
+    key: consdb-password
+oods-password:
+  description: >-
+    PostgreSQL password  for the OODS user Butler database.
+lfa-password:
+  description: >-
+    LFA password

--- a/docs/applications/onepassword-connect/add-new-environment.rst
+++ b/docs/applications/onepassword-connect/add-new-environment.rst
@@ -34,7 +34,7 @@ In the following steps, you'll change the permissions of the 1Password Connect s
 
 #. Log on to the 1Password UI via a web browser.
 
-#. Click on :menuselection:`Integrations` in the right sidebar under **LSST IT**.
+#. Click on :menuselection:`Developer Tools` in the right sidebar under **LSST IT**.
 
 #. Click on the Secrets Management workflow for the 1Password Connect server that will be serving this environment.
 
@@ -44,7 +44,7 @@ In the following steps, you'll change the permissions of the 1Password Connect s
 
 #. Next to :guilabel:`Access Tokens`, click on :guilabel:`New Token`.
 
-#. Under :guilabel:`Environment Name`, enter the same name as the 1Password vault name for your environment.
+#. Under :guilabel:`Token Name`, enter the name of the Phalanx environment.
    Then, click :guilabel:`Choose Vaults` and select the corresponding vault (and only that one).
    Click :guilabel:`Issue Token` to continue.
 
@@ -52,7 +52,7 @@ In the following steps, you'll change the permissions of the 1Password Connect s
    Then, click on :guilabel:`View Details` to continue.
 
 #. Go back to home by clicking on the icon on the upper left.
-   Go to the SQuaRE vault, find the ``RSP 1Password tokens``, and edit it.
+   Go to the SQuaRE vault, find the ``Phalanx 1Password tokens`` items, and edit it.
    Add the token to that item as another key/value pair, where the key is the short name of the enviroment.
    Mark the value as a password.
 

--- a/environments/values-base.yaml
+++ b/environments/values-base.yaml
@@ -1,5 +1,8 @@
 name: base
 fqdn: base-lsp.lsst.codes
+onepassword:
+  connectUrl: "https://roundtable-dev.lsst.cloud/1password"
+  vaultTitle: "RSP base-lsp.lsst.codes"
 vaultPathPrefix: secret/k8s_operator/base-lsp.lsst.codes
 
 applications:


### PR DESCRIPTION
Fix the documentation for adding a new 1Password environment, and add the 1Password Connect information for tucson-teststand.