### PR TITLE
Fix the ACL for idfdemo

### DIFF
--- a/applications/argocd/values-idfdemo.yaml
+++ b/applications/argocd/values-idfdemo.yaml
@@ -19,7 +19,7 @@ argo-cd:
     rbac:
       policy.csv: |
         g, lsst-sqre:square, role:admin
-        g, lsst:ops, role:developer
+        g, lsst:Ops, role:developer
 
         p, role:developer, applications, *, */*, allow
         p, role:developer, applications, get, infrastructure/*, allow


### PR DESCRIPTION
The Ops team is capitalized, and the capitalization needs to match.