### PR TITLE
DM-43409: Move Vault token duration to the chart

### DIFF
--- a/applications/vault-secrets-operator/README.md
+++ b/applications/vault-secrets-operator/README.md
@@ -8,7 +8,7 @@
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| vault-secrets-operator.environmentVars | list | Set `VAULT_TOKEN` and `VAULT_TOKEN_LEASE_DURATION` from secret | Additional environment variables used to configure the operator |
+| vault-secrets-operator.environmentVars | list | See `values.yaml` | Additional environment variables used to configure the operator |
 | vault-secrets-operator.serviceAccount.createSecret | bool | `false` | Disable creation of a secret for the service account. It shouldn't be needed and it conflicts with the secret we create that contains the credentials for talking to Vault. |
 | vault-secrets-operator.vault.address | string | Set by Argo CD | URL of the underlying Vault implementation |
 | vault-secrets-operator.vault.reconciliationTime | int | `60` | Sync secrets from vault on this cadence |

--- a/applications/vault-secrets-operator/values-idfdev.yaml
+++ b/applications/vault-secrets-operator/values-idfdev.yaml
@@ -1,14 +1,14 @@
 vault-secrets-operator:
   environmentVars:
-    - name: VAULT_ROLE_ID
+    - name: "VAULT_ROLE_ID"
       valueFrom:
         secretKeyRef:
-          name: vault-credentials
-          key: VAULT_ROLE_ID
-    - name: VAULT_SECRET_ID
+          name: "vault-credentials"
+          key: "VAULT_ROLE_ID"
+    - name: "VAULT_SECRET_ID"
       valueFrom:
         secretKeyRef:
-          name: vault-credentials
-          key: VAULT_SECRET_ID
+          name: "vault-credentials"
+          key: "VAULT_SECRET_ID"
   vault:
-    authMethod: approle
+    authMethod: "approle"

--- a/applications/vault-secrets-operator/values-idfint.yaml
+++ b/applications/vault-secrets-operator/values-idfint.yaml
@@ -1,14 +1,14 @@
 vault-secrets-operator:
   environmentVars:
-    - name: VAULT_ROLE_ID
+    - name: "VAULT_ROLE_ID"
       valueFrom:
         secretKeyRef:
-          name: vault-credentials
-          key: VAULT_ROLE_ID
-    - name: VAULT_SECRET_ID
+          name: "vault-credentials"
+          key: "VAULT_ROLE_ID"
+    - name: "VAULT_SECRET_ID"
       valueFrom:
         secretKeyRef:
-          name: vault-credentials
-          key: VAULT_SECRET_ID
+          name: "vault-credentials"
+          key: "VAULT_SECRET_ID"
   vault:
-    authMethod: approle
+    authMethod: "approle"

--- a/applications/vault-secrets-operator/values-idfprod.yaml
+++ b/applications/vault-secrets-operator/values-idfprod.yaml
@@ -1,14 +1,14 @@
 vault-secrets-operator:
   environmentVars:
-    - name: VAULT_ROLE_ID
+    - name: "VAULT_ROLE_ID"
       valueFrom:
         secretKeyRef:
-          name: vault-credentials
-          key: VAULT_ROLE_ID
-    - name: VAULT_SECRET_ID
+          name: "vault-credentials"
+          key: "VAULT_ROLE_ID"
+    - name: "VAULT_SECRET_ID"
       valueFrom:
         secretKeyRef:
-          name: vault-credentials
-          key: VAULT_SECRET_ID
+          name: "vault-credentials"
+          key: "VAULT_SECRET_ID"
   vault:
-    authMethod: approle
+    authMethod: "approle"

--- a/applications/vault-secrets-operator/values-minikube.yaml
+++ b/applications/vault-secrets-operator/values-minikube.yaml
@@ -1,14 +1,18 @@
 vault-secrets-operator:
   environmentVars:
-    - name: VAULT_ROLE_ID
+    - name: "VAULT_ROLE_ID"
       valueFrom:
         secretKeyRef:
-          name: vault-credentials
-          key: VAULT_ROLE_ID
-    - name: VAULT_SECRET_ID
+          name: "vault-credentials"
+          key: "VAULT_ROLE_ID"
+    - name: "VAULT_SECRET_ID"
       valueFrom:
         secretKeyRef:
