### PR TITLE
DM-42925: Add support for preprocessing pipeline to Prompt Processing

### DIFF
--- a/applications/prompt-proto-service-hsc-gpu/README.md
+++ b/applications/prompt-proto-service-hsc-gpu/README.md
@@ -27,7 +27,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.instrument.calibRepo | string | None, must be set | URI to the shared repo used for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself. |
 | prompt-proto-service.instrument.calibRepoPguser | string | None, must be set | Postgres username to access the shared butler repo for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, a local redirect is used and its config may override this config. |
 | prompt-proto-service.instrument.name | string | `"HSC"` | The "short" name of the instrument |
-| prompt-proto-service.instrument.pipelines | string | None, must be set | Machine-readable string describing which pipeline(s) should be run for which visits. Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |
+| prompt-proto-service.instrument.pipelines.main | string | None, must be set | Machine-readable string describing which pipeline(s) should be run for which visits. Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |
 | prompt-proto-service.instrument.skymap | string | `"hsc_rings_v1"` | Skymap to use with the instrument |
 | prompt-proto-service.knative.cpuLimit | string | `"1"` | The maximum cpu cores. |
 | prompt-proto-service.knative.cpuRequest | string | `"1"` | The cpu cores requested. |

--- a/applications/prompt-proto-service-hsc-gpu/README.md
+++ b/applications/prompt-proto-service-hsc-gpu/README.md
@@ -28,6 +28,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.instrument.calibRepoPguser | string | None, must be set | Postgres username to access the shared butler repo for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, a local redirect is used and its config may override this config. |
 | prompt-proto-service.instrument.name | string | `"HSC"` | The "short" name of the instrument |
 | prompt-proto-service.instrument.pipelines.main | string | None, must be set | Machine-readable string describing which pipeline(s) should be run for which visits. Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |
+| prompt-proto-service.instrument.pipelines.preprocessing | string | None, must be set | Machine-readable string describing which pipeline(s) should be run before which visits' raw arrival. |
 | prompt-proto-service.instrument.skymap | string | `"hsc_rings_v1"` | Skymap to use with the instrument |
 | prompt-proto-service.knative.cpuLimit | string | `"1"` | The maximum cpu cores. |
 | prompt-proto-service.knative.cpuRequest | string | `"1"` | The cpu cores requested. |

--- a/applications/prompt-proto-service-hsc-gpu/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-hsc-gpu/values-usdfdev-prompt-processing.yaml
@@ -13,6 +13,7 @@ prompt-proto-service:
   instrument:
     pipelines:
       main: (survey="SURVEY")=[${PROMPT_PROCESSING_DIR}/pipelines/HSC/ApPipe.yaml]
+      preprocessing: (survey="SURVEY")=[]
     calibRepo: s3://rubin-pp-dev-users/central_repo/
     calibRepoPguser: hsc_prompt
 

--- a/applications/prompt-proto-service-hsc-gpu/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-hsc-gpu/values-usdfdev-prompt-processing.yaml
@@ -11,7 +11,8 @@ prompt-proto-service:
     tag: latest
 
   instrument:
-    pipelines: (survey="SURVEY")=[${PROMPT_PROCESSING_DIR}/pipelines/HSC/ApPipe.yaml]
+    pipelines:
+      main: (survey="SURVEY")=[${PROMPT_PROCESSING_DIR}/pipelines/HSC/ApPipe.yaml]
     calibRepo: s3://rubin-pp-dev-users/central_repo/
     calibRepoPguser: hsc_prompt
 

--- a/applications/prompt-proto-service-hsc-gpu/values.yaml
+++ b/applications/prompt-proto-service-hsc-gpu/values.yaml
@@ -28,10 +28,11 @@ prompt-proto-service:
   instrument:
     # -- The "short" name of the instrument
     name: HSC
-    # -- Machine-readable string describing which pipeline(s) should be run for which visits.
-    # Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples.
-    # @default -- None, must be set
-    pipelines: ""
+    pipelines:
+      # -- Machine-readable string describing which pipeline(s) should be run for which visits.
+      # Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples.
+      # @default -- None, must be set
+      main: ""
     # -- Skymap to use with the instrument
     skymap: hsc_rings_v1
     # -- URI to the shared repo used for calibrations, templates, and pipeline outputs.

--- a/applications/prompt-proto-service-hsc-gpu/values.yaml
+++ b/applications/prompt-proto-service-hsc-gpu/values.yaml
@@ -33,6 +33,9 @@ prompt-proto-service:
       # Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples.
       # @default -- None, must be set
       main: ""
