### PR TITLE
DM-44008: Fix repeated environment installs

### DIFF
--- a/src/phalanx/constants.py
+++ b/src/phalanx/constants.py
@@ -12,7 +12,8 @@ __all__ = [
     "HELM_DOCLINK_ANNOTATION",
     "ONEPASSWORD_ENCODED_WARNING",
     "PULL_SECRET_DESCRIPTION",
-    "VAULT_SECRET_TEMPLATE",
+    "VAULT_APPROLE_SECRET_TEMPLATE",
+    "VAULT_TOKEN_SECRET_TEMPLATE",
     "VAULT_WRITE_TOKEN_LIFETIME",
     "VAULT_WRITE_TOKEN_WARNING_LIFETIME",
 ]
@@ -34,7 +35,7 @@ PULL_SECRET_DESCRIPTION = (
 )
 """Description to put in the static secrets YAML file for ``pull-secret``."""
 
-VAULT_SECRET_TEMPLATE = """\
+VAULT_APPROLE_SECRET_TEMPLATE = """\
 apiVersion: v1
 kind: Secret
 metadata:
@@ -46,6 +47,18 @@ data:
 type: Opaque
 """
 """Template for a ``Secret`` containing AppRole credentials."""
+
+VAULT_TOKEN_SECRET_TEMPLATE = """\
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {name}
+  namespace: vault-secrets-operator
+data:
+  VAULT_TOKEN: {token}
+type: Opaque
+"""
+"""Template for a ``Secret`` containing token credentials."""
 
 VAULT_WRITE_TOKEN_LIFETIME = "3650d"
 """Default lifetime to set for Vault write tokens."""

--- a/src/phalanx/services/environment.py
+++ b/src/phalanx/services/environment.py
@@ -118,10 +118,10 @@ class EnvironmentService:
             self._kubernetes.create_namespace(
                 "vault-secrets-operator", ignore_fail=True
             )
-            self._kubernetes.create_generic_secret(
+            self._kubernetes.create_vault_secret(
                 "vault-credentials",
                 "vault-secrets-operator",
-                vault_credentials.to_secret_data(),
+                vault_credentials,
             )
             self._helm.dependency_update("vault-secrets-operator")
             self._helm.upgrade_application(

--- a/src/phalanx/storage/command.py
+++ b/src/phalanx/storage/command.py
@@ -77,6 +77,7 @@ class Command:
         cwd: Path | None = None,
         ignore_fail: bool = False,
         quiet: bool = False,
+        stdin: str | None = None,
         timeout: timedelta | None = None,
     ) -> None:
         """Run the command with the provided arguments.
@@ -95,6 +96,8 @@ class Command:
             running the command.
         ignore_fail
             If `True`, do not raise an exception on failure.
+        stdin
+            Input for the command.
         quiet
             If `True`, discard standard output. Standard error is still
             displayed on the process standard error stream.
@@ -115,10 +118,13 @@ class Command:
             Raised if the command could not be executed at all.
         """
         cmdline = [self._command, *args]
+        stdin_bytes = stdin.encode() if stdin is not None else None
         stdout = subprocess.DEVNULL if quiet else None
         check = not ignore_fail
         try:
-            subprocess.run(cmdline, check=check, cwd=cwd, stdout=stdout)
+            subprocess.run(
+                cmdline, check=check, cwd=cwd, input=stdin_bytes, stdout=stdout
+            )
         except subprocess.CalledProcessError as e:
             raise CommandFailedError(self._command, args, e) from e
         except subprocess.TimeoutExpired as e:

--- a/tests/cli/vault_test.py
+++ b/tests/cli/vault_test.py
@@ -11,7 +11,10 @@ import jinja2
 import yaml
 from safir.datetime import current_datetime
 
-from phalanx.constants import VAULT_SECRET_TEMPLATE, VAULT_WRITE_TOKEN_LIFETIME
+from phalanx.constants import (
+    VAULT_APPROLE_SECRET_TEMPLATE,
+    VAULT_WRITE_TOKEN_LIFETIME,
+)
 from phalanx.factory import Factory
 from phalanx.models.vault import VaultAppRole, VaultToken
 
@@ -204,7 +207,7 @@ def test_create_read_approle(
     secret = yaml.safe_load(result.output)
     r = mock_vault.read_role_id(role_name)
     role_id = r["data"]["role_id"]
-    expected = VAULT_SECRET_TEMPLATE.format(
+    expected = VAULT_APPROLE_SECRET_TEMPLATE.format(
         name="vault-credentials",
         role_id=b64encode(role_id.encode()).decode(),
         secret_id=secret["data"]["VAULT_SECRET_ID"],


### PR DESCRIPTION
The second time one ran phalanx environment install for the same environment with the same cluster and partial resources, it would fail because it tried to create the vault-secrets-operator secret and could not overwrite it. Change the installer to use kubectl apply instead of kubectl create, similar to the old bash script, which avoids this problem. As a bonus, this will avoid leaking the Vault tokens to error output if the secret creation fails.
