### PR TITLE
tickets/DM-44373

### DIFF
--- a/applications/giftless/templates/configmap.yaml
+++ b/applications/giftless/templates/configmap.yaml
@@ -8,6 +8,7 @@ data:
   giftless.conf.yaml: |-
     AUTH_PROVIDERS:
       - "giftless.auth.allow_anon:read_only"
+    LEGACY_ENDPOINTS: true
     TRANSFER_ADAPTERS:
       basic:
         factory: "giftless.transfer.basic_external:factory"

--- a/applications/giftless/values-roundtable-dev.yaml
+++ b/applications/giftless/values-roundtable-dev.yaml
@@ -1,7 +1,7 @@
 image:
   pullPolicy: "Always"
   repository: "docker.io/lsstsqre/giftless"
-  tag: "ajt-test"
+  tag: "upstream"
 server:
   debug: true
 ingress:

--- a/applications/giftless/values-roundtable-dev.yaml
+++ b/applications/giftless/values-roundtable-dev.yaml
@@ -1,7 +1,7 @@
 image:
   pullPolicy: "Always"
   repository: "docker.io/lsstsqre/giftless"
-  tag: "upstream"
+  tag: "ajt-test"
 server:
   debug: true
 ingress:


### PR DESCRIPTION
Adopt service-discovery-endpoint capable Giftless build.

In fact, we don't need this yet, because `LEGACY_ENDPOINTS` currently defaults to `true` but I want to make sure that in the future, when the default changes, nothing breaks.