### PR TITLE
DM-43966: Prevent copying Vault secrets onto themselves

### DIFF
--- a/src/phalanx/exceptions.py
+++ b/src/phalanx/exceptions.py
@@ -24,6 +24,7 @@ __all__ = [
     "UnresolvedSecretsError",
     "UsageError",
     "VaultNotFoundError",
+    "VaultPathConflictError",
 ]
 
 
@@ -263,8 +264,7 @@ class UnknownEnvironmentError(UsageError):
     """
 
     def __init__(self, name: str) -> None:
-        msg = f"No configuration found for environment {name}"
-        super().__init__(msg)
+        super().__init__(f"No configuration found for environment {name}")
 
 
 class VaultNotFoundError(UsageError):
@@ -286,3 +286,16 @@ class VaultNotFoundError(UsageError):
         else:
             msg = f"Vault secret {path} not found in server {url}"
         super().__init__(msg)
+
+
+class VaultPathConflictError(UsageError):
+    """Attempt to copy a Vault tree onto itself.
+
+    Parameters
+    ----------
+    path
+        Path inside Vault being copied.
+    """
+
+    def __init__(self, path: str) -> None:
+        super().__init__(f"Vault path {path} cannot be copied onto itself")

--- a/tests/cli/vault_test.py
+++ b/tests/cli/vault_test.py
@@ -138,6 +138,19 @@ def test_copy_secrets(
 
     assert_json_dirs_match(tmp_path, vault_input_path)
 
+    # Check that the Vault secrets cannot be copied over themselves.
+    config_storage = factory.create_config_storage()
+    environment = config_storage.load_environment_config("idfdev")
+    result = run_cli(
+        "vault",
+        "copy-secrets",
+        "idfdev",
+        environment.vault_path_prefix,
+        env={"VAULT_TOKEN": "sometoken"},
+    )
+    assert result.exit_code == 2
+    assert "cannot be copied onto itself" in result.output
+
 
 def test_create_read_approle(
     factory: Factory,

--- a/tests/data/output/idfdev/copy-output
+++ b/tests/data/output/idfdev/copy-output
@@ -1,3 +1,4 @@
+Copying secrets from k8s_operator/data-dev.lsst.cloud to phalanx/idfdev
 Copied Vault secret for argocd
 Copied Vault secret for gafaelfawr
 Copied Vault secret for mobu


### PR DESCRIPTION
phalanx vault copy-secrets was prone to copying secrets onto themselves if people forgot to update the Vault secrets path in the environment configuration. Catch that case and fail early with an error instead.