### PR TITLE
DM-44096: Migrate Prompt Processing to external APDB configs

### DIFF
--- a/applications/prompt-proto-service-hsc-gpu/README.md
+++ b/applications/prompt-proto-service-hsc-gpu/README.md
@@ -17,6 +17,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.alerts.server | string | `"usdf-alert-stream-dev-broker-0.lsst.cloud:9094"` | Server address for the alert stream |
 | prompt-proto-service.alerts.topic | string | `"alert-stream-test"` | Topic name where alerts will be sent |
 | prompt-proto-service.alerts.username | string | `"kafka-admin"` | Username for sending alerts to the alert stream |
+| prompt-proto-service.apdb.config | string | None, must be set | URL to a serialized APDB configuration, or the "label:" prefix followed by the indexed name of such a config. |
 | prompt-proto-service.apdb.namespace | string | `"pp_apdb_hsc"` | Database namespace for the APDB |
 | prompt-proto-service.apdb.url | string | None, must be set | URL to the APDB, in any form recognized by SQLAlchemy |
 | prompt-proto-service.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |

--- a/applications/prompt-proto-service-hsc-gpu/README.md
+++ b/applications/prompt-proto-service-hsc-gpu/README.md
@@ -18,8 +18,6 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.alerts.topic | string | `"alert-stream-test"` | Topic name where alerts will be sent |
 | prompt-proto-service.alerts.username | string | `"kafka-admin"` | Username for sending alerts to the alert stream |
 | prompt-proto-service.apdb.config | string | None, must be set | URL to a serialized APDB configuration, or the "label:" prefix followed by the indexed name of such a config. |
-| prompt-proto-service.apdb.namespace | string | `"pp_apdb_hsc"` | Database namespace for the APDB |
-| prompt-proto-service.apdb.url | string | None, must be set | URL to the APDB, in any form recognized by SQLAlchemy |
 | prompt-proto-service.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
 | prompt-proto-service.image.repository | string | `"ghcr.io/lsst-dm/prompt-service"` | Image to use in the PP deployment |
 | prompt-proto-service.image.tag | string | `"latest"` | Overrides the image tag whose default is the chart appVersion. |

--- a/applications/prompt-proto-service-hsc-gpu/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-hsc-gpu/values-usdfdev-prompt-processing.yaml
@@ -24,6 +24,7 @@ prompt-proto-service:
     topic: prompt-processing-dev
 
   apdb:
+    config: s3://rubin-pp-dev-users/apdb_config/pp_apdb_hsc-dev.py
     url: postgresql://rubin@usdf-prompt-processing-dev.slac.stanford.edu:5432/lsst-devl
 
   sasquatch:

--- a/applications/prompt-proto-service-hsc-gpu/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-hsc-gpu/values-usdfdev-prompt-processing.yaml
@@ -25,7 +25,6 @@ prompt-proto-service:
 
   apdb:
     config: s3://rubin-pp-dev-users/apdb_config/pp_apdb_hsc-dev.py
-    url: postgresql://rubin@usdf-prompt-processing-dev.slac.stanford.edu:5432/lsst-devl
 
   sasquatch:
     endpointUrl: https://usdf-rsp-dev.slac.stanford.edu/sasquatch-rest-proxy

--- a/applications/prompt-proto-service-hsc-gpu/values.yaml
+++ b/applications/prompt-proto-service-hsc-gpu/values.yaml
@@ -66,6 +66,10 @@ prompt-proto-service:
     imageTimeout: '20'
 
   apdb:
+    # -- URL to a serialized APDB configuration, or the "label:" prefix
+    # followed by the indexed name of such a config.
+    # @default -- None, must be set
+    config: ""
     # -- URL to the APDB, in any form recognized by SQLAlchemy
     # @default -- None, must be set
     url: ""

--- a/applications/prompt-proto-service-hsc-gpu/values.yaml
+++ b/applications/prompt-proto-service-hsc-gpu/values.yaml
@@ -70,11 +70,6 @@ prompt-proto-service:
     # followed by the indexed name of such a config.
     # @default -- None, must be set
     config: ""
-    # -- URL to the APDB, in any form recognized by SQLAlchemy
-    # @default -- None, must be set
-    url: ""
-    # -- Database namespace for the APDB
-    namespace: pp_apdb_hsc
 
   alerts:
     # -- Username for sending alerts to the alert stream

