### PR TITLE
DM-43608: Turn off force source handling in prompt processing default

### DIFF
--- a/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
@@ -11,10 +11,10 @@ prompt-proto-service:
 
   instrument:
     pipelines: >-
-      (survey="AUXTEL_PHOTO_IMAGING")=[${PROMPT_PROCESSING_DIR}/pipelines/LATISS/ApPipe.yaml,
+      (survey="AUXTEL_PHOTO_IMAGING")=[${PROMPT_PROCESSING_DIR}/pipelines/LATISS/ApPipe-noForced.yaml,
       ${PROMPT_PROCESSING_DIR}/pipelines/LATISS/SingleFrame.yaml,
       ${PROMPT_PROCESSING_DIR}/pipelines/LATISS/Isr.yaml]
-      (survey="AUXTEL_DRP_IMAGING")=[${PROMPT_PROCESSING_DIR}/pipelines/LATISS/ApPipe.yaml,
+      (survey="AUXTEL_DRP_IMAGING")=[${PROMPT_PROCESSING_DIR}/pipelines/LATISS/ApPipe-noForced.yaml,
       ${PROMPT_PROCESSING_DIR}/pipelines/LATISS/SingleFrame.yaml,
       ${PROMPT_PROCESSING_DIR}/pipelines/LATISS/Isr.yaml]
       (survey="cwfs")=[]

--- a/applications/prompt-proto-service-lsstcomcamsim/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcomcamsim/values-usdfprod-prompt-processing.yaml
@@ -16,7 +16,7 @@ prompt-proto-service:
 
   instrument:
     pipelines: >-
-      (survey="ops-rehearsal-3")=[${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCamSim/ApPipe.yaml,
+      (survey="ops-rehearsal-3")=[${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCamSim/ApPipe-noForced.yaml,
       ${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCamSim/SingleFrame.yaml,
       ${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCamSim/Isr.yaml]
       (survey="")=[]


### PR DESCRIPTION
I'm turning it off as the dev default too, so it's getting tested by default.