### PR TITLE
DM-41829: Affinity and tolerations refactor.  Enable isolated nodes for LATISS prod

### DIFF
--- a/applications/prompt-proto-service-hsc-gpu/README.md
+++ b/applications/prompt-proto-service-hsc-gpu/README.md
@@ -51,3 +51,4 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.sasquatch.auth_env | bool | `true` | If set, this application's Vault secret must contain a `sasquatch_token` key containing the authentication token for `sasquatch.endpointUrl`. Leave unset to attempt anonymous access. |
 | prompt-proto-service.sasquatch.endpointUrl | string | `""` | Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload. This is a preliminary implementation of Sasquatch support, and this parameter may be deprecated if we instead support `SasquatchDatastore` in the future. |
 | prompt-proto-service.sasquatch.namespace | string | `"lsst.prompt"` | Namespace in the Sasquatch system with which to associate metrics. |
+| prompt-proto-service.tolerations | list | `[{"effect":"NoSchedule","key":"nvidia.com/gpu"}]` | Tolerations for the prompt processing pods |

--- a/applications/prompt-proto-service-hsc-gpu/values.yaml
+++ b/applications/prompt-proto-service-hsc-gpu/values.yaml
@@ -129,3 +129,8 @@ prompt-proto-service:
 
   # -- Affinity rules for the prompt processing pods
   affinity: {}
+
+   # -- Tolerations for the prompt processing pods
+  tolerations:
+  - effect: NoSchedule
+    key: nvidia.com/gpu

--- a/applications/prompt-proto-service-hsc/README.md
+++ b/applications/prompt-proto-service-hsc/README.md
@@ -51,3 +51,4 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.sasquatch.auth_env | bool | `true` | If set, this application's Vault secret must contain a `sasquatch_token` key containing the authentication token for `sasquatch.endpointUrl`. Leave unset to attempt anonymous access. |
 | prompt-proto-service.sasquatch.endpointUrl | string | `""` | Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload. This is a preliminary implementation of Sasquatch support, and this parameter may be deprecated if we instead support `SasquatchDatastore` in the future. |
 | prompt-proto-service.sasquatch.namespace | string | `"lsst.prompt"` | Namespace in the Sasquatch system with which to associate metrics. |
+| prompt-proto-service.tolerations | list | `[]` | Tolerations for the prompt processing pods |

--- a/applications/prompt-proto-service-hsc/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-hsc/values-usdfdev-prompt-processing.yaml
@@ -1,6 +1,7 @@
 prompt-proto-service:
 
   podAnnotations:
+    autoscaling.knative.dev/max-scale: "200"
     # Update this field if using latest or static image tag in dev
     revision: "1"
 
@@ -34,3 +35,17 @@ prompt-proto-service:
   cacheCalibs: false
 
   fullnameOverride: "prompt-proto-service-hsc"
+
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: edu.stanford.slac.sdf.project
+            operator: In
+            values:
+            - prompt-processing
+
+  tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/prompt-processing

--- a/applications/prompt-proto-service-hsc/values.yaml
+++ b/applications/prompt-proto-service-hsc/values.yaml
@@ -129,3 +129,6 @@ prompt-proto-service:
 
   # -- Affinity rules for the prompt processing pods
   affinity: {}
+
+  # -- Tolerations for the prompt processing pods
+  tolerations: []

--- a/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
@@ -56,13 +56,18 @@ prompt-proto-service:
     ephemeralStorageRequest: "50Gi"
     ephemeralStorageLimit: "50Gi"
 
-  # Schedule on nodes that do not have Intel NIC due to packet drops
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
         - matchExpressions:
-          - key: feature.node.kubernetes.io/pci-8086.present
-            operator: DoesNotExist
+          - key: edu.stanford.slac.sdf.project
+            operator: In
+            values:
+            - prompt-processing
+
+  tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/prompt-processing
 
   fullnameOverride: "prompt-proto-service-latiss"

--- a/charts/prompt-proto-service/templates/prompt-proto-service.yaml
+++ b/charts/prompt-proto-service/templates/prompt-proto-service.yaml
@@ -118,10 +118,6 @@ spec:
         {{- with .Values.additionalVolumeMounts }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        readinessProbe:
-          successThreshold: 1
-          tcpSocket:
-            port: 0
         resources:
           requests:
             cpu: {{ .Values.knative.cpuRequest }}
@@ -163,16 +159,15 @@ spec:
           - key: central_repo_file
             path: butler.yaml
       {{- end }}
-      {{- if .Values.knative.gpu }}
+      {{- with .Values.tolerations }}
       tolerations:
-      - effect: NoSchedule
-        key: nvidia.com/gpu
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      enableServiceLinks: false
+      enableServiceLinks: true
       timeoutSeconds: {{ .Values.knative.timeout }}
       idleTimeoutSeconds: {{ .Values.knative.idleTimeout }}
       responseStartTimeoutSeconds: {{ .Values.knative.responseStartTimeout }}

--- a/charts/prompt-proto-service/values.yaml
+++ b/charts/prompt-proto-service/values.yaml
@@ -140,10 +140,10 @@ cacheCalibs: true
 # Any volumes required by other config options are automatically handled by the Helm chart.
 additionalVolumeMounts: []
 
+affinity: {}
+
 imagePullSecrets: []
 
 nodeSelector: {}
 
 tolerations: []
-
-affinity: {}


### PR DESCRIPTION
Refactor tolerations to allow for variable inputs.  Add affinity and toleration to schedule to isolated nodes for latiss prod.  Enable service links.  Remove readiness probe configuration as this is set by knative.