--- a/applications/prompt-proto-service-hsc/README.md
+++ b/applications/prompt-proto-service-hsc/README.md
@@ -17,6 +17,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.alerts.server | string | `"usdf-alert-stream-dev-broker-0.lsst.cloud:9094"` | Server address for the alert stream |
 | prompt-proto-service.alerts.topic | string | `"alert-stream-test"` | Topic name where alerts will be sent |
 | prompt-proto-service.alerts.username | string | `"kafka-admin"` | Username for sending alerts to the alert stream |
+| prompt-proto-service.apdb.config | string | None, must be set | URL to a serialized APDB configuration, or the "label:" prefix followed by the indexed name of such a config. |
 | prompt-proto-service.apdb.namespace | string | `"pp_apdb_hsc"` | Database namespace for the APDB |
 | prompt-proto-service.apdb.url | string | None, must be set | URL to the APDB, in any form recognized by SQLAlchemy |
 | prompt-proto-service.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |

--- a/applications/prompt-proto-service-hsc/README.md
+++ b/applications/prompt-proto-service-hsc/README.md
@@ -18,8 +18,6 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.alerts.topic | string | `"alert-stream-test"` | Topic name where alerts will be sent |
 | prompt-proto-service.alerts.username | string | `"kafka-admin"` | Username for sending alerts to the alert stream |
 | prompt-proto-service.apdb.config | string | None, must be set | URL to a serialized APDB configuration, or the "label:" prefix followed by the indexed name of such a config. |
-| prompt-proto-service.apdb.namespace | string | `"pp_apdb_hsc"` | Database namespace for the APDB |
-| prompt-proto-service.apdb.url | string | None, must be set | URL to the APDB, in any form recognized by SQLAlchemy |
 | prompt-proto-service.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
 | prompt-proto-service.image.repository | string | `"ghcr.io/lsst-dm/prompt-service"` | Image to use in the PP deployment |
 | prompt-proto-service.image.tag | string | `"latest"` | Overrides the image tag whose default is the chart appVersion. |

--- a/applications/prompt-proto-service-hsc/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-hsc/values-usdfdev-prompt-processing.yaml
@@ -25,6 +25,7 @@ prompt-proto-service:
     topic: prompt-processing-dev
 
   apdb:
+    config: s3://rubin-pp-dev-users/apdb_config/pp_apdb_hsc-dev.py
     url: postgresql://rubin@usdf-prompt-processing-dev.slac.stanford.edu:5432/lsst-devl
 
   sasquatch:

--- a/applications/prompt-proto-service-hsc/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-hsc/values-usdfdev-prompt-processing.yaml
@@ -26,7 +26,6 @@ prompt-proto-service:
 
   apdb:
     config: s3://rubin-pp-dev-users/apdb_config/pp_apdb_hsc-dev.py
-    url: postgresql://rubin@usdf-prompt-processing-dev.slac.stanford.edu:5432/lsst-devl
 
   sasquatch:
     endpointUrl: https://usdf-rsp-dev.slac.stanford.edu/sasquatch-rest-proxy

--- a/applications/prompt-proto-service-hsc/values.yaml
+++ b/applications/prompt-proto-service-hsc/values.yaml
@@ -66,6 +66,10 @@ prompt-proto-service:
     imageTimeout: '20'
 
   apdb:
+    # -- URL to a serialized APDB configuration, or the "label:" prefix
+    # followed by the indexed name of such a config.
+    # @default -- None, must be set
+    config: ""
     # -- URL to the APDB, in any form recognized by SQLAlchemy
     # @default -- None, must be set
     url: ""

--- a/applications/prompt-proto-service-hsc/values.yaml
+++ b/applications/prompt-proto-service-hsc/values.yaml
@@ -70,11 +70,6 @@ prompt-proto-service:
     # followed by the indexed name of such a config.
     # @default -- None, must be set
     config: ""
-    # -- URL to the APDB, in any form recognized by SQLAlchemy
-    # @default -- None, must be set
-    url: ""
-    # -- Database namespace for the APDB
-    namespace: pp_apdb_hsc
 
   alerts:
     # -- Username for sending alerts to the alert stream