-          name: vault-credentials
-          key: VAULT_SECRET_ID
+          name: "vault-credentials"
+          key: "VAULT_SECRET_ID"
+    # Set the token lifetime to six hours to minimize the spam of
+    # not-yet-expired tokens in Vault from GitHub Actions CI tests.
+    - name: "VAULT_TOKEN_MAX_TTL"
+      value: "21600"
   vault:
-    authMethod: approle
+    authMethod: "approle"

--- a/applications/vault-secrets-operator/values-roe.yaml
+++ b/applications/vault-secrets-operator/values-roe.yaml
@@ -1,14 +1,14 @@
 vault-secrets-operator:
   environmentVars:
-    - name: VAULT_ROLE_ID
+    - name: "VAULT_ROLE_ID"
       valueFrom:
         secretKeyRef:
-          name: vault-credentials
-          key: VAULT_ROLE_ID
-    - name: VAULT_SECRET_ID
+          name: "vault-credentials"
+          key: "VAULT_ROLE_ID"
+    - name: "VAULT_SECRET_ID"
       valueFrom:
         secretKeyRef:
-          name: vault-credentials
-          key: VAULT_SECRET_ID
+          name: "vault-credentials"
+          key: "VAULT_SECRET_ID"
   vault:
-    authMethod: approle
+    authMethod: "approle"

--- a/applications/vault-secrets-operator/values-roundtable-dev.yaml
+++ b/applications/vault-secrets-operator/values-roundtable-dev.yaml
@@ -1,14 +1,14 @@
 vault-secrets-operator:
   environmentVars:
-    - name: VAULT_ROLE_ID
+    - name: "VAULT_ROLE_ID"
       valueFrom:
         secretKeyRef:
-          name: vault-credentials
-          key: VAULT_ROLE_ID
-    - name: VAULT_SECRET_ID
+          name: "vault-credentials"
+          key: "VAULT_ROLE_ID"
+    - name: "VAULT_SECRET_ID"
       valueFrom:
         secretKeyRef:
-          name: vault-credentials
-          key: VAULT_SECRET_ID
+          name: "vault-credentials"
+          key: "VAULT_SECRET_ID"
   vault:
-    authMethod: approle
+    authMethod: "approle"

--- a/applications/vault-secrets-operator/values-roundtable-prod.yaml
+++ b/applications/vault-secrets-operator/values-roundtable-prod.yaml
@@ -1,14 +1,14 @@
 vault-secrets-operator:
   environmentVars:
-    - name: VAULT_ROLE_ID
+    - name: "VAULT_ROLE_ID"
       valueFrom:
         secretKeyRef:
-          name: vault-credentials
-          key: VAULT_ROLE_ID
-    - name: VAULT_SECRET_ID
+          name: "vault-credentials"
+          key: "VAULT_ROLE_ID"
+    - name: "VAULT_SECRET_ID"
       valueFrom:
         secretKeyRef:
-          name: vault-credentials
-          key: VAULT_SECRET_ID
+          name: "vault-credentials"
+          key: "VAULT_SECRET_ID"
   vault:
-    authMethod: approle
+    authMethod: "approle"

--- a/applications/vault-secrets-operator/values-usdf-tel-rsp.yaml
+++ b/applications/vault-secrets-operator/values-usdf-tel-rsp.yaml
@@ -1,21 +1,19 @@
 vault-secrets-operator:
   environmentVars:
-    - name: VAULT_AUTH_METHOD
-      value: approle
-    - name: VAULT_ROLE_ID
+    - name: "VAULT_ROLE_ID"
       valueFrom:
         secretKeyRef:
-          name: vault-secrets-operator
-          key: VAULT_ROLE_ID
-    - name: VAULT_SECRET_ID
+          name: "vault-secrets-operator"
+          key: "VAULT_ROLE_ID"
+    - name: "VAULT_SECRET_ID"
       valueFrom:
         secretKeyRef:
-          name: vault-secrets-operator
-          key: VAULT_SECRET_ID
-    - name: VAULT_TOKEN_MAX_TTL
+          name: "vault-secrets-operator"
+          key: "VAULT_SECRET_ID"
+    - name: "VAULT_TOKEN_MAX_TTL"
       valueFrom:
         secretKeyRef:
-          name: vault-secrets-operator
-          key: VAULT_TOKEN_MAX_TTL
+          name: "vault-secrets-operator"
+          key: "VAULT_TOKEN_MAX_TTL"
   vault:
-    authMethod: approle
+    authMethod: "approle"

