### PR TITLE
tickets/PREOPS-5118: Update the schedview snapshot dashboard running in phalanx to support access to an S3 bucket

### DIFF
--- a/applications/schedview-snapshot/Chart.yaml
+++ b/applications/schedview-snapshot/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v0.10.0
+appVersion: v0.12.0
 description: Dashboard for examination of scheduler snapshots
 name: schedview-snapshot
 sources:

--- a/applications/schedview-snapshot/secrets.yaml
+++ b/applications/schedview-snapshot/secrets.yaml
@@ -1,0 +1,9 @@
+# Follow the example of plot-navigator, but only getting the aws-credentials
+
+"aws-credentials.ini":
+  description: >-
+    Cloud storage for access to the LFA, from which scheduler snapshots
+    can be loaded.
+  copy:
+    application: nublado
+    key: "aws-credentials.ini"

--- a/applications/schedview-snapshot/templates/_helpers.tpl
+++ b/applications/schedview-snapshot/templates/_helpers.tpl
@@ -1,29 +1,4 @@
 {{/*
-Expand the name of the chart.
-*/}}
-{{- define "schedview-snapshot.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
-{{- end }}
-
-{{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
-*/}}
-{{- define "schedview-snapshot.fullname" -}}
-{{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
-{{- end }}
-{{- end }}
-
-{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "schedview-snapshot.chart" -}}

--- a/applications/schedview-snapshot/templates/_helpers.tpl
+++ b/applications/schedview-snapshot/templates/_helpers.tpl
@@ -1,4 +1,29 @@
 {{/*
+Expand the name of the chart.
+*/}}
+{{- define "schedview-snapshot.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "schedview-snapshot.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "schedview-snapshot.chart" -}}

--- a/applications/schedview-snapshot/templates/deployment.yaml
+++ b/applications/schedview-snapshot/templates/deployment.yaml
@@ -34,6 +34,8 @@ spec:
           env:
             - name: BOKEH_ALLOW_WS_ORIGIN
               value: {{ .Values.global.host }}
+            - name: AWS_SHARED_CREDENTIALS_FILE
+              value: /opt/schedview/aws-credentials.ini
           ports:
             - name: "http"
               containerPort: 8080
@@ -52,6 +54,9 @@ spec:
               mountPath: /tmp
             - name: slashdatcache
               mountPath: /.cache
+            - name: "schedview-snapshot-secrets"
+              mountPath: "/opt/schedview"
+              readOnly: true
           command:
             - /bin/bash
             - -c
@@ -77,3 +82,7 @@ spec:
           emptyDir: {}
         - name: slashdatcache
           emptyDir: {}
+        - name: schedview-snapshot-secrets
+          secret:
+            secretName: {{ include "schedview-snapshot.fullname" . }}
+

--- a/applications/schedview-snapshot/templates/deployment.yaml
+++ b/applications/schedview-snapshot/templates/deployment.yaml
@@ -55,7 +55,7 @@ spec:
           command:
             - /bin/bash
             - -c
-            - micromamba run scheduler_dashboard --data_dir /home/mambauser/schedview/test_data
+            - micromamba run scheduler_dashboard --lfa
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/applications/schedview-snapshot/templates/deployment.yaml
+++ b/applications/schedview-snapshot/templates/deployment.yaml
@@ -84,5 +84,4 @@ spec:
           emptyDir: {}
         - name: schedview-snapshot-secrets
           secret:
-            secretName: {{ include "schedview-snapshot.fullname" . }}
-
+            secretName: schedview-snapshot

--- a/applications/schedview-snapshot/templates/vault-secrets.yaml
+++ b/applications/schedview-snapshot/templates/vault-secrets.yaml
@@ -1,0 +1,11 @@
+# Follow the example of plot-navigator
+
+apiVersion: ricoberger.de/v1alpha1
+kind: VaultSecret
+metadata:
+  name: {{ template "schedview-snapshot.fullname" . }}
+  labels:
+    {{- include "schedview-snapshot.labels" . | nindent 4 }}
+spec:
+  path: "{{ .Values.global.vaultSecretsPath }}/butler-secret"
+  type: Opaque

--- a/applications/schedview-snapshot/templates/vault-secrets.yaml
+++ b/applications/schedview-snapshot/templates/vault-secrets.yaml
@@ -3,7 +3,7 @@
 apiVersion: ricoberger.de/v1alpha1
 kind: VaultSecret
 metadata:
-  name: {{ template "schedview-snapshot.fullname" . }}
+  name: schedview-snapshot
   labels:
     {{- include "schedview-snapshot.labels" . | nindent 4 }}
 spec:

--- a/applications/schedview-snapshot/templates/vault-secrets.yaml
+++ b/applications/schedview-snapshot/templates/vault-secrets.yaml
@@ -7,5 +7,5 @@ metadata:
   labels:
     {{- include "schedview-snapshot.labels" . | nindent 4 }}
 spec:
-  path: "{{ .Values.global.vaultSecretsPath }}/butler-secret"
+  path: "{{ .Values.global.vaultSecretsPath }}/schedview-snapshot"
   type: Opaque

--- a/applications/schedview-snapshot/values-usdfdev.yaml
+++ b/applications/schedview-snapshot/values-usdfdev.yaml
@@ -1,3 +1,3 @@
 image:
   # -- Overrides the image tag whose default is the chart appVersion.
-  tag: "tickets-preops-5118"
+  tag: "v0.12.0"

--- a/applications/schedview-snapshot/values-usdfdev.yaml
+++ b/applications/schedview-snapshot/values-usdfdev.yaml
@@ -1,3 +1,3 @@
 image:
   # -- Overrides the image tag whose default is the chart appVersion.
-  tag: "tickets-preops-4603"
+  tag: "tickets-preops-5118"

--- a/applications/schedview-snapshot/values-usdfint.yaml
+++ b/applications/schedview-snapshot/values-usdfint.yaml
@@ -1,0 +1,3 @@
+image:
+  # -- Overrides the image tag whose default is the chart appVersion.
+  tag: "v0.12.0"

--- a/environments/values-usdfint.yaml
+++ b/environments/values-usdfint.yaml
@@ -22,6 +22,7 @@ applications:
   portal: true
   postgres: true
   sasquatch: true
+  schedview-snapshot: true
   semaphore: true
   ssotap: true
   squareone: true


### PR DESCRIPTION
This change requires not just updating the schedview version, but also requires configuring phalanx to provide it with the secret it needs.
For this, I was guided by a combination of the phalanx documentation, the configuration of plot-navigator (from which some changes were cut-and-pasted), and [this thread on slack](https://lsstc.slack.com/archives/C2JP8GGVC/p1714426470147829).
It seems to work like this, but I'm not 100% sure copying the secret from nublado using the butler's vault is the right thing to do, in that I think it give this app write access it doesn't need (although KT [says this is okay](https://lsstc.slack.com/archives/C2JP8GGVC/p1714580872053049?thread_ts=1714426470.147829&cid=C2JP8GGVC)).