### PR TITLE
DM-43965: Make descriptions optional for copied secrets

### DIFF
--- a/applications/datalinker/secrets.yaml
+++ b/applications/datalinker/secrets.yaml
@@ -1,20 +1,12 @@
 "aws-credentials.ini":
-  description: >-
-    Google Cloud Storage credentials to the Butler data store, formatted using
-    AWS syntax for use with boto.
   copy:
     application: nublado
     key: "aws-credentials.ini"
 "butler-gcs-idf-creds.json":
-  description: >-
-    Google Cloud Storage credentials to the Butler data store in the native
-    Google syntax, containing the private asymmetric key.
   copy:
     application: nublado
     key: "butler-gcs-idf-creds.json"
 "postgres-credentials.txt":
-  description: >-
-    PostgreSQL credentials in its pgpass format for the Butler database.
   copy:
     application: nublado
     key: "postgres-credentials.txt"

--- a/docs/developers/secrets-spec.rst
+++ b/docs/developers/secrets-spec.rst
@@ -7,14 +7,17 @@ The key corresponds to the key under which this secret is stored in the secret e
 
 The specification of the secret has the following keys:
 
-``description`` (string, required)
+``description`` (string, required unless ``copy`` is set)
     Human-readable description of the secret.
     This should include a summary of what the secret is used for, any useful information about the consequences if it should be leaked, and any details on how to rotate it if needed.
     The description must be formatted with reStructuredText_.
 
+.. _reStructuredText: https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
+
     The ``>`` and ``|`` features of YAML may be helpful in keeping this description readable inside the YAML file.
 
-.. _reStructuredText: https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
+    If a non-conditional ``copy`` setting is also present (see below), this field may be omitted.
+    In this case, the description will be copied from the source of the secret.
 
 ``if`` (string, optional)
     If present, specifies the conditions under which this secret is required.

--- a/docs/extras/schemas/secrets.json
+++ b/docs/extras/schemas/secrets.json
@@ -18,9 +18,17 @@
           "title": "Copy rules"
         },
         "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
           "description": "Description of the secret",
-          "title": "Description",
-          "type": "string"
+          "title": "Description"
         },
         "generate": {
           "anyOf": [
@@ -76,9 +84,6 @@
           "title": "Value"
         }
       },
-      "required": [
-        "description"
-      ],
       "title": "ConditionalSecretConfig",
       "type": "object"
     },

--- a/src/phalanx/models/secrets.py
+++ b/src/phalanx/models/secrets.py
@@ -195,8 +195,8 @@ class SecretOnepasswordConfig(BaseModel):
 class SecretConfig(BaseModel):
     """Specification for an application secret."""
 
-    description: str = Field(
-        ..., title="Description", description="Description of the secret"
+    description: str | None = Field(
+        None, title="Description", description="Description of the secret"
     )
 
     copy_rules: SecretCopyRules | None = Field(
@@ -240,6 +240,13 @@ class ConditionalSecretConfig(SecretConfig, ConditionalMixin):
         title="Generation rules",
         description="Rules for how the secret should be generated",
     )
+
+    @model_validator(mode="after")
+    def _validate_description(self) -> Self:
+        has_copy = self.copy_rules and not self.copy_rules.condition
+        if not self.description and not has_copy:
+            raise ValueError("description must be set")
+        return self
 
     @model_validator(mode="after")
     def _validate_generate(self) -> Self:


### PR DESCRIPTION
If a secret has an unconditional copy directive, make the description field optional. This allows people to inherit the description from the source of a copied secret if desired.