--- a/applications/prompt-proto-service-latiss/README.md
+++ b/applications/prompt-proto-service-latiss/README.md
@@ -18,8 +18,6 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.alerts.topic | string | `"alert-stream-test"` | Topic name where alerts will be sent |
 | prompt-proto-service.alerts.username | string | `"kafka-admin"` | Username for sending alerts to the alert stream |
 | prompt-proto-service.apdb.config | string | None, must be set | URL to a serialized APDB configuration, or the "label:" prefix followed by the indexed name of such a config. |
-| prompt-proto-service.apdb.namespace | string | `"pp_apdb_latiss"` | Database namespace for the APDB |
-| prompt-proto-service.apdb.url | string | None, must be set | URL to the APDB, in any form recognized by SQLAlchemy |
 | prompt-proto-service.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
 | prompt-proto-service.image.repository | string | `"ghcr.io/lsst-dm/prompt-service"` | Image to use in the PP deployment |
 | prompt-proto-service.image.tag | string | `"latest"` | Overrides the image tag whose default is the chart appVersion. |

--- a/applications/prompt-proto-service-latiss/README.md
+++ b/applications/prompt-proto-service-latiss/README.md
@@ -17,6 +17,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.alerts.server | string | `"usdf-alert-stream-dev-broker-0.lsst.cloud:9094"` | Server address for the alert stream |
 | prompt-proto-service.alerts.topic | string | `"alert-stream-test"` | Topic name where alerts will be sent |
 | prompt-proto-service.alerts.username | string | `"kafka-admin"` | Username for sending alerts to the alert stream |
+| prompt-proto-service.apdb.config | string | None, must be set | URL to a serialized APDB configuration, or the "label:" prefix followed by the indexed name of such a config. |
 | prompt-proto-service.apdb.namespace | string | `"pp_apdb_latiss"` | Database namespace for the APDB |
 | prompt-proto-service.apdb.url | string | None, must be set | URL to the APDB, in any form recognized by SQLAlchemy |
 | prompt-proto-service.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |

--- a/applications/prompt-proto-service-latiss/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfdev-prompt-processing.yaml
@@ -26,7 +26,6 @@ prompt-proto-service:
 
   apdb:
     config: s3://rubin-pp-dev-users/apdb_config/pp_apdb_latiss-dev.py
-    url: postgresql://rubin@usdf-prompt-processing-dev.slac.stanford.edu/lsst-devl
 
   sasquatch:
     endpointUrl: https://usdf-rsp-dev.slac.stanford.edu/sasquatch-rest-proxy

--- a/applications/prompt-proto-service-latiss/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfdev-prompt-processing.yaml
@@ -25,6 +25,7 @@ prompt-proto-service:
     topic: prompt-processing-dev
 
   apdb:
+    config: s3://rubin-pp-dev-users/apdb_config/pp_apdb_latiss-dev.py
     url: postgresql://rubin@usdf-prompt-processing-dev.slac.stanford.edu/lsst-devl
 
   sasquatch:

--- a/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
@@ -44,7 +44,6 @@ prompt-proto-service:
 
   apdb:
     config: s3://rubin-summit-users/apdb_config/pp_apdb_latiss.py
-    url: postgresql://rubin@usdf-prompt-processing.slac.stanford.edu:5432/lsst-devl
 
   sasquatch:
     endpointUrl: https://usdf-rsp-dev.slac.stanford.edu/sasquatch-rest-proxy

--- a/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
@@ -43,6 +43,7 @@ prompt-proto-service:
     imageTimeout: '110'
 
   apdb:
+    config: s3://rubin-summit-users/apdb_config/pp_apdb_latiss.py
     url: postgresql://rubin@usdf-prompt-processing.slac.stanford.edu:5432/lsst-devl
 
   sasquatch:

--- a/applications/prompt-proto-service-latiss/values.yaml
+++ b/applications/prompt-proto-service-latiss/values.yaml
@@ -66,6 +66,10 @@ prompt-proto-service:
     imageTimeout: '20'
 
   apdb:
+    # -- URL to a serialized APDB configuration, or the "label:" prefix
+    # followed by the indexed name of such a config.
+    # @default -- None, must be set
+    config: ""
     # -- URL to the APDB, in any form recognized by SQLAlchemy
     # @default -- None, must be set
     url: ""

--- a/applications/prompt-proto-service-latiss/values.yaml
+++ b/applications/prompt-proto-service-latiss/values.yaml
@@ -70,11 +70,6 @@ prompt-proto-service:
     # followed by the indexed name of such a config.
     # @default -- None, must be set
     config: ""
