### PR TITLE
DM-43837: Support limiting AppRole token lifetime

### DIFF
--- a/applications/vault-secrets-operator/values-minikube.yaml
+++ b/applications/vault-secrets-operator/values-minikube.yaml
@@ -10,7 +10,7 @@ vault-secrets-operator:
         secretKeyRef:
           name: "vault-credentials"
           key: "VAULT_SECRET_ID"
-    # Set the token lifetime to six hours to minimize the spam of
+    # Set the token lifetime to one hour to minimize the spam of
     # not-yet-expired tokens in Vault from GitHub Actions CI tests.
     - name: "VAULT_TOKEN_MAX_TTL"
-      value: "21600"
+      value: "3600"

--- a/docs/admin/secrets-setup.rst
+++ b/docs/admin/secrets-setup.rst
@@ -71,6 +71,9 @@ This normally requires a Vault admin or provisioner token or some equivalent.
     The output includes the RoleID and SecretID for the AppRole, which can then be provided to `Vault Secrets Operator`_.
     The optional ``--as-secret`` flag may be provided to write the AppRole credentials in a form suitable for piping to :command:`kubectl apply` to create a secret for `Vault Secrets Operator`_.
 
+    When creating an AppRole for GitHub Actions (usually the :px-env:`minikube` environment), pass ``--token-lifetime 3600`` to this command to limit the maximum token lifetime to an hour.
+    This avoids accumulating AppRole tokens in Vault that slow down other Vault operations.
+
 :samp:`phalanx vault create-write-token {environment}`
     Creates a new Vault token with write (create, update, and delete) access to the Vault secrets path for the given environment.
     If any write token previously created by :command:`phalanx` already exists, it is revoked.

--- a/src/phalanx/models/vault.py
+++ b/src/phalanx/models/vault.py
@@ -7,7 +7,7 @@ from base64 import b64encode
 from datetime import datetime
 
 import yaml
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from ..constants import VAULT_SECRET_TEMPLATE
 
@@ -30,6 +30,25 @@ class VaultAppRoleMetadata(BaseModel):
 
     policies: list[str]
     """Policies applied to this AppRole."""
+
+    token_ttl: int | str = Field(
+        0,
+        title="Token lifetime",
+        description=(
+            "Either an integer number of seconds or a duration string."
+            " 0 means there is no limit other than Vault defaults."
+        ),
+    )
+
+    token_max_ttl: int | str = Field(
+        0,
+        title="Maximum token lifetime",
+        description=(
+            "Maximum token lifetime even after renewal. Either an integer"
+            " number of seconds or a duration string. 0 means there is no"
+            " limit other than Vault defaults."
+        ),
+    )
 
 
 class VaultAppRole(VaultAppRoleMetadata):

--- a/src/phalanx/services/vault.py
+++ b/src/phalanx/services/vault.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from datetime import timedelta
 from pathlib import Path
 
 import jinja2
@@ -93,7 +94,9 @@ class VaultService:
             new_vault_client.store_application_secret(name, secret)
             print("Copied Vault secret for", name)
 
-    def create_read_approle(self, environment: str) -> VaultAppRole:
+    def create_read_approle(
+        self, environment: str, *, token_lifetime: timedelta | None = None
+    ) -> VaultAppRole:
         """Create a new Vault read AppRole for the given environment.
 
         This will create (or update) a read policy whose name is the Vault
@@ -110,6 +113,9 @@ class VaultService:
         ----------
         environment
             Name of the environment.
+        token_lifetime
+            If given, limit the token lifetime (both default and renewable) to
+            the given length of time.
 
         Returns
         -------
@@ -125,7 +131,9 @@ class VaultService:
         if approle:
             vault_client.revoke_approle_secret_ids(config.vault_read_approle)
         return vault_client.create_approle(
-            config.vault_read_approle, [config.vault_read_policy]
+            config.vault_read_approle,
+            [config.vault_read_policy],
+            token_lifetime=token_lifetime,
         )
 
     def create_write_token(

--- a/tests/support/vault.py
+++ b/tests/support/vault.py
@@ -114,7 +114,13 @@ class MockVaultClient:
         }
 
     def create_or_update_approle(
-        self, role_name: str, *, token_policies: list[str], token_type: str
+        self,
+        role_name: str,
+        *,
+        token_policies: list[str],
+        token_type: str,
+        token_ttl: int | None = None,
+        token_max_ttl: int | None = None,
     ) -> None:
         """Create or update an AppRole.
 
@@ -126,10 +132,17 @@ class MockVaultClient:
             List of policies to apply to the AppRole.
         token_type
             Type of token (must be ``service``).
+        token_ttl
+            Lifetime of tokens in seconds.
+        token_max_ttl
+            Maximum lifetime of tokens in seconds.
         """
         assert token_type == "service"
         self._approles[role_name] = VaultAppRoleMetadata(
-            role_id=str(uuid4()), policies=token_policies
+            role_id=str(uuid4()),
+            policies=token_policies,
+            token_ttl=token_ttl or 0,
+            token_max_ttl=token_max_ttl or 0,
         )
 
     def create_or_update_policy(self, path: str, policy: str) -> None:
@@ -377,7 +390,9 @@ class MockVaultClient:
             raise InvalidPath(f"Unknown AppRole {role_name}")
         return {
             "data": {
-                "token_policies": list(self._approles[role_name].policies)
+                "token_policies": list(self._approles[role_name].policies),
+                "token_ttl": self._approles[role_name].token_ttl,
+                "token_max_ttl": self._approles[role_name].token_max_ttl,
             }
         }
 


### PR DESCRIPTION
The minikube GitHub CI environment performs two AppRole logins for every test, one for the installer and one for vault-secrets-operator. These create Vault tokens, which then have to be examined by other Vault operations such as create-write-token that need to audit the existing tokens.

Support limiting the lifetime of those tokens so that they will expire faster and thus prevent token accumulation that slows down other operations. Limit the token lifetime obtained by vault-secrets-operator for minikube to one hour, since the minikube AppRole now has a maximum token lifetime of two hours.