--- a/applications/vault-secrets-operator/values-usdfdev.yaml
+++ b/applications/vault-secrets-operator/values-usdfdev.yaml
@@ -1,21 +1,19 @@
 vault-secrets-operator:
   environmentVars:
-    - name: VAULT_AUTH_METHOD
-      value: approle
-    - name: VAULT_ROLE_ID
+    - name: "VAULT_ROLE_ID"
       valueFrom:
         secretKeyRef:
-          name: vault-secrets-operator
-          key: VAULT_ROLE_ID
-    - name: VAULT_SECRET_ID
+          name: "vault-secrets-operator"
+          key: "VAULT_ROLE_ID"
+    - name: "VAULT_SECRET_ID"
       valueFrom:
         secretKeyRef:
-          name: vault-secrets-operator
-          key: VAULT_SECRET_ID
-    - name: VAULT_TOKEN_MAX_TTL
+          name: "vault-secrets-operator"
+          key: "VAULT_SECRET_ID"
+    - name: "VAULT_TOKEN_MAX_TTL"
       valueFrom:
         secretKeyRef:
-          name: vault-secrets-operator
-          key: VAULT_TOKEN_MAX_TTL
+          name: "vault-secrets-operator"
+          key: "VAULT_TOKEN_MAX_TTL"
   vault:
-    authMethod: approle
+    authMethod: "approle"

--- a/applications/vault-secrets-operator/values-usdfint.yaml
+++ b/applications/vault-secrets-operator/values-usdfint.yaml
@@ -1,22 +1,19 @@
 vault-secrets-operator:
   environmentVars:
-    - name: VAULT_AUTH_METHOD
-      value: approle
-    - name: VAULT_ROLE_ID
+    - name: "VAULT_ROLE_ID"
       valueFrom:
         secretKeyRef:
-          name: vault-secrets-operator
-          key: VAULT_ROLE_ID
-    - name: VAULT_SECRET_ID
+          name: "vault-secrets-operator"
+          key: "VAULT_ROLE_ID"
+    - name: "VAULT_SECRET_ID"
       valueFrom:
         secretKeyRef:
-          name: vault-secrets-operator
-          key: VAULT_SECRET_ID
-    - name: VAULT_TOKEN_MAX_TTL
+          name: "vault-secrets-operator"
+          key: "VAULT_SECRET_ID"
+    - name: "VAULT_TOKEN_MAX_TTL"
       valueFrom:
         secretKeyRef:
-          name: vault-secrets-operator
-          key: VAULT_TOKEN_MAX_TTL
+          name: "vault-secrets-operator"
+          key: "VAULT_TOKEN_MAX_TTL"
   vault:
-    address: "https://vault.slac.stanford.edu"
-    authMethod: approle
+    authMethod: "approle"

--- a/applications/vault-secrets-operator/values-usdfprod.yaml
+++ b/applications/vault-secrets-operator/values-usdfprod.yaml
@@ -1,21 +1,19 @@
 vault-secrets-operator:
   environmentVars:
-    - name: VAULT_AUTH_METHOD
-      value: approle
-    - name: VAULT_ROLE_ID
+    - name: "VAULT_ROLE_ID"
       valueFrom:
         secretKeyRef:
-          name: vault-secrets-operator
-          key: VAULT_ROLE_ID
-    - name: VAULT_SECRET_ID
+          name: "vault-secrets-operator"
+          key: "VAULT_ROLE_ID"
+    - name: "VAULT_SECRET_ID"
       valueFrom:
         secretKeyRef:
-          name: vault-secrets-operator
-          key: VAULT_SECRET_ID
-    - name: VAULT_TOKEN_MAX_TTL
+          name: "vault-secrets-operator"
+          key: "VAULT_SECRET_ID"
+    - name: "VAULT_TOKEN_MAX_TTL"
       valueFrom:
         secretKeyRef:
-          name: vault-secrets-operator
-          key: VAULT_TOKEN_MAX_TTL
+          name: "vault-secrets-operator"
+          key: "VAULT_TOKEN_MAX_TTL"
   vault:
-    authMethod: approle
+    authMethod: "approle"

--- a/applications/vault-secrets-operator/values.yaml
+++ b/applications/vault-secrets-operator/values.yaml
@@ -2,7 +2,7 @@
 
 vault-secrets-operator:
   # -- Additional environment variables used to configure the operator
