### PR TITLE
DM-43581: Add rubintv to usdfprod.

### DIFF
--- a/applications/rubintv/README.md
+++ b/applications/rubintv/README.md
@@ -55,7 +55,7 @@ Real-time display front end
 | workers.nodeSelector | object | `{}` | Node selector rules for the rubintv worker pods |
 | workers.pathPrefix | string | `"/"` | Prefix for the (internal) worker API routes |
 | workers.podAnnotations | object | `{}` | Annotations for the rubintv worker pods |
-| workers.replicas | int | `5` | how many replicas to use |
+| workers.replicas | int | `0` | how many replicas to use |
 | workers.resources | object | `{}` | Resource limits and requests for the rubintv worker pods |
 | workers.script | string | `"slac/rubintv/workerPod1.py"` | Script that runs in RUN_ARG.  This dynamic mechanism needs to be replaced with something less scary, but there is resistance to that, at least while iterating. |
 | workers.tolerations | list | `[]` | Tolerations for the rubintv worker pods |

--- a/applications/rubintv/templates/deployment-workers.yaml
+++ b/applications/rubintv/templates/deployment-workers.yaml
@@ -1,3 +1,5 @@
+{{- $replicas := .Values.workers.replicas | int }}
+{{- if (gt $replicas 0) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -130,3 +132,4 @@ spec:
     tolerations:
       {{- toYaml . | nindent 6 }}
     {{- end }}
+{{- end }}

--- a/applications/rubintv/values-usdfdev.yaml
+++ b/applications/rubintv/values-usdfdev.yaml
@@ -15,7 +15,7 @@ frontend:
     pullPolicy: Always
 
 workers:
-  replicas: 1
+  replicas: 0
   image:
     repository: lsstts/rubintv-broadcaster
     tag: c0030_usdf

--- a/applications/rubintv/values-usdfprod.yaml
+++ b/applications/rubintv/values-usdfprod.yaml
@@ -1,0 +1,14 @@
+imagePullSecrets:
+- name: pull-secret
+
+frontend:
+  debug: true
+  env:
+  - name: S3_ENDPOINT_URL
+    value: "https://s3dfrgw.slac.stanford.edu"
+  - name: RAPID_ANALYSIS_LOCATION
+    value: "USDF"
+  image:
+    repository: lsstts/rubintv
+    tag: c0036
+    pullPolicy: Always

--- a/applications/rubintv/values-usdfprod.yaml
+++ b/applications/rubintv/values-usdfprod.yaml
@@ -9,6 +9,6 @@ frontend:
   - name: RAPID_ANALYSIS_LOCATION
     value: "USDF"
   image:
-    repository: lsstts/rubintv
+    repository: ts-dockerhub.lsst.org/rubintv
     tag: c0036
     pullPolicy: Always

--- a/applications/rubintv/values.yaml
+++ b/applications/rubintv/values.yaml
@@ -51,7 +51,7 @@ frontend:
 
 workers:
   # -- how many replicas to use
-  replicas: 5
+  replicas: 0
 
   # -- If set to true, enable more verbose logging.
   debug: false

--- a/environments/values-usdfprod.yaml
+++ b/environments/values-usdfprod.yaml
@@ -24,6 +24,7 @@ applications:
   plot-navigator: true
   portal: true
   postgres: true
+  rubintv: true
   sasquatch: true
   semaphore: true
   siav2: true


### PR DESCRIPTION
I added the ability to turn off the worker deployment by setting the number of replicas to zero, since they don't seem to be used right now and I don't want to add non-working config to usdf-prod just to make helm happy.