### PR TITLE
DM-43837: Allow the app-of-apps name to be configured

### DIFF
--- a/docs/extras/schemas/environment.json
+++ b/docs/extras/schemas/environment.json
@@ -176,6 +176,19 @@
       "title": "Domain name",
       "type": "string"
     },
+    "appOfAppsName": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Name of the parent Argo CD app-of-apps that manages all of the enabled applications. This is required in the merged values file that includes environment overrides, but the environment override file doesn't need to set it, so it's marked as optional for schema checking purposes to allow the override file to be schema-checked independently.",
+      "title": "Argo CD app-of-apps name"
+    },
     "butlerRepositoryIndex": {
       "anyOf": [
         {

--- a/environments/README.md
+++ b/environments/README.md
@@ -4,6 +4,7 @@
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| appOfAppsName | string | `"app-of-apps"` | Name of the parent Argo CD app-of-apps that manages all the applications enabled for this environment |
 | applications.alert-stream-broker | bool | `false` | Enable the alert-stream-broker application |
 | applications.argo-workflows | bool | `false` | Enable the argo-workflows application |
 | applications.argocd | bool | `true` | Enable the Argo CD application. This must be enabled for all environments and is present here only because it makes parsing easier |

--- a/environments/values-base.yaml
+++ b/environments/values-base.yaml
@@ -1,6 +1,7 @@
-name: base
-fqdn: base-lsp.lsst.codes
-vaultPathPrefix: secret/k8s_operator/base-lsp.lsst.codes
+name: "base"
+fqdn: "base-lsp.lsst.codes"
+appOfAppsName: "science-platform"
+vaultPathPrefix: "secret/k8s_operator/base-lsp.lsst.codes"
 
 applications:
   argo-workflows: true

--- a/environments/values-ccin2p3.yaml
+++ b/environments/values-ccin2p3.yaml
@@ -1,6 +1,7 @@
-name: ccin2p3
-fqdn: data-dev.lsst.eu
-vaultPathPrefix: secret/k8s_operator/rsp-cc
+name: "ccin2p3"
+fqdn: "data-dev.lsst.eu"
+appOfAppsName: "science-platform"
+vaultPathPrefix: "secret/k8s_operator/rsp-cc"
 
 applications:
   datalinker: true

--- a/environments/values-idfdev.yaml
+++ b/environments/values-idfdev.yaml
@@ -1,5 +1,6 @@
 name: "idfdev"
 fqdn: "data-dev.lsst.cloud"
+appOfAppsName: "science-platform"
 butlerRepositoryIndex: "s3://butler-us-central1-repo-locations/data-dev-repos.yaml"
 butlerServerRepositories:
   dp02: "https://data-dev.lsst.cloud/api/butler/repo/dp02/butler.yaml"

--- a/environments/values-idfint.yaml
+++ b/environments/values-idfint.yaml
@@ -1,5 +1,6 @@
 name: "idfint"
 fqdn: "data-int.lsst.cloud"
+appOfAppsName: "science-platform"
 butlerRepositoryIndex: "s3://butler-us-central1-repo-locations/data-int-repos.yaml"
 butlerServerRepositories:
   dp02: "https://data-int.lsst.cloud/api/butler/repo/dp02/butler.yaml"

--- a/environments/values-idfprod.yaml
+++ b/environments/values-idfprod.yaml
@@ -1,5 +1,6 @@
 name: "idfprod"
 fqdn: "data.lsst.cloud"
+appOfAppsName: "science-platform"
 butlerRepositoryIndex: "s3://butler-us-central1-repo-locations/data-repos.yaml"
 butlerServerRepositories:
   dp01: "https://data.lsst.cloud/api/butler/repo/dp01/butler.yaml"

--- a/environments/values-minikube.yaml
+++ b/environments/values-minikube.yaml
@@ -1,9 +1,9 @@
-name: minikube
-fqdn: minikube.lsst.codes
+name: "minikube"
+fqdn: "minikube.lsst.codes"
 onepassword:
   connectUrl: "https://roundtable-dev.lsst.cloud/1password"
   vaultTitle: "RSP minikube.lsst.codes"
-vaultPathPrefix: secret/phalanx/minikube
+vaultPathPrefix: "secret/phalanx/minikube"
 
 # The primary constraint on enabling applications is the low available memory
 # of a GitHub Actions runner, since minikube is used for smoke testing of new

--- a/environments/values-roe.yaml
+++ b/environments/values-roe.yaml
@@ -1,7 +1,8 @@
-name: roe
-fqdn: rsp.lsst.ac.uk
+name: "roe"
+fqdn: "rsp.lsst.ac.uk"
+appOfAppsName: "science-platform"
 vaultUrl: "https://vault.lsst.ac.uk"
-vaultPathPrefix: secret/k8s_operator/roe
+vaultPathPrefix: "secret/k8s_operator/roe"
 
 applications:
   mobu: true

--- a/environments/values-roundtable-dev.yaml
+++ b/environments/values-roundtable-dev.yaml
@@ -1,5 +1,6 @@
 name: "roundtable-dev"
 fqdn: "roundtable-dev.lsst.cloud"
+appOfAppsName: "roundtable"
 gcp:
   projectId: "roundtable-dev-abe2"
   region: "us-central1"

--- a/environments/values-roundtable-prod.yaml
+++ b/environments/values-roundtable-prod.yaml
@@ -1,5 +1,6 @@
 name: "roundtable-prod"
 fqdn: "roundtable.lsst.cloud"
+appOfAppsName: "roundtable"
 gcp:
   projectId: "roundtable-prod-f6fd"
   region: "us-central1"

--- a/environments/values-summit.yaml
+++ b/environments/values-summit.yaml
@@ -1,6 +1,7 @@
-name: summit
-fqdn: summit-lsp.lsst.codes
-vaultPathPrefix: secret/k8s_operator/summit-lsp.lsst.codes
+name: "summit"
+fqdn: "summit-lsp.lsst.codes"
+appOfAppsName: "science-platform"
+vaultPathPrefix: "secret/k8s_operator/summit-lsp.lsst.codes"
 
 applications:
   consdb: true

--- a/environments/values-tucson-teststand.yaml
+++ b/environments/values-tucson-teststand.yaml
@@ -1,5 +1,6 @@
 name: "tucson-teststand"
 fqdn: "tucson-teststand.lsst.codes"
+appOfAppsName: "science-platform"
 onepassword:
   connectUrl: "https://roundtable-dev.lsst.cloud/1password"
   vaultTitle: "RSP tucson-teststand.lsst.codes"

--- a/environments/values-usdfdev.yaml
+++ b/environments/values-usdfdev.yaml
@@ -1,10 +1,11 @@
+fqdn: "usdf-rsp-dev.slac.stanford.edu"
+name: "usdfdev"
+appOfAppsName: "science-platform"
 butlerRepositoryIndex: "s3://rubin-summit-users/data-repos.yaml"
 butlerServerRepositories:
   embargo: "https://usdf-rsp-dev.slac.stanford.edu/api/butler/repo/embargo/butler.yaml"
-fqdn: usdf-rsp-dev.slac.stanford.edu
-name: usdfdev
 vaultUrl: "https://vault.slac.stanford.edu"
-vaultPathPrefix: secret/rubin/usdf-rsp-dev
+vaultPathPrefix: "secret/rubin/usdf-rsp-dev"
 
 applications:
   # This environment uses an ingress managed in a separate Kubernetes cluster,

--- a/environments/values-usdfint.yaml
+++ b/environments/values-usdfint.yaml
@@ -1,10 +1,11 @@
+fqdn: "usdf-rsp-int.slac.stanford.edu"
+name: "usdfint"
+appOfAppsName: "science-platform"
 butlerRepositoryIndex: "s3://rubin-summit-users/data-repos.yaml"
 butlerServerRepositories:
   embargo: "https://usdf-rsp-int.slac.stanford.edu/api/butler/repo/embargo/butler.yaml"
-fqdn: usdf-rsp-int.slac.stanford.edu
-name: usdfint
 vaultUrl: "https://vault.slac.stanford.edu"
-vaultPathPrefix: secret/rubin/usdf-rsp-int
+vaultPathPrefix: "secret/rubin/usdf-rsp-int"
 
 applications:
   # This environment uses an ingress managed in a separate Kubernetes cluster,

--- a/environments/values-usdfprod.yaml
+++ b/environments/values-usdfprod.yaml
@@ -1,10 +1,11 @@
+fqdn: "usdf-rsp.slac.stanford.edu"
+name: "usdfprod"
+appOfAppsName: "science-platform"
 butlerRepositoryIndex: "s3://rubin-summit-users/data-repos.yaml"
 butlerServerRepositories:
   embargo: "https://usdf-rsp.slac.stanford.edu/api/butler/repo/embargo/butler.yaml"
-fqdn: usdf-rsp.slac.stanford.edu
-name: usdfprod
 vaultUrl: "https://vault.slac.stanford.edu"
-vaultPathPrefix: secret/rubin/usdf-rsp
+vaultPathPrefix: "secret/rubin/usdf-rsp"
 
 applications:
   # This environment uses an ingress managed in a separate Kubernetes cluster,

--- a/environments/values.yaml
+++ b/environments/values.yaml
@@ -1,5 +1,17 @@
 # These four settings should be set in each environment values-*.yaml file.
 
+# -- Name of the environment
+# @default -- None, must be set
+name: ""
+
+# -- Fully-qualified domain name where the environment is running
+# @default -- None, must be set
+fqdn: ""
+
+# -- Name of the parent Argo CD app-of-apps that manages all the applications
+# enabled for this environment
+appOfAppsName: "app-of-apps"
+
 # -- Butler repository index URI to use for this environment, for services that
 # connect directly to the Butler database.
 # @default -- None, must be set
@@ -9,14 +21,6 @@ butlerRepositoryIndex: ""
 # dictionary from repository label to URI.
 # @default -- None, must be set
 butlerServerRepositories: {}
-
-# -- Name of the environment
-# @default -- None, must be set
-name: ""
-
-# -- Fully-qualified domain name where the environment is running
-# @default -- None, must be set
-fqdn: ""
 
 # -- URL of the repository for all applications
 repoUrl: https://github.com/lsst-sqre/phalanx.git

--- a/src/phalanx/models/environments.py
+++ b/src/phalanx/models/environments.py
@@ -151,7 +151,9 @@ class ControlSystemConfig(CamelCaseModel):
 
 
 class EnvironmentBaseConfig(CamelCaseModel):
-    """Configuration common to `~phalanx.models.environments.EnvironmentConfig`
+    """Environment configuration options.
+
+    Configuration common to `~phalanx.models.environments.EnvironmentConfig`
     and `~phalanx.models.environments.Environment`.
     """
 
@@ -162,6 +164,19 @@ class EnvironmentBaseConfig(CamelCaseModel):
         title="Domain name",
         description=(
             "Fully-qualified domain name on which the environment listens"
+        ),
+    )
+
+    app_of_apps_name: str | None = Field(
+        None,
+        title="Argo CD app-of-apps name",
+        description=(
+            "Name of the parent Argo CD app-of-apps that manages all of the"
+            " enabled applications. This is required in the merged values"
+            " file that includes environment overrides, but the environment"
+            " override file doesn't need to set it, so it's marked as"
+            " optional for schema checking purposes to allow the override"
+            " file to be schema-checked independently."
         ),
     )
 

--- a/src/phalanx/storage/helm.py
+++ b/src/phalanx/storage/helm.py
@@ -308,7 +308,9 @@ class HelmStorage:
             sys.stderr.write(result.stderr)
         return result.stdout
 
-    def template_environment(self, environment: str) -> str:
+    def template_environment(
+        self, environment: str, app_of_apps_name: str
+    ) -> str:
         """Expand the top-level chart into its Kubernetes resources.
 
         Runs :command:`helm template` to expand the top-level chart into its
@@ -319,6 +321,8 @@ class HelmStorage:
         ----------
         environment
             Name of the environment for which to expand the chart.
+        app_of_apps_name
+            Name of the app-of-apps for that environment.
 
         Returns
         -------
@@ -334,7 +338,7 @@ class HelmStorage:
         try:
             result = self._helm.capture(
                 "template",
-                "science-platform",
+                app_of_apps_name,
                 str(path),
                 "--include-crds",
                 "--values",

--- a/tests/data/input/environments/values-idfdev.yaml
+++ b/tests/data/input/environments/values-idfdev.yaml
@@ -1,5 +1,6 @@
 name: idfdev
 fqdn: data-dev.lsst.cloud
+appOfAppsName: science-platform
 gcp:
   projectId: science-platform-dev-7696
   region: us-central1

--- a/tests/data/input/environments/values.yaml
+++ b/tests/data/input/environments/values.yaml
@@ -8,6 +8,10 @@ name: ""
 # @default -- None, must be set
 fqdn: ""
 
+# -- Name of the parent Argo CD app-of-apps that manages all the applications
+# enabled for this environment
+appOfAppsName: "app-of-apps"
+
 onepassword:
   # -- URL to the 1Password server for this environment, if 1Password is used
   # for static secrets.

--- a/tests/data/output/minikube/values-after-add.yaml
+++ b/tests/data/output/minikube/values-after-add.yaml
@@ -8,6 +8,10 @@ name: ""
 # @default -- None, must be set
 fqdn: ""
 
+# -- Name of the parent Argo CD app-of-apps that manages all the applications
+# enabled for this environment
+appOfAppsName: "app-of-apps"
+
 onepassword:
   # -- URL to the 1Password server for this environment, if 1Password is used
   # for static secrets.


### PR DESCRIPTION
Previously, the installer hard-coded science-platform as the name of the top-level app-of-apps, but this is only appropriate for RSP Phalanx environments. Change the default to app-of-apps, allow it to be overridden, keep it as science-platform for RSP environments, and change it to roundtable for Roundtable.