-    # -- URL to the APDB, in any form recognized by SQLAlchemy
-    # @default -- None, must be set
-    url: ""
-    # -- Database namespace for the APDB
-    namespace: pp_apdb_latiss
 
   alerts:
     # -- Username for sending alerts to the alert stream

--- a/applications/prompt-proto-service-lsstcam/README.md
+++ b/applications/prompt-proto-service-lsstcam/README.md
@@ -17,6 +17,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.alerts.server | string | `"usdf-alert-stream-dev-broker-0.lsst.cloud:9094"` | Server address for the alert stream |
 | prompt-proto-service.alerts.topic | string | `"alert-stream-test"` | Topic name where alerts will be sent |
 | prompt-proto-service.alerts.username | string | `"kafka-admin"` | Username for sending alerts to the alert stream |
+| prompt-proto-service.apdb.config | string | None, must be set | URL to a serialized APDB configuration, or the "label:" prefix followed by the indexed name of such a config. |
 | prompt-proto-service.apdb.namespace | string | `"pp_apdb_lsstcam"` | Database namespace for the APDB |
 | prompt-proto-service.apdb.url | string | None, must be set | URL to the APDB, in any form recognized by SQLAlchemy |
 | prompt-proto-service.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |

--- a/applications/prompt-proto-service-lsstcam/README.md
+++ b/applications/prompt-proto-service-lsstcam/README.md
@@ -18,8 +18,6 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.alerts.topic | string | `"alert-stream-test"` | Topic name where alerts will be sent |
 | prompt-proto-service.alerts.username | string | `"kafka-admin"` | Username for sending alerts to the alert stream |
 | prompt-proto-service.apdb.config | string | None, must be set | URL to a serialized APDB configuration, or the "label:" prefix followed by the indexed name of such a config. |
-| prompt-proto-service.apdb.namespace | string | `"pp_apdb_lsstcam"` | Database namespace for the APDB |
-| prompt-proto-service.apdb.url | string | None, must be set | URL to the APDB, in any form recognized by SQLAlchemy |
 | prompt-proto-service.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
 | prompt-proto-service.image.repository | string | `"ghcr.io/lsst-dm/prompt-service"` | Image to use in the PP deployment |
 | prompt-proto-service.image.tag | string | `"latest"` | Overrides the image tag whose default is the chart appVersion. |

--- a/applications/prompt-proto-service-lsstcam/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcam/values-usdfdev-prompt-processing.yaml
@@ -23,7 +23,4 @@ prompt-proto-service:
     kafkaClusterAddress: prompt-processing-kafka-bootstrap.kafka:9092
     topic: rubin-prompt-processing
 
-  apdb:
-    url: postgresql://rubin@usdf-prompt-processing-dev.slac.stanford.edu:5432/lsst-devl
-
   fullnameOverride: "prompt-proto-service-lsstcam"

--- a/applications/prompt-proto-service-lsstcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcam/values.yaml
@@ -66,6 +66,10 @@ prompt-proto-service:
     imageTimeout: '20'
 
   apdb:
+    # -- URL to a serialized APDB configuration, or the "label:" prefix
+    # followed by the indexed name of such a config.
+    # @default -- None, must be set
+    config: ""
     # -- URL to the APDB, in any form recognized by SQLAlchemy
     # @default -- None, must be set
     url: ""

--- a/applications/prompt-proto-service-lsstcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcam/values.yaml
@@ -70,11 +70,6 @@ prompt-proto-service:
     # followed by the indexed name of such a config.
     # @default -- None, must be set
     config: ""
-    # -- URL to the APDB, in any form recognized by SQLAlchemy
-    # @default -- None, must be set
-    url: ""
-    # -- Database namespace for the APDB
-    namespace: pp_apdb_lsstcam
 
   alerts:
     # -- Username for sending alerts to the alert stream

--- a/applications/prompt-proto-service-lsstcomcam/README.md
+++ b/applications/prompt-proto-service-lsstcomcam/README.md
@@ -18,8 +18,6 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.alerts.topic | string | `"alert-stream-test"` | Topic name where alerts will be sent |
 | prompt-proto-service.alerts.username | string | `"kafka-admin"` | Username for sending alerts to the alert stream |
 | prompt-proto-service.apdb.config | string | None, must be set | URL to a serialized APDB configuration, or the "label:" prefix followed by the indexed name of such a config. |