+      # -- Machine-readable string describing which pipeline(s) should be run before which visits' raw arrival.
+      # @default -- None, must be set
+      preprocessing: ""
     # -- Skymap to use with the instrument
     skymap: hsc_rings_v1
     # -- URI to the shared repo used for calibrations, templates, and pipeline outputs.

--- a/applications/prompt-proto-service-hsc/README.md
+++ b/applications/prompt-proto-service-hsc/README.md
@@ -27,7 +27,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.instrument.calibRepo | string | None, must be set | URI to the shared repo used for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself. |
 | prompt-proto-service.instrument.calibRepoPguser | string | None, must be set | Postgres username to access the shared butler repo for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, a local redirect is used and its config may override this config. |
 | prompt-proto-service.instrument.name | string | `"HSC"` | The "short" name of the instrument |
-| prompt-proto-service.instrument.pipelines | string | None, must be set | Machine-readable string describing which pipeline(s) should be run for which visits. Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |
+| prompt-proto-service.instrument.pipelines.main | string | None, must be set | Machine-readable string describing which pipeline(s) should be run for which visits. Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |
 | prompt-proto-service.instrument.skymap | string | `"hsc_rings_v1"` | Skymap to use with the instrument |
 | prompt-proto-service.knative.cpuLimit | string | `"1"` | The maximum cpu cores. |
 | prompt-proto-service.knative.cpuRequest | string | `"1"` | The cpu cores requested. |

--- a/applications/prompt-proto-service-hsc/README.md
+++ b/applications/prompt-proto-service-hsc/README.md
@@ -28,6 +28,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.instrument.calibRepoPguser | string | None, must be set | Postgres username to access the shared butler repo for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, a local redirect is used and its config may override this config. |
 | prompt-proto-service.instrument.name | string | `"HSC"` | The "short" name of the instrument |
 | prompt-proto-service.instrument.pipelines.main | string | None, must be set | Machine-readable string describing which pipeline(s) should be run for which visits. Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |
+| prompt-proto-service.instrument.pipelines.preprocessing | string | None, must be set | Machine-readable string describing which pipeline(s) should be run before which visits' raw arrival. |
 | prompt-proto-service.instrument.skymap | string | `"hsc_rings_v1"` | Skymap to use with the instrument |
 | prompt-proto-service.knative.cpuLimit | string | `"1"` | The maximum cpu cores. |
 | prompt-proto-service.knative.cpuRequest | string | `"1"` | The cpu cores requested. |

--- a/applications/prompt-proto-service-hsc/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-hsc/values-usdfdev-prompt-processing.yaml
@@ -12,7 +12,8 @@ prompt-proto-service:
     tag: latest
 
   instrument:
-    pipelines: (survey="SURVEY")=[${PROMPT_PROCESSING_DIR}/pipelines/HSC/ApPipe.yaml]
+    pipelines:
+      main: (survey="SURVEY")=[${PROMPT_PROCESSING_DIR}/pipelines/HSC/ApPipe.yaml]
     calibRepo: s3://rubin-pp-dev-users/central_repo/
     calibRepoPguser: hsc_prompt
 

--- a/applications/prompt-proto-service-hsc/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-hsc/values-usdfdev-prompt-processing.yaml
@@ -14,6 +14,7 @@ prompt-proto-service:
   instrument:
     pipelines:
       main: (survey="SURVEY")=[${PROMPT_PROCESSING_DIR}/pipelines/HSC/ApPipe.yaml]
+      preprocessing: (survey="SURVEY")=[]
     calibRepo: s3://rubin-pp-dev-users/central_repo/
     calibRepoPguser: hsc_prompt
 

--- a/applications/prompt-proto-service-hsc/values.yaml
+++ b/applications/prompt-proto-service-hsc/values.yaml
@@ -28,10 +28,11 @@ prompt-proto-service:
   instrument:
     # -- The "short" name of the instrument
     name: HSC
-    # -- Machine-readable string describing which pipeline(s) should be run for which visits.
-    # Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples.
-    # @default -- None, must be set
-    pipelines: ""
+    pipelines:
+      # -- Machine-readable string describing which pipeline(s) should be run for which visits.
+      # Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples.
+      # @default -- None, must be set
+      main: ""
     # -- Skymap to use with the instrument
     skymap: hsc_rings_v1
     # -- URI to the shared repo used for calibrations, templates, and pipeline outputs.

