### PR TITLE
DM-44093: Add a fastapi-safir starter

### DIFF
--- a/docs/developers/helm-chart/create-new-chart.rst
+++ b/docs/developers/helm-chart/create-new-chart.rst
@@ -15,13 +15,16 @@ Then, create the files for the new application, including the start of a Helm ch
 Replace ``<application>`` with the name of your new application, which will double as the name of the Helm chart.
 The application name must start with a lowercase letter and consist of lowercase letters, numbers, and hyphen (``-``).
 
-By default, this will create a Helm chart for a FastAPI web service.
+By default, this will create a Helm chart for a FastAPI web service created from the `SQuaRE template <https://safir.lsst.io/user-guide/set-up-from-template.html>`__.
 Use the ``--starter`` flag to specify a different Helm chart starter.
-There are two options:
+There are three options:
+
+fastapi-safir
+    Use this starter for FastAPI web services based on Safir, created from the "FastAPI application (Safir)" template.
+    This is the default.
 
 web-service
-    Use this starter if the new Helm application is a web service, such as a new Safir_ FastAPI_ service.
-    This is the default.
+    Use this starter if the new Helm application is some other web service.
 
 empty
     Use this starter for any other type of application.

--- a/src/phalanx/cli.py
+++ b/src/phalanx/cli.py
@@ -243,7 +243,7 @@ def application_add_helm_repos(
     "-s",
     "--starter",
     type=click.Choice([s.value for s in HelmStarter]),
-    default=HelmStarter.WEB_SERVICE.value,
+    default=HelmStarter.FASTAPI_SAFIR.value,
     help="Helm starter to use as the basis for the chart.",
 )
 @_report_usage_errors

--- a/src/phalanx/models/helm.py
+++ b/src/phalanx/models/helm.py
@@ -26,3 +26,4 @@ class HelmStarter(Enum):
 
     EMPTY = "empty"
     WEB_SERVICE = "web-service"
+    FASTAPI_SAFIR = "fastapi-safir"

--- a/src/phalanx/services/application.py
+++ b/src/phalanx/services/application.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from typing import Any
 
 import jinja2
-import yaml
 
 from ..exceptions import ApplicationExistsError
 from ..models.applications import Project
@@ -118,23 +117,7 @@ class ApplicationService:
         path = self._config.get_application_chart_path(name)
         if path.exists():
             raise ApplicationExistsError(name)
-        self._helm.create(name, starter)
-
-        # Unfortunately, Helm completely ignores the Chart.yaml in a starter
-        # so far as I can tell, so we have to load the starter Chart.yaml
-        # ourselves and replace the generated Chart.yaml with it, but
-        # preserving the substitutions that Helm does make.
-        starter_path = self._config.get_starter_path(starter)
-        chart = yaml.safe_load((starter_path / "Chart.yaml").read_text())
-        helm_chart = yaml.safe_load((path / "Chart.yaml").read_text())
-        chart["name"] = helm_chart["name"]
-        chart["description"] = description
-        if "sources" in chart:
-            chart["sources"] = [
-                s.replace("<CHARTNAME>", name) for s in chart["sources"]
-            ]
-        with (path / "Chart.yaml").open("w") as fh:
-            yaml.dump(chart, fh)
+        self._helm.create(name, description, starter)
 
         # Add the environment configuration.
         self._create_application_template(name, project)

--- a/starters/fastapi-safir/.helmignore
+++ b/starters/fastapi-safir/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/starters/fastapi-safir/Chart.yaml
+++ b/starters/fastapi-safir/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: <CHARTNAME>
+type: application
+version: 1.0.0
+description: "Helm starter chart for a new FastAPI Safir app"
+sources:
+  - "https://github.com/lsst-sqre/<CHARTNAME>"
+appVersion: "0.1.0"

