### PR TITLE
DM-43444: Add new write:files scope

### DIFF
--- a/applications/gafaelfawr/values-idfdev.yaml
+++ b/applications/gafaelfawr/values-idfdev.yaml
@@ -55,6 +55,8 @@ config:
       - "g_users"
     "read:tap":
       - "g_users"
+    "write:files":
+      - "g_users"
     "write:sasquatch":
       - "g_admins"
 

--- a/applications/gafaelfawr/values-idfint.yaml
+++ b/applications/gafaelfawr/values-idfint.yaml
@@ -57,6 +57,8 @@ config:
       - "g_users"
     "read:tap":
       - "g_users"
+    "write:files":
+      - "g_users"
     "write:sasquatch":
       - "g_admins"
 

--- a/applications/gafaelfawr/values-idfprod.yaml
+++ b/applications/gafaelfawr/values-idfprod.yaml
@@ -49,6 +49,8 @@ config:
       - "g_users"
     "read:tap":
       - "g_users"
+    "write:files":
+      - "g_users"
 
   initialAdmins:
     - "afausti"

--- a/applications/gafaelfawr/values.yaml
+++ b/applications/gafaelfawr/values.yaml
@@ -290,6 +290,8 @@ config:
       Retrieve images from project datasets
     "read:tap": >-
       Execute SELECT queries in the TAP interface on project datasets
+    "write:files": >-
+      Write access to POSIX file space
     "write:sasquatch": >-
       Write access to the Sasquatch telemetry service
     "user:token": >-

--- a/applications/nublado/templates/controller-ingress-files.yaml
+++ b/applications/nublado/templates/controller-ingress-files.yaml
@@ -9,7 +9,7 @@ config:
   baseUrl: {{ .Values.global.baseUrl | quote }}
   scopes:
     all:
-      - "exec:notebook"
+      - "write:files"
   delegate:
     internal:
       service: "nublado"

--- a/applications/portal/templates/ingress.yaml
+++ b/applications/portal/templates/ingress.yaml
@@ -16,6 +16,7 @@ config:
       scopes:
         - "read:image"
         - "read:tap"
+        - "write:files"
 template:
   metadata:
     name: {{ include "portal.fullname" . }}


### PR DESCRIPTION
Define a new write:files scope and assign it to all users on the IDF deployments where we plan to run the WebDAV file server. Change the scope used to control access to WebDAV from exec:notebook to write:files, and add this to the list of scopes delegated to the Portal.