### PR TITLE
DM-44270: Update Ook jobs to use new Kafka info

### DIFF
--- a/applications/ook/templates/cronjob-audit.yaml
+++ b/applications/ook/templates/cronjob-audit.yaml
@@ -56,19 +56,16 @@ spec:
                 # Writeable directory for concatenating certs. See "tmp" volume.
                 - name: "KAFKA_CERT_TEMP_DIR"
                   value: "/tmp/kafka_certs"
+                - name: "KAFKA_SECURITY_PROTOCOL"
+                  value: "SSL"
                 # From KafkaAccess
                 - name: "KAFKA_BOOTSTRAP_SERVERS"
                   valueFrom:
-                      secretKeyRef:
-                        name: {{ template "ook.fullname" . }}-kafka
-                        key: "bootstrapServers"
-                - name: "KAFKA_SECURITY_PROTOCOL"
-                  value: "SSL"
-                # From replicated KafkaUser secret
+                    secretKeyRef:
+                      name: {{ template "ook.fullname" . }}-kafka
+                      key: "bootstrapServers"
                 - name: "KAFKA_SSL_CLUSTER_CAFILE"
                   value: "/etc/kafkacluster/ca.crt"
-                - name: "KAFKA_SSL_CLIENT_CAFILE"
-                  value: "/etc/kafkauser/ca.crt"
                 - name: "KAFKA_SSL_CLIENT_CERTFILE"
                   value: "/etc/kafkauser/user.crt"
                 - name: "KAFKA_SSL_CLIENT_KEYFILE"
@@ -101,18 +98,15 @@ spec:
                     - "all"
                 readOnlyRootFilesystem: true
               volumeMounts:
-                - name: "{{ template "ook.fullname" . }}"
+                - name: "kafka"
                   mountPath: "/etc/kafkacluster/ca.crt"
-                  subPath: "ca.crt"
-                - name: "kafka-user"
-                  mountPath: "/etc/kafkauser/ca.crt"
-                  subPath: "ca.crt"
-                - name: "kafka-user"
+                  subPath: "ssl.truststore.crt" # CA cert from the Kafka cluster
+                - name: "kafka"
                   mountPath: "/etc/kafkauser/user.crt"
-                  subPath: "user.crt"
-                - name: "kafka-user"
+                  subPath: "ssl.keystore.crt" # User cert from the Kafka cluster signed by the clients' CA
+                - name: "kafka"
                   mountPath: "/etc/kafkauser/user.key"
-                  subPath: "user.key"
+                  subPath: "ssl.keystore.key" # private key for the consuming client
                 - name: "tmp"
                   mountPath: "/tmp/kafka_certs"
           {{with .Values.nodeSelector }}
@@ -128,9 +122,10 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumes:
-            - name: "kafka-user"
+            # This secret comes from the KafkaAccess operator
+            - name: "kafka"
               secret:
-                secretName: {{ template "ook.fullname" . }}-kafka-user
+                secretName: ook-kafka
             - name: "{{ template "ook.fullname" . }}"
               secret:
                 secretName: {{ template "ook.fullname" . }}

--- a/applications/ook/templates/cronjob-ingest-updated.yaml
+++ b/applications/ook/templates/cronjob-ingest-updated.yaml
@@ -55,14 +55,20 @@ spec:
                 # Writeable directory for concatenating certs. See "tmp" volume.
                 - name: "KAFKA_CERT_TEMP_DIR"
                   value: "/tmp/kafka_certs"
+                - name: "KAFKA_SECURITY_PROTOCOL"
+                  value: "SSL"
                 # From KafkaAccess
                 - name: "KAFKA_BOOTSTRAP_SERVERS"
                   valueFrom:
-                      secretKeyRef:
-                        name: {{ template "ook.fullname" . }}-kafka
-                        key: "bootstrapServers"
-                - name: "KAFKA_SECURITY_PROTOCOL"
-                  value: "SSL"
+                    secretKeyRef:
+                      name: {{ template "ook.fullname" . }}-kafka
+                      key: "bootstrapServers"
+                - name: "KAFKA_SSL_CLUSTER_CAFILE"
+                  value: "/etc/kafkacluster/ca.crt"
+                - name: "KAFKA_SSL_CLIENT_CERTFILE"
+                  value: "/etc/kafkauser/user.crt"
+                - name: "KAFKA_SSL_CLIENT_KEYFILE"
+                  value: "/etc/kafkauser/user.key"
                 # From replicated KafkaUser secret
                 - name: "KAFKA_SSL_CLUSTER_CAFILE"
                   value: "/etc/kafkacluster/ca.crt"
@@ -100,18 +106,15 @@ spec:
                     - "all"
                 readOnlyRootFilesystem: true
               volumeMounts:
-                - name: "{{ template "ook.fullname" . }}"
+                - name: "kafka"
                   mountPath: "/etc/kafkacluster/ca.crt"
-                  subPath: "ca.crt"
-                - name: "kafka-user"
-                  mountPath: "/etc/kafkauser/ca.crt"
-                  subPath: "ca.crt"
-                - name: "kafka-user"
+                  subPath: "ssl.truststore.crt" # CA cert from the Kafka cluster
+                - name: "kafka"
                   mountPath: "/etc/kafkauser/user.crt"
-                  subPath: "user.crt"
-                - name: "kafka-user"
+                  subPath: "ssl.keystore.crt" # User cert from the Kafka cluster signed by the clients' CA
+                - name: "kafka"
                   mountPath: "/etc/kafkauser/user.key"
-                  subPath: "user.key"
+                  subPath: "ssl.keystore.key" # private key for the consuming client
                 - name: "tmp"
                   mountPath: "/tmp/kafka_certs"
           {{with .Values.nodeSelector }}
@@ -127,9 +130,10 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumes:
-            - name: "kafka-user"
+            # This secret comes from the KafkaAccess operator
+            - name: "kafka"
               secret:
-                secretName: {{ template "ook.fullname" . }}-kafka-user
+                secretName: ook-kafka
             - name: "{{ template "ook.fullname" . }}"
               secret:
                 secretName: {{ template "ook.fullname" . }}


### PR DESCRIPTION
Now that we no longer replicate the KafkaUser secret, Ook's Job-based resources need to use the new set of secrets from Kafka Access Operator.