### PR TITLE
DM-43859: Update Squareone

### DIFF
--- a/applications/squareone/Chart.yaml
+++ b/applications/squareone/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
     url: https://github.com/jonathansick
 
 # The default version tag of the squareone docker image
-appVersion: "tickets-DM-43859"
+appVersion: "0.12.0"

--- a/applications/squareone/Chart.yaml
+++ b/applications/squareone/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
     url: https://github.com/jonathansick
 
 # The default version tag of the squareone docker image
-appVersion: "0.11.0"
+appVersion: "tickets-DM-43859"


### PR DESCRIPTION
See https://github.com/lsst-sqre/squareone/pull/164

This deploys Squareone 0.12.0. https://github.com/lsst-sqre/squareone/releases/tag/squareone%400.12.0