### PR TITLE
DM-43430: Add Butler server at USDF

### DIFF
--- a/applications/butler/README.md
+++ b/applications/butler/README.md
@@ -15,9 +15,8 @@ Server for Butler data abstraction service
 | autoscaling.maxReplicas | int | `100` | Maximum number of butler deployment pods |
 | autoscaling.minReplicas | int | `1` | Minimum number of butler deployment pods |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU utilization of butler deployment pods |
-| config.indexUri | string | `""` | URI to the DirectButler repository index file listing the configurations for each repository to be hosted by this server. |
 | config.pathPrefix | string | `"/api/butler"` | The prefix of the path portion of the URL where the Butler service will be exposed.  For example, if the service should be exposed at `https://data.lsst.cloud/api/butler`, this should be set to `/api/butler` |
-| config.repositoryLabels | list | `[]` | List of Butler repository labels which will be hosted by this server, matching those from the index file. |
+| config.repositories | object | `{}` | Mapping from Butler repository label to Butler configuration URI for repositories which will be hosted by this server. |
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |

--- a/applications/butler/README.md
+++ b/applications/butler/README.md
@@ -16,6 +16,7 @@ Server for Butler data abstraction service
 | autoscaling.minReplicas | int | `1` | Minimum number of butler deployment pods |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU utilization of butler deployment pods |
 | config.pathPrefix | string | `"/api/butler"` | The prefix of the path portion of the URL where the Butler service will be exposed.  For example, if the service should be exposed at `https://data.lsst.cloud/api/butler`, this should be set to `/api/butler` |
+| config.pguser | string | Use values specified in per-repository Butler config files. | Postgres username used to connect to the Butler DB |
 | config.repositories | object | `{}` | Mapping from Butler repository label to Butler configuration URI for repositories which will be hosted by this server. |
 | config.s3_endpoint_url | string | `""` | URL for the S3 service where files for datasets are stored by Butler. |
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |

--- a/applications/butler/README.md
+++ b/applications/butler/README.md
@@ -18,7 +18,7 @@ Server for Butler data abstraction service
 | config.pathPrefix | string | `"/api/butler"` | The prefix of the path portion of the URL where the Butler service will be exposed.  For example, if the service should be exposed at `https://data.lsst.cloud/api/butler`, this should be set to `/api/butler` |
 | config.pguser | string | Use values specified in per-repository Butler config files. | Postgres username used to connect to the Butler DB |
 | config.repositories | object | `{}` | Mapping from Butler repository label to Butler configuration URI for repositories which will be hosted by this server. |
-| config.s3_endpoint_url | string | `""` | URL for the S3 service where files for datasets are stored by Butler. |
+| config.s3EndpointUrl | string | `""` | URL for the S3 service where files for datasets are stored by Butler. |
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |

--- a/applications/butler/README.md
+++ b/applications/butler/README.md
@@ -17,6 +17,7 @@ Server for Butler data abstraction service
 | autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU utilization of butler deployment pods |
 | config.pathPrefix | string | `"/api/butler"` | The prefix of the path portion of the URL where the Butler service will be exposed.  For example, if the service should be exposed at `https://data.lsst.cloud/api/butler`, this should be set to `/api/butler` |
 | config.repositories | object | `{}` | Mapping from Butler repository label to Butler configuration URI for repositories which will be hosted by this server. |
+| config.s3_endpoint_url | string | `""` | URL for the S3 service where files for datasets are stored by Butler. |
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |

--- a/applications/butler/templates/deployment.yaml
+++ b/applications/butler/templates/deployment.yaml
@@ -50,8 +50,8 @@ spec:
               value: "/opt/lsst/butler/secrets/butler-gcs-creds.json"
             - name: S3_ENDPOINT_URL
               value: "https://storage.googleapis.com"
