### PR TITLE
DM-41829: Prompt Processing Add Node Affinity

### DIFF
--- a/applications/prompt-proto-service-hsc-gpu/README.md
+++ b/applications/prompt-proto-service-hsc-gpu/README.md
@@ -13,6 +13,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | prompt-proto-service.additionalVolumeMounts | list | `[]` | Kubernetes YAML configs for extra container volume(s). Any volumes required by other config options are automatically handled by the Helm chart. |
+| prompt-proto-service.affinity | object | `{}` | Affinity rules for the prompt processing pods |
 | prompt-proto-service.apdb.namespace | string | `"pp_apdb_hsc"` | Database namespace for the APDB |
 | prompt-proto-service.apdb.url | string | None, must be set | URL to the APDB, in any form recognized by SQLAlchemy |
 | prompt-proto-service.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |

--- a/applications/prompt-proto-service-hsc-gpu/values.yaml
+++ b/applications/prompt-proto-service-hsc-gpu/values.yaml
@@ -116,3 +116,6 @@ prompt-proto-service:
   # -- Kubernetes YAML configs for extra container volume(s).
   # Any volumes required by other config options are automatically handled by the Helm chart.
   additionalVolumeMounts: []
+
+  # -- Affinity rules for the prompt processing pods
+  affinity: {}

--- a/applications/prompt-proto-service-hsc/README.md
+++ b/applications/prompt-proto-service-hsc/README.md
@@ -13,6 +13,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | prompt-proto-service.additionalVolumeMounts | list | `[]` | Kubernetes YAML configs for extra container volume(s). Any volumes required by other config options are automatically handled by the Helm chart. |
+| prompt-proto-service.affinity | object | `{}` | Affinity rules for the prompt processing pods |
 | prompt-proto-service.apdb.namespace | string | `"pp_apdb_hsc"` | Database namespace for the APDB |
 | prompt-proto-service.apdb.url | string | None, must be set | URL to the APDB, in any form recognized by SQLAlchemy |
 | prompt-proto-service.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |

--- a/applications/prompt-proto-service-hsc/values.yaml
+++ b/applications/prompt-proto-service-hsc/values.yaml
@@ -116,3 +116,6 @@ prompt-proto-service:
   # -- Kubernetes YAML configs for extra container volume(s).
   # Any volumes required by other config options are automatically handled by the Helm chart.
   additionalVolumeMounts: []
+
+  # -- Affinity rules for the prompt processing pods
+  affinity: {}

--- a/applications/prompt-proto-service-latiss/README.md
+++ b/applications/prompt-proto-service-latiss/README.md
@@ -13,6 +13,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | prompt-proto-service.additionalVolumeMounts | list | `[]` | Kubernetes YAML configs for extra container volume(s). Any volumes required by other config options are automatically handled by the Helm chart. |
+| prompt-proto-service.affinity | object | `{}` | Affinity rules for the prompt processing pods |
 | prompt-proto-service.apdb.namespace | string | `"pp_apdb_latiss"` | Database namespace for the APDB |
 | prompt-proto-service.apdb.url | string | None, must be set | URL to the APDB, in any form recognized by SQLAlchemy |
 | prompt-proto-service.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |

--- a/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
@@ -49,4 +49,13 @@ prompt-proto-service:
     ephemeralStorageRequest: "50Gi"
     ephemeralStorageLimit: "50Gi"
 
+  # Schedule on nodes that do not have Intel NIC due to packet drops
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: feature.node.kubernetes.io/pci-8086.present
+            operator: DoesNotExist
+
   fullnameOverride: "prompt-proto-service-latiss"

--- a/applications/prompt-proto-service-latiss/values.yaml
+++ b/applications/prompt-proto-service-latiss/values.yaml
@@ -116,3 +116,6 @@ prompt-proto-service:
   # -- Kubernetes YAML configs for extra container volume(s).
   # Any volumes required by other config options are automatically handled by the Helm chart.
   additionalVolumeMounts: []
+
+  # -- Affinity rules for the prompt processing pods
+  affinity: {}

