### PR TITLE
DM-43462: Update LATISS Prompt Processing configs

### DIFF
--- a/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
@@ -17,6 +17,8 @@ prompt-proto-service:
       (survey="AUXTEL_DRP_IMAGING")=[${PROMPT_PROCESSING_DIR}/pipelines/LATISS/ApPipe.yaml,
       ${PROMPT_PROCESSING_DIR}/pipelines/LATISS/SingleFrame.yaml,
       ${PROMPT_PROCESSING_DIR}/pipelines/LATISS/Isr.yaml]
+      (survey="cwfs")=[]
+      (survey="cwfs-focus-sweep")=[]
       (survey="spec")=[]
       (survey="spec-survey")=[]
       (survey="spec_with_rotation")=[]

--- a/applications/prompt-proto-service-latiss/values.yaml
+++ b/applications/prompt-proto-service-latiss/values.yaml
@@ -4,7 +4,7 @@ prompt-proto-service:
   # @default -- See the `values.yaml` file.
   podAnnotations:
     autoscaling.knative.dev/min-scale: "3"
-    autoscaling.knative.dev/max-scale: "100"
+    autoscaling.knative.dev/max-scale: "30"  # Continuous observing maxes out at 12 concurrent requests
     autoscaling.knative.dev/target-utilization-percentage: "60"
     autoscaling.knative.dev/target-burst-capacity: "-1"
     queue.sidecar.serving.knative.dev/cpu-resource-request: "1"


### PR DESCRIPTION
This PR updates the LATISS Prompt Processing configs (mostly in `usdfprod`) to reflect new surveys and more experience working with LATISS.