### PR TITLE
Use prompt-service 2.2.2 in Prompt Processing prod.

### DIFF
--- a/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
@@ -7,7 +7,7 @@ prompt-proto-service:
   image:
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: 2.2.0
+    tag: 2.2.2
 
   instrument:
     pipelines: >-

--- a/applications/prompt-proto-service-lsstcomcamsim/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcomcamsim/values-usdfprod-prompt-processing.yaml
@@ -12,7 +12,7 @@ prompt-proto-service:
     repository: ghcr.io/lsst-dm/prompt-service
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: w_2024_12
+    tag: 2.2.2
 
   instrument:
     pipelines: >-


### PR DESCRIPTION
This PR updates both the LATISS and LSSTComCamSim services to [version 2.2.2](https://github.com/lsst-dm/prompt_processing/releases/tag/2.2.2), which fixes a Butler compatibility problem.