--- a/applications/prompt-proto-service-hsc/values.yaml
+++ b/applications/prompt-proto-service-hsc/values.yaml
@@ -33,6 +33,9 @@ prompt-proto-service:
       # Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples.
       # @default -- None, must be set
       main: ""
+      # -- Machine-readable string describing which pipeline(s) should be run before which visits' raw arrival.
+      # @default -- None, must be set
+      preprocessing: ""
     # -- Skymap to use with the instrument
     skymap: hsc_rings_v1
     # -- URI to the shared repo used for calibrations, templates, and pipeline outputs.

--- a/applications/prompt-proto-service-latiss/README.md
+++ b/applications/prompt-proto-service-latiss/README.md
@@ -27,7 +27,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.instrument.calibRepo | string | None, must be set | URI to the shared repo used for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself. |
 | prompt-proto-service.instrument.calibRepoPguser | string | None, must be set | Postgres username to access the shared butler repo for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, a local redirect is used and its config may override this config. |
 | prompt-proto-service.instrument.name | string | `"LATISS"` | The "short" name of the instrument |
-| prompt-proto-service.instrument.pipelines | string | None, must be set | Machine-readable string describing which pipeline(s) should be run for which visits. Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |
+| prompt-proto-service.instrument.pipelines.main | string | None, must be set | Machine-readable string describing which pipeline(s) should be run for which visits. Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |
 | prompt-proto-service.instrument.skymap | string | `"latiss_v1"` | Skymap to use with the instrument |
 | prompt-proto-service.knative.cpuLimit | string | `"1"` | The maximum cpu cores. |
 | prompt-proto-service.knative.cpuRequest | string | `"1"` | The cpu cores requested. |

--- a/applications/prompt-proto-service-latiss/README.md
+++ b/applications/prompt-proto-service-latiss/README.md
@@ -28,6 +28,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.instrument.calibRepoPguser | string | None, must be set | Postgres username to access the shared butler repo for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, a local redirect is used and its config may override this config. |
 | prompt-proto-service.instrument.name | string | `"LATISS"` | The "short" name of the instrument |
 | prompt-proto-service.instrument.pipelines.main | string | None, must be set | Machine-readable string describing which pipeline(s) should be run for which visits. Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |
+| prompt-proto-service.instrument.pipelines.preprocessing | string | None, must be set | Machine-readable string describing which pipeline(s) should be run before which visits' raw arrival. |
 | prompt-proto-service.instrument.skymap | string | `"latiss_v1"` | Skymap to use with the instrument |
 | prompt-proto-service.knative.cpuLimit | string | `"1"` | The maximum cpu cores. |
 | prompt-proto-service.knative.cpuRequest | string | `"1"` | The cpu cores requested. |

--- a/applications/prompt-proto-service-latiss/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfdev-prompt-processing.yaml
@@ -10,9 +10,10 @@ prompt-proto-service:
     tag: latest
 
   instrument:
-    pipelines: >-
-      (survey="SURVEY")=[${PROMPT_PROCESSING_DIR}/pipelines/LATISS/ApPipe.yaml,
-      ${PROMPT_PROCESSING_DIR}/pipelines/LATISS/Isr.yaml]
+    pipelines:
+      main: >-
+        (survey="SURVEY")=[${PROMPT_PROCESSING_DIR}/pipelines/LATISS/ApPipe.yaml,
+        ${PROMPT_PROCESSING_DIR}/pipelines/LATISS/Isr.yaml]
     calibRepo: s3://rubin-pp-dev-users/central_repo/
     calibRepoPguser: latiss_prompt
 

--- a/applications/prompt-proto-service-latiss/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfdev-prompt-processing.yaml
@@ -14,6 +14,7 @@ prompt-proto-service:
       main: >-
         (survey="SURVEY")=[${PROMPT_PROCESSING_DIR}/pipelines/LATISS/ApPipe.yaml,
         ${PROMPT_PROCESSING_DIR}/pipelines/LATISS/Isr.yaml]
+      preprocessing: (survey="SURVEY")=[]
     calibRepo: s3://rubin-pp-dev-users/central_repo/
     calibRepoPguser: latiss_prompt
 

--- a/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
@@ -28,6 +28,19 @@ prompt-proto-service:
         (survey="spec_pole")=[]
         (survey="spec_pole_with_rotation")=[]
         (survey="")=[]
