### PR TITLE
DM-44008: Fix typo in install warning

### DIFF
--- a/src/phalanx/cli.py
+++ b/src/phalanx/cli.py
@@ -71,8 +71,8 @@ Your current cluster is:
 
 {context}
 
-If this is the correct cluster, answer no and change default clusters with
-kubectl config set-context before continuing.
+If this is not the correct cluster, answer no and change default clusters
+with kubectl config set-context before continuing.
 """
 """Warning message displayed by :command:`phalanx environment install`."""
 


### PR DESCRIPTION
The warning should have read "if this is not the correct cluster."