### PR TITLE
Add Dan Fuchs as Argo CD admin on Google envs

### DIFF
--- a/applications/argocd/values-idfdev.yaml
+++ b/applications/argocd/values-idfdev.yaml
@@ -28,6 +28,7 @@ argo-cd:
 
         g, adam@lsst.cloud, role:admin
         g, afausti@lsst.cloud, role:admin
+        g, dfuchs@lsst.cloud, role:admin
         g, dspeck@lsst.cloud, role:admin
         g, frossie@lsst.cloud, role:admin
         g, jsick@lsst.cloud, role:admin

--- a/applications/argocd/values-idfint.yaml
+++ b/applications/argocd/values-idfint.yaml
@@ -28,6 +28,7 @@ argo-cd:
 
         g, adam@lsst.cloud, role:admin
         g, afausti@lsst.cloud, role:admin
+        g, dfuchs@lsst.cloud, role:admin
         g, dspeck@lsst.cloud, role:admin
         g, frossie@lsst.cloud, role:admin
         g, jsick@lsst.cloud, role:admin

--- a/applications/argocd/values-idfprod.yaml
+++ b/applications/argocd/values-idfprod.yaml
@@ -28,6 +28,7 @@ argo-cd:
 
         g, adam@lsst.cloud, role:admin
         g, afausti@lsst.cloud, role:admin
+        g, dfuchs@lsst.cloud, role:admin
         g, dspeck@lsst.cloud, role:admin
         g, frossie@lsst.cloud, role:admin
         g, jsick@lsst.cloud, role:admin

--- a/applications/argocd/values-roundtable-dev.yaml
+++ b/applications/argocd/values-roundtable-dev.yaml
@@ -19,6 +19,7 @@ argo-cd:
       policy.csv: |
         g, adam@lsst.cloud, role:admin
         g, afausti@lsst.cloud, role:admin
+        g, dfuchs@lsst.cloud, role:admin
         g, dspeck@lsst.cloud, role:admin
         g, frossie@lsst.cloud, role:admin
         g, jsick@lsst.cloud, role:admin

--- a/applications/argocd/values-roundtable-prod.yaml
+++ b/applications/argocd/values-roundtable-prod.yaml
@@ -19,6 +19,7 @@ argo-cd:
       policy.csv: |
         g, adam@lsst.cloud, role:admin
         g, afausti@lsst.cloud, role:admin
+        g, dfuchs@lsst.cloud, role:admin
         g, dspeck@lsst.cloud, role:admin
         g, frossie@lsst.cloud, role:admin
         g, jsick@lsst.cloud, role:admin


### PR DESCRIPTION
This adds Dan as an admin on the idf and roundtable clusters. I haven't
updated the usdf values in this PR.