+      preprocessing: >-
+        (survey="AUXTEL_PHOTO_IMAGING")=[]
+        (survey="AUXTEL_DRP_IMAGING")=[]
+        (survey="cwfs")=[]
+        (survey="cwfs-focus-sweep")=[]
+        (survey="spec")=[]
+        (survey="spec-survey")=[]
+        (survey="spec_with_rotation")=[]
+        (survey="spec_bright")=[]
+        (survey="spec_bright_with_rotation")=[]
+        (survey="spec_pole")=[]
+        (survey="spec_pole_with_rotation")=[]
+        (survey="")=[]
     calibRepo: s3://rubin-summit-users
     calibRepoPguser: latiss_prompt
 

--- a/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
@@ -10,23 +10,24 @@ prompt-proto-service:
     tag: 2.6.0
 
   instrument:
-    pipelines: >-
-      (survey="AUXTEL_PHOTO_IMAGING")=[${PROMPT_PROCESSING_DIR}/pipelines/LATISS/ApPipe-noForced.yaml,
-      ${PROMPT_PROCESSING_DIR}/pipelines/LATISS/SingleFrame.yaml,
-      ${PROMPT_PROCESSING_DIR}/pipelines/LATISS/Isr.yaml]
-      (survey="AUXTEL_DRP_IMAGING")=[${PROMPT_PROCESSING_DIR}/pipelines/LATISS/ApPipe-noForced.yaml,
-      ${PROMPT_PROCESSING_DIR}/pipelines/LATISS/SingleFrame.yaml,
-      ${PROMPT_PROCESSING_DIR}/pipelines/LATISS/Isr.yaml]
-      (survey="cwfs")=[]
-      (survey="cwfs-focus-sweep")=[]
-      (survey="spec")=[]
-      (survey="spec-survey")=[]
-      (survey="spec_with_rotation")=[]
-      (survey="spec_bright")=[]
-      (survey="spec_bright_with_rotation")=[]
-      (survey="spec_pole")=[]
-      (survey="spec_pole_with_rotation")=[]
-      (survey="")=[]
+    pipelines:
+      main: >-
+        (survey="AUXTEL_PHOTO_IMAGING")=[${PROMPT_PROCESSING_DIR}/pipelines/LATISS/ApPipe-noForced.yaml,
+        ${PROMPT_PROCESSING_DIR}/pipelines/LATISS/SingleFrame.yaml,
+        ${PROMPT_PROCESSING_DIR}/pipelines/LATISS/Isr.yaml]
+        (survey="AUXTEL_DRP_IMAGING")=[${PROMPT_PROCESSING_DIR}/pipelines/LATISS/ApPipe-noForced.yaml,
+        ${PROMPT_PROCESSING_DIR}/pipelines/LATISS/SingleFrame.yaml,
+        ${PROMPT_PROCESSING_DIR}/pipelines/LATISS/Isr.yaml]
+        (survey="cwfs")=[]
+        (survey="cwfs-focus-sweep")=[]
+        (survey="spec")=[]
+        (survey="spec-survey")=[]
+        (survey="spec_with_rotation")=[]
+        (survey="spec_bright")=[]
+        (survey="spec_bright_with_rotation")=[]
+        (survey="spec_pole")=[]
+        (survey="spec_pole_with_rotation")=[]
+        (survey="")=[]
     calibRepo: s3://rubin-summit-users
     calibRepoPguser: latiss_prompt
 

--- a/applications/prompt-proto-service-latiss/values.yaml
+++ b/applications/prompt-proto-service-latiss/values.yaml
@@ -29,10 +29,11 @@ prompt-proto-service:
   instrument:
     # -- The "short" name of the instrument
     name: LATISS
-    # -- Machine-readable string describing which pipeline(s) should be run for which visits.
-    # Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples.
-    # @default -- None, must be set
-    pipelines: ""
+    pipelines:
+      # -- Machine-readable string describing which pipeline(s) should be run for which visits.
+      # Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples.
+      # @default -- None, must be set
+      main: ""
     # -- Skymap to use with the instrument
     skymap: latiss_v1
     # -- URI to the shared repo used for calibrations, templates, and pipeline outputs.

--- a/applications/prompt-proto-service-latiss/values.yaml
+++ b/applications/prompt-proto-service-latiss/values.yaml
@@ -34,6 +34,9 @@ prompt-proto-service:
       # Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples.
       # @default -- None, must be set
       main: ""