-            - name: DAF_BUTLER_REPOSITORY_INDEX
-              value: {{ .Values.config.indexUri | quote }}
+            - name: DAF_BUTLER_REPOSITORIES
+              value: {{ .Values.config.repositories | toJson | quote }}
           volumeMounts:
             - name: "butler-secrets"
               mountPath: "/opt/lsst/butler/secrets"

--- a/applications/butler/templates/deployment.yaml
+++ b/applications/butler/templates/deployment.yaml
@@ -52,6 +52,10 @@ spec:
               value: {{ .Values.config.s3_endpoint_url | quote }}
             - name: DAF_BUTLER_REPOSITORIES
               value: {{ .Values.config.repositories | toJson | quote }}
+            {{ if .Values.config.pguser }}
+            - name: PGUSER
+              value: {{ .Values.config.pguser | quote }}
+            {{ end }}
           volumeMounts:
             - name: "butler-secrets"
               mountPath: "/opt/lsst/butler/secrets"

--- a/applications/butler/templates/deployment.yaml
+++ b/applications/butler/templates/deployment.yaml
@@ -49,7 +49,7 @@ spec:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: "/opt/lsst/butler/secrets/butler-gcs-creds.json"
             - name: S3_ENDPOINT_URL
-              value: {{ .Values.config.s3_endpoint_url | quote }}
+              value: {{ .Values.config.s3EndpointUrl | quote }}
             - name: DAF_BUTLER_REPOSITORIES
               value: {{ .Values.config.repositories | toJson | quote }}
             {{ if .Values.config.pguser }}

--- a/applications/butler/templates/deployment.yaml
+++ b/applications/butler/templates/deployment.yaml
@@ -49,7 +49,7 @@ spec:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: "/opt/lsst/butler/secrets/butler-gcs-creds.json"
             - name: S3_ENDPOINT_URL
-              value: "https://storage.googleapis.com"
+              value: {{ .Values.config.s3_endpoint_url | quote }}
             - name: DAF_BUTLER_REPOSITORIES
               value: {{ .Values.config.repositories | toJson | quote }}
           volumeMounts:

--- a/applications/butler/templates/ingress-anonymous.yaml
+++ b/applications/butler/templates/ingress-anonymous.yaml
@@ -27,7 +27,7 @@ template:
             # to the existence of the Butler server -- they are passed the URI
             # for a repository root on the filesystem or HTTP, from which a
             # configuration file is loaded.
-            {{- range $repositoryLabel := .Values.config.repositoryLabels }}
+            {{- range $repositoryLabel, $unused := .Values.config.repositories }}
             - path: "{{ $.Values.config.pathPrefix }}/repo/{{ $repositoryLabel }}/butler.yaml"
               pathType: "Exact"
               backend:

--- a/applications/butler/templates/ingress-authenticated.yaml
+++ b/applications/butler/templates/ingress-authenticated.yaml
@@ -29,7 +29,7 @@ template:
       - host: {{ required "global.host must be set" .Values.global.host | quote }}
         http:
           paths:
-            {{- range $repositoryLabel := .Values.config.repositoryLabels }}
+            {{- range $repositoryLabel, $unused := .Values.config.repositories }}
             - path: "{{ $.Values.config.pathPrefix }}/repo/{{ $repositoryLabel }}"
               pathType: "Prefix"
               backend:

--- a/applications/butler/values-idfdev.yaml
+++ b/applications/butler/values-idfdev.yaml
@@ -2,6 +2,5 @@ image:
   pullPolicy: Always
 
 config:
-  indexUri: "s3://butler-us-central1-repo-locations/data-dev-repos.yaml"
-  repositoryLabels:
-    - dp02
+  repositories:
+    dp02: "s3://butler-us-central1-panda-dev/dc2/butler-external-idfdev.yaml"

--- a/applications/butler/values-idfdev.yaml
+++ b/applications/butler/values-idfdev.yaml
@@ -2,5 +2,6 @@ image:
   pullPolicy: Always
 
 config:
