### PR TITLE
Deploy Prompt Processing 2.4.0

### DIFF
--- a/applications/prompt-proto-service-hsc/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-hsc/values-usdfdev-prompt-processing.yaml
@@ -1,7 +1,7 @@
 prompt-proto-service:
 
   podAnnotations:
-    autoscaling.knative.dev/max-scale: "200"
+    autoscaling.knative.dev/max-scale: "150"  # More than ~165 is starved for storage
     # Update this field if using latest or static image tag in dev
     revision: "1"
 

--- a/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
@@ -7,7 +7,7 @@ prompt-proto-service:
   image:
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: 2.2.2
+    tag: 2.4.0
 
   instrument:
     pipelines: >-

--- a/applications/prompt-proto-service-lsstcomcamsim/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcomcamsim/values-usdfprod-prompt-processing.yaml
@@ -12,7 +12,7 @@ prompt-proto-service:
   image:
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: 2.2.2
+    tag: 2.4.0
 
   instrument:
     pipelines: >-


### PR DESCRIPTION
This PR updates the default release for all `usdfprod` Prompt Processing services to 2.4.0 in preparation for the Ops Rehearsal. It also scales back a limit on the `usdfdev` service that was causing resource shortages.