### PR TITLE
Fix broken links

### DIFF
--- a/applications/exposurelog/Chart.yaml
+++ b/applications/exposurelog/Chart.yaml
@@ -3,7 +3,7 @@ name: exposurelog
 description: Log messages related to an exposure
 type: application
 sources:
-  - https://github.com/lsst-sqre/exposurelog
+  - https://github.com/lsst-ts/exposurelog
 
 # The chart version. SQuaRE convention is to use 1.0.0
 version: 1.0.0

--- a/applications/exposurelog/README.md
+++ b/applications/exposurelog/README.md
@@ -4,7 +4,7 @@ Log messages related to an exposure
 
 ## Source Code
 
-* <https://github.com/lsst-sqre/exposurelog>
+* <https://github.com/lsst-ts/exposurelog>
 
 ## Values
 

--- a/applications/narrativelog/Chart.yaml
+++ b/applications/narrativelog/Chart.yaml
@@ -3,7 +3,7 @@ name: narrativelog
 type: application
 description: Narrative log service
 sources:
-  - https://github.com/lsst-sqre/narrativelog
+  - https://github.com/lsst-ts/narrativelog
 
 # The chart version. SQuaRE convention is to use 1.0.0
 version: 1.0.0

--- a/applications/narrativelog/README.md
+++ b/applications/narrativelog/README.md
@@ -4,7 +4,7 @@ Narrative log service
 
 ## Source Code
 
-* <https://github.com/lsst-sqre/narrativelog>
+* <https://github.com/lsst-ts/narrativelog>
 
 ## Values
 


### PR DESCRIPTION
Change the upstream links for exposurelog and narrativelog to reflect the move of those repositories. Add an empty values files for consdb on usdfdev, since it's enabled there.