### PR TITLE
DM-43460: Add NOTEBURST_WORKER_MAX_CONCURRENT_JOBS config

### DIFF
--- a/applications/noteburst/Chart.yaml
+++ b/applications/noteburst/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: noteburst
 version: 1.0.0
-appVersion: "tickets-DM-43460"
+appVersion: "0.10.0"
 description: Noteburst is a notebook execution service for the Rubin Science Platform.
 type: application
 home: https://noteburst.lsst.io/

--- a/applications/noteburst/Chart.yaml
+++ b/applications/noteburst/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: noteburst
 version: 1.0.0
-appVersion: "0.9.1"
+appVersion: "tickets-DM-43460"
 description: Noteburst is a notebook execution service for the Rubin Science Platform.
 type: application
 home: https://noteburst.lsst.io/

--- a/applications/noteburst/README.md
+++ b/applications/noteburst/README.md
@@ -25,6 +25,7 @@ Noteburst is a notebook execution service for the Rubin Science Platform.
 | config.worker.imageSelector | string | `"recommended"` | Nublado image stream to select: "recommended", "weekly" or "reference" |
 | config.worker.jobTimeout | int | `300` | The default notebook execution timeout, in seconds. |
 | config.worker.keepAlive | string | `"normal"` | Worker keep alive mode: "normal", "fast", "disabled" |
+| config.worker.maxConcurrentJobs | int | `3` | Max number of concurrent notebook executions per worker |
 | config.worker.tokenLifetime | string | `"2419200"` | Worker token lifetime, in seconds. |
 | config.worker.tokenScopes | string | `"exec:notebook,read:image,read:tap,read:alertdb"` | Nublado2 worker account's token scopes as a comma-separated list. |
 | config.worker.workerCount | int | `1` | Number of workers to run |

--- a/applications/noteburst/templates/worker-configmap.yaml
+++ b/applications/noteburst/templates/worker-configmap.yaml
@@ -17,3 +17,4 @@ data:
   NOTEBURST_WORKER_IMAGE_REFERENCE: {{ .Values.config.worker.imageReference | quote  }}
   NOTEBURST_WORKER_TOKEN_SCOPES: {{ .Values.config.worker.tokenScopes | quote }}
   NOTEBURST_WORKER_KEEPALIVE: {{ .Values.config.worker.keepAlive | quote }}
+  NOTEBURST_WORKER_MAX_CONCURRENT_JOBS: {{ .Values.config.worker.maxConcurrentJobs | quote }}

--- a/applications/noteburst/values.yaml
+++ b/applications/noteburst/values.yaml
@@ -115,6 +115,9 @@ config:
     # -- The default notebook execution timeout, in seconds.
     jobTimeout: 300
 
+    # -- Max number of concurrent notebook executions per worker
+    maxConcurrentJobs: 3
+
     # -- Worker token lifetime, in seconds.
     tokenLifetime: "2419200"
 


### PR DESCRIPTION
This limits the number of concurrent notebook execution jobs run on a noteburst worker to less than the number of CPUs. This should reduce the occurrence of HTTP timeouts from the noteburst execution endpoint in JupyterLab pods.

See https://github.com/lsst-sqre/noteburst/pull/74