--- a/starters/fastapi-safir/templates/_helpers.tpl
+++ b/starters/fastapi-safir/templates/_helpers.tpl
@@ -1,0 +1,26 @@
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "<CHARTNAME>.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "<CHARTNAME>.labels" -}}
+helm.sh/chart: {{ include "<CHARTNAME>.chart" . }}
+{{ include "<CHARTNAME>.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "<CHARTNAME>.selectorLabels" -}}
+app.kubernetes.io/name: "<CHARTNAME>"
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/starters/fastapi-safir/templates/configmap.yaml
+++ b/starters/fastapi-safir/templates/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "<CHARTNAME>"
+  labels:
+    {{- include "<CHARTNAME>.labels" . | nindent 4 }}
+data:
+  <CHARTENVPREFIX>_LOG_LEVEL: {{ .Values.config.logLevel | quote }}
+  <CHARTENVPREFIX>_PATH_PREFIX: {{ .Values.config.pathPrefix | quote }}
+  <CHARTENVPREFIX>_PROFILE: {{ .Values.config.logProfile | quote }}

--- a/starters/fastapi-safir/templates/deployment.yaml
+++ b/starters/fastapi-safir/templates/deployment.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "<CHARTNAME>"
+  labels:
+    {{- include "<CHARTNAME>.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "<CHARTNAME>.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath “/configmap.yaml”) . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "<CHARTNAME>.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      automountServiceAccountToken: false
+      containers:
+        - name: {{ .Chart.Name }}
+          envFrom:
+            - configMapRef:
+                name: "<CHARTNAME>"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: "http"
+              containerPort: 8080
+              protocol: "TCP"
+          readinessProbe:
+            httpGet:
+              path: "/"
+              port: "http"
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+            readOnlyRootFilesystem: true
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000

--- a/starters/fastapi-safir/templates/ingress.yaml
+++ b/starters/fastapi-safir/templates/ingress.yaml
@@ -1,0 +1,30 @@
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
+metadata:
+  name: "<CHARTNAME>"
+  labels:
+    {{- include "<CHARTNAME>.labels" . | nindent 4 }}
+config:
+  baseUrl: {{ .Values.global.baseUrl | quote }}
+  scopes:
+    all:
+      - "read:image"
+template:
+  metadata:
+    name: "<CHARTNAME>"
+    {{- with .Values.ingress.annotations }}
+    annotations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  spec:
+    rules:
+      - host: {{ required "global.host must be set" .Values.global.host | quote }}
+        http:
+          paths:
+            - path: "/<CHARTNAME>"
+              pathType: "Prefix"
+              backend:
+                service:
+                  name: "<CHARTNAME>"
+                  port:
+                    number: 8080

--- a/starters/fastapi-safir/templates/networkpolicy.yaml
+++ b/starters/fastapi-safir/templates/networkpolicy.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: "<CHARTNAME>"
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "<CHARTNAME>.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - "Ingress"
+  ingress:
+    # Allow inbound access from pods (in any namespace) labeled
+    # gafaelfawr.lsst.io/ingress: true.
+    - from:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              gafaelfawr.lsst.io/ingress: "true"
+      ports:
+        - protocol: "TCP"
+          port: 8080

--- a/starters/fastapi-safir/templates/service.yaml
+++ b/starters/fastapi-safir/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "<CHARTNAME>"
+  labels:
+    {{- include "<CHARTNAME>.labels" . | nindent 4 }}
+spec:
+  type: "ClusterIP"
+  ports:
+    - port: 8080
+      targetPort: "http"
+      protocol: "TCP"
+      name: "http"
+  selector:
+    {{- include "<CHARTNAME>.selectorLabels" . | nindent 4 }}

--- a/starters/fastapi-safir/values.yaml
+++ b/starters/fastapi-safir/values.yaml
@@ -15,6 +15,17 @@ image:
   # -- Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
+config:
+  # -- Logging level
+  logLevel: "INFO"
+
+  # -- Logging profile (`production` for JSON, `development` for
+  # human-friendly)
+  logProfile: "production"
+
+  # -- URL path prefix
+  pathPrefix: "/<CHARTNAME>"
+
 ingress:
   # -- Additional annotations for the ingress rule
   annotations: {}

--- a/tests/cli/application_test.py
+++ b/tests/cli/application_test.py
@@ -78,6 +78,8 @@ def test_create(tmp_path: Path) -> None:
         "application",
         "create",
         "hips",
+        "--starter",
+        "web-service",
         "--project",
         "rsp",
         "--description",
@@ -92,8 +94,6 @@ def test_create(tmp_path: Path) -> None:
         "application",
         "create",
         "zzz-other-app",
-        "--starter",
-        "empty",
         "--project",
         "rsp",
         "--description",
@@ -153,14 +153,22 @@ def test_create(tmp_path: Path) -> None:
         assert environment.applications[app].chart["version"] == "1.0.0"
 
     # Charts created from the empty starter should not have appVersion. Charts
-    # using the web-service starter should, set to 0.1.0.
+    # using the web-service or fastapi-safir starters should, set to 0.1.0.
     assert "appVersion" not in environment.applications["aaa-new-app"].chart
-    assert "appVersion" not in environment.applications["zzz-other-app"].chart
     assert environment.applications["hips"].chart["appVersion"] == "0.1.0"
+    zzz_other_app = environment.applications["zzz-other-app"]
+    assert zzz_other_app.chart["appVersion"] == "0.1.0"
 
     # Charts using the web-service starter should have a default sources.
     expected = "https://github.com/lsst-sqre/hips"
     assert environment.applications["hips"].chart["sources"][0] == expected
+
+    # Check that <CHARTENVPREFIX> was substituted correctly in the ConfigMap
+    # template for the fastapi-safir chart.
+    path = apps_path / "zzz-other-app" / "templates" / "configmap.yaml"
+    config_map = path.read_text()
+    assert "  ZZZ_OTHER_APP_LOG_LEVEL:" in config_map
+    assert "  ZZZ_OTHER_APP_PATH_PREFIX:" in config_map
 
 
 def test_create_errors(tmp_path: Path) -> None:

--- a/tests/data/input/starters/fastapi-safir/.helmignore
+++ b/tests/data/input/starters/fastapi-safir/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/tests/data/input/starters/fastapi-safir/Chart.yaml
+++ b/tests/data/input/starters/fastapi-safir/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: <CHARTNAME>
+type: application
+version: 1.0.0
+description: "Helm starter chart for a new FastAPI Safir app"
+sources:
+  - "https://github.com/lsst-sqre/<CHARTNAME>"
+appVersion: "0.1.0"

--- a/tests/data/input/starters/fastapi-safir/templates/_helpers.tpl
+++ b/tests/data/input/starters/fastapi-safir/templates/_helpers.tpl
@@ -1,0 +1,26 @@
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "<CHARTNAME>.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "<CHARTNAME>.labels" -}}
+helm.sh/chart: {{ include "<CHARTNAME>.chart" . }}
+{{ include "<CHARTNAME>.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "<CHARTNAME>.selectorLabels" -}}
+app.kubernetes.io/name: "<CHARTNAME>"
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/tests/data/input/starters/fastapi-safir/templates/configmap.yaml
+++ b/tests/data/input/starters/fastapi-safir/templates/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "<CHARTNAME>"
+  labels:
+    {{- include "<CHARTNAME>.labels" . | nindent 4 }}
+data:
+  <CHARTENVPREFIX>_LOG_LEVEL: {{ .Values.config.logLevel | quote }}
+  <CHARTENVPREFIX>_PATH_PREFIX: {{ .Values.config.pathPrefix | quote }}
+  <CHARTENVPREFIX>_PROFILE: {{ .Values.config.logProfile | quote }}

--- a/tests/data/input/starters/fastapi-safir/templates/deployment.yaml
+++ b/tests/data/input/starters/fastapi-safir/templates/deployment.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "<CHARTNAME>"
+  labels:
+    {{- include "<CHARTNAME>.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "<CHARTNAME>.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath “/configmap.yaml”) . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "<CHARTNAME>.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      automountServiceAccountToken: false
+      containers:
+        - name: {{ .Chart.Name }}
+          envFrom:
+            - configMapRef:
+                name: "<CHARTNAME>"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: "http"
+              containerPort: 8080
+              protocol: "TCP"
+          readinessProbe:
+            httpGet:
+              path: "/"
+              port: "http"
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+            readOnlyRootFilesystem: true
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000

--- a/tests/data/input/starters/fastapi-safir/templates/ingress.yaml
+++ b/tests/data/input/starters/fastapi-safir/templates/ingress.yaml
@@ -1,0 +1,30 @@
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
+metadata:
+  name: "<CHARTNAME>"
+  labels:
+    {{- include "<CHARTNAME>.labels" . | nindent 4 }}
+config:
+  baseUrl: {{ .Values.global.baseUrl | quote }}
+  scopes:
+    all:
+      - "read:image"
+template:
+  metadata:
+    name: "<CHARTNAME>"
+    {{- with .Values.ingress.annotations }}
+    annotations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  spec:
+    rules:
+      - host: {{ required "global.host must be set" .Values.global.host | quote }}
+        http:
+          paths:
+            - path: "/<CHARTNAME>"
+              pathType: "Prefix"
+              backend:
+                service:
+                  name: "<CHARTNAME>"
+                  port:
+                    number: 8080

--- a/tests/data/input/starters/fastapi-safir/templates/networkpolicy.yaml
+++ b/tests/data/input/starters/fastapi-safir/templates/networkpolicy.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: "<CHARTNAME>"
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "<CHARTNAME>.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - "Ingress"
+  ingress:
+    # Allow inbound access from pods (in any namespace) labeled
+    # gafaelfawr.lsst.io/ingress: true.
+    - from:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              gafaelfawr.lsst.io/ingress: "true"
+      ports:
+        - protocol: "TCP"
+          port: 8080

--- a/tests/data/input/starters/fastapi-safir/templates/service.yaml
+++ b/tests/data/input/starters/fastapi-safir/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "<CHARTNAME>"
+  labels:
+    {{- include "<CHARTNAME>.labels" . | nindent 4 }}
+spec:
+  type: "ClusterIP"
+  ports:
+    - port: 8080
+      targetPort: "http"
+      protocol: "TCP"
+      name: "http"
+  selector:
+    {{- include "<CHARTNAME>.selectorLabels" . | nindent 4 }}

--- a/tests/data/input/starters/fastapi-safir/values.yaml
+++ b/tests/data/input/starters/fastapi-safir/values.yaml
@@ -15,6 +15,17 @@ image:
   # -- Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
+config:
+  # -- Logging level
+  logLevel: "INFO"
+
+  # -- Logging profile (`production` for JSON, `development` for
+  # human-friendly)
+  logProfile: "production"
+
+  # -- URL path prefix
+  pathPrefix: "/<CHARTNAME>"
+
 ingress:
   # -- Additional annotations for the ingress rule
   annotations: {}


### PR DESCRIPTION
Add a new starter based on the web-service starter, but with a ConfigMap with settings for a FastAPI Safir app out of the box. Add support for a new substitution variable on new Helm charts so that we can set an environment variable prefix for the ConfigMap.