+  s3_endpoint_url: "https://storage.googleapis.com"
   repositories:
     dp02: "s3://butler-us-central1-panda-dev/dc2/butler-external-idfdev.yaml"

--- a/applications/butler/values-idfint.yaml
+++ b/applications/butler/values-idfint.yaml
@@ -1,3 +1,4 @@
 config:
+  s3_endpoint_url: "https://storage.googleapis.com"
   repositories:
     dp02: "s3://butler-us-central1-panda-dev/dc2/butler-external.yaml"

--- a/applications/butler/values-idfint.yaml
+++ b/applications/butler/values-idfint.yaml
@@ -1,4 +1,3 @@
 config:
-  indexUri: "s3://butler-us-central1-repo-locations/data-int-repos.yaml"
-  repositoryLabels:
-    - dp02
+  repositories:
+    dp02: "s3://butler-us-central1-panda-dev/dc2/butler-external.yaml"

--- a/applications/butler/values-idfprod.yaml
+++ b/applications/butler/values-idfprod.yaml
@@ -1,4 +1,5 @@
 config:
+  s3_endpoint_url: "https://storage.googleapis.com"
   repositories:
     dp01: "s3://butler-us-central1-dp01/"
     dp02: "s3://butler-us-central1-dp02-user/"

--- a/applications/butler/values-idfprod.yaml
+++ b/applications/butler/values-idfprod.yaml
@@ -1,5 +1,4 @@
 config:
-  indexUri: "s3://butler-us-central1-repo-locations/data-repos.yaml"
-  repositoryLabels:
-    - dp01
-    - dp02
+  repositories:
+    dp01: "s3://butler-us-central1-dp01/"
+    dp02: "s3://butler-us-central1-dp02-user/"

--- a/applications/butler/values-usdfdev.yaml
+++ b/applications/butler/values-usdfdev.yaml
@@ -1,0 +1,5 @@
+config:
+  pguser: "rubin"
+  s3_endpoint_url: "https://s3dfrgw.slac.stanford.edu"
+  repositories:
+    embargo: "s3://rubin-summit-users/butler.yaml"

--- a/applications/butler/values-usdfdev.yaml
+++ b/applications/butler/values-usdfdev.yaml
@@ -1,5 +1,5 @@
 config:
   pguser: "rubin"
-  s3_endpoint_url: "https://s3dfrgw.slac.stanford.edu"
+  s3EndpointUrl: "https://s3dfrgw.slac.stanford.edu"
   repositories:
     embargo: "s3://rubin-summit-users/butler.yaml"

--- a/applications/butler/values-usdfint.yaml
+++ b/applications/butler/values-usdfint.yaml
@@ -1,0 +1,5 @@
+config:
+  pguser: "rubin"
+  s3_endpoint_url: "https://s3dfrgw.slac.stanford.edu"
+  repositories:
+    embargo: "s3://rubin-summit-users/butler.yaml"

--- a/applications/butler/values-usdfint.yaml
+++ b/applications/butler/values-usdfint.yaml
@@ -1,5 +1,5 @@
 config:
   pguser: "rubin"
-  s3_endpoint_url: "https://s3dfrgw.slac.stanford.edu"
+  s3EndpointUrl: "https://s3dfrgw.slac.stanford.edu"
   repositories:
     embargo: "s3://rubin-summit-users/butler.yaml"

--- a/applications/butler/values-usdfprod.yaml
+++ b/applications/butler/values-usdfprod.yaml
@@ -1,0 +1,5 @@
+config:
+  pguser: "rubin"
+  s3_endpoint_url: "https://s3dfrgw.slac.stanford.edu"
+  repositories:
+    embargo: "s3://rubin-summit-users/butler.yaml"

--- a/applications/butler/values-usdfprod.yaml
+++ b/applications/butler/values-usdfprod.yaml
@@ -1,5 +1,5 @@
 config:
   pguser: "rubin"
-  s3_endpoint_url: "https://s3dfrgw.slac.stanford.edu"
+  s3EndpointUrl: "https://s3dfrgw.slac.stanford.edu"
   repositories:
     embargo: "s3://rubin-summit-users/butler.yaml"

