### PR TITLE
DM-44392: Update Squareone

### DIFF
--- a/applications/squareone/Chart.yaml
+++ b/applications/squareone/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
     url: https://github.com/jonathansick
 
 # The default version tag of the squareone docker image
-appVersion: "0.12.0"
+appVersion: "tickets-DM-44392"

--- a/applications/squareone/Chart.yaml
+++ b/applications/squareone/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
     url: https://github.com/jonathansick
 
 # The default version tag of the squareone docker image
-appVersion: "tickets-DM-44392"
+appVersion: "0.13.0"


### PR DESCRIPTION
For the removal of Reach UI components from Squareone.

See https://github.com/lsst-sqre/squareone/pull/166