+      # -- Machine-readable string describing which pipeline(s) should be run before which visits' raw arrival.
+      # @default -- None, must be set
+      preprocessing: ""
     # -- Skymap to use with the instrument
     skymap: latiss_v1
     # -- URI to the shared repo used for calibrations, templates, and pipeline outputs.

--- a/applications/prompt-proto-service-lsstcam/README.md
+++ b/applications/prompt-proto-service-lsstcam/README.md
@@ -27,7 +27,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.instrument.calibRepo | string | None, must be set | URI to the shared repo used for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself. |
 | prompt-proto-service.instrument.calibRepoPguser | string | None, must be set | Postgres username to access the shared butler repo for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, a local redirect is used and its config may override this config. |
 | prompt-proto-service.instrument.name | string | `""` | The "short" name of the instrument |
-| prompt-proto-service.instrument.pipelines | string | None, must be set | Machine-readable string describing which pipeline(s) should be run for which visits. Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |
+| prompt-proto-service.instrument.pipelines.main | string | None, must be set | Machine-readable string describing which pipeline(s) should be run for which visits. Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |
 | prompt-proto-service.instrument.skymap | string | `""` | Skymap to use with the instrument |
 | prompt-proto-service.knative.cpuLimit | string | `"1"` | The maximum cpu cores. |
 | prompt-proto-service.knative.cpuRequest | string | `"1"` | The cpu cores requested. |

--- a/applications/prompt-proto-service-lsstcam/README.md
+++ b/applications/prompt-proto-service-lsstcam/README.md
@@ -28,6 +28,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.instrument.calibRepoPguser | string | None, must be set | Postgres username to access the shared butler repo for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, a local redirect is used and its config may override this config. |
 | prompt-proto-service.instrument.name | string | `""` | The "short" name of the instrument |
 | prompt-proto-service.instrument.pipelines.main | string | None, must be set | Machine-readable string describing which pipeline(s) should be run for which visits. Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |
+| prompt-proto-service.instrument.pipelines.preprocessing | string | None, must be set | Machine-readable string describing which pipeline(s) should be run before which visits' raw arrival. |
 | prompt-proto-service.instrument.skymap | string | `""` | Skymap to use with the instrument |
 | prompt-proto-service.knative.cpuLimit | string | `"1"` | The maximum cpu cores. |
 | prompt-proto-service.knative.cpuRequest | string | `"1"` | The cpu cores requested. |

--- a/applications/prompt-proto-service-lsstcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcam/values.yaml
@@ -28,10 +28,11 @@ prompt-proto-service:
   instrument:
     # -- The "short" name of the instrument
     name: ""
-    # -- Machine-readable string describing which pipeline(s) should be run for which visits.
-    # Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples.
-    # @default -- None, must be set
-    pipelines: ""
+    pipelines:
+      # -- Machine-readable string describing which pipeline(s) should be run for which visits.
+      # Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples.
+      # @default -- None, must be set
+      main: ""
     # -- Skymap to use with the instrument
     skymap: ""
     # -- URI to the shared repo used for calibrations, templates, and pipeline outputs.

--- a/applications/prompt-proto-service-lsstcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcam/values.yaml
@@ -33,6 +33,9 @@ prompt-proto-service:
       # Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples.
       # @default -- None, must be set
       main: ""
+      # -- Machine-readable string describing which pipeline(s) should be run before which visits' raw arrival.
+      # @default -- None, must be set
+      preprocessing: ""
     # -- Skymap to use with the instrument
     skymap: ""
     # -- URI to the shared repo used for calibrations, templates, and pipeline outputs.

--- a/applications/prompt-proto-service-lsstcomcam/README.md
+++ b/applications/prompt-proto-service-lsstcomcam/README.md
@@ -27,7 +27,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.instrument.calibRepo | string | None, must be set | URI to the shared repo used for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself. |
 | prompt-proto-service.instrument.calibRepoPguser | string | None, must be set | Postgres username to access the shared butler repo for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, a local redirect is used and its config may override this config. |
 | prompt-proto-service.instrument.name | string | `""` | The "short" name of the instrument |
-| prompt-proto-service.instrument.pipelines | string | None, must be set | Machine-readable string describing which pipeline(s) should be run for which visits. Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |
+| prompt-proto-service.instrument.pipelines.main | string | None, must be set | Machine-readable string describing which pipeline(s) should be run for which visits. Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |
 | prompt-proto-service.instrument.skymap | string | `""` | Skymap to use with the instrument |
 | prompt-proto-service.knative.cpuLimit | string | `"1"` | The maximum cpu cores. |
 | prompt-proto-service.knative.cpuRequest | string | `"1"` | The cpu cores requested. |

