### PR TITLE
DM-42739: Configure Prompt Processing production service for Sasquatch upload

### DIFF
--- a/applications/prompt-proto-service-hsc-gpu/README.md
+++ b/applications/prompt-proto-service-hsc-gpu/README.md
@@ -47,3 +47,4 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.s3.imageBucket | string | None, must be set | Bucket containing the incoming raw images |
 | prompt-proto-service.sasquatch.auth_env | bool | `true` | If set, this application's Vault secret must contain a `sasquatch_token` key containing the authentication token for `sasquatch.endpointUrl`. Leave unset to attempt anonymous access. |
 | prompt-proto-service.sasquatch.endpointUrl | string | `""` | Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload. This is a preliminary implementation of Sasquatch support, and this parameter may be deprecated if we instead support `SasquatchDatastore` in the future. |
+| prompt-proto-service.sasquatch.namespace | string | `"lsst.prompt"` | Namespace in the Sasquatch system with which to associate metrics. |

--- a/applications/prompt-proto-service-hsc-gpu/values.yaml
+++ b/applications/prompt-proto-service-hsc-gpu/values.yaml
@@ -85,6 +85,8 @@ prompt-proto-service:
     # This is a preliminary implementation of Sasquatch support, and this parameter may be deprecated
     # if we instead support `SasquatchDatastore` in the future.
     endpointUrl: ""
+    # -- Namespace in the Sasquatch system with which to associate metrics.
+    namespace: lsst.prompt
     # -- If set, this application's Vault secret must contain a `sasquatch_token` key containing the authentication token for `sasquatch.endpointUrl`.
     # Leave unset to attempt anonymous access.
     auth_env: true

--- a/applications/prompt-proto-service-hsc/README.md
+++ b/applications/prompt-proto-service-hsc/README.md
@@ -47,3 +47,4 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.s3.imageBucket | string | None, must be set | Bucket containing the incoming raw images |
 | prompt-proto-service.sasquatch.auth_env | bool | `true` | If set, this application's Vault secret must contain a `sasquatch_token` key containing the authentication token for `sasquatch.endpointUrl`. Leave unset to attempt anonymous access. |
 | prompt-proto-service.sasquatch.endpointUrl | string | `""` | Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload. This is a preliminary implementation of Sasquatch support, and this parameter may be deprecated if we instead support `SasquatchDatastore` in the future. |
+| prompt-proto-service.sasquatch.namespace | string | `"lsst.prompt"` | Namespace in the Sasquatch system with which to associate metrics. |

--- a/applications/prompt-proto-service-hsc/values.yaml
+++ b/applications/prompt-proto-service-hsc/values.yaml
@@ -85,6 +85,8 @@ prompt-proto-service:
     # This is a preliminary implementation of Sasquatch support, and this parameter may be deprecated
     # if we instead support `SasquatchDatastore` in the future.
     endpointUrl: ""
+    # -- Namespace in the Sasquatch system with which to associate metrics.
+    namespace: lsst.prompt
     # -- If set, this application's Vault secret must contain a `sasquatch_token` key containing the authentication token for `sasquatch.endpointUrl`.
     # Leave unset to attempt anonymous access.
     auth_env: true

--- a/applications/prompt-proto-service-latiss/README.md
+++ b/applications/prompt-proto-service-latiss/README.md
@@ -47,3 +47,4 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.s3.imageBucket | string | None, must be set | Bucket containing the incoming raw images |
 | prompt-proto-service.sasquatch.auth_env | bool | `true` | If set, this application's Vault secret must contain a `sasquatch_token` key containing the authentication token for `sasquatch.endpointUrl`. Leave unset to attempt anonymous access. |
 | prompt-proto-service.sasquatch.endpointUrl | string | `""` | Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload. This is a preliminary implementation of Sasquatch support, and this parameter may be deprecated if we instead support `SasquatchDatastore` in the future. |
+| prompt-proto-service.sasquatch.namespace | string | `"lsst.prompt"` | Namespace in the Sasquatch system with which to associate metrics. |

--- a/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
@@ -45,6 +45,11 @@ prompt-proto-service:
   apdb:
     url: postgresql://rubin@usdf-prompt-processing.slac.stanford.edu:5432/lsst-devl
 