--- a/applications/prompt-proto-service-lsstcam/README.md
+++ b/applications/prompt-proto-service-lsstcam/README.md
@@ -13,6 +13,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | prompt-proto-service.additionalVolumeMounts | list | `[]` | Kubernetes YAML configs for extra container volume(s). Any volumes required by other config options are automatically handled by the Helm chart. |
+| prompt-proto-service.affinity | object | `{}` | Affinity rules for the prompt processing pods |
 | prompt-proto-service.apdb.namespace | string | `"pp_apdb_lsstcam"` | Database namespace for the APDB |
 | prompt-proto-service.apdb.url | string | None, must be set | URL to the APDB, in any form recognized by SQLAlchemy |
 | prompt-proto-service.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |

--- a/applications/prompt-proto-service-lsstcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcam/values.yaml
@@ -116,3 +116,6 @@ prompt-proto-service:
   # -- Kubernetes YAML configs for extra container volume(s).
   # Any volumes required by other config options are automatically handled by the Helm chart.
   additionalVolumeMounts: []
+
+  # -- Affinity rules for the prompt processing pods
+  affinity: {}

--- a/applications/prompt-proto-service-lsstcomcam/README.md
+++ b/applications/prompt-proto-service-lsstcomcam/README.md
@@ -12,6 +12,8 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| prompt-proto-service.additionalVolumeMounts | list | `[]` | Kubernetes YAML configs for extra container volume(s). Any volumes required by other config options are automatically handled by the Helm chart. |
+| prompt-proto-service.affinity | object | `{}` | Affinity rules for the prompt processing pods |
 | prompt-proto-service.apdb.namespace | string | `"pp_apdb_lsstcomcam"` | Database namespace for the APDB |
 | prompt-proto-service.apdb.url | string | None, must be set | URL to the APDB, in any form recognized by SQLAlchemy |
 | prompt-proto-service.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |

--- a/applications/prompt-proto-service-lsstcomcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/values.yaml
@@ -112,3 +112,10 @@ prompt-proto-service:
     idleTimeout: 900
     # -- Maximum time that a container can send nothing to the fanout service after initial submission (seconds).
     responseStartTimeout: 900
+
+  # -- Kubernetes YAML configs for extra container volume(s).
+  # Any volumes required by other config options are automatically handled by the Helm chart.
+  additionalVolumeMounts: []
+
+  # -- Affinity rules for the prompt processing pods
+  affinity: {}

--- a/applications/prompt-proto-service-lsstcomcamsim/README.md
+++ b/applications/prompt-proto-service-lsstcomcamsim/README.md
@@ -13,6 +13,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | prompt-proto-service.additionalVolumeMounts | list | `[]` | Kubernetes YAML configs for extra container volume(s). Any volumes required by other config options are automatically handled by the Helm chart. |
+| prompt-proto-service.affinity | object | `{}` | Affinity rules for the prompt processing pods |
 | prompt-proto-service.apdb.namespace | string | `"pp_apdb_lsstcomcamsim"` | Database namespace for the APDB |
 | prompt-proto-service.apdb.url | string | None, must be set | URL to the APDB, in any form recognized by SQLAlchemy |
 | prompt-proto-service.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |

--- a/applications/prompt-proto-service-lsstcomcamsim/values.yaml
+++ b/applications/prompt-proto-service-lsstcomcamsim/values.yaml
@@ -116,3 +116,6 @@ prompt-proto-service:
   # -- Kubernetes YAML configs for extra container volume(s).
   # Any volumes required by other config options are automatically handled by the Helm chart.
   additionalVolumeMounts: []
+
+  # -- Affinity rules for the prompt processing pods
+  affinity: {}

--- a/charts/prompt-proto-service/templates/prompt-proto-service.yaml
+++ b/charts/prompt-proto-service/templates/prompt-proto-service.yaml
@@ -155,6 +155,10 @@ spec:
       - effect: NoSchedule
         key: nvidia.com/gpu
       {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       enableServiceLinks: false
       timeoutSeconds: {{ .Values.knative.timeout }}
       idleTimeoutSeconds: {{ .Values.knative.idleTimeout }}


### PR DESCRIPTION
Enable node affinity to avoid scheduling to nodes with Intel NICs at USDF due to issue with Intel NICS dropping packets.