### PR TITLE
Relax livenes probe for gafaelfawr-operator

### DIFF
--- a/applications/gafaelfawr/templates/deployment-operator.yaml
+++ b/applications/gafaelfawr/templates/deployment-operator.yaml
@@ -44,11 +44,13 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
           livenessProbe:
+            failureThreshold: 3
             httpGet:
               path: "/health"
               port: "http"
             initialDelaySeconds: 60
             periodSeconds: 60
+            timeoutSeconds: 5
           ports:
             - containerPort: 8080
               name: "http"


### PR DESCRIPTION
We were seeing spurious failures and restarts, probably because pushing the end-to-end check through the queue can take a bit if some other object is already being processed. Make the timeout longer and set an explicit failure threshold.