### PR TITLE
[DM-44337] Configure timestamp precision in the Telegraf Kafka Consumer input plugin 

### DIFF
--- a/applications/sasquatch/charts/telegraf-kafka-consumer/templates/configmap.yaml
+++ b/applications/sasquatch/charts/telegraf-kafka-consumer/templates/configmap.yaml
@@ -19,7 +19,6 @@ data:
       metric_batch_size = {{ default 1000 $value.metric_batch_size }}
       metric_buffer_limit = 10000
       omit_hostname = true
-      precision = ""
       quiet = false
       round_interval = true
 
@@ -63,6 +62,7 @@ data:
       topic_regexps = {{ $value.topicRegexps }}
       offset = "newest"
       consumer_fetch_default = "20MB"
+      precision = "1us"
 
     [[inputs.internal]]
       collect_memstats = false


### PR DESCRIPTION
The precision configuration setting determines how much timestamp precision is retained in the points received from input plugins. All incoming timestamps are truncated to the given precision.
We are doing that in the Telegraph Kafka input plugin configuration to make sure timestamps are truncated to microseconds (same behaviour of the InfluxDB Sink connectors)