### PR TITLE
Allow Argo CD auth to idfdemo from lsst org

### DIFF
--- a/applications/argocd/values-idfdemo.yaml
+++ b/applications/argocd/values-idfdemo.yaml
@@ -14,6 +14,7 @@ argo-cd:
               # Reference to key in argo-secret Kubernetes resource
               clientSecret: $dex.clientSecret
               orgs:
+                - name: lsst
                 - name: lsst-sqre
     rbac:
       policy.csv: |


### PR DESCRIPTION
We added the lsst:ops group but didn't allow authentication from the lsst org. Add it.