### PR TITLE
DM-43966: Standardize error handling in Phalanx CLI

### DIFF
--- a/docs/documenteer.toml
+++ b/docs/documenteer.toml
@@ -42,6 +42,7 @@ python_api_dir = "internals/api"
 rst_epilog_file = "_rst_epilog.rst"
 
 [sphinx.intersphinx.projects]
+click = "https://click.palletsprojects.com/en/8.1.x/"
 python = "https://docs.python.org/3/"
 safir = "https://safir.lsst.io/"
 sphinx = "https://www.sphinx-doc.org/en/master/"

--- a/src/phalanx/exceptions.py
+++ b/src/phalanx/exceptions.py
@@ -22,22 +22,9 @@ __all__ = [
     "NoVaultCredentialsError",
     "UnknownEnvironmentError",
     "UnresolvedSecretsError",
+    "UsageError",
     "VaultNotFoundError",
 ]
-
-
-class ApplicationExistsError(Exception):
-    """Application being created already exists.
-
-    Parameters
-    ----------
-    name
-        Name of the application.
-    """
-
-    def __init__(self, name: str) -> None:
-        msg = f"Application {name} already exists"
-        super().__init__(msg)
 
 
 class CommandFailedError(Exception):
@@ -110,7 +97,34 @@ class GitRemoteError(Exception):
     """Unable to get necessary information from a Git remote."""
 
 
-class InvalidApplicationConfigError(Exception):
+class NoOnepasswordConfigError(Exception):
+    """Environment does not use 1Password."""
+
+
+class UsageError(Exception):
+    """An error that should be printed to standard error without a backtrace.
+
+    Usage errors are caught by the CLI and turned into `click.UsageError`
+    without the backtrace. Use this as a base class for user errors and
+    configuration errors where the backtrace is not useful.
+    """
+
+
+class ApplicationExistsError(UsageError):
+    """Application being created already exists.
+
+    Parameters
+    ----------
+    name
+        Name of the application.
+    """
+
+    def __init__(self, name: str) -> None:
+        msg = f"Application {name} already exists"
+        super().__init__(msg)
+
+
+class InvalidApplicationConfigError(UsageError):
     """Configuration for an application is invalid.
 
     Parameters
@@ -133,7 +147,7 @@ class InvalidApplicationConfigError(Exception):
         super().__init__(msg)
 
 
-class InvalidEnvironmentConfigError(Exception):
+class InvalidEnvironmentConfigError(UsageError):
     """Configuration for an environment is invalid.
 
     Parameters
@@ -149,7 +163,7 @@ class InvalidEnvironmentConfigError(Exception):
         super().__init__(msg)
 
 
-class InvalidSecretConfigError(Exception):
+class InvalidSecretConfigError(UsageError):
     """Secret configuration is invalid.
 
     Parameters
@@ -168,7 +182,7 @@ class InvalidSecretConfigError(Exception):
         super().__init__(msg)
 
 
-class MalformedOnepasswordSecretError(Exception):
+class MalformedOnepasswordSecretError(UsageError):
     """A secret stored in 1Password was malformed.
 
     The most common cause of this error is that the secret was marked as
@@ -190,7 +204,7 @@ class MalformedOnepasswordSecretError(Exception):
         super().__init__(msg)
 
 
-class MissingOnepasswordSecretsError(Exception):
+class MissingOnepasswordSecretsError(UsageError):
     """Secrets are missing from 1Password.
 
     Parameters
@@ -208,11 +222,7 @@ class MissingOnepasswordSecretsError(Exception):
         super().__init__(msg)
 
 
-class NoOnepasswordConfigError(Exception):
-    """Environment does not use 1Password."""
-
-
-class NoOnepasswordCredentialsError(Exception):
+class NoOnepasswordCredentialsError(UsageError):
     """1Password is configured, but no credentials were supplied."""
 
     def __init__(self) -> None:
@@ -220,7 +230,7 @@ class NoOnepasswordCredentialsError(Exception):
         super().__init__(msg)
 
 
-class NoVaultCredentialsError(Exception):
+class NoVaultCredentialsError(UsageError):
     """Vault credentials are required and were not supplied."""
 
     def __init__(self) -> None:
@@ -228,7 +238,7 @@ class NoVaultCredentialsError(Exception):
         super().__init__(msg)
 
 
-class UnresolvedSecretsError(Exception):
+class UnresolvedSecretsError(UsageError):
     """Some secrets could not be resolved.
 
     Parameters
@@ -243,7 +253,7 @@ class UnresolvedSecretsError(Exception):
         super().__init__(msg)
 
 
-class UnknownEnvironmentError(Exception):
+class UnknownEnvironmentError(UsageError):
     """No configuration found for an environment name.
 
     Parameters
@@ -257,7 +267,7 @@ class UnknownEnvironmentError(Exception):
         super().__init__(msg)
 
 
-class VaultNotFoundError(Exception):
+class VaultNotFoundError(UsageError):
     """Secret could not be found in Vault.
 
     Parameters

--- a/tests/cli/secrets_test.py
+++ b/tests/cli/secrets_test.py
@@ -10,12 +10,10 @@ from pathlib import Path
 
 import bcrypt
 import click
-import pytest
 import yaml
 from cryptography.fernet import Fernet
 from safir.datetime import current_datetime
 
-from phalanx.exceptions import MalformedOnepasswordSecretError
 from phalanx.factory import Factory
 from phalanx.models.gafaelfawr import Token
 
@@ -330,15 +328,15 @@ def test_sync_onepassword_errors(
             field.value = "invalid base64"
 
     # sync should throw an exception containing the application and key.
-    with pytest.raises(MalformedOnepasswordSecretError) as excinfo:
-        run_cli(
-            "secrets",
-            "sync",
-            "minikube",
-            env={"OP_CONNECT_TOKEN": "sometoken", "VAULT_TOKEN": "sometoken"},
-        )
-    assert app_name in str(excinfo.value)
-    assert key in str(excinfo.value)
+    result = run_cli(
+        "secrets",
+        "sync",
+        "minikube",
+        env={"OP_CONNECT_TOKEN": "sometoken", "VAULT_TOKEN": "sometoken"},
+    )
+    assert result.exit_code == 2
+    assert app_name in result.output
+    assert key in result.output
 
     # Instead set the secret to a value that is valid base64, but of binary
     # data that cannot be decoded to a string.
@@ -347,15 +345,15 @@ def test_sync_onepassword_errors(
             field.value = b64encode("ää".encode("iso-8859-1")).decode()
 
     # sync should throw an exception containing the application and key.
-    with pytest.raises(MalformedOnepasswordSecretError) as excinfo:
-        run_cli(
-            "secrets",
-            "sync",
-            "minikube",
-            env={"OP_CONNECT_TOKEN": "sometoken", "VAULT_TOKEN": "sometoken"},
-        )
-    assert app_name in str(excinfo.value)
-    assert key in str(excinfo.value)
+    run_cli(
+        "secrets",
+        "sync",
+        "minikube",
+        env={"OP_CONNECT_TOKEN": "sometoken", "VAULT_TOKEN": "sometoken"},
+    )
+    assert result.exit_code == 2
+    assert app_name in result.output
+    assert key in result.output
 
 
 def test_sync_regenerate(


### PR DESCRIPTION
Add a class of usage error exceptions and a decorator that translates them into Click UsageErrors that just display the error message without a stack backtrace.