### PR TITLE
[DM-43491] Migrate Kafka to KRaft mode in Sasquatch

### DIFF
--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -411,13 +411,13 @@ Rubin Observatory's telemetry service.
 | strimzi-kafka.kafka.listeners.tls.enabled | bool | `false` | Whether internal TLS listener is enabled. |
 | strimzi-kafka.kafka.metricsConfig.enabled | bool | `false` | Whether metric configuration is enabled. |
 | strimzi-kafka.kafka.replicas | int | `3` | Number of Kafka broker replicas to run. |
-| strimzi-kafka.kafka.resources | object | `{"limits":{"cpu":"12","memory":"64Gi"},"requests":{"cpu":"8","memory":"64Gi"}}` | Resource specification for the Kafka brokers. |
+| strimzi-kafka.kafka.resources | object | `{"limits":{"cpu":"8","memory":"64Gi"},"requests":{"cpu":"4","memory":"32Gi"}}` | Resource specification for the Kafka brokers. |
 | strimzi-kafka.kafka.storage.size | string | `"500Gi"` | Size of the backing storage disk for each of the Kafka brokers. |
 | strimzi-kafka.kafka.storage.storageClassName | string | `""` | Name of a StorageClass to use when requesting persistent volumes. |
 | strimzi-kafka.kafka.tolerations | list | `[]` | Tolerations for Kafka broker pod assignment. |
 | strimzi-kafka.kafka.version | string | `"3.7.0"` | Version of Kafka to deploy. |
 | strimzi-kafka.kafkaController.enabled | bool | `false` | Enable Kafka Controller |
-| strimzi-kafka.kafkaController.resources | object | `{"limits":{"cpu":"12","memory":"64Gi"},"requests":{"cpu":"8","memory":"64Gi"}}` | Resource specification for Kafka Controller |
+| strimzi-kafka.kafkaController.resources | object | `{"limits":{"cpu":"8","memory":"64Gi"},"requests":{"cpu":"4","memory":"32Gi"}}` | Resource specification for Kafka Controller |
 | strimzi-kafka.kafkaController.storage.size | string | `"20Gi"` | Size of the backing storage disk for each of the Kafka controllers. |
 | strimzi-kafka.kafkaController.storage.storageClassName | string | `""` | Name of a StorageClass to use when requesting persistent volumes. |
 | strimzi-kafka.kafkaExporter.enableSaramaLogging | bool | `false` | Enable Sarama logging for pod |

--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -425,6 +425,7 @@ Rubin Observatory's telemetry service.
 | strimzi-kafka.kafkaExporter.logging | string | `"info"` | Logging level |
 | strimzi-kafka.kafkaExporter.resources | object | `{}` | Resource specification for Kafka exporter |
 | strimzi-kafka.kafkaExporter.topicRegex | string | `".*"` | Kafka topics to monitor |
+| strimzi-kafka.kraft.enabled | bool | `false` | Enable KRaft mode for Kafka. |
 | strimzi-kafka.mirrormaker2.enabled | bool | `false` | Enable replication in the target (passive) cluster. |
 | strimzi-kafka.mirrormaker2.replicas | int | `3` |  |
 | strimzi-kafka.mirrormaker2.replication.policy.class | string | IdentityReplicationPolicy | Replication policy. |

--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -415,6 +415,10 @@ Rubin Observatory's telemetry service.
 | strimzi-kafka.kafka.storage.storageClassName | string | `""` | Name of a StorageClass to use when requesting persistent volumes. |
 | strimzi-kafka.kafka.tolerations | list | `[]` | Tolerations for Kafka broker pod assignment. |
 | strimzi-kafka.kafka.version | string | `"3.7.0"` | Version of Kafka to deploy. |
+| strimzi-kafka.kafkaController.enabled | bool | `false` | Enable Kafka Controller |
+| strimzi-kafka.kafkaController.resources | object | `{"limits":{"cpu":"12","memory":"64Gi"},"requests":{"cpu":"8","memory":"64Gi"}}` | Resource specification for Kafka Controller |
+| strimzi-kafka.kafkaController.storage.size | string | `"20Gi"` | Size of the backing storage disk for each of the Kafka controllers. |
+| strimzi-kafka.kafkaController.storage.storageClassName | string | `""` | Name of a StorageClass to use when requesting persistent volumes. |
 | strimzi-kafka.kafkaExporter.enableSaramaLogging | bool | `false` | Enable Sarama logging for pod |
 | strimzi-kafka.kafkaExporter.enabled | bool | `false` | Enable Kafka exporter |
 | strimzi-kafka.kafkaExporter.groupRegex | string | `".*"` | Consumer groups to monitor |

