### PR TITLE
DM-44239: Remove unused minikube configurations

### DIFF
--- a/applications/exposurelog/values-minikube.yaml
+++ b/applications/exposurelog/values-minikube.yaml
@@ -1,2 +1,0 @@
-config:
-  site_id: minikube

--- a/applications/narrativelog/values-minikube.yaml
+++ b/applications/narrativelog/values-minikube.yaml
@@ -1,2 +1,0 @@
-config:
-  site_id: minikube

--- a/applications/noteburst/values-minikube.yaml
+++ b/applications/noteburst/values-minikube.yaml
@@ -1,6 +1,0 @@
-config:
-  worker:
-    workerCount: 0
-    identities:
-      - uid: 90000
-        username: "noteburst90000"

--- a/applications/portal/values-minikube.yaml
+++ b/applications/portal/values-minikube.yaml
@@ -1,4 +1,0 @@
-resources:
-  limits:
-    cpu: 0.3
-    memory: "2Gi"

--- a/applications/semaphore/values-minikube.yaml
+++ b/applications/semaphore/values-minikube.yaml
@@ -1,2 +1,0 @@
-config:
-  phalanx_env: "minikube"

--- a/applications/strimzi/values-minikube.yaml
+++ b/applications/strimzi/values-minikube.yaml
@@ -1,4 +1,0 @@
-strimzi-kafka-operator:
-  watchNamespaces:
-    - "sasquatch"
-  logLevel: "INFO"


### PR DESCRIPTION
Remove configurations for the minikube environment that are not used by the GitHub CI testing, which is now the only thing that we use minikube for. These configurations weren't tested and tend to bitrot.