### PR TITLE
DM-43523: Update retention values, increase number of partitions and update Kafka version

### DIFF
--- a/applications/alert-stream-broker/README.md
+++ b/applications/alert-stream-broker/README.md
@@ -78,7 +78,7 @@ Alert transmission to community brokers
 | alert-stream-broker.kafkaExporter.groupRegex | string | `".*"` | Consumer groups to monitor |
 | alert-stream-broker.kafkaExporter.logLevel | string | `"warning"` | Log level for Sarama logging |
 | alert-stream-broker.kafkaExporter.topicRegex | string | `".*"` | Kafka topics to monitor |
-| alert-stream-broker.maxBytesRetained | string | `"24000000000"` | Maximum number of bytes for the replay topic, per partition, per replica. Default is 100GB, but should be lower to not fill storage. |
+| alert-stream-broker.maxBytesRetained | string | `"1000000000000"` | Maximum number of bytes for the replay topic, per partition, per replica. Default is 100GB, but should be lower to not fill storage. |
 | alert-stream-broker.maxMillisecondsRetained | string | `"604800000"` | Maximum amount of time to save simulated alerts in the replay topic, in milliseconds. Default is 7 days. |
 | alert-stream-broker.nameOverride | string | `""` |  |
 | alert-stream-broker.schemaID | int | `1` | Integer ID to use in the prefix of alert data packets. This should be a valid Confluent Schema Registry ID associated with the schema used. |

--- a/applications/alert-stream-broker/charts/alert-stream-broker/README.md
+++ b/applications/alert-stream-broker/charts/alert-stream-broker/README.md
@@ -35,7 +35,7 @@ Kafka broker cluster for distributing alerts
 | kafkaExporter.groupRegex | string | `".*"` | Consumer groups to monitor |
 | kafkaExporter.logLevel | string | `"warning"` | Log level for Sarama logging |
 | kafkaExporter.topicRegex | string | `".*"` | Kafka topics to monitor |
-| maxBytesRetained | string | `"24000000000"` | Maximum number of bytes for the replay topic, per partition, per replica. Default is 100GB, but should be lower to not fill storage. |
+| maxBytesRetained | string | `"1000000000000"` | Maximum number of bytes for the replay topic, per partition, per replica. Default is 100GB, but should be lower to not fill storage. |
 | maxMillisecondsRetained | string | `"604800000"` | Maximum amount of time to save simulated alerts in the replay topic, in milliseconds. Default is 7 days. |
 | nameOverride | string | `""` |  |
 | schemaID | int | `1` | Integer ID to use in the prefix of alert data packets. This should be a valid Confluent Schema Registry ID associated with the schema used. |

--- a/applications/alert-stream-broker/charts/alert-stream-broker/values.yaml
+++ b/applications/alert-stream-broker/charts/alert-stream-broker/values.yaml
@@ -169,7 +169,7 @@ maxMillisecondsRetained: "604800000"
 
 # -- Maximum number of bytes for the replay topic, per partition, per replica.
 # Default is 100GB, but should be lower to not fill storage.
-maxBytesRetained: "24000000000"
+maxBytesRetained: "1000000000000"
 
 testTopicPartitions: 8
 

--- a/applications/alert-stream-broker/values-usdfdev-alert-stream-broker.yaml
+++ b/applications/alert-stream-broker/values-usdfdev-alert-stream-broker.yaml
@@ -9,7 +9,7 @@ alert-stream-broker:
 
   kafka:
 
-    version: 3.5.1
+    version: 3.7.0
     # -- Encoding version for messages, see
     # https://strimzi.io/docs/operators/latest/deploying.html#ref-kafka-versions-str.
     logMessageFormatVersion: 3.4
@@ -111,7 +111,7 @@ alert-stream-broker:
       groups: ["pittgoogle-idfint"]
 
   testTopicName: "alert-stream-test"
-  testTopicPartitions: 20
+  testTopicPartitions: 400
   testTopicReplicas: 1
 
 alert-stream-schema-registry:


### PR DESCRIPTION
Increase number of partitions for the alert-stream-test topic as well as increase the retention size to 1 Tb. Update the kafka version to match the latest version used by strimzi