### PR TITLE
DM-44239: Add PostgreSQL secret for livetap

### DIFF
--- a/applications/livetap/secrets.yaml
+++ b/applications/livetap/secrets.yaml
@@ -2,3 +2,7 @@
   description: >-
     Google service account credentials used to write async job output to
     Google Cloud Storage.
+pgpassword:
+  description: >-
+    Password to external PostgreSQL server that contains the live-updating
+    ObsCore data.


### PR DESCRIPTION
livetap uses the PostgreSQL backend for TAP, which requires a password secret. Copy the description from ssotap and update the description.