-  # @default -- Set `VAULT_TOKEN` and `VAULT_TOKEN_LEASE_DURATION` from secret
+  # @default -- See `values.yaml`
   environmentVars:
     - name: "VAULT_TOKEN"
       valueFrom:
@@ -10,10 +10,7 @@ vault-secrets-operator:
           name: "vault-secrets-operator"
           key: "VAULT_TOKEN"
     - name: "VAULT_TOKEN_LEASE_DURATION"
-      valueFrom:
-        secretKeyRef:
-          name: "vault-secrets-operator"
-          key: "VAULT_TOKEN_LEASE_DURATION"
+      value: "31536000"
 
   serviceAccount:
     # -- Disable creation of a secret for the service account. It shouldn't be

--- a/docs/admin/secrets-setup.rst
+++ b/docs/admin/secrets-setup.rst
@@ -34,6 +34,8 @@ So, for example, all secrets for Gafaelfawr for a given environment may be store
 This path is configured for each environment via the ``vaultPathPrefix`` setting in the environment :file:`values-{environment}.yaml` file.
 The URL to the Vault server is set via the ``vaultUrl`` setting in the same file and defaults to the SQuaRE-run Vault server.
 
+.. _admin-vault-credentials:
+
 Vault credentials
 =================
 

--- a/docs/applications/vault-secrets-operator/bootstrap.rst
+++ b/docs/applications/vault-secrets-operator/bootstrap.rst
@@ -7,7 +7,23 @@ Bootstrapping vault-secrets-operator
 Vault Secrets Operator is the only component of the Science Platform whose secret has to be manually created, so that it can create the secrets for all other applications.
 This will be done automatically by the `install script <https://github.com/lsst-sqre/phalanx/blob/main/installer/install.sh>`__.
 
-Its secret will look like this:
+When using the newer, recommended :ref:`secrets management system <admin-vault-credentials>`, the secret created by the installer will look like this:
+
+.. code-block:: yaml
+
+   apiVersion: v1
+   kind: Secret
+   metadata:
+     name: vault-credentials
+     namespace: vault-secrets-operator
+   stringData:
+     VAULT_ROLE_ID: <role-id>
+     VAULT_SECRET_ID: <secret-id>
+   type: Opaque
+
+This secret will normally be created by either the installer or :command:`phalanx vault create-read-approle`.
+
+Using a regular Vault token is still supported, in which case the secret will look like this:
 
 .. code-block:: yaml
 
@@ -16,12 +32,10 @@ Its secret will look like this:
    metadata:
      name: vault-secrets-operator
      namespace: vault-secrets-operator
-   type: Opaque
    stringData:
      VAULT_TOKEN: <token>
-     VAULT_TOKEN_LEASE_DURATION: 86400
+   type: Opaque
 
-Replace ``<token>`` with the ``read`` Vault token for the path ``secret/k8s_operator/<cluster-name>`` in Vault (or whatever Vault enclave you plan to use for this Phalanx environment).
-The path must match the path configured in ``values-<environment>.yaml`` in `/environments <https://github.com/lsst-sqre/phalanx/tree/main/environments>`__.
+This secret will be created by the installer when given a ``VAULT_TOKEN`` parameter.
 
-See :dmtn:`112` for more information.
+In either case, the Vault token or AppRole must have read access to the Vault path configured in :file:`environments/values-{environment}.yaml` for your environment.

--- a/environments/values-tucson-teststand.yaml
+++ b/environments/values-tucson-teststand.yaml
@@ -2,7 +2,7 @@ name: "tucson-teststand"
 fqdn: "tucson-teststand.lsst.codes"
 onepassword:
   connectUrl: "https://roundtable-dev.lsst.cloud/1password"
-  vaultTitle: "RSP base-lsp.lsst.codes"
+  vaultTitle: "RSP tucson-teststand.lsst.codes"
 vaultPathPrefix: "secret/k8s_operator/tucson-teststand.lsst.codes"
 
 applications:

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -5,12 +5,12 @@
 ################################################################################
 
 # Usage:
-#   ./install.sh ENVIRONMENT=env [VAULT_ROLE_ID=<vault> VAULT_SECRET_ID=<vault> | VAULT_TOKEN=<value> [VAULT_TOKEN_LEASE_DURATION=<value>]]
+#   ./install.sh ENVIRONMENT=env [VAULT_ROLE_ID=<vault> VAULT_SECRET_ID=<vault> | VAULT_TOKEN=<value>
 
 # Arguments
 #   - The environment variable is mandatory and should be provided as the first argument.
 #   - If two positional arguments are provided, assume they are VAULT_ROLE_ID and VAULT_SECRET_ID.