--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -411,6 +411,7 @@ Rubin Observatory's telemetry service.
 | strimzi-kafka.kafka.listeners.tls.enabled | bool | `false` | Whether internal TLS listener is enabled. |
 | strimzi-kafka.kafka.metricsConfig.enabled | bool | `false` | Whether metric configuration is enabled. |
 | strimzi-kafka.kafka.replicas | int | `3` | Number of Kafka broker replicas to run. |
+| strimzi-kafka.kafka.resources | object | `{"limits":{"cpu":"12","memory":"64Gi"},"requests":{"cpu":"8","memory":"64Gi"}}` | Resource specification for the Kafka brokers. |
 | strimzi-kafka.kafka.storage.size | string | `"500Gi"` | Size of the backing storage disk for each of the Kafka brokers. |
 | strimzi-kafka.kafka.storage.storageClassName | string | `""` | Name of a StorageClass to use when requesting persistent volumes. |
 | strimzi-kafka.kafka.tolerations | list | `[]` | Tolerations for Kafka broker pod assignment. |

--- a/applications/sasquatch/charts/strimzi-kafka/README.md
+++ b/applications/sasquatch/charts/strimzi-kafka/README.md
@@ -32,13 +32,13 @@ A subchart to deploy Strimzi Kafka components for Sasquatch.
 | kafka.listeners.tls.enabled | bool | `false` | Whether internal TLS listener is enabled. |
 | kafka.metricsConfig.enabled | bool | `false` | Whether metric configuration is enabled. |
 | kafka.replicas | int | `3` | Number of Kafka broker replicas to run. |
-| kafka.resources | object | `{"limits":{"cpu":"12","memory":"64Gi"},"requests":{"cpu":"8","memory":"64Gi"}}` | Resource specification for the Kafka brokers. |
+| kafka.resources | object | `{"limits":{"cpu":"8","memory":"64Gi"},"requests":{"cpu":"4","memory":"32Gi"}}` | Resource specification for the Kafka brokers. |
 | kafka.storage.size | string | `"500Gi"` | Size of the backing storage disk for each of the Kafka brokers. |
 | kafka.storage.storageClassName | string | `""` | Name of a StorageClass to use when requesting persistent volumes. |
 | kafka.tolerations | list | `[]` | Tolerations for Kafka broker pod assignment. |
 | kafka.version | string | `"3.7.0"` | Version of Kafka to deploy. |
 | kafkaController.enabled | bool | `false` | Enable Kafka Controller |
-| kafkaController.resources | object | `{"limits":{"cpu":"12","memory":"64Gi"},"requests":{"cpu":"8","memory":"64Gi"}}` | Resource specification for Kafka Controller |
+| kafkaController.resources | object | `{"limits":{"cpu":"8","memory":"64Gi"},"requests":{"cpu":"4","memory":"32Gi"}}` | Resource specification for Kafka Controller |
 | kafkaController.storage.size | string | `"20Gi"` | Size of the backing storage disk for each of the Kafka controllers. |
 | kafkaController.storage.storageClassName | string | `""` | Name of a StorageClass to use when requesting persistent volumes. |
 | kafkaExporter.enableSaramaLogging | bool | `false` | Enable Sarama logging for pod |

--- a/applications/sasquatch/charts/strimzi-kafka/README.md
+++ b/applications/sasquatch/charts/strimzi-kafka/README.md
@@ -32,6 +32,7 @@ A subchart to deploy Strimzi Kafka components for Sasquatch.
 | kafka.listeners.tls.enabled | bool | `false` | Whether internal TLS listener is enabled. |
 | kafka.metricsConfig.enabled | bool | `false` | Whether metric configuration is enabled. |
 | kafka.replicas | int | `3` | Number of Kafka broker replicas to run. |
+| kafka.resources | object | `{"limits":{"cpu":"12","memory":"64Gi"},"requests":{"cpu":"8","memory":"64Gi"}}` | Resource specification for the Kafka brokers. |
 | kafka.storage.size | string | `"500Gi"` | Size of the backing storage disk for each of the Kafka brokers. |
 | kafka.storage.storageClassName | string | `""` | Name of a StorageClass to use when requesting persistent volumes. |
 | kafka.tolerations | list | `[]` | Tolerations for Kafka broker pod assignment. |

