### PR TITLE
Example of a service using the Butler for boot camp

### DIFF
--- a/applications/butler-example-service/README.md
+++ b/applications/butler-example-service/README.md
@@ -15,6 +15,7 @@ Example of service using Butler for boot camp
 | config.logProfile | string | `"production"` | Logging profile (`production` for JSON, `development` for human-friendly) |
 | config.pathPrefix | string | `"/butler-example-service"` | URL path prefix |
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |
+| global.butlerServerRepositories | string | Set by Argo CD | Butler repositories accessible via Butler server |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the butler-example-service image |

--- a/applications/butler-example-service/templates/deployment.yaml
+++ b/applications/butler-example-service/templates/deployment.yaml
@@ -29,6 +29,9 @@ spec:
           envFrom:
             - configMapRef:
                 name: "butler-example-service"
+          env:
+            - name: "DAF_BUTLER_REPOSITORIES"
+              value: {{ .Values.global.butlerServerRepositories | b64dec | quote }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:

--- a/applications/butler-example-service/templates/ingress.yaml
+++ b/applications/butler-example-service/templates/ingress.yaml
@@ -9,6 +9,13 @@ config:
   scopes:
     all:
       - "read:image"
+  # Request a delegated token to use for making calls to Butler server with the
+  # end-user's credentials.
+  delegate:
+    internal:
+      service: "butler-example-service"
+      scopes:
+        - "read:image"
 template:
   metadata:
     name: "butler-example-service"

--- a/applications/butler-example-service/values.yaml
+++ b/applications/butler-example-service/values.yaml
@@ -53,6 +53,10 @@ global:
   # @default -- Set by Argo CD
   baseUrl: ""
 
+  # -- Butler repositories accessible via Butler server
+  # @default -- Set by Argo CD
+  butlerServerRepositories: ""
+
   # -- Host name for ingress
   # @default -- Set by Argo CD
   host: ""

--- a/environments/templates/applications/rsp/butler-example-service.yaml
+++ b/environments/templates/applications/rsp/butler-example-service.yaml
@@ -26,6 +26,8 @@ spec:
           value: {{ .Values.fqdn | quote }}
         - name: "global.baseUrl"
           value: "https://{{ .Values.fqdn }}"
+        - name: "global.butlerServerRepositories"
+          value: {{ .Values.butlerServerRepositories | toJson | b64enc }}
         - name: "global.vaultSecretsPath"
           value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:


### PR DESCRIPTION
This PR shows the setup necessary to configure a service to use client/server Butler.  This was presented during the "Butler client-server" talk at the [SQRE services bootcamp](https://confluence.lsstcorp.org/display/DM/SQuaRE+Bootcamp+-+May+6-10+2024)