### PR TITLE
Let Prompt Processing quietly accept empty surveys.

### DIFF
--- a/applications/prompt-proto-service-lsstcomcamsim/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcomcamsim/values-usdfprod-prompt-processing.yaml
@@ -19,6 +19,7 @@ prompt-proto-service:
       (survey="ops-rehearsal-3")=[${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCamSim/ApPipe.yaml,
       ${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCamSim/SingleFrame.yaml,
       ${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCamSim/Isr.yaml]
+      (survey="")=[]
     calibRepo: s3://rubin-summit-users
     calibRepoPguser: lsstcomcamsim_prompt
 


### PR DESCRIPTION
This PR adds an entry for the `""` survey to the LSSTComCamSim Prompt Processing config. This survey is likely to be associated with calibrations and other off-sky observations.