### PR TITLE
DM-43923: Get Vault write tokens from static secrets

### DIFF
--- a/docs/admin/audit-secrets.rst
+++ b/docs/admin/audit-secrets.rst
@@ -8,7 +8,10 @@ To check that all of the necessary secrets for an environment named ``<environme
 
    phalanx secrets audit <environment>
 
-The ``VAULT_TOKEN`` environment variable must be set to the Vault write token for this environment (or a read token; this command will not make any changes).
+Add the ``--secrets`` command-line option or set ``OP_CONNECT_TOKEN`` if needed for your choice of a :ref:`static secrets source <admin-static-secrets>`.
+For SQuaRE-managed deployments, the 1Password token for ``OP_CONNECT_TOKEN`` comes from the ``Phalanx 1Password tokens`` item in the SQuaRE 1Password vault.
+
+If you did not store the Vault write token for your environment with the static secrets, the ``VAULT_TOKEN`` environment variable must be set to the Vault write token for this environment (or a read token; this command will not make any changes).
 For SQuaRE-managed environments, you can get the write token from the ``Phalanx Vault write tokens`` item in the SQuaRE 1Password vault.
 
 The output of the command will be a report of any inconsistencies or problems found in the Vault secrets for this environment.

--- a/docs/admin/migrating-secrets.rst
+++ b/docs/admin/migrating-secrets.rst
@@ -139,7 +139,7 @@ Update secrets
    See :doc:`add-new-secret` for detailed instructions on how to add static secrets for an application.
    You will need to do this for every application.
 
-   To obtain the current values of static secrets, look either in the old ``RSP-Vault`` 1Password vault (for SQuaRE-managed environments) or use the :command:`vault kv get` command to read the current value of the static secret out of Vault (copied to the new path in the previous step).
+   To obtain the current values of static secrets, use the :command:`vault kv get` command to read the current value of the static secret out of Vault (copied to the new path in the previous step).
 
    For example, to see all the current secrets for the application ``nublado``, run:
 
@@ -151,6 +151,8 @@ Update secrets
 
 #. If you are using 1Password as the source for static secrets, set ``OP_CONNECT_TOKEN`` to the 1Password Connect token for this environment.
    For SQuaRE-managed environments, this can be found in the ``RSP 1Password tokens`` item in the SQuaRE 1Password vault.
+
+   Also, add the :ref:`pull secret <admin-onepassword-pull-secret>` and :ref:`Vault write token <admin-onepassword-vault-token>` to the 1Password vault for this environment if appropriate.
 
 #. Check what secrets are missing or incorrect and fix them.
 

--- a/docs/admin/sync-secrets.rst
+++ b/docs/admin/sync-secrets.rst
@@ -11,11 +11,11 @@ To populate Vault with all of the necessary secrets for an environment named ``<
 
    phalanx secrets sync <environment>
 
-The ``VAULT_TOKEN`` environment variable must be set to the Vault write token for this environment.
-For SQuaRE-managed environments, you can get the write token from the ``Phalanx Vault write tokens`` item in the SQuaRE 1Password vault.
-
 Add the ``--secrets`` command-line option or set ``OP_CONNECT_TOKEN`` if needed for your choice of a :ref:`static secrets source <admin-static-secrets>`.
 For SQuaRE-managed deployments, the 1Password token for ``OP_CONNECT_TOKEN`` comes from the ``Phalanx 1Password tokens`` item in the SQuaRE 1Password vault.
+
+If you did not store the Vault write token for your environment with the static secrets, the ``VAULT_TOKEN`` environment variable must be set to the Vault write token for this environment.
+For SQuaRE-managed environments, you can get the write token from the ``Phalanx Vault write tokens`` item in the SQuaRE 1Password vault.
 
 This must be done before installing a Phalanx environment for the first time.
 It can then be run again whenever the secrets for that environment change.

--- a/docs/admin/update-a-secret.rst
+++ b/docs/admin/update-a-secret.rst
@@ -9,14 +9,14 @@ Static secrets in a YAML file
 =============================
 
 If the environment stores static secrets in a secure YAML file, the environment administrator should update that file with the newly-required static secrets.
-Then, sync the secrets into Vault following the instructions in :doc:`/admin/sync-secrets`.
+Then, sync the secrets into Vault following the instructions in :doc:`sync-secrets`.
 
 Static secrets stored directly in Vault
 =======================================
 
 If the environment stores static secrets directly in Vault, the environment administrator should change the static secret directly in Vault.
 Be aware that when multiple applications use the same static secret, one of them is defined as the "owner" and the other applications use ``copy`` directives in their :file:`secrets.yaml` files to copy the secret from the "owning" application.
