### PR TITLE
DM-43837: Add more documentation pointers for Sasquatch

### DIFF
--- a/applications/sasquatch/Chart.yaml
+++ b/applications/sasquatch/Chart.yaml
@@ -1,7 +1,13 @@
 apiVersion: v2
 name: sasquatch
 version: 1.0.0
-description: Rubin Observatory's telemetry service.
+description: "Rubin Observatory's telemetry service"
+home: "https://sasquatch.lsst.io/"
+sources:
+  - "https://github.com/influxdata/influxdb"
+  - "https://github.com/obsidiandynamics/kafdrop"
+  - "https://github.com/confluentinc/kafka-rest"
+  - "https://github.com/lsst-sqre/sasquatch"
 appVersion: 0.1.0
 
 dependencies:

--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -1,6 +1,15 @@
 # sasquatch
 
-Rubin Observatory's telemetry service.
+Rubin Observatory's telemetry service
+
+**Homepage:** <https://sasquatch.lsst.io/>
+
+## Source Code
+
+* <https://github.com/influxdata/influxdb>
+* <https://github.com/obsidiandynamics/kafdrop>
+* <https://github.com/confluentinc/kafka-rest>
+* <https://github.com/lsst-sqre/sasquatch>
 
 ## Values
 

--- a/docs/applications/sasquatch/index.rst
+++ b/docs/applications/sasquatch/index.rst
@@ -5,6 +5,7 @@ sasquatch — Observatory telemetry
 #################################
 
 Rubin Observatory's telemetry service.
+See the `Sasquatch documentation <https://sasquatch.lsst.io>`__ for more details.
 
 .. jinja:: sasquatch
    :file: applications/_summary.rst.jinja


### PR DESCRIPTION
Link to the Sasquatch documentation and add references to the sources of various Sasquatch components to its Chart.yaml.