### PR TITLE
DM-43409: Configure 1Password for Tucson teststand

### DIFF
--- a/docs/admin/migrating-secrets.rst
+++ b/docs/admin/migrating-secrets.rst
@@ -193,7 +193,7 @@ Switch to the new secrets tree
    Applications to review:
 
    - :px-app:`datalinker` (``config.separateSecrets``)
-   - :px-app:`nublado` (``secrets.templateSecrets``)
+   - :px-app:`nublado` (``hub.internalDatabase``, ``secrets.templateSecrets``)
    - :px-app:`obsloctap` (``config.separateSecrets``)
    - :px-app:`plot-navigator` (``config.separateSecrets``)
    - :px-app:`production-tools` (``config.separateSecrets``)

--- a/environments/values-base.yaml
+++ b/environments/values-base.yaml
@@ -1,8 +1,5 @@
 name: base
 fqdn: base-lsp.lsst.codes
-onepassword:
-  connectUrl: "https://roundtable-dev.lsst.cloud/1password"
-  vaultTitle: "RSP base-lsp.lsst.codes"
 vaultPathPrefix: secret/k8s_operator/base-lsp.lsst.codes
 
 applications:

--- a/environments/values-tucson-teststand.yaml
+++ b/environments/values-tucson-teststand.yaml
@@ -1,6 +1,9 @@
-name: tucson-teststand
-fqdn: tucson-teststand.lsst.codes
-vaultPathPrefix: secret/k8s_operator/tucson-teststand.lsst.codes
+name: "tucson-teststand"
+fqdn: "tucson-teststand.lsst.codes"
+onepassword:
+  connectUrl: "https://roundtable-dev.lsst.cloud/1password"
+  vaultTitle: "RSP base-lsp.lsst.codes"
+vaultPathPrefix: "secret/k8s_operator/tucson-teststand.lsst.codes"
 
 applications:
   argo-workflows: true
@@ -23,6 +26,6 @@ applications:
   telegraf-ds: true
 
 controlSystem:
-  imageTag: k0001
-  siteTag: tucson
-  s3EndpointUrl: https://s3.tu.lsst.org
+  imageTag: "k0001"
+  siteTag: "tucson"
+  s3EndpointUrl: "https://s3.tu.lsst.org"


### PR DESCRIPTION
Remove the incorrect configuration for base, which is not ready for 1Password yet. Add configuration for Tucson teststand, and add a note to the migration documentation that we ran into.