--- a/applications/butler/values.yaml
+++ b/applications/butler/values.yaml
@@ -64,13 +64,9 @@ global:
   vaultSecretsPath: ""
 
 config:
-  # -- URI to the DirectButler repository index file listing the configurations
-  # for each repository to be hosted by this server.
-  indexUri: ""
-
-  # -- List of Butler repository labels which will be hosted by this server,
-  # matching those from the index file.
-  repositoryLabels: []
+  # -- Mapping from Butler repository label to Butler configuration URI for
+  # repositories which will be hosted by this server.
+  repositories: {}
 
   # -- The prefix of the path portion of the URL where the Butler service will
   # be exposed.  For example, if the service should be exposed at

--- a/applications/butler/values.yaml
+++ b/applications/butler/values.yaml
@@ -68,6 +68,10 @@ config:
   # repositories which will be hosted by this server.
   repositories: {}
 
+  # -- Postgres username used to connect to the Butler DB
+  # @default -- Use values specified in per-repository Butler config files.
+  pguser: ""
+
   # -- URL for the S3 service where files for datasets are stored by Butler.
   s3_endpoint_url: ""
 

--- a/applications/butler/values.yaml
+++ b/applications/butler/values.yaml
@@ -73,7 +73,7 @@ config:
   pguser: ""
 
   # -- URL for the S3 service where files for datasets are stored by Butler.
-  s3_endpoint_url: ""
+  s3EndpointUrl: ""
 
   # -- The prefix of the path portion of the URL where the Butler service will
   # be exposed.  For example, if the service should be exposed at

--- a/applications/butler/values.yaml
+++ b/applications/butler/values.yaml
@@ -68,6 +68,9 @@ config:
   # repositories which will be hosted by this server.
   repositories: {}
 
+  # -- URL for the S3 service where files for datasets are stored by Butler.
+  s3_endpoint_url: ""
+
   # -- The prefix of the path portion of the URL where the Butler service will
   # be exposed.  For example, if the service should be exposed at
   # `https://data.lsst.cloud/api/butler`, this should be set to `/api/butler`

--- a/applications/datalinker/README.md
+++ b/applications/datalinker/README.md
@@ -24,7 +24,7 @@ IVOA DataLink-based service and data discovery
 | config.slackAlerts | bool | `false` | Whether to send certain serious alerts to Slack. If `true`, the `slack-webhook` secret must also be set. |
 | config.storageBackend | string | `"GCS"` | Storage backend to use (either `GCS` or `S3`) |
 | config.tapMetadataUrl | string | `"https://github.com/lsst/sdm_schemas/releases/download/1.2.0/datalink-columns.zip"` | URL containing TAP schema metadata used to construct queries |
-| config.useButlerServer | bool | `false` | If true, use Butler in client/server mode instead of connecting directly to the Butler database |
+| config.useButlerServer | bool | `true` | If true, use Butler in client/server mode instead of connecting directly to the Butler database |
 | fullnameOverride | string | `""` | Override the full name for resources (includes the release name) |
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.butlerRepositoryIndex | string | Set by Argo CD | URI to the Butler configuration of available repositories |

--- a/applications/datalinker/values-idfdev.yaml
+++ b/applications/datalinker/values-idfdev.yaml
@@ -1,4 +1,3 @@
 config:
   separateSecrets: true
-  useButlerServer: true
   slackAlerts: true

--- a/applications/datalinker/values-idfint.yaml
+++ b/applications/datalinker/values-idfint.yaml
@@ -1,4 +1,3 @@
 config:
   separateSecrets: true
-  useButlerServer: true
   slackAlerts: true

--- a/applications/datalinker/values-idfprod.yaml
+++ b/applications/datalinker/values-idfprod.yaml
@@ -1,4 +1,3 @@
 config:
   separateSecrets: true
