### PR TITLE
Bump memory request and limit for vo-cutout worker

### DIFF
--- a/applications/vo-cutouts/values.yaml
+++ b/applications/vo-cutouts/values.yaml
@@ -133,10 +133,10 @@ cutoutWorker:
   resources:
     limits:
       cpu: "1"
-      memory: "700Mi"
+      memory: "1Gi"
     requests:
       cpu: "0.1"
-      memory: "350Mi"
+      memory: "550Mi"
 
   # -- Annotations for the cutout worker pod
   podAnnotations: {}


### PR DESCRIPTION
The vo-cutout worker was restarted due to being OOM killed and is on average taking up more memory than we're allocating. Bump the requests and limits.