### PR TITLE
DM-43846: Upgrade Butler server and clients

### DIFF
--- a/applications/butler/Chart.yaml
+++ b/applications/butler/Chart.yaml
@@ -1,8 +1,7 @@
 apiVersion: v2
-appVersion: server-1.0.2
-description: Server for Butler data abstraction service
 name: butler
-sources:
-- https://github.com/lsst/daf_butler
-type: application
 version: 1.0.0
+description: Server for Butler data abstraction service
+sources:
+  - https://github.com/lsst/daf_butler
+appVersion: w.2024.15

--- a/applications/datalinker/Chart.yaml
+++ b/applications/datalinker/Chart.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 description: IVOA DataLink-based service and data discovery
 sources:
   - https://github.com/lsst-sqre/datalinker
-appVersion: 1.7.0
+appVersion: 1.7.1
 annotations:
   phalanx.lsst.io/docs: |
     - id: "DMTN-238"

--- a/applications/vo-cutouts/Chart.yaml
+++ b/applications/vo-cutouts/Chart.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 description: "Image cutout service complying with IVOA SODA"
 sources:
   - "https://github.com/lsst-sqre/vo-cutouts"
-appVersion: 1.1.0
+appVersion: 1.1.1
 
 dependencies:
   - name: redis


### PR DESCRIPTION
Update the Butler server to the latest weekly, and update datalinker and vo-cutouts to the latest Butler client release.