### PR TITLE
DM-43610: Increase memory limit for datalinker

### DIFF
--- a/applications/datalinker/values.yaml
+++ b/applications/datalinker/values.yaml
@@ -81,7 +81,7 @@ podAnnotations: {}
 resources:
   limits:
     cpu: "1"
-    memory: "200Mi"
+    memory: "300Mi"
   requests:
     cpu: "50m"
     memory: "150Mi"


### PR DESCRIPTION
datalinker cycles around the 150MiB request, but it regularly comes very close to the 200MiB limit and has gotten OOM-killed a few times on data-dev because it goes over. Increase the limit to 300MiB.