### PR TITLE
Adjust resource request and limits fork Kafka at TTS

### DIFF
--- a/applications/sasquatch/values-tucson-teststand.yaml
+++ b/applications/sasquatch/values-tucson-teststand.yaml
@@ -21,6 +21,13 @@ strimzi-kafka:
           host: sasquatch-tts-kafka-1.lsst.codes
         - loadBalancerIP: "140.252.146.47"
           host: sasquatch-tts-kafka-2.lsst.codes
+    resources:
+      requests:
+        memory: 80Gi
+        cpu: 4
+      limits:
+        memory: 80Gi
+        cpu: 4
     metricsConfig:
       enabled: true
   kafkaExporter:


### PR DESCRIPTION
We added default resource rquests and limits for Kafka in Sasquatch. That doesn’t seem enough for TTS which runs the Control System.
For TTS, we are requesting 80G of memory and 4 CPUs for Kafka.