### PR TITLE
DM-43837: Add current cluster to install prompt

### DIFF
--- a/src/phalanx/cli.py
+++ b/src/phalanx/cli.py
@@ -58,10 +58,12 @@ into whatever Kubernetes cluster is currently configured as your default
 cluster.
 
 THIS WILL OVERWRITE THE APPLICATIONS IN YOUR CURRENT KUBERNETES CLUSTER.
+Your current cluster is:
 
-If you have not verified, with kubectl config current-context, that this is
-the correct cluster immediately before running this command, answer no and
-double-check the cluster before continuing.
+{context}
+
+If this is the correct cluster, answer no and change default clusters with
+kubectl config set-context before continuing.
 """
 """Warning message displayed by :command:`phalanx environment install`."""
 
@@ -429,8 +431,12 @@ def environment_install(
         raise click.UsageError(msg)
 
     # Prompt the user unless they specifically said not to.
+    kubernetes_storage = factory.create_kubernetes_storage()
+    context = kubernetes_storage.get_current_context()
     if not force_noninteractive:
-        print(_INSTALL_WARNING.format(environment=environment))
+        print(
+            _INSTALL_WARNING.format(environment=environment, context=context)
+        )
         click.confirm(
             "Are you certain you want to continue?", abort=True, default=False
         )

--- a/src/phalanx/factory.py
+++ b/src/phalanx/factory.py
@@ -64,10 +64,20 @@ class Factory:
         return EnvironmentService(
             config_storage=config_storage,
             argocd_storage=ArgoCDStorage(),
-            kubernetes_storage=KubernetesStorage(),
+            kubernetes_storage=self.create_kubernetes_storage(),
             helm_storage=HelmStorage(config_storage),
             vault_storage=VaultStorage(),
         )
+
+    def create_kubernetes_storage(self) -> KubernetesStorage:
+        """Create storage object for interacting with Kubernetes.
+
+        Returns
+        -------
+        KubernetesStorage
+            Storage object for interacting with Kubernetes.
+        """
+        return KubernetesStorage()
 
     def create_secrets_service(self) -> SecretsService:
         """Create service for manipulating Phalanx secrets.

--- a/src/phalanx/storage/kubernetes.py
+++ b/src/phalanx/storage/kubernetes.py
@@ -65,6 +65,17 @@ class KubernetesStorage:
             args.append(f"--from-literal={key}={value}")
         self._kubectl.run(*args)
 
+    def get_current_context(self) -> str:
+        """Get the current context (the default Kubernetes cluster).
+
+        Returns
+        -------
+        str
+            Name of the current Kubernetes context.
+        """
+        result = self._kubectl.capture("config", "current-context")
+        return result.stdout.strip()
+
     def wait_for_rollout(self, name: str, namespace: str) -> None:
         """Wait for a Kubernetes rollout to complete.
 


### PR DESCRIPTION
When warning the user before doing an install, print the current cluster from kubectl config current-context. This avoids making the user verify the cluster themselves.