### PR TITLE
DM-43837: Ignore copied Kafka secrets in Argo CD

### DIFF
--- a/environments/templates/applications/roundtable/ook.yaml
+++ b/environments/templates/applications/roundtable/ook.yaml
@@ -31,4 +31,13 @@ spec:
       valueFiles:
         - "values.yaml"
         - "values-{{ .Values.name }}.yaml"
+  ignoreDifferences:
+    - kind: "Secret"
+      name: "ook-kafka-user"
+      jsonPointers:
+        - "/data/ca.crt"
+        - "/data/user.crt"
+        - "/data/user.key"
+        - "/data/user.p12"
+        - "/data/user.password"
 {{- end -}}

--- a/environments/templates/applications/roundtable/squarebot.yaml
+++ b/environments/templates/applications/roundtable/squarebot.yaml
@@ -31,4 +31,13 @@ spec:
       valueFiles:
         - "values.yaml"
         - "values-{{ .Values.name }}.yaml"
+  ignoreDifferences:
+    - kind: "Secret"
+      name: "squarebot-kafka-user"
+      jsonPointers:
+        - "/data/ca.crt"
+        - "/data/user.crt"
+        - "/data/user.key"
+        - "/data/user.p12"
+        - "/data/user.password"
 {{- end -}}

--- a/environments/templates/applications/roundtable/unfurlbot.yaml
+++ b/environments/templates/applications/roundtable/unfurlbot.yaml
@@ -31,4 +31,13 @@ spec:
       valueFiles:
         - "values.yaml"
         - "values-{{ .Values.name }}.yaml"
+  ignoreDifferences:
+    - kind: "Secret"
+      name: "unfurlbot-kafka-user"
+      jsonPointers:
+        - "/data/ca.crt"
+        - "/data/user.crt"
+        - "/data/user.key"
+        - "/data/user.p12"
+        - "/data/user.password"
 {{- end -}}


### PR DESCRIPTION
Several Roundtable apps use generated and copied Kafka secrets, which should not count as meaningful differences for an Argo CD diff. Add the appropriate ignore rules.