### PR TITLE
Prevent merging branches with merges from main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,9 @@ jobs:
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.1
 
+  rebase:
+    uses: lsst/rubin_workflows/.github/workflows/rebase_checker.yaml@main
+
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 10


### PR DESCRIPTION
Adopt the shared workflow used elsewhere in DM to ensure that we don't merge Phalanx branches that have merges back from main. DM style is to always rebase instead.