### PR TITLE
DM-43837: Mask the Argo CD password in GitHub Actions

### DIFF
--- a/src/phalanx/storage/argocd.py
+++ b/src/phalanx/storage/argocd.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from datetime import timedelta
 
+from pydantic import SecretStr
+
 from ..models.applications import Project
 from .command import Command
 
@@ -78,7 +80,7 @@ class ArgoCDStorage:
             "argocd",
         )
 
-    def login(self, username: str, password: str) -> None:
+    def login(self, username: str, password: SecretStr) -> None:
         """Authenticate to Argo CD.
 
         Authenticates using username and password authentication with port
@@ -103,7 +105,7 @@ class ArgoCDStorage:
             "--username",
             username,
             "--password",
-            password,
+            password.get_secret_value(),
             "--port-forward",
             "--port-forward-namespace",
             "argocd",


### PR DESCRIPTION
Use the special output commands in GitHub Actions to register and mask the Argo CD password at the start of the installer, since it may otherwise appear in exception error messages if login fails.

Pass the secret through to the login method as a SecretStr instead of a str.