--- a/applications/sasquatch/charts/strimzi-kafka/README.md
+++ b/applications/sasquatch/charts/strimzi-kafka/README.md
@@ -36,6 +36,10 @@ A subchart to deploy Strimzi Kafka components for Sasquatch.
 | kafka.storage.storageClassName | string | `""` | Name of a StorageClass to use when requesting persistent volumes. |
 | kafka.tolerations | list | `[]` | Tolerations for Kafka broker pod assignment. |
 | kafka.version | string | `"3.7.0"` | Version of Kafka to deploy. |
+| kafkaController.enabled | bool | `false` | Enable Kafka Controller |
+| kafkaController.resources | object | `{"limits":{"cpu":"12","memory":"64Gi"},"requests":{"cpu":"8","memory":"64Gi"}}` | Resource specification for Kafka Controller |
+| kafkaController.storage.size | string | `"20Gi"` | Size of the backing storage disk for each of the Kafka controllers. |
+| kafkaController.storage.storageClassName | string | `""` | Name of a StorageClass to use when requesting persistent volumes. |
 | kafkaExporter.enableSaramaLogging | bool | `false` | Enable Sarama logging for pod |
 | kafkaExporter.enabled | bool | `false` | Enable Kafka exporter |
 | kafkaExporter.groupRegex | string | `".*"` | Consumer groups to monitor |

--- a/applications/sasquatch/charts/strimzi-kafka/README.md
+++ b/applications/sasquatch/charts/strimzi-kafka/README.md
@@ -46,6 +46,7 @@ A subchart to deploy Strimzi Kafka components for Sasquatch.
 | kafkaExporter.logging | string | `"info"` | Logging level |
 | kafkaExporter.resources | object | `{}` | Resource specification for Kafka exporter |
 | kafkaExporter.topicRegex | string | `".*"` | Kafka topics to monitor |
+| kraft.enabled | bool | `false` | Enable KRaft mode for Kafka. |
 | mirrormaker2.enabled | bool | `false` | Enable replication in the target (passive) cluster. |
 | mirrormaker2.replicas | int | `3` |  |
 | mirrormaker2.replication.policy.class | string | IdentityReplicationPolicy | Replication policy. |

--- a/applications/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
@@ -53,7 +53,7 @@ kind: Kafka
 metadata:
   name: {{ .Values.cluster.name }}
   annotations:
-    strimzi.io/kraft: migration
+    strimzi.io/kraft: enabled
     strimzi.io/node-pools: enabled
 spec:
   kafka:

--- a/applications/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
@@ -1,8 +1,60 @@
-# Based on the kafka-persistent.yaml example from the Strimzi documentation
+{{- if .Values.kafkaController.enabled }}
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaNodePool
+metadata:
+  name: controller
+  labels:
+    strimzi.io/cluster: {{ .Values.cluster.name }}
+spec:
+  replicas: {{ .Values.kafka.replicas }}
+  roles:
+    - controller
+  storage:
+    type: jbod
+    volumes:
+    - id: 0
+      type: persistent-claim
+      size: {{ .Values.kafkaController.storage.size }}
+      {{- if .Values.kafkaController.storage.storageClassName }}
+      class: {{ .Values.kafkaController.storage.storageClassName }}
+      {{- end}}
+      deleteClaim: false
+    {{- with .Values.kafkaController.resources }}
+    resources:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+{{- end }}
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaNodePool
+metadata:
+  name: kafka
+  labels:
+    strimzi.io/cluster: {{ .Values.cluster.name }}
+  annotations:
+    strimzi.io/next-node-ids: "[0-99]"
+spec:
+  replicas: {{ .Values.kafka.replicas }}
+  roles:
+    - broker
+  storage:
+    type: jbod
+    volumes:
+    - id: 0
+      type: persistent-claim
+      size: {{ .Values.kafka.storage.size }}
+      {{- if .Values.kafka.storage.storageClassName }}
+      class: {{ .Values.kafka.storage.storageClassName }}
+      {{- end}}
+      deleteClaim: false
+---
 apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
   name: {{ .Values.cluster.name }}
+  annotations:
+    strimzi.io/kraft: disabled
+    strimzi.io/node-pools: enabled
 spec:
   kafka:
     template:

--- a/applications/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
@@ -53,7 +53,9 @@ kind: Kafka
 metadata:
   name: {{ .Values.cluster.name }}
   annotations:
+    {{- if .Values.kraft.enabled }}
     strimzi.io/kraft: enabled