-#   - If named arguments are provided, parse them for ENVIRONMENT, VAULT_ROLE_ID, VAULT_SECRET_ID, VAULT_TOKEN, and VAULT_TOKEN_LEASE_DURATION.
+#   - If named arguments are provided, parse them for ENVIRONMENT, VAULT_ROLE_ID, VAULT_SECRET_ID, and VAULT_TOKEN.
 
 # Environment Configuration:
 #   The environment configuration is retrieved from ../environments/values-${ENVIRONMENT}.yaml.
@@ -22,7 +22,7 @@
 #
 #   Using authentication with a token:
 #     ./install.sh ENVIRONMENT=myenv VAULT_TOKEN=your-vault-token
-#     ./install.sh ENVIRONMENT=myenv VAULT_TOKEN=your-vault-token VAULT_TOKEN_LEASE_DURATION=31536000
+#     ./install.sh ENVIRONMENT=myenv VAULT_TOKEN=your-vault-token
 #     ./install.sh myenv VAULT_TOKEN=your-vault-token
 
 # Script Dependencies:
@@ -41,12 +41,11 @@
 
 ################################################################################
 
-USAGE="Usage: ./install.sh ENVIRONMENT=env [VAULT_ROLE_ID=<vault> VAULT_SECRET_ID=<vault> | VAULT_TOKEN=<value> [VAULT_TOKEN_LEASE_DURATION=<value>]]"
+USAGE="Usage: ./install.sh ENVIRONMENT=env [VAULT_ROLE_ID=<vault> VAULT_SECRET_ID=<vault> | VAULT_TOKEN=<value>]"
 
 unset ENVIRONMENT
 unset VAULT_ROLE_ID
 unset VAULT_TOKEN
-unset VAULT_TOKEN_LEASE_DURATION
 unset VAULT_SECRET_ID
 
 # Function to display usage and exit
@@ -105,9 +104,6 @@ for arg in "$@"; do
         VAULT_TOKEN=*|vault_token=*)
             VAULT_TOKEN="${arg#*=}"
             ;;
-        VAULT_TOKEN_LEASE_DURATION=*|vault_token_lease_duration=*)
-            VAULT_TOKEN_LEASE_DURATION="${arg#*=}"
-            ;;
         *)
             ;;
     esac
@@ -159,10 +155,6 @@ if [ -z "$VAULT_ROLE_ID" ] || [ -z "$VAULT_SECRET_ID" ]; then
     if [ -z "$VAULT_TOKEN" ]; then
         echo "Invalid arguments provided. Please provide either VAULT_ROLE_ID and VAULT_SECRET_ID or VAULT_TOKEN."
         display_usage
-    else
-        if [ -z "$VAULT_TOKEN_LEASE_DURATION" ]; then
-          VAULT_TOKEN_LEASE_DURATION=31536000  # Default lease duration: 1 year
-        fi
     fi
 fi
 
@@ -182,8 +174,7 @@ if [ -n "$VAULT_ROLE_ID" ] && [ -n "$VAULT_SECRET_ID" ]; then
         --from-literal=VAULT_SECRET_ID="$VAULT_SECRET_ID"
 elif [ -n "$VAULT_TOKEN" ]; then
     create_kubernetes_secret "vault-secrets-operator" \
-        --from-literal=VAULT_TOKEN="$VAULT_TOKEN" \
-        --from-literal=VAULT_TOKEN_LEASE_DURATION="$VAULT_TOKEN_LEASE_DURATION"
+        --from-literal=VAULT_TOKEN="$VAULT_TOKEN"
 else
     echo "Invalid arguments provided. Please provide either VAULT_ROLE_ID and VAULT_SECRET_ID or VAULT_TOKEN."
     display_usage


### PR DESCRIPTION
We previously were configuring the Vault token duration in the secret, which makes absolutely no sense since its value is not a secret. Move this configuration to the chart, setting the chart default to the same length of time we were previously putting in the secret.

Quote all of the values files for vault-secrets-operator for consistency, and delete pointless environment variable settings that are handled by the chart.

Update the vault-secrets-operator bootstrapping documentation for the new secrets management system.