### PR TITLE
DM-43584: Add an option to turn off caching entirely

### DIFF
--- a/applications/prompt-proto-service-lsstcomcamsim/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcomcamsim/values-usdfprod-prompt-processing.yaml
@@ -43,7 +43,10 @@ prompt-proto-service:
 
   knative:
     # TODO DM-40193: Scaled down from 50Gi to avoid hitting global ephemeral storage limits.
-    ephemeralStorageRequest: "10Gi"
-    ephemeralStorageLimit: "10Gi"
+    # A value below 10 GiB is only viable if cacheAny is false.
+    ephemeralStorageRequest: "5Gi"
+    ephemeralStorageLimit: "5Gi"
+
+  cacheAny: false
 
   fullnameOverride: "prompt-proto-service-lsstcomcamsim"

--- a/charts/prompt-proto-service/README.md
+++ b/charts/prompt-proto-service/README.md
@@ -19,7 +19,8 @@ Event-driven processing of camera images
 | alerts.username | string | `"kafka-admin"` | Username for sending alerts to the alert stream |
 | apdb.namespace | string | None, must be set | Database namespace for the APDB |
 | apdb.url | string | None, must be set | URL to the APDB, in any form recognized by SQLAlchemy |
-| cacheCalibs | bool | `true` | Whether or not calibs should be cached between runs of a pod. This is a temporary flag that should only be unset in specific circumstances, and only in the development environment. |
+| cacheAny | bool | `true` | Whether or not any pipeline inputs should be cached between runs of a pod. This is a temporary flag that should only be unset in specific circumstances. |
+| cacheCalibs | bool | `true` | Whether or not calibs should be cached between runs of a pod. This is a temporary flag that should only be unset in specific circumstances, and only in the development environment. It only has an effect if `cacheAny` is true. |
 | containerConcurrency | int | `1` | The number of Knative requests that can be handled simultaneously by one container |
 | fullnameOverride | string | `"prompt-proto-service"` | Override the full name for resources (includes the release name) |
 | image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |

--- a/charts/prompt-proto-service/templates/prompt-proto-service.yaml
+++ b/charts/prompt-proto-service/templates/prompt-proto-service.yaml
@@ -101,6 +101,8 @@ spec:
           value: {{ .Values.logLevel }}
         - name: DEBUG_CACHE_CALIBS
           value: {{ if .Values.cacheCalibs }}'1'{{ else }}'0'{{ end }}
+        - name: DEBUG_CACHE_INPUTS
+          value: {{ if .Values.cacheAny }}'1'{{ else }}'0'{{ end }}
         volumeMounts:
         - mountPath: /tmp-butler
           name: ephemeral

--- a/charts/prompt-proto-service/values.yaml
+++ b/charts/prompt-proto-service/values.yaml
@@ -134,7 +134,11 @@ containerConcurrency: 1
 
 # -- Whether or not calibs should be cached between runs of a pod.
 # This is a temporary flag that should only be unset in specific circumstances, and only in the development environment.
+# It only has an effect if `cacheAny` is true.
 cacheCalibs: true
+# -- Whether or not any pipeline inputs should be cached between runs of a pod.
+# This is a temporary flag that should only be unset in specific circumstances.
+cacheAny: true
 
 # -- Kubernetes YAML configs for extra container volume(s).
 # Any volumes required by other config options are automatically handled by the Helm chart.


### PR DESCRIPTION
This PR adds a flag to the Prompt Processing service that toggles caching all inputs. This allows large-scale deployments that won't run out of storage space, but hurts preload performance. The flag is kept out of the published API as much as possible to make it easy to remove once the local repo is self-managing (DM-40193).