+  sasquatch:
+    endpointUrl: https://usdf-rsp-dev.slac.stanford.edu/sasquatch-rest-proxy
+    namespace: lsst.prompt.prod
+    auth_env: false
+
   logLevel: timer.lsst.activator=DEBUG lsst.resources=DEBUG
 
   knative:

--- a/applications/prompt-proto-service-latiss/values.yaml
+++ b/applications/prompt-proto-service-latiss/values.yaml
@@ -85,6 +85,8 @@ prompt-proto-service:
     # This is a preliminary implementation of Sasquatch support, and this parameter may be deprecated
     # if we instead support `SasquatchDatastore` in the future.
     endpointUrl: ""
+    # -- Namespace in the Sasquatch system with which to associate metrics.
+    namespace: lsst.prompt
     # -- If set, this application's Vault secret must contain a `sasquatch_token` key containing the authentication token for `sasquatch.endpointUrl`.
     # Leave unset to attempt anonymous access.
     auth_env: true

--- a/applications/prompt-proto-service-lsstcam/README.md
+++ b/applications/prompt-proto-service-lsstcam/README.md
@@ -47,3 +47,4 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.s3.imageBucket | string | None, must be set | Bucket containing the incoming raw images |
 | prompt-proto-service.sasquatch.auth_env | bool | `true` | If set, this application's Vault secret must contain a `sasquatch_token` key containing the authentication token for `sasquatch.endpointUrl`. Leave unset to attempt anonymous access. |
 | prompt-proto-service.sasquatch.endpointUrl | string | `""` | Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload. This is a preliminary implementation of Sasquatch support, and this parameter may be deprecated if we instead support `SasquatchDatastore` in the future. |
+| prompt-proto-service.sasquatch.namespace | string | `"lsst.prompt"` | Namespace in the Sasquatch system with which to associate metrics. |

--- a/applications/prompt-proto-service-lsstcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcam/values.yaml
@@ -85,6 +85,8 @@ prompt-proto-service:
     # This is a preliminary implementation of Sasquatch support, and this parameter may be deprecated
     # if we instead support `SasquatchDatastore` in the future.
     endpointUrl: ""
+    # -- Namespace in the Sasquatch system with which to associate metrics.
+    namespace: lsst.prompt
     # -- If set, this application's Vault secret must contain a `sasquatch_token` key containing the authentication token for `sasquatch.endpointUrl`.
     # Leave unset to attempt anonymous access.
     auth_env: true

--- a/applications/prompt-proto-service-lsstcomcam/README.md
+++ b/applications/prompt-proto-service-lsstcomcam/README.md
@@ -47,3 +47,4 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.s3.imageBucket | string | None, must be set | Bucket containing the incoming raw images |
 | prompt-proto-service.sasquatch.auth_env | bool | `true` | If set, this application's Vault secret must contain a `sasquatch_token` key containing the authentication token for `sasquatch.endpointUrl`. Leave unset to attempt anonymous access. |
 | prompt-proto-service.sasquatch.endpointUrl | string | `""` | Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload. This is a preliminary implementation of Sasquatch support, and this parameter may be deprecated if we instead support `SasquatchDatastore` in the future. |
+| prompt-proto-service.sasquatch.namespace | string | `"lsst.prompt"` | Namespace in the Sasquatch system with which to associate metrics. |

--- a/applications/prompt-proto-service-lsstcomcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/values.yaml
@@ -85,6 +85,8 @@ prompt-proto-service:
     # This is a preliminary implementation of Sasquatch support, and this parameter may be deprecated
     # if we instead support `SasquatchDatastore` in the future.
     endpointUrl: ""
+    # -- Namespace in the Sasquatch system with which to associate metrics.
+    namespace: lsst.prompt
     # -- If set, this application's Vault secret must contain a `sasquatch_token` key containing the authentication token for `sasquatch.endpointUrl`.
     # Leave unset to attempt anonymous access.
     auth_env: true