-In this case, the static secret must be updated separately for every copy.
+In this case, the copies of the secret will be update when you :doc:`sync secrets <sync-secrets>`.
 
 When the static secrets are stored directly in Vault, no separate sync step is required.
 

--- a/src/phalanx/exceptions.py
+++ b/src/phalanx/exceptions.py
@@ -19,6 +19,7 @@ __all__ = [
     "MissingOnepasswordSecretsError",
     "NoOnepasswordConfigError",
     "NoOnepasswordCredentialsError",
+    "NoVaultCredentialsError",
     "UnknownEnvironmentError",
     "UnresolvedSecretsError",
     "VaultNotFoundError",
@@ -216,6 +217,14 @@ class NoOnepasswordCredentialsError(Exception):
 
     def __init__(self) -> None:
         msg = "No 1Password Connect credentials (OP_CONNECT_TOKEN) set"
+        super().__init__(msg)
+
+
+class NoVaultCredentialsError(Exception):
+    """Vault credentials are required and were not supplied."""
+
+    def __init__(self) -> None:
+        msg = "No Vault credentials in static secrets and VAULT_TOKEN not set"
         super().__init__(msg)
 
 

--- a/src/phalanx/factory.py
+++ b/src/phalanx/factory.py
@@ -79,6 +79,16 @@ class Factory:
         """
         return KubernetesStorage()
 
+    def create_onepassword_storage(self) -> OnepasswordStorage:
+        """Create storage object for interacting with 1Password.
+
+        Returns
+        -------
+        OnepasswordStorage
+            Storage object for interacting with 1Password.
+        """
+        return OnepasswordStorage()
+
     def create_secrets_service(self) -> SecretsService:
         """Create service for manipulating Phalanx secrets.
 
@@ -87,11 +97,10 @@ class Factory:
         SecretsService
             Service for manipulating secrets.
         """
-        config_storage = self.create_config_storage()
-        onepassword_storage = OnepasswordStorage()
-        vault_storage = VaultStorage()
         return SecretsService(
-            config_storage, onepassword_storage, vault_storage
+            self.create_config_storage(),
+            self.create_onepassword_storage(),
+            VaultStorage(),
         )
 
     def create_vault_service(self) -> VaultService:

--- a/src/phalanx/models/secrets.py
+++ b/src/phalanx/models/secrets.py
@@ -390,6 +390,13 @@ class StaticSecrets(BaseModel):
         alias="pull-secret",
     )
 
+    vault_write_token: SecretStr | None = Field(
+        None,
+        title="Vault write token",
+        description="Vault write token for this environment",
+        alias="vault-write-token",
+    )
+
     model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
     @classmethod

--- a/tests/data/input/onepassword/minikube.yaml
+++ b/tests/data/input/onepassword/minikube.yaml
@@ -18,3 +18,4 @@ pull-secret:
     hub.docker.com:
       username: sqrereadonly
       password: docker-password
+vault-write-token: a-vault-write-token

--- a/tests/data/output/idfdev/static-secrets.yaml
+++ b/tests/data/output/idfdev/static-secrets.yaml
@@ -69,3 +69,4 @@ pull-secret:
     have two keys, username and password, that provide the HTTP Basic Auth
     credentials for that registry.
   registries: {}
+vault-write-token: null

--- a/tests/data/output/minikube/onepassword-secrets.yaml
+++ b/tests/data/output/minikube/onepassword-secrets.yaml
@@ -23,3 +23,4 @@ pull-secret:
     hub.docker.com:
       password: docker-password
       username: sqrereadonly
+vault-write-token: a-vault-write-token

--- a/tests/support/onepassword.py
+++ b/tests/support/onepassword.py
@@ -82,6 +82,11 @@ class MockOnepasswordClient:
             self._data[vault]["pull-secret"] = Item(
                 title="pull-secret", fields=fields, sections=sections
             )
+        if secrets.vault_write_token:
+            token = secrets.vault_write_token.get_secret_value()
+            fields = [Field(label="vault-token", value=token)]
+            item = Item(title="vault-write-token", fields=fields)
+            self._data[vault]["vault-write-token"] = item
 
     def get_item(self, title: str, vault_id: str) -> Item:
         """Get an item from a 1Password vault.


### PR DESCRIPTION
Allow people to put the Vault write token for their environments into the static secrets file or 1Password source, since it's roughly equivalent in power to the other secrets also stored there. This allows environments that use 1Password to set only OP_CONNECT_TOKEN and not worry about the Vault write token.