--- a/applications/prompt-proto-service-lsstcomcam/README.md
+++ b/applications/prompt-proto-service-lsstcomcam/README.md
@@ -28,6 +28,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.instrument.calibRepoPguser | string | None, must be set | Postgres username to access the shared butler repo for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, a local redirect is used and its config may override this config. |
 | prompt-proto-service.instrument.name | string | `""` | The "short" name of the instrument |
 | prompt-proto-service.instrument.pipelines.main | string | None, must be set | Machine-readable string describing which pipeline(s) should be run for which visits. Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |
+| prompt-proto-service.instrument.pipelines.preprocessing | string | None, must be set | Machine-readable string describing which pipeline(s) should be run before which visits' raw arrival. |
 | prompt-proto-service.instrument.skymap | string | `""` | Skymap to use with the instrument |
 | prompt-proto-service.knative.cpuLimit | string | `"1"` | The maximum cpu cores. |
 | prompt-proto-service.knative.cpuRequest | string | `"1"` | The cpu cores requested. |

--- a/applications/prompt-proto-service-lsstcomcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/values.yaml
@@ -28,10 +28,11 @@ prompt-proto-service:
   instrument:
     # -- The "short" name of the instrument
     name: ""
-    # -- Machine-readable string describing which pipeline(s) should be run for which visits.
-    # Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples.
-    # @default -- None, must be set
-    pipelines: ""
+    pipelines:
+      # -- Machine-readable string describing which pipeline(s) should be run for which visits.
+      # Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples.
+      # @default -- None, must be set
+      main: ""
     # -- Skymap to use with the instrument
     skymap: ""
     # -- URI to the shared repo used for calibrations, templates, and pipeline outputs.

--- a/applications/prompt-proto-service-lsstcomcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/values.yaml
@@ -33,6 +33,9 @@ prompt-proto-service:
       # Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples.
       # @default -- None, must be set
       main: ""
+      # -- Machine-readable string describing which pipeline(s) should be run before which visits' raw arrival.
+      # @default -- None, must be set
+      preprocessing: ""
     # -- Skymap to use with the instrument
     skymap: ""
     # -- URI to the shared repo used for calibrations, templates, and pipeline outputs.

--- a/applications/prompt-proto-service-lsstcomcamsim/README.md
+++ b/applications/prompt-proto-service-lsstcomcamsim/README.md
@@ -28,6 +28,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.instrument.calibRepoPguser | string | None, must be set | Postgres username to access the shared butler repo for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, a local redirect is used and its config may override this config. |
 | prompt-proto-service.instrument.name | string | `"LSSTComCamSim"` | The "short" name of the instrument |
 | prompt-proto-service.instrument.pipelines.main | string | None, must be set | Machine-readable string describing which pipeline(s) should be run for which visits. Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |
+| prompt-proto-service.instrument.pipelines.preprocessing | string | None, must be set | Machine-readable string describing which pipeline(s) should be run before which visits' raw arrival. |
 | prompt-proto-service.instrument.skymap | string | `"ops_rehersal_prep_2k_v1"` | Skymap to use with the instrument |
 | prompt-proto-service.knative.cpuLimit | string | `"1"` | The maximum cpu cores. |
 | prompt-proto-service.knative.cpuRequest | string | `"1"` | The cpu cores requested. |

--- a/applications/prompt-proto-service-lsstcomcamsim/README.md
+++ b/applications/prompt-proto-service-lsstcomcamsim/README.md
@@ -27,7 +27,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.instrument.calibRepo | string | None, must be set | URI to the shared repo used for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself. |
 | prompt-proto-service.instrument.calibRepoPguser | string | None, must be set | Postgres username to access the shared butler repo for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, a local redirect is used and its config may override this config. |
 | prompt-proto-service.instrument.name | string | `"LSSTComCamSim"` | The "short" name of the instrument |
-| prompt-proto-service.instrument.pipelines | string | None, must be set | Machine-readable string describing which pipeline(s) should be run for which visits. Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |
+| prompt-proto-service.instrument.pipelines.main | string | None, must be set | Machine-readable string describing which pipeline(s) should be run for which visits. Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |
 | prompt-proto-service.instrument.skymap | string | `"ops_rehersal_prep_2k_v1"` | Skymap to use with the instrument |
 | prompt-proto-service.knative.cpuLimit | string | `"1"` | The maximum cpu cores. |
 | prompt-proto-service.knative.cpuRequest | string | `"1"` | The cpu cores requested. |

