### PR TITLE
DM-44136: Use much longer timeout for gafaelfawr-operator

### DIFF
--- a/applications/gafaelfawr/templates/deployment-operator.yaml
+++ b/applications/gafaelfawr/templates/deployment-operator.yaml
@@ -50,7 +50,7 @@ spec:
               port: "http"
             initialDelaySeconds: 60
             periodSeconds: 60
-            timeoutSeconds: 5
+            timeoutSeconds: 20
           ports:
             - containerPort: 8080
               name: "http"


### PR DESCRIPTION
The liveness probe for gafaelfawr-operator is constantly restarting the pod still. Use a much longer timeout in case this is just due to queued processing inside Kopf.