### PR TITLE
DM-44008: Handle the case of a nonexistent Vault path

### DIFF
--- a/src/phalanx/cli.py
+++ b/src/phalanx/cli.py
@@ -636,6 +636,10 @@ def secrets_audit(
     A Vault token with read access to the Vault data for the given environment
     must be available in the static secrets or present in the VAULT_TOKEN
     environment variable.
+
+    The Vault server does not clearly distinguish between unknown paths and
+    permission denied errors, so if the Vault token doesn't have write access
+    or if the path doesn't exist, all secrets will be reported as missing.
     """
     if not config:
         config = _find_config()


### PR DESCRIPTION
Do not error out if the Vault path doesn't exist in secrets audit and secrets sync, since otherwise we can't create the tree for a new environment from scratch. Unfortunately, the Vault server returns permission denied for nonexistent paths, so we can't distinguish between this case and using the wrong Vault token until we try to write.