+    {{- end }}
     strimzi.io/node-pools: enabled
 spec:
   kafka:

--- a/applications/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
@@ -53,9 +53,7 @@ kind: Kafka
 metadata:
   name: {{ .Values.cluster.name }}
   annotations:
-    {{- if .Values.kraft.enabled }}
-    strimzi.io/kraft: enabled
-    {{- end }}
+    strimzi.io/kraft: migration
     strimzi.io/node-pools: enabled
 spec:
   kafka:

--- a/applications/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
@@ -19,10 +19,10 @@ spec:
       class: {{ .Values.kafkaController.storage.storageClassName }}
       {{- end}}
       deleteClaim: false
-    {{- with .Values.kafkaController.resources }}
-    resources:
-      {{- toYaml . | nindent 6 }}
-    {{- end }}
+  {{- with .Values.kafkaController.resources }}
+  resources:
+    {{- toYaml . | nindent 6 }}
+  {{- end }}
 {{- end }}
 ---
 apiVersion: kafka.strimzi.io/v1beta2
@@ -53,7 +53,9 @@ kind: Kafka
 metadata:
   name: {{ .Values.cluster.name }}
   annotations:
-    strimzi.io/kraft: disabled
+    {{- if .Values.kraft.enabled }}
+    strimzi.io/kraft: enabled
+    {{- end }}
     strimzi.io/node-pools: enabled
 spec:
   kafka:

--- a/applications/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
@@ -47,6 +47,10 @@ spec:
       class: {{ .Values.kafka.storage.storageClassName }}
       {{- end}}
       deleteClaim: false
+  {{- with .Values.kafka.resources }}
+  resources:
+    {{- toYaml . | nindent 6 }}
+  {{- end }}
 ---
 apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka

--- a/applications/sasquatch/charts/strimzi-kafka/values.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/values.yaml
@@ -100,11 +100,11 @@ kafka:
   # -- Resource specification for the Kafka brokers.
   resources:
     requests:
-      memory: 64Gi
-      cpu: "8"
+      memory: 32Gi
+      cpu: "4"
     limits:
       memory: 64Gi
-      cpu: "12"
+      cpu: "8"
 
 kraft:
   # -- Enable KRaft mode for Kafka.
@@ -121,11 +121,11 @@ kafkaController:
   # -- Resource specification for Kafka Controller
   resources:
     requests:
-      memory: 64Gi
-      cpu: "8"
+      memory: 32Gi
+      cpu: "4"
     limits:
       memory: 64Gi
-      cpu: "12"
+      cpu: "8"
 
 kafkaExporter:
   # -- Enable Kafka exporter

--- a/applications/sasquatch/charts/strimzi-kafka/values.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/values.yaml
@@ -97,6 +97,23 @@ kafka:
   # -- Tolerations for Kafka broker pod assignment.
   tolerations: []
 
+kafkaController:
+  # -- Enable Kafka Controller
+  enabled: false
+  storage:
+    # -- Size of the backing storage disk for each of the Kafka controllers.
+    size: 20Gi
+    # -- Name of a StorageClass to use when requesting persistent volumes.
+    storageClassName: ""
+  # -- Resource specification for Kafka Controller
+  resources:
+    requests:
+      memory: 64Gi
+      cpu: "8"
+    limits:
+      memory: 64Gi
+      cpu: "12"
+
 kafkaExporter:
   # -- Enable Kafka exporter
   enabled: false

--- a/applications/sasquatch/charts/strimzi-kafka/values.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/values.yaml
@@ -97,6 +97,10 @@ kafka:
   # -- Tolerations for Kafka broker pod assignment.
   tolerations: []
 
+kraft:
+  # -- Enable KRaft mode for Kafka.
+  enabled: false
+
 kafkaController:
   # -- Enable Kafka Controller
   enabled: false

--- a/applications/sasquatch/charts/strimzi-kafka/values.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/values.yaml
@@ -97,6 +97,15 @@ kafka:
   # -- Tolerations for Kafka broker pod assignment.
   tolerations: []
 
+  # -- Resource specification for the Kafka brokers.
+  resources:
+    requests:
+      memory: 64Gi
+      cpu: "8"
+    limits:
+      memory: 64Gi
+      cpu: "12"
+
 kraft:
   # -- Enable KRaft mode for Kafka.
   enabled: false

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -22,6 +22,8 @@ strimzi-kafka:
       enabled: true
     kafkaConnectManager:
       enabled: true