--- a/applications/prompt-proto-service-lsstcomcamsim/README.md
+++ b/applications/prompt-proto-service-lsstcomcamsim/README.md
@@ -47,3 +47,4 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.s3.imageBucket | string | None, must be set | Bucket containing the incoming raw images |
 | prompt-proto-service.sasquatch.auth_env | bool | `true` | If set, this application's Vault secret must contain a `sasquatch_token` key containing the authentication token for `sasquatch.endpointUrl`. Leave unset to attempt anonymous access. |
 | prompt-proto-service.sasquatch.endpointUrl | string | `""` | Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload. This is a preliminary implementation of Sasquatch support, and this parameter may be deprecated if we instead support `SasquatchDatastore` in the future. |
+| prompt-proto-service.sasquatch.namespace | string | `"lsst.prompt"` | Namespace in the Sasquatch system with which to associate metrics. |

--- a/applications/prompt-proto-service-lsstcomcamsim/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcomcamsim/values-usdfprod-prompt-processing.yaml
@@ -34,6 +34,11 @@ prompt-proto-service:
   apdb:
     url: postgresql://rubin@usdf-prompt-processing.slac.stanford.edu:5432/lsst-devl
 
+  sasquatch:
+    endpointUrl: https://usdf-rsp-dev.slac.stanford.edu/sasquatch-rest-proxy
+    namespace: lsst.prompt.prod
+    auth_env: false
+
   logLevel: timer.lsst.activator=DEBUG
 
   knative:

--- a/applications/prompt-proto-service-lsstcomcamsim/values.yaml
+++ b/applications/prompt-proto-service-lsstcomcamsim/values.yaml
@@ -85,6 +85,8 @@ prompt-proto-service:
     # This is a preliminary implementation of Sasquatch support, and this parameter may be deprecated
     # if we instead support `SasquatchDatastore` in the future.
     endpointUrl: ""
+    # -- Namespace in the Sasquatch system with which to associate metrics.
+    namespace: lsst.prompt
     # -- If set, this application's Vault secret must contain a `sasquatch_token` key containing the authentication token for `sasquatch.endpointUrl`.
     # Leave unset to attempt anonymous access.
     auth_env: true

--- a/charts/prompt-proto-service/README.md
+++ b/charts/prompt-proto-service/README.md
@@ -52,4 +52,5 @@ Event-driven processing of camera images
 | s3.imageBucket | string | None, must be set | Bucket containing the incoming raw images |
 | sasquatch.auth_env | bool | `true` | If set, this application's Vault secret must contain a `sasquatch_token` key containing the authentication token for `sasquatch.endpointUrl`. Leave unset to attempt anonymous access. |
 | sasquatch.endpointUrl | string | `""` | Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload. This is a preliminary implementation of Sasquatch support, and this parameter may be deprecated if we instead support `SasquatchDatastore` in the future. |
+| sasquatch.namespace | string | `"lsst.prompt"` | Namespace in the Sasquatch system with which to associate metrics. |
 | tolerations | list | `[]` |  |

--- a/charts/prompt-proto-service/templates/prompt-proto-service.yaml
+++ b/charts/prompt-proto-service/templates/prompt-proto-service.yaml
@@ -62,6 +62,8 @@ spec:
               name: {{ template "prompt-proto-service.fullname" . }}-secret
               key: sasquatch_token
         {{- end }}
+        - name: DAF_BUTLER_SASQUATCH_NAMESPACE
+          value: {{ .Values.sasquatch.namespace }}
         - name: S3_ENDPOINT_URL
           value: {{ .Values.s3.endpointUrl }}
         {{- if .Values.s3.auth_env }}

--- a/charts/prompt-proto-service/values.yaml
+++ b/charts/prompt-proto-service/values.yaml
@@ -84,6 +84,8 @@ sasquatch:
   # This is a preliminary implementation of Sasquatch support, and this parameter may be deprecated
   # if we instead support `SasquatchDatastore` in the future.
   endpointUrl: ""
+  # -- Namespace in the Sasquatch system with which to associate metrics.
+  namespace: lsst.prompt
   # -- If set, this application's Vault secret must contain a `sasquatch_token` key containing the authentication token for `sasquatch.endpointUrl`.
   # Leave unset to attempt anonymous access.
   auth_env: true


### PR DESCRIPTION
This PR allows customization of Prompt Processing's Sasquatch namespace, and configures the production services to upload metrics to a custom namespace.