### PR TITLE
DM-44129: Use config.pathPrefix in fastapi-safir starter

### DIFF
--- a/starters/fastapi-safir/templates/ingress.yaml
+++ b/starters/fastapi-safir/templates/ingress.yaml
@@ -21,7 +21,7 @@ template:
       - host: {{ required "global.host must be set" .Values.global.host | quote }}
         http:
           paths:
-            - path: "/<CHARTNAME>"
+            - path: {{ .Values.config.pathPrefix | quote }}
               pathType: "Prefix"
               backend:
                 service:


### PR DESCRIPTION
I added the setting and then forgot to use it in the GafaelfawrIngress. Plumb it through rather than hard-coding the path.