### PR TITLE
Prompt Processing: LATISS Prod Lower Disk Size

### DIFF
--- a/applications/prompt-proto-service-hsc/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-hsc/values-usdfdev-prompt-processing.yaml
@@ -35,17 +35,3 @@ prompt-proto-service:
   cacheCalibs: false
 
   fullnameOverride: "prompt-proto-service-hsc"
-
-  affinity:
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-        - matchExpressions:
-          - key: edu.stanford.slac.sdf.project
-            operator: In
-            values:
-            - prompt-processing
-
-  tolerations:
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/prompt-processing

--- a/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
@@ -52,10 +52,6 @@ prompt-proto-service:
 
   logLevel: timer.lsst.activator=DEBUG lsst.resources=DEBUG
 
-  knative:
-    ephemeralStorageRequest: "50Gi"
-    ephemeralStorageLimit: "50Gi"
-
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
Remove 50Gb storage request and inherit default 20Gb.  50 Gb is no longer needed and the request is causing issues with not enough nodes with available ephemeral storage.  Remove affinity and tolerations from HSC.