-  useButlerServer: true
   slackAlerts: true

--- a/applications/datalinker/values-usdfdev.yaml
+++ b/applications/datalinker/values-usdfdev.yaml
@@ -1,3 +1,0 @@
-config:
-  storageBackend: "S3"
-  s3EndpointUrl: "https://s3dfrgw.slac.stanford.edu"

--- a/applications/datalinker/values-usdfprod.yaml
+++ b/applications/datalinker/values-usdfprod.yaml
@@ -1,3 +1,0 @@
-config:
-  storageBackend: "S3"
-  s3EndpointUrl: "https://s3dfrgw.slac.stanford.edu"

--- a/applications/datalinker/values.yaml
+++ b/applications/datalinker/values.yaml
@@ -63,7 +63,7 @@ config:
 
   # -- If true, use Butler in client/server mode instead of connecting
   # directly to the Butler database
-  useButlerServer: false
+  useButlerServer: true
 
   # -- User to use from the PGPASSFILE if datalinker is using a direct Butler
   # connection (`useButlerServer` is false)

--- a/environments/values-usdfdev.yaml
+++ b/environments/values-usdfdev.yaml
@@ -1,4 +1,6 @@
 butlerRepositoryIndex: "s3://rubin-summit-users/data-repos.yaml"
+butlerServerRepositories:
+  embargo: "https://usdf-rsp-dev.slac.stanford.edu/api/butler/repo/embargo/butler.yaml"
 fqdn: usdf-rsp-dev.slac.stanford.edu
 name: usdfdev
 vaultUrl: "https://vault.slac.stanford.edu"

--- a/environments/values-usdfdev.yaml
+++ b/environments/values-usdfdev.yaml
@@ -11,6 +11,7 @@ applications:
   ingress-nginx: false
 
   alert-stream-broker: true
+  butler: true
   consdb: true
   datalinker: true
   exposurelog: true

--- a/environments/values-usdfint.yaml
+++ b/environments/values-usdfint.yaml
@@ -10,6 +10,7 @@ applications:
   cert-manager: false
   ingress-nginx: false
 
+  butler: true
   datalinker: true
   livetap: true
   mobu: true

--- a/environments/values-usdfint.yaml
+++ b/environments/values-usdfint.yaml
@@ -1,4 +1,6 @@
 butlerRepositoryIndex: "s3://rubin-summit-users/data-repos.yaml"
+butlerServerRepositories:
+  embargo: "https://usdf-rsp-int.slac.stanford.edu/api/butler/repo/embargo/butler.yaml"
 fqdn: usdf-rsp-int.slac.stanford.edu
 name: usdfint
 vaultUrl: "https://vault.slac.stanford.edu"

--- a/environments/values-usdfprod.yaml
+++ b/environments/values-usdfprod.yaml
@@ -1,4 +1,6 @@
 butlerRepositoryIndex: "s3://rubin-summit-users/data-repos.yaml"
+butlerServerRepositories:
+  embargo: "https://usdf-rsp.slac.stanford.edu/api/butler/repo/embargo/butler.yaml"
 fqdn: usdf-rsp.slac.stanford.edu
 name: usdfprod
 vaultUrl: "https://vault.slac.stanford.edu"

--- a/environments/values-usdfprod.yaml
+++ b/environments/values-usdfprod.yaml
@@ -10,6 +10,7 @@ applications:
   cert-manager: false
   ingress-nginx: false
 
+  butler: true
   consdb: false
   datalinker: true
   exposurelog: true


### PR DESCRIPTION
Added a Butler server at USDF providing access to the `embargo` Butler repository, and configured datalinker to use it.  This fixes an issue where Firefly would display a 500 server error when trying to load images via datalinker for Live ObsCore TAP searches.

Previously Datalinker was not properly configured at USDF -- it was pointed at a Butler repository index file containing mostly repositories hosted as POSIX filesystems unreachable from the service, and was missing postgres configuration necessary to access the Butler DB.