### PR TITLE
DM-44239: Add blank lines to secrets audit output

### DIFF
--- a/src/phalanx/services/secrets.py
+++ b/src/phalanx/services/secrets.py
@@ -61,10 +61,14 @@ class SecretsAuditReport:
             secrets = "\n• ".join(sorted(self.missing))
             report += "Missing secrets:\n• " + secrets + "\n"
         if self.mismatch:
+            if self.missing:
+                report += "\n"
             secrets = "\n• ".join(sorted(self.mismatch))
             heading = "Secrets that do not have their expected value:"
             report += f"{heading}\n• " + secrets + "\n"
         if self.unknown:
+            if self.missing or self.mismatch:
+                report += "\n"
             secrets = "\n• ".join(sorted(self.unknown))
             report += "Unknown secrets in Vault:\n• " + secrets + "\n"
         return report

--- a/tests/data/output/idfdev/secrets-audit
+++ b/tests/data/output/idfdev/secrets-audit
@@ -9,9 +9,11 @@ Missing secrets:
 • nublado postgres-credentials.txt
 • nublado proxy_token
 • portal ADMIN_PASSWORD
+
 Secrets that do not have their expected value:
 • gafaelfawr database-password
 • postgres nublado3_password
+
 Unknown secrets in Vault:
 • gafaelfawr cilogon
 • unknown some-secret


### PR DESCRIPTION
Put a blank line before headings in secrets audit output to make it more readable.