### PR TITLE
Prompt Processing Kafka Address Change

### DIFF
--- a/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
@@ -35,7 +35,7 @@ prompt-proto-service:
     endpointUrl: https://s3dfrgw.slac.stanford.edu
 
   imageNotifications:
-    kafkaClusterAddress: prompt-processing-kafka-bootstrap.kafka:9092
+    kafkaClusterAddress: prompt-processing-2-kafka-bootstrap.kafka:9092
     topic: rubin-prompt-processing-prod
     # Scheduler adds an extra 60-80-second delay for first visit in a sequence,
     # and files can take up to 20 seconds to arrive. Scheduler delay associated


### PR DESCRIPTION
Change kafka address after cluster rebuild.  Rebuild initiated based on comcamsim testing.