-| prompt-proto-service.apdb.namespace | string | `"pp_apdb_lsstcomcam"` | Database namespace for the APDB |
-| prompt-proto-service.apdb.url | string | None, must be set | URL to the APDB, in any form recognized by SQLAlchemy |
 | prompt-proto-service.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
 | prompt-proto-service.image.repository | string | `"ghcr.io/lsst-dm/prompt-service"` | Image to use in the PP deployment |
 | prompt-proto-service.image.tag | string | `"latest"` | Overrides the image tag whose default is the chart appVersion. |

--- a/applications/prompt-proto-service-lsstcomcam/README.md
+++ b/applications/prompt-proto-service-lsstcomcam/README.md
@@ -17,6 +17,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.alerts.server | string | `"usdf-alert-stream-dev-broker-0.lsst.cloud:9094"` | Server address for the alert stream |
 | prompt-proto-service.alerts.topic | string | `"alert-stream-test"` | Topic name where alerts will be sent |
 | prompt-proto-service.alerts.username | string | `"kafka-admin"` | Username for sending alerts to the alert stream |
+| prompt-proto-service.apdb.config | string | None, must be set | URL to a serialized APDB configuration, or the "label:" prefix followed by the indexed name of such a config. |
 | prompt-proto-service.apdb.namespace | string | `"pp_apdb_lsstcomcam"` | Database namespace for the APDB |
 | prompt-proto-service.apdb.url | string | None, must be set | URL to the APDB, in any form recognized by SQLAlchemy |
 | prompt-proto-service.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |

--- a/applications/prompt-proto-service-lsstcomcam/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/values-usdfdev-prompt-processing.yaml
@@ -23,7 +23,4 @@ prompt-proto-service:
     kafkaClusterAddress: prompt-processing-kafka-bootstrap.kafka:9092
     topic: rubin-prompt-processing
 
-  apdb:
-    url: postgresql://rubin@usdf-prompt-processing-dev.slac.stanford.edu:5432/lsst-devl
-
   fullnameOverride: "prompt-proto-service-lsstcomcam"

--- a/applications/prompt-proto-service-lsstcomcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/values.yaml
@@ -66,6 +66,10 @@ prompt-proto-service:
     imageTimeout: '20'
 
   apdb:
+    # -- URL to a serialized APDB configuration, or the "label:" prefix
+    # followed by the indexed name of such a config.
+    # @default -- None, must be set
+    config: ""
     # -- URL to the APDB, in any form recognized by SQLAlchemy
     # @default -- None, must be set
     url: ""

--- a/applications/prompt-proto-service-lsstcomcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/values.yaml
@@ -70,11 +70,6 @@ prompt-proto-service:
     # followed by the indexed name of such a config.
     # @default -- None, must be set
     config: ""
-    # -- URL to the APDB, in any form recognized by SQLAlchemy
-    # @default -- None, must be set
-    url: ""
-    # -- Database namespace for the APDB
-    namespace: pp_apdb_lsstcomcam
 
   alerts:
     # -- Username for sending alerts to the alert stream

--- a/applications/prompt-proto-service-lsstcomcamsim/README.md
+++ b/applications/prompt-proto-service-lsstcomcamsim/README.md
@@ -17,6 +17,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.alerts.server | string | `"usdf-alert-stream-dev-broker-0.lsst.cloud:9094"` | Server address for the alert stream |
 | prompt-proto-service.alerts.topic | string | `"alert-stream-test"` | Topic name where alerts will be sent |
 | prompt-proto-service.alerts.username | string | `"kafka-admin"` | Username for sending alerts to the alert stream |
+| prompt-proto-service.apdb.config | string | None, must be set | URL to a serialized APDB configuration, or the "label:" prefix followed by the indexed name of such a config. |
 | prompt-proto-service.apdb.namespace | string | `"pp_apdb_lsstcomcamsim"` | Database namespace for the APDB |
 | prompt-proto-service.apdb.url | string | None, must be set | URL to the APDB, in any form recognized by SQLAlchemy |
 | prompt-proto-service.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |

--- a/applications/prompt-proto-service-lsstcomcamsim/README.md
+++ b/applications/prompt-proto-service-lsstcomcamsim/README.md
@@ -18,8 +18,6 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.alerts.topic | string | `"alert-stream-test"` | Topic name where alerts will be sent |
 | prompt-proto-service.alerts.username | string | `"kafka-admin"` | Username for sending alerts to the alert stream |
 | prompt-proto-service.apdb.config | string | None, must be set | URL to a serialized APDB configuration, or the "label:" prefix followed by the indexed name of such a config. |