--- a/applications/prompt-proto-service-lsstcomcamsim/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcomcamsim/values-usdfdev-prompt-processing.yaml
@@ -10,10 +10,11 @@ prompt-proto-service:
     tag: latest
 
   instrument:
-    pipelines: >-
-      (survey="SURVEY")=[${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCamSim/ApPipe.yaml,
-      ${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCamSim/SingleFrame.yaml,
-      ${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCamSim/Isr.yaml]
+    pipelines:
+      main: >-
+        (survey="SURVEY")=[${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCamSim/ApPipe.yaml,
+        ${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCamSim/SingleFrame.yaml,
+        ${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCamSim/Isr.yaml]
     calibRepo: s3://rubin-pp-dev-users/central_repo/
     calibRepoPguser: lsstcomcamsim_prompt
 

--- a/applications/prompt-proto-service-lsstcomcamsim/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcomcamsim/values-usdfdev-prompt-processing.yaml
@@ -15,6 +15,7 @@ prompt-proto-service:
         (survey="SURVEY")=[${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCamSim/ApPipe.yaml,
         ${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCamSim/SingleFrame.yaml,
         ${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCamSim/Isr.yaml]
+      preprocessing: (survey="SURVEY")=[]
     calibRepo: s3://rubin-pp-dev-users/central_repo/
     calibRepoPguser: lsstcomcamsim_prompt
 

--- a/applications/prompt-proto-service-lsstcomcamsim/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcomcamsim/values-usdfprod-prompt-processing.yaml
@@ -15,11 +15,12 @@ prompt-proto-service:
     tag: 2.5.0
 
   instrument:
-    pipelines: >-
-      (survey="ops-rehearsal-3")=[${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCamSim/ApPipe-noForced.yaml,
-      ${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCamSim/SingleFrame.yaml,
-      ${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCamSim/Isr.yaml]
-      (survey="")=[]
+    pipelines:
+      main: >-
+        (survey="ops-rehearsal-3")=[${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCamSim/ApPipe-noForced.yaml,
+        ${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCamSim/SingleFrame.yaml,
+        ${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCamSim/Isr.yaml]
+        (survey="")=[]
     calibRepo: s3://rubin-summit-users
     calibRepoPguser: lsstcomcamsim_prompt
 

--- a/applications/prompt-proto-service-lsstcomcamsim/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcomcamsim/values-usdfprod-prompt-processing.yaml
@@ -21,6 +21,9 @@ prompt-proto-service:
         ${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCamSim/SingleFrame.yaml,
         ${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCamSim/Isr.yaml]
         (survey="")=[]
+      preprocessing: >-
+        (survey="ops-rehearsal-3")=[]
+        (survey="")=[]
     calibRepo: s3://rubin-summit-users
     calibRepoPguser: lsstcomcamsim_prompt
 

--- a/applications/prompt-proto-service-lsstcomcamsim/values.yaml
+++ b/applications/prompt-proto-service-lsstcomcamsim/values.yaml
@@ -29,10 +29,11 @@ prompt-proto-service:
   instrument:
     # -- The "short" name of the instrument
     name: LSSTComCamSim
-    # -- Machine-readable string describing which pipeline(s) should be run for which visits.
-    # Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples.
-    # @default -- None, must be set
-    pipelines: ""
+    pipelines:
+      # -- Machine-readable string describing which pipeline(s) should be run for which visits.
+      # Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples.
+      # @default -- None, must be set
+      main: ""
     # -- Skymap to use with the instrument
     skymap: ops_rehersal_prep_2k_v1
     # -- URI to the shared repo used for calibrations, templates, and pipeline outputs.

--- a/applications/prompt-proto-service-lsstcomcamsim/values.yaml
+++ b/applications/prompt-proto-service-lsstcomcamsim/values.yaml
@@ -34,6 +34,9 @@ prompt-proto-service:
       # Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples.
       # @default -- None, must be set
       main: ""
+      # -- Machine-readable string describing which pipeline(s) should be run before which visits' raw arrival.
+      # @default -- None, must be set
+      preprocessing: ""
     # -- Skymap to use with the instrument
     skymap: ops_rehersal_prep_2k_v1
     # -- URI to the shared repo used for calibrations, templates, and pipeline outputs.

--- a/charts/prompt-proto-service/README.md
+++ b/charts/prompt-proto-service/README.md
@@ -31,7 +31,7 @@ Event-driven processing of camera images
 | imagePullSecrets | list | `[]` |  |
 | instrument.calibRepo | string | None, must be set | URI to the shared repo used for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself. |
 | instrument.name | string | None, must be set | The "short" name of the instrument |
-| instrument.pipelines | string | None, must be set | Machine-readable string describing which pipeline(s) should be run for which visits. Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |
+| instrument.pipelines.main | string | None, must be set | Machine-readable string describing which pipeline(s) should be run for which visits' raws. Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |
 | instrument.skymap | string | `""` | Skymap to use with the instrument |
 | knative.cpuLimit | string | `"1"` | The maximum cpu cores. |
 | knative.cpuRequest | string | `"1"` | The cpu cores requested. |

--- a/charts/prompt-proto-service/README.md
+++ b/charts/prompt-proto-service/README.md
@@ -32,6 +32,7 @@ Event-driven processing of camera images
 | instrument.calibRepo | string | None, must be set | URI to the shared repo used for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself. |
 | instrument.name | string | None, must be set | The "short" name of the instrument |
 | instrument.pipelines.main | string | None, must be set | Machine-readable string describing which pipeline(s) should be run for which visits' raws. Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |
+| instrument.pipelines.preprocessing | string | None, must be set | Machine-readable string describing which pipeline(s) should be run before which visits' raw arrival. |
 | instrument.skymap | string | `""` | Skymap to use with the instrument |
 | knative.cpuLimit | string | `"1"` | The maximum cpu cores. |
 | knative.cpuRequest | string | `"1"` | The cpu cores requested. |

--- a/charts/prompt-proto-service/templates/prompt-proto-service.yaml
+++ b/charts/prompt-proto-service/templates/prompt-proto-service.yaml
@@ -31,8 +31,8 @@ spec:
         env:
         - name: RUBIN_INSTRUMENT
           value: {{ .Values.instrument.name }}
-        - name: PIPELINES_CONFIG
-          value: {{ .Values.instrument.pipelines }}
+        - name: MAIN_PIPELINES_CONFIG
+          value: {{ .Values.instrument.pipelines.main }}
         - name: SKYMAP
           value: {{ .Values.instrument.skymap }}
         - name: IMAGE_BUCKET

--- a/charts/prompt-proto-service/templates/prompt-proto-service.yaml
+++ b/charts/prompt-proto-service/templates/prompt-proto-service.yaml
@@ -31,6 +31,8 @@ spec:
         env:
         - name: RUBIN_INSTRUMENT
           value: {{ .Values.instrument.name }}
+        - name: PREPROCESSING_PIPELINES_CONFIG
+          value: {{ .Values.instrument.pipelines.preprocessing }}
         - name: MAIN_PIPELINES_CONFIG
           value: {{ .Values.instrument.pipelines.main }}
         - name: SKYMAP

--- a/charts/prompt-proto-service/values.yaml
+++ b/charts/prompt-proto-service/values.yaml
@@ -30,10 +30,11 @@ instrument:
   # -- The "short" name of the instrument
   # @default -- None, must be set
   name: ""
-  # -- Machine-readable string describing which pipeline(s) should be run for which visits.
-  # Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples.
-  # @default -- None, must be set
-  pipelines: ""
+  pipelines:
+    # -- Machine-readable string describing which pipeline(s) should be run for which visits' raws.
+    # Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples.
+    # @default -- None, must be set
+    main: ""
   # -- Skymap to use with the instrument
   skymap: ""
   # -- URI to the shared repo used for calibrations, templates, and pipeline outputs.

--- a/charts/prompt-proto-service/values.yaml
+++ b/charts/prompt-proto-service/values.yaml
@@ -35,6 +35,9 @@ instrument:
     # Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples.
     # @default -- None, must be set
     main: ""
+    # -- Machine-readable string describing which pipeline(s) should be run before which visits' raw arrival.
+    # @default -- None, must be set
+    preprocessing: ""
   # -- Skymap to use with the instrument
   skymap: ""
   # -- URI to the shared repo used for calibrations, templates, and pipeline outputs.


### PR DESCRIPTION
This PR creates separate config fields for Prompt Processing to specify the main and preprocessing pipeline(s) to run on a given visit. Currently, the preprocessing configs are set to run nothing, as we don't yet have any preprocessing tasks.

This PR makes a breaking change to Prompt Processing's configuration interface, and must be merged together with lsst-dm/prompt_processing#164.