### PR TITLE
DM-44238: Handle pull-secret with no static secrets

### DIFF
--- a/src/phalanx/services/secrets.py
+++ b/src/phalanx/services/secrets.py
@@ -150,7 +150,12 @@ class SecretsService:
             return "Unresolved secrets:\n• " + "\n• ".join(e.secrets) + "\n"
 
         # Compare the resolved secrets to the Vault data.
-        report = self._audit_secrets(resolved, vault_secrets, pull_secret)
+        report = self._audit_secrets(
+            resolved,
+            vault_secrets,
+            pull_secret,
+            has_static_secrets=bool(static_secrets),
+        )
 
         # Generate the textual report.
         return report.to_text()
@@ -277,9 +282,12 @@ class SecretsService:
             regenerate=regenerate,
         )
 
-        # Replace any Vault secrets that are incorrect.
+        # Replace any Vault secrets that are incorrect. If there are no static
+        # secrets, tell _clean_vault_secrets that we have a pull secret to
+        # ensure that it doesn't delete any pull secret stored directly in
+        # Vault.
         self._sync_application_secrets(vault_client, vault_secrets, resolved)
-        has_pull_secret = False
+        has_pull_secret = bool(not static_secrets)
         if resolved.pull_secret and resolved.pull_secret.registries:
             has_pull_secret = True
             pull_secret = resolved.pull_secret
@@ -299,6 +307,8 @@ class SecretsService:
         resolved: ResolvedSecrets,
         vault_secrets: dict[str, dict[str, SecretStr]],
         pull_secret: PullSecret | None,
+        *,
+        has_static_secrets: bool,
     ) -> SecretsAuditReport:
         """Compare resolved secrets with the contents of Vault.
 
@@ -310,6 +320,10 @@ class SecretsService:
             Vault secrets for that environment.
         pull_secret
             Pull secret for the environment, if one is needed.
+        has_static_secrets
+            Whether static secrets were provided. If no static secrets were
+            provided, we should not complain about any pull secret that was
+            found, even if we don't have one.
 
         Returns
         -------
@@ -342,7 +356,7 @@ class SecretsService:
                     mismatch.append("pull-secret")
             else:
                 missing.append("pull-secret")
-        elif "pull-secret" in vault_secrets:
+        elif "pull-secret" in vault_secrets and has_static_secrets:
             unknown.append("pull-secret")
 
         # Return the report.

--- a/tests/cli/secrets_test.py
+++ b/tests/cli/secrets_test.py
@@ -251,6 +251,30 @@ def test_sync(factory: Factory, mock_vault: MockVaultClient) -> None:
     del gafaelfawr["cilogon"]
     assert after == gafaelfawr
 
+    # Add a pull-secret to Vault, run secrets sync --delete again without
+    # static secrets, and ensure that pull-secret wasn't deleted.
+    pull_secret = read_output_json("minikube", "pull-secret")
+    mock_vault.create_or_update_secret(
+        f"{base_vault_path}/pull-secret", pull_secret
+    )
+    result = run_cli(
+        "secrets",
+        "sync",
+        "--delete",
+        "idfdev",
+        env={"VAULT_TOKEN": "sometoken"},
+    )
+    assert result.exit_code == 0
+    assert result.output == ""
+
+    # Test the same path for audit. This is a bit misplaced, but all the data
+    # is set up properly here.
+    result = run_cli(
+        "secrets", "audit", "idfdev", env={"VAULT_TOKEN": "sometoken"}
+    )
+    assert result.exit_code == 0
+    assert result.output == ""
+
 
 def test_sync_onepassword(
     factory: Factory,


### PR DESCRIPTION
If there are no static secrets, and therefore Phalanx should assume the static secrets are already stored in Vault, make sure that audit doesn't complain about and sync doesn't delete a pull-secret.