### PR TITLE
DM-43444: Remove duplicate ingress-nginx configuration

### DIFF
--- a/applications/ingress-nginx/values-idfdev.yaml
+++ b/applications/ingress-nginx/values-idfdev.yaml
@@ -2,5 +2,7 @@ ingress-nginx:
   controller:
     config:
       error-log-level: "error"
+      large-client-header-buffers: "4 64k"
+      proxy-buffer-size: "64k"
     service:
       loadBalancerIP: "35.225.112.77"

--- a/applications/ingress-nginx/values-usdfdev.yaml
+++ b/applications/ingress-nginx/values-usdfdev.yaml
@@ -1,12 +1,8 @@
 ingress-nginx:
   controller:
     config:
-      compute-full-forwarded-for: "true"
       large-client-header-buffers: "4 64k"
-      proxy-body-size: "100m"
       proxy-buffer-size: "64k"
-      ssl-redirect: "true"
-      use-forwarded-headers: "true"
     service:
       externalTrafficPolicy: Local
       loadBalancerIP: "134.79.138.113"

--- a/applications/ingress-nginx/values-usdfprod.yaml
+++ b/applications/ingress-nginx/values-usdfprod.yaml
@@ -1,12 +1,8 @@
 ingress-nginx:
   controller:
     config:
-      compute-full-forwarded-for: "true"
       large-client-header-buffers: "4 64k"
-      proxy-body-size: "100m"
       proxy-buffer-size: "64k"
-      ssl-redirect: "true"
-      use-forwarded-headers: "true"
     service:
       externalTrafficPolicy: Local
     podLabels:

--- a/applications/portal/templates/ingress.yaml
+++ b/applications/portal/templates/ingress.yaml
@@ -21,16 +21,14 @@ template:
   metadata:
     name: {{ include "portal.fullname" . }}
     annotations:
-      nginx.ingress.kubernetes.io/ssl-redirect: "true"
       nginx.ingress.kubernetes.io/affinity: "cookie"
-      nginx.ingress.kubernetes.io/session-cookie-change-on-failure: "true"
-      nginx.ingress.kubernetes.io/proxy-body-size: "0m"
-      nginx.ingress.kubernetes.io/proxy-buffer-size: "24k"
       nginx.ingress.kubernetes.io/client-header-buffer-size: "24k"
-      nginx.ingress.kubernetes.io/rewrite-target: "/suit$1$2"
+      nginx.ingress.kubernetes.io/proxy-body-size: "0m"
+      nginx.ingress.kubernetes.io/proxy-cookie-path: "/suit /portal/app"
       nginx.ingress.kubernetes.io/proxy-redirect-from: "/suit/"
       nginx.ingress.kubernetes.io/proxy-redirect-to: "/portal/app/"
-      nginx.ingress.kubernetes.io/proxy-cookie-path: "/suit /portal/app"
+      nginx.ingress.kubernetes.io/rewrite-target: "/suit$1$2"
+      nginx.ingress.kubernetes.io/session-cookie-change-on-failure: "true"
       nginx.ingress.kubernetes.io/session-cookie-path: "/portal/app"
       nginx.ingress.kubernetes.io/configuration-snippet: |
         proxy_set_header X-Original-URI $request_uri;


### PR DESCRIPTION
Make idfdev match the other IDF environments. Remove ingress-nginx configuration that just replicates configuration already applied at a higher level in the per-environment ingress-nginx configurations and in the Portal ingress.