### PR TITLE
Fix invalid characters in fastapi-safir starter

### DIFF
--- a/starters/fastapi-safir/templates/deployment.yaml
+++ b/starters/fastapi-safir/templates/deployment.yaml
@@ -12,7 +12,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath “/configmap.yaml”) . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
Cut and paste from Google Slides is not the greatest.