### PR TITLE
DM-43837: Diagnose missing environment variables

### DIFF
--- a/src/phalanx/cli.py
+++ b/src/phalanx/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 import shutil
 import sys
@@ -116,6 +117,23 @@ def _require_command(command: str) -> None:
     """
     if not shutil.which(command):
         raise click.UsageError(f"{command} not found on PATH, not installed?")
+
+
+def _require_env(variable: str) -> None:
+    """Require that a given environment variable be set.
+
+    Parameters
+    ----------
+    variable
+        Name of the environment variable.
+
+    Raises
+    ------
+    click.UsageError
+        Raised if the environment variable isn't set.
+    """
+    if not os.getenv(variable):
+        raise click.UsageError(f"{variable} must be set in the environment")
 
 
 @click.group(context_settings={"help_option_names": ["-h", "--help"]})
@@ -584,6 +602,7 @@ def secrets_audit(
     The environment variable VAULT_TOKEN must be set to a token with read
     access to the Vault data for the given environment.
     """
+    _require_env("VAULT_TOKEN")
     if not config:
         config = _find_config()
     static_secrets = StaticSecrets.from_path(secrets) if secrets else None
@@ -644,6 +663,7 @@ def secrets_onepassword_secrets(
     The environment variable OP_CONNECT_TOKEN must be set to the 1Password
     Connect token for the given environment.
     """
+    _require_env("OP_CONNECT_TOKEN")
     if not config:
         config = _find_config()
     factory = Factory(config)
@@ -770,6 +790,7 @@ def secrets_sync(
     access). If Vault credentials are managed through this tool, such a token
     can be created with the ``phalanx vault create-write-token`` command.
     """
+    _require_env("VAULT_TOKEN")
     if not config:
         config = _find_config()
     static_secrets = StaticSecrets.from_path(secrets) if secrets else None
@@ -803,6 +824,7 @@ def vault_audit(environment: str, *, config: Path | None) -> None:
     The environment variable VAULT_TOKEN must be set to a token with access to
     read policies, AppRoles, tokens, and token accessors.
     """
+    _require_env("VAULT_TOKEN")
     if not config:
         config = _find_config()
     factory = Factory(config)
@@ -837,6 +859,7 @@ def vault_copy_secrets(
     access to the old path and write access to the currently configured Vault
     path for the given environment.
     """
+    _require_env("VAULT_TOKEN")
     if not config:
         config = _find_config()
     factory = Factory(config)
@@ -886,6 +909,7 @@ def vault_create_read_approle(
     create policies and AppRoles, list AppRole SecretID accessors, and revoke
     AppRole SecretIDs.
     """
+    _require_env("VAULT_TOKEN")
     if not config:
         config = _find_config()
     factory = Factory(config)
@@ -929,6 +953,7 @@ def vault_create_write_token(
     The environment variable VAULT_TOKEN must be set to a token with access to
     list token accessors, create policies, and create and revoke tokens.
     """
+    _require_env("VAULT_TOKEN")
     if not config:
         config = _find_config()
     factory = Factory(config)
@@ -959,6 +984,7 @@ def vault_export_secrets(
     The environment variable VAULT_TOKEN must be set to a token with read
     access to the Vault data for the given environment.
     """
+    _require_env("VAULT_TOKEN")
     if not config:
         config = _find_config()
     factory = Factory(config)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,18 @@ from .support.onepassword import MockOnepasswordClient, patch_onepassword
 from .support.vault import MockVaultClient, patch_vault
 
 
+@pytest.fixture(autouse=True)
+def _clear_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Remove dangerous environment variables.
+
+    Ensure that none of the tests can accidentally authenticate to a live
+    Vault or 1Password Connect server by clearing the relevant environment
+    variables.
+    """
+    monkeypatch.delenv("OP_CONNECT_TOKEN", raising=False)
+    monkeypatch.delenv("VAULT_TOKEN", raising=False)
+
+
 @pytest.fixture
 def factory() -> Factory:
     """Create a factory pointing at the test data."""

--- a/tests/support/cli.py
+++ b/tests/support/cli.py
@@ -12,7 +12,10 @@ __all__ = ["run_cli"]
 
 
 def run_cli(
-    *command: str, needs_config: bool = True, stdin: str | None = None
+    *command: str,
+    env: dict[str, str] | None = None,
+    needs_config: bool = True,
+    stdin: str | None = None,
 ) -> Result:
     """Run the given command in the Click testing harness.
 
@@ -22,6 +25,8 @@ def run_cli(
     ----------
     *command
         Command to run.
+    env
+        Environment variable overrides.
     needs_config
         Whether to add the ``--config`` flag pointing to the test data to the
         end of the command.
@@ -32,4 +37,6 @@ def run_cli(
     if needs_config:
         args.extend(["--config", str(phalanx_test_path())])
     runner = CliRunner()
-    return runner.invoke(main, args, catch_exceptions=False, input=stdin)
+    return runner.invoke(
+        main, args, catch_exceptions=False, env=env, input=stdin
+    )

--- a/tests/support/onepassword.py
+++ b/tests/support/onepassword.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import uuid
 from collections.abc import Iterator
 from unittest.mock import patch
@@ -158,10 +157,4 @@ def patch_onepassword() -> Iterator[MockOnepasswordClient]:
     """
     mock = MockOnepasswordClient()
     with patch("phalanx.storage.onepassword.new_client", return_value=mock):
-        old = os.getenv("OP_CONNECT_TOKEN")
-        os.environ["OP_CONNECT_TOKEN"] = "some-token"
         yield mock
-        if old:
-            os.environ["OP_CONNECT_TOKEN"] = old
-        else:
-            del os.environ["OP_CONNECT_TOKEN"]


### PR DESCRIPTION
Check for required environment variables in phalanx CLI commands and raise a clear error. Adjust the test suite to set required environment variables to dummy values, and add a global fixture to ensure that any environment variables set in the test runner's environment don't leak.