### PR TITLE
Unwind monitoring destination changes for tts/base

### DIFF
--- a/applications/telegraf-ds/values-base.yaml
+++ b/applications/telegraf-ds/values-base.yaml
@@ -1,0 +1,2 @@
+config:
+  influxdb2Url: "https://monitoring.lsst.codes"

--- a/applications/telegraf-ds/values-tucson-teststand.yaml
+++ b/applications/telegraf-ds/values-tucson-teststand.yaml
@@ -1,0 +1,2 @@
+config:
+  influxdb2Url: "https://monitoring.lsst.codes"

--- a/applications/telegraf/values-base.yaml
+++ b/applications/telegraf/values-base.yaml
@@ -1,0 +1,2 @@
+config:
+  influxdb2Url: "https://monitoring.lsst.codes"

--- a/applications/telegraf/values-tucson-teststand.yaml
+++ b/applications/telegraf/values-tucson-teststand.yaml
@@ -1,0 +1,2 @@
+config:
+  influxdb2Url: "https://monitoring.lsst.codes"


### PR DESCRIPTION
TTS new-style secret management isn't working, and base hasn't gotten to it yet...so let's postpone repointing for a bit.