+  kraft:
+    enabled: true
   kafkaController:
     enabled: true
     resources:

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -23,7 +23,14 @@ strimzi-kafka:
     kafkaConnectManager:
       enabled: true
   kafkaController:
-    enabled: false
+    enabled: true
+    resources:
+      requests:
+        memory: 16Gi
+        cpu: "2"
+      limits:
+        memory: 16Gi
+        cpu: "2"
 
   registry:
     ingress:

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -4,14 +4,14 @@ strimzi-kafka:
       tls:
         enabled: true
       bootstrap:
-        loadBalancerIP: "34.72.64.180"
+        loadBalancerIP: ""
         host: sasquatch-dev-kafka-bootstrap.lsst.cloud
       brokers:
-        - loadBalancerIP: "34.66.20.239"
+        - loadBalancerIP: ""
           host: sasquatch-dev-kafka-0.lsst.cloud
-        - loadBalancerIP: "35.192.19.206"
+        - loadBalancerIP: ""
           host: sasquatch-dev-kafka-1.lsst.cloud
-        - loadBalancerIP: "34.71.207.19"
+        - loadBalancerIP: ""
           host: sasquatch-dev-kafka-2.lsst.cloud
   users:
     replicator:
@@ -22,6 +22,8 @@ strimzi-kafka:
       enabled: true
     kafkaConnectManager:
       enabled: true
+  kafkaController:
+    enabled: false
 
   registry:
     ingress:

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -13,6 +13,13 @@ strimzi-kafka:
           host: sasquatch-dev-kafka-1.lsst.cloud
         - loadBalancerIP: ""
           host: sasquatch-dev-kafka-2.lsst.cloud
+    resources:
+      requests:
+        memory: 16Gi
+        cpu: 2
+      limits:
+        memory: 16Gi
+        cpu: 2
   users:
     replicator:
       enabled: true

--- a/applications/sasquatch/values-idfint.yaml
+++ b/applications/sasquatch/values-idfint.yaml
@@ -36,7 +36,7 @@ strimzi-kafka:
     kafkaConnectManager:
       enabled: true
   kraft:
-    enabled: false
+    enabled: true
   kafkaController:
     enabled: true
     resources:

--- a/applications/sasquatch/values-idfint.yaml
+++ b/applications/sasquatch/values-idfint.yaml
@@ -35,6 +35,17 @@ strimzi-kafka:
       enabled: true
     kafkaConnectManager:
       enabled: true
+  kraft:
+    enabled: false
+  kafkaController:
+    enabled: true
+    resources:
+      requests:
+        memory: 16Gi
+        cpu: "2"
+      limits:
+        memory: 16Gi
+        cpu: "2"
 
 influxdb:
   ingress:

--- a/applications/sasquatch/values-tucson-teststand.yaml
+++ b/applications/sasquatch/values-tucson-teststand.yaml
@@ -58,6 +58,17 @@ strimzi-kafka:
     config:
       key.converter: org.apache.kafka.connect.json.JsonConverter
       key.converter.schemas.enable: false
+  kraft:
+    enabled: false
+  kafkaController:
+    enabled: true
+    resources:
+      requests:
+        memory: 16Gi
+        cpu: "2"
+      limits:
+        memory: 16Gi
+        cpu: "2"
 
 influxdb:
   persistence:

--- a/applications/sasquatch/values-tucson-teststand.yaml
+++ b/applications/sasquatch/values-tucson-teststand.yaml
@@ -59,7 +59,7 @@ strimzi-kafka:
       key.converter: org.apache.kafka.connect.json.JsonConverter
       key.converter.schemas.enable: false
   kraft:
-    enabled: false
+    enabled: true
   kafkaController:
     enabled: true
     resources:


### PR DESCRIPTION
Migration to KRaft mode is described in [Deploying and Upgrading (0.40.0)](https://strimzi.io/docs/operators/0.40.0/deploying.html#proc-deploy-migrate-kraft-str)  and with more details in this blog post [Migrate your Strimzi-operated cluster from ZooKeeper to KRaft](https://strimzi.io/blog/2024/03/22/strimzi-kraft-migration/)

It requires Strimzi 0.40.0 and Kafka 3.7.0.

Another requirement for migrating to KRaft mode is to add a `KafkaNodePool` resource for kafka.

In this PR, we practice the migration to KRaft mode on idv-dev, but let it disabled in the other environments for the moment.

Merging this PR will add the KafkaNodePool with resource configuration for Kafka. The plan is to roll out this change first on IDF and Telescope environments and then USDF. 