### PR TITLE
DM-43837: Stop testing squareone on minikube

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -92,10 +92,10 @@ jobs:
           filters: |
             minikube:
               - ".github/workflows/ci.yaml"
-              - "applications/{argocd,gafaelfawr,ingress-nginx,mobu,postgres,squareone,vault-secrets-operator}/Chart.yaml"
-              - "applications/{argocd,gafaelfawr,ingress-nginx,mobu,postgres,squareone,vault-secrets-operator}/templates/**"
-              - "applications/{argocd,gafaelfawr,ingress-nginx,mobu,postgres,squareone,vault-secrets-operator}/values.yaml"
-              - "applications/{argocd,gafaelfawr,ingress-nginx,mobu,postgres,squareone,vault-secrets-operator}/values-minikube.yaml"
+              - "applications/{argocd,gafaelfawr,ingress-nginx,mobu,postgres,vault-secrets-operator}/Chart.yaml"
+              - "applications/{argocd,gafaelfawr,ingress-nginx,mobu,postgres,vault-secrets-operator}/templates/**"
+              - "applications/{argocd,gafaelfawr,ingress-nginx,mobu,postgres,vault-secrets-operator}/values.yaml"
+              - "applications/{argocd,gafaelfawr,ingress-nginx,mobu,postgres,vault-secrets-operator}/values-minikube.yaml"
               - "environments/Chart.yaml"
               - "environments/templates/applications/infrastructure/*"
               - "environments/values-minikube.yaml"

--- a/applications/squareone/values-minikube.yaml
+++ b/applications/squareone/values-minikube.yaml
@@ -1,2 +1,0 @@
-config:
-  siteName: "Rubin Science Platform @ minikube"

--- a/environments/values-minikube.yaml
+++ b/environments/values-minikube.yaml
@@ -13,4 +13,3 @@ vaultPathPrefix: secret/phalanx/minikube
 applications:
   mobu: true
   postgres: true
-  squareone: true


### PR DESCRIPTION
Now that Argo CD does the TLS setup, stop installing squareone on minikube. It's not part of the core infrastructure that minikube is meant to be testing.