-| prompt-proto-service.apdb.namespace | string | `"pp_apdb_lsstcomcamsim"` | Database namespace for the APDB |
-| prompt-proto-service.apdb.url | string | None, must be set | URL to the APDB, in any form recognized by SQLAlchemy |
 | prompt-proto-service.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
 | prompt-proto-service.image.repository | string | `"ghcr.io/lsst-dm/prompt-service"` | Image to use in the PP deployment |
 | prompt-proto-service.image.tag | string | `"latest"` | Overrides the image tag whose default is the chart appVersion. |

--- a/applications/prompt-proto-service-lsstcomcamsim/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcomcamsim/values-usdfdev-prompt-processing.yaml
@@ -26,6 +26,7 @@ prompt-proto-service:
     topic: prompt-processing-dev
 
   apdb:
+    config: s3://rubin-pp-dev-users/apdb_config/pp_apdb_lsstcomcamsim-dev.py
     url: postgresql://rubin@usdf-prompt-processing-dev.slac.stanford.edu/lsst-devl
 
   sasquatch:

--- a/applications/prompt-proto-service-lsstcomcamsim/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcomcamsim/values-usdfdev-prompt-processing.yaml
@@ -27,7 +27,6 @@ prompt-proto-service:
 
   apdb:
     config: s3://rubin-pp-dev-users/apdb_config/pp_apdb_lsstcomcamsim-dev.py
-    url: postgresql://rubin@usdf-prompt-processing-dev.slac.stanford.edu/lsst-devl
 
   sasquatch:
     endpointUrl: https://usdf-rsp-dev.slac.stanford.edu/sasquatch-rest-proxy

--- a/applications/prompt-proto-service-lsstcomcamsim/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcomcamsim/values-usdfprod-prompt-processing.yaml
@@ -33,7 +33,6 @@ prompt-proto-service:
 
   apdb:
     config: s3://rubin-summit-users/apdb_config/pp_apdb_lsstcomcamsim.py
-    url: postgresql://rubin@usdf-prompt-processing.slac.stanford.edu:5432/lsst-devl
 
   sasquatch:
     endpointUrl: https://usdf-rsp-dev.slac.stanford.edu/sasquatch-rest-proxy

--- a/applications/prompt-proto-service-lsstcomcamsim/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcomcamsim/values-usdfprod-prompt-processing.yaml
@@ -32,6 +32,7 @@ prompt-proto-service:
     topic: rubin-prompt-processing-prod
 
   apdb:
+    config: s3://rubin-summit-users/apdb_config/pp_apdb_lsstcomcamsim.py
     url: postgresql://rubin@usdf-prompt-processing.slac.stanford.edu:5432/lsst-devl
 
   sasquatch:

--- a/applications/prompt-proto-service-lsstcomcamsim/values.yaml
+++ b/applications/prompt-proto-service-lsstcomcamsim/values.yaml
@@ -70,11 +70,6 @@ prompt-proto-service:
     # followed by the indexed name of such a config.
     # @default -- None, must be set
     config: ""
-    # -- URL to the APDB, in any form recognized by SQLAlchemy
-    # @default -- None, must be set
-    url: ""
-    # -- Database namespace for the APDB
-    namespace: pp_apdb_lsstcomcamsim
 
   alerts:
     # -- Username for sending alerts to the alert stream

--- a/applications/prompt-proto-service-lsstcomcamsim/values.yaml
+++ b/applications/prompt-proto-service-lsstcomcamsim/values.yaml
@@ -66,6 +66,10 @@ prompt-proto-service:
     imageTimeout: '120'  # Simulated survey has up to 2-minute slews, but most visits are faster
 
   apdb:
+    # -- URL to a serialized APDB configuration, or the "label:" prefix
+    # followed by the indexed name of such a config.
+    # @default -- None, must be set
+    config: ""
     # -- URL to the APDB, in any form recognized by SQLAlchemy
     # @default -- None, must be set
     url: ""

--- a/charts/prompt-proto-service/README.md
+++ b/charts/prompt-proto-service/README.md
@@ -17,6 +17,7 @@ Event-driven processing of camera images
 | alerts.server | string | `"usdf-alert-stream-dev-broker-0.lsst.cloud:9094"` | Server address for the alert stream |
 | alerts.topic | string | alert-stream-test | Topic name where alerts will be sent |
 | alerts.username | string | `"kafka-admin"` | Username for sending alerts to the alert stream |
+| apdb.config | string | None, must be set | URL to a serialized APDB configuration, or the "label:" prefix followed by the indexed name of such a config. |
 | apdb.namespace | string | None, must be set | Database namespace for the APDB |
 | apdb.url | string | None, must be set | URL to the APDB, in any form recognized by SQLAlchemy |
 | cacheAny | bool | `true` | Whether or not any pipeline inputs should be cached between runs of a pod. This is a temporary flag that should only be unset in specific circumstances. |

--- a/charts/prompt-proto-service/README.md
+++ b/charts/prompt-proto-service/README.md
@@ -18,8 +18,6 @@ Event-driven processing of camera images
 | alerts.topic | string | alert-stream-test | Topic name where alerts will be sent |
 | alerts.username | string | `"kafka-admin"` | Username for sending alerts to the alert stream |
 | apdb.config | string | None, must be set | URL to a serialized APDB configuration, or the "label:" prefix followed by the indexed name of such a config. |
-| apdb.namespace | string | None, must be set | Database namespace for the APDB |
-| apdb.url | string | None, must be set | URL to the APDB, in any form recognized by SQLAlchemy |
 | cacheAny | bool | `true` | Whether or not any pipeline inputs should be cached between runs of a pod. This is a temporary flag that should only be unset in specific circumstances. |
 | cacheCalibs | bool | `true` | Whether or not calibs should be cached between runs of a pod. This is a temporary flag that should only be unset in specific circumstances, and only in the development environment. It only has an effect if `cacheAny` is true. |
 | containerConcurrency | int | `1` | The number of Knative requests that can be handled simultaneously by one container |

--- a/charts/prompt-proto-service/templates/prompt-proto-service.yaml
+++ b/charts/prompt-proto-service/templates/prompt-proto-service.yaml
@@ -49,10 +49,6 @@ spec:
           value: {{ .Values.s3.disableBucketValidation | quote }}
         - name: CONFIG_APDB
           value: {{ .Values.apdb.config }}
-        - name: URL_APDB
-          value: {{ .Values.apdb.url }}
-        - name: NAMESPACE_APDB
-          value: {{ .Values.apdb.namespace }}
         - name: KAFKA_CLUSTER
           value: {{ .Values.imageNotifications.kafkaClusterAddress }}
         - name: SASQUATCH_URL

--- a/charts/prompt-proto-service/templates/prompt-proto-service.yaml
+++ b/charts/prompt-proto-service/templates/prompt-proto-service.yaml
@@ -47,6 +47,8 @@ spec:
           value: {{ .Values.instrument.calibRepo }}
         - name: LSST_DISABLE_BUCKET_VALIDATION
           value: {{ .Values.s3.disableBucketValidation | quote }}
+        - name: CONFIG_APDB
+          value: {{ .Values.apdb.config }}
         - name: URL_APDB
           value: {{ .Values.apdb.url }}
         - name: NAMESPACE_APDB

--- a/charts/prompt-proto-service/values.yaml
+++ b/charts/prompt-proto-service/values.yaml
@@ -64,6 +64,10 @@ imageNotifications:
   imageTimeout: '20'
 
 apdb:
+  # -- URL to a serialized APDB configuration, or the "label:" prefix followed
+  # by the indexed name of such a config.
+  # @default -- None, must be set
+  config: ""
   # -- URL to the APDB, in any form recognized by SQLAlchemy
   # @default -- None, must be set
   url: ""

--- a/charts/prompt-proto-service/values.yaml
+++ b/charts/prompt-proto-service/values.yaml
@@ -68,12 +68,6 @@ apdb:
   # by the indexed name of such a config.
   # @default -- None, must be set
   config: ""
-  # -- URL to the APDB, in any form recognized by SQLAlchemy
-  # @default -- None, must be set
-  url: ""
-  # -- Database namespace for the APDB
-  # @default -- None, must be set
-  namespace: ""
 
 alerts:
   # -- Username for sending alerts to the alert stream


### PR DESCRIPTION
This PR updates the Prompt Processing service config to use persisted APDB config files instead of specifying all APDB parameters directly. This PR should be merged after lsst-dm/prompt_processing#157.