### PR TITLE
DM-43837: Ignore more of the copied Kafka secrets

### DIFF
--- a/environments/templates/applications/roundtable/ook.yaml
+++ b/environments/templates/applications/roundtable/ook.yaml
@@ -35,9 +35,5 @@ spec:
     - kind: "Secret"
       name: "ook-kafka-user"
       jsonPointers:
-        - "/data/ca.crt"
-        - "/data/user.crt"
-        - "/data/user.key"
-        - "/data/user.p12"
-        - "/data/user.password"
+        - "/data"
 {{- end -}}

--- a/environments/templates/applications/roundtable/squarebot.yaml
+++ b/environments/templates/applications/roundtable/squarebot.yaml
@@ -35,9 +35,5 @@ spec:
     - kind: "Secret"
       name: "squarebot-kafka-user"
       jsonPointers:
-        - "/data/ca.crt"
-        - "/data/user.crt"
-        - "/data/user.key"
-        - "/data/user.p12"
-        - "/data/user.password"
+        - "/data"
 {{- end -}}

--- a/environments/templates/applications/roundtable/unfurlbot.yaml
+++ b/environments/templates/applications/roundtable/unfurlbot.yaml
@@ -35,9 +35,5 @@ spec:
     - kind: "Secret"
       name: "unfurlbot-kafka-user"
       jsonPointers:
-        - "/data/ca.crt"
-        - "/data/user.crt"
-        - "/data/user.key"
-        - "/data/user.p12"
-        - "/data/user.password"
+        - "/data"
 {{- end -}}


### PR DESCRIPTION
Ignoring the individual elements still leaves a diff between an empty object and no object. Ignore the entire data key of copied secrets.