### PR TITLE
DM-44141: Migrate APDB/Butler credentials from .pgpass to db-auth

### DIFF
--- a/applications/prompt-proto-service-hsc-gpu/README.md
+++ b/applications/prompt-proto-service-hsc-gpu/README.md
@@ -25,7 +25,6 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.imageNotifications.kafkaClusterAddress | string | None, must be set | Hostname and port of the Kafka provider |
 | prompt-proto-service.imageNotifications.topic | string | None, must be set | Topic where raw image arrival notifications appear |
 | prompt-proto-service.instrument.calibRepo | string | None, must be set | URI to the shared repo used for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself. |
-| prompt-proto-service.instrument.calibRepoPguser | string | None, must be set | Postgres username to access the shared butler repo for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, a local redirect is used and its config may override this config. |
 | prompt-proto-service.instrument.name | string | `"HSC"` | The "short" name of the instrument |
 | prompt-proto-service.instrument.pipelines.main | string | None, must be set | Machine-readable string describing which pipeline(s) should be run for which visits. Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |
 | prompt-proto-service.instrument.pipelines.preprocessing | string | None, must be set | Machine-readable string describing which pipeline(s) should be run before which visits' raw arrival. |

--- a/applications/prompt-proto-service-hsc-gpu/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-hsc-gpu/values-usdfdev-prompt-processing.yaml
@@ -15,7 +15,6 @@ prompt-proto-service:
       main: (survey="SURVEY")=[${PROMPT_PROCESSING_DIR}/pipelines/HSC/ApPipe.yaml]
       preprocessing: (survey="SURVEY")=[]
     calibRepo: s3://rubin-pp-dev-users/central_repo/
-    calibRepoPguser: hsc_prompt
 
   s3:
     imageBucket: rubin-pp-dev

--- a/applications/prompt-proto-service-hsc-gpu/values.yaml
+++ b/applications/prompt-proto-service-hsc-gpu/values.yaml
@@ -42,10 +42,6 @@ prompt-proto-service:
     # If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself.
     # @default -- None, must be set
     calibRepo: ""
-    # -- Postgres username to access the shared butler repo for calibrations, templates, and pipeline outputs.
-    # If `registry.centralRepoFile` is set, a local redirect is used and its config may override this config.
-    # @default -- None, must be set
-    calibRepoPguser: ""
 
   s3:
     # -- Bucket containing the incoming raw images

--- a/applications/prompt-proto-service-hsc/README.md
+++ b/applications/prompt-proto-service-hsc/README.md
@@ -25,7 +25,6 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.imageNotifications.kafkaClusterAddress | string | None, must be set | Hostname and port of the Kafka provider |
 | prompt-proto-service.imageNotifications.topic | string | None, must be set | Topic where raw image arrival notifications appear |
 | prompt-proto-service.instrument.calibRepo | string | None, must be set | URI to the shared repo used for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself. |
-| prompt-proto-service.instrument.calibRepoPguser | string | None, must be set | Postgres username to access the shared butler repo for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, a local redirect is used and its config may override this config. |
 | prompt-proto-service.instrument.name | string | `"HSC"` | The "short" name of the instrument |
 | prompt-proto-service.instrument.pipelines.main | string | None, must be set | Machine-readable string describing which pipeline(s) should be run for which visits. Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |
 | prompt-proto-service.instrument.pipelines.preprocessing | string | None, must be set | Machine-readable string describing which pipeline(s) should be run before which visits' raw arrival. |

--- a/applications/prompt-proto-service-hsc/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-hsc/values-usdfdev-prompt-processing.yaml
@@ -16,7 +16,6 @@ prompt-proto-service:
       main: (survey="SURVEY")=[${PROMPT_PROCESSING_DIR}/pipelines/HSC/ApPipe.yaml]
       preprocessing: (survey="SURVEY")=[]
     calibRepo: s3://rubin-pp-dev-users/central_repo/
-    calibRepoPguser: hsc_prompt
 
   s3:
     imageBucket: rubin-pp-dev

--- a/applications/prompt-proto-service-hsc/values.yaml
+++ b/applications/prompt-proto-service-hsc/values.yaml
@@ -42,10 +42,6 @@ prompt-proto-service:
     # If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself.
     # @default -- None, must be set
     calibRepo: ""
-    # -- Postgres username to access the shared butler repo for calibrations, templates, and pipeline outputs.
-    # If `registry.centralRepoFile` is set, a local redirect is used and its config may override this config.
-    # @default -- None, must be set
-    calibRepoPguser: ""
 
   s3:
     # -- Bucket containing the incoming raw images

--- a/applications/prompt-proto-service-latiss/README.md
+++ b/applications/prompt-proto-service-latiss/README.md
@@ -25,7 +25,6 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.imageNotifications.kafkaClusterAddress | string | None, must be set | Hostname and port of the Kafka provider |
 | prompt-proto-service.imageNotifications.topic | string | None, must be set | Topic where raw image arrival notifications appear |
 | prompt-proto-service.instrument.calibRepo | string | None, must be set | URI to the shared repo used for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself. |
-| prompt-proto-service.instrument.calibRepoPguser | string | None, must be set | Postgres username to access the shared butler repo for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, a local redirect is used and its config may override this config. |
 | prompt-proto-service.instrument.name | string | `"LATISS"` | The "short" name of the instrument |
 | prompt-proto-service.instrument.pipelines.main | string | None, must be set | Machine-readable string describing which pipeline(s) should be run for which visits. Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |
 | prompt-proto-service.instrument.pipelines.preprocessing | string | None, must be set | Machine-readable string describing which pipeline(s) should be run before which visits' raw arrival. |

--- a/applications/prompt-proto-service-latiss/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfdev-prompt-processing.yaml
@@ -16,7 +16,6 @@ prompt-proto-service:
         ${PROMPT_PROCESSING_DIR}/pipelines/LATISS/Isr.yaml]
       preprocessing: (survey="SURVEY")=[]
     calibRepo: s3://rubin-pp-dev-users/central_repo/
-    calibRepoPguser: latiss_prompt
 
   s3:
     imageBucket: rubin-pp-dev

--- a/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
@@ -42,7 +42,6 @@ prompt-proto-service:
         (survey="spec_pole_with_rotation")=[]
         (survey="")=[]
     calibRepo: s3://rubin-summit-users
-    calibRepoPguser: latiss_prompt
 
   s3:
     imageBucket: rubin-summit

--- a/applications/prompt-proto-service-latiss/values.yaml
+++ b/applications/prompt-proto-service-latiss/values.yaml
@@ -43,10 +43,6 @@ prompt-proto-service:
     # If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself.
     # @default -- None, must be set
     calibRepo: ""
-    # -- Postgres username to access the shared butler repo for calibrations, templates, and pipeline outputs.
-    # If `registry.centralRepoFile` is set, a local redirect is used and its config may override this config.
-    # @default -- None, must be set
-    calibRepoPguser: ""
 
   s3:
     # -- Bucket containing the incoming raw images

--- a/applications/prompt-proto-service-lsstcam/README.md
+++ b/applications/prompt-proto-service-lsstcam/README.md
@@ -25,7 +25,6 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.imageNotifications.kafkaClusterAddress | string | None, must be set | Hostname and port of the Kafka provider |
 | prompt-proto-service.imageNotifications.topic | string | None, must be set | Topic where raw image arrival notifications appear |
 | prompt-proto-service.instrument.calibRepo | string | None, must be set | URI to the shared repo used for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself. |
-| prompt-proto-service.instrument.calibRepoPguser | string | None, must be set | Postgres username to access the shared butler repo for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, a local redirect is used and its config may override this config. |
 | prompt-proto-service.instrument.name | string | `""` | The "short" name of the instrument |
 | prompt-proto-service.instrument.pipelines.main | string | None, must be set | Machine-readable string describing which pipeline(s) should be run for which visits. Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |
 | prompt-proto-service.instrument.pipelines.preprocessing | string | None, must be set | Machine-readable string describing which pipeline(s) should be run before which visits' raw arrival. |

--- a/applications/prompt-proto-service-lsstcam/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcam/values-usdfdev-prompt-processing.yaml
@@ -12,7 +12,6 @@ prompt-proto-service:
 
   instrument:
     calibRepo: s3://rubin-summit-users/
-    calibRepoPguser: rubin
 
   s3:
     imageBucket: rubin:rubin-pp

--- a/applications/prompt-proto-service-lsstcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcam/values.yaml
@@ -42,10 +42,6 @@ prompt-proto-service:
     # If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself.
     # @default -- None, must be set
     calibRepo: ""
-    # -- Postgres username to access the shared butler repo for calibrations, templates, and pipeline outputs.
-    # If `registry.centralRepoFile` is set, a local redirect is used and its config may override this config.
-    # @default -- None, must be set
-    calibRepoPguser: ""
 
   s3:
     # -- Bucket containing the incoming raw images

--- a/applications/prompt-proto-service-lsstcomcam/README.md
+++ b/applications/prompt-proto-service-lsstcomcam/README.md
@@ -25,7 +25,6 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.imageNotifications.kafkaClusterAddress | string | None, must be set | Hostname and port of the Kafka provider |
 | prompt-proto-service.imageNotifications.topic | string | None, must be set | Topic where raw image arrival notifications appear |
 | prompt-proto-service.instrument.calibRepo | string | None, must be set | URI to the shared repo used for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself. |
-| prompt-proto-service.instrument.calibRepoPguser | string | None, must be set | Postgres username to access the shared butler repo for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, a local redirect is used and its config may override this config. |
 | prompt-proto-service.instrument.name | string | `""` | The "short" name of the instrument |
 | prompt-proto-service.instrument.pipelines.main | string | None, must be set | Machine-readable string describing which pipeline(s) should be run for which visits. Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |
 | prompt-proto-service.instrument.pipelines.preprocessing | string | None, must be set | Machine-readable string describing which pipeline(s) should be run before which visits' raw arrival. |

--- a/applications/prompt-proto-service-lsstcomcam/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/values-usdfdev-prompt-processing.yaml
@@ -12,7 +12,6 @@ prompt-proto-service:
 
   instrument:
     calibRepo: s3://rubin-summit-users/
-    calibRepoPguser: rubin
 
   s3:
     imageBucket: rubin:rubin-pp

--- a/applications/prompt-proto-service-lsstcomcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/values.yaml
@@ -42,10 +42,6 @@ prompt-proto-service:
     # If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself.
     # @default -- None, must be set
     calibRepo: ""
-    # -- Postgres username to access the shared butler repo for calibrations, templates, and pipeline outputs.
-    # If `registry.centralRepoFile` is set, a local redirect is used and its config may override this config.
-    # @default -- None, must be set
-    calibRepoPguser: ""
 
   s3:
     # -- Bucket containing the incoming raw images

--- a/applications/prompt-proto-service-lsstcomcamsim/README.md
+++ b/applications/prompt-proto-service-lsstcomcamsim/README.md
@@ -25,7 +25,6 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.imageNotifications.kafkaClusterAddress | string | None, must be set | Hostname and port of the Kafka provider |
 | prompt-proto-service.imageNotifications.topic | string | None, must be set | Topic where raw image arrival notifications appear |
 | prompt-proto-service.instrument.calibRepo | string | None, must be set | URI to the shared repo used for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself. |
-| prompt-proto-service.instrument.calibRepoPguser | string | None, must be set | Postgres username to access the shared butler repo for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, a local redirect is used and its config may override this config. |
 | prompt-proto-service.instrument.name | string | `"LSSTComCamSim"` | The "short" name of the instrument |
 | prompt-proto-service.instrument.pipelines.main | string | None, must be set | Machine-readable string describing which pipeline(s) should be run for which visits. Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |
 | prompt-proto-service.instrument.pipelines.preprocessing | string | None, must be set | Machine-readable string describing which pipeline(s) should be run before which visits' raw arrival. |

--- a/applications/prompt-proto-service-lsstcomcamsim/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcomcamsim/values-usdfdev-prompt-processing.yaml
@@ -17,7 +17,6 @@ prompt-proto-service:
         ${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCamSim/Isr.yaml]
       preprocessing: (survey="SURVEY")=[]
     calibRepo: s3://rubin-pp-dev-users/central_repo/
-    calibRepoPguser: lsstcomcamsim_prompt
 
   s3:
     imageBucket: rubin-pp-dev

--- a/applications/prompt-proto-service-lsstcomcamsim/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcomcamsim/values-usdfprod-prompt-processing.yaml
@@ -25,7 +25,6 @@ prompt-proto-service:
         (survey="ops-rehearsal-3")=[]
         (survey="")=[]
     calibRepo: s3://rubin-summit-users
-    calibRepoPguser: lsstcomcamsim_prompt
 
   s3:
     imageBucket: rubin-summit

--- a/applications/prompt-proto-service-lsstcomcamsim/values.yaml
+++ b/applications/prompt-proto-service-lsstcomcamsim/values.yaml
@@ -43,10 +43,6 @@ prompt-proto-service:
     # If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself.
     # @default -- None, must be set
     calibRepo: ""
-    # -- Postgres username to access the shared butler repo for calibrations, templates, and pipeline outputs.
-    # If `registry.centralRepoFile` is set, a local redirect is used and its config may override this config.
-    # @default -- None, must be set
-    calibRepoPguser: ""
 
   s3:
     # -- Bucket containing the incoming raw images

--- a/charts/prompt-proto-service/templates/prompt-proto-service.yaml
+++ b/charts/prompt-proto-service/templates/prompt-proto-service.yaml
@@ -54,8 +54,6 @@ spec:
           value: {{ .Values.imageNotifications.topic }}
         - name: IMAGE_TIMEOUT
           value: {{ .Values.imageNotifications.imageTimeout | quote }}
-        - name: PGUSER
-          value: {{ .Values.instrument.calibRepoPguser }}
         - name: CALIB_REPO
           value: {{ .Values.instrument.calibRepo }}
         - name: LSST_DISABLE_BUCKET_VALIDATION

--- a/charts/prompt-proto-service/templates/prompt-proto-service.yaml
+++ b/charts/prompt-proto-service/templates/prompt-proto-service.yaml
@@ -24,6 +24,17 @@ spec:
           readOnly: true
         - mountPath: /app/pgsql
           name: pgpass-credentials-file
+      - name: init-db-auth
+        # Make a copy of the read-only secret that's owned by lsst
+        # lsst account is created by main image with id 1000
+        image: busybox
+        command: ["sh", "-c", "cp -L /app/db-auth-mount/db-auth.yaml /app/dbauth/ && chown 1000:1000 /app/dbauth/db-auth.yaml && chmod u=r,go-rwx /app/dbauth/db-auth.yaml"]
+        volumeMounts:
+        - mountPath: /app/db-auth-mount
+          name: db-auth-mount
+          readOnly: true
+        - mountPath: /app/dbauth
+          name: db-auth-credentials-file
       containers:
       - image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
@@ -84,6 +95,8 @@ spec:
         {{- end }}
         - name: PGPASSFILE
           value: /app/pgsql/.pgpass
+        - name: LSST_DB_AUTH
+          value: /app/lsst-credentials/db-auth.yaml
         - name: AP_KAFKA_PRODUCER_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -108,6 +121,9 @@ spec:
           name: ephemeral
         - mountPath: /app/pgsql
           name: pgpass-credentials-file
+          readOnly: true
+        - mountPath: /app/lsst-credentials
+          name: db-auth-credentials-file
           readOnly: true
         {{- if .Values.s3.cred_file_auth }}
         - mountPath: /app/s3/
@@ -145,6 +161,17 @@ spec:
             path: .pgpass
           defaultMode: 0400  # Minimal permissions, as extra protection
       - name: pgpass-credentials-file
+        emptyDir:
+          sizeLimit: 10Ki  # Just a text file!
+      - name: db-auth-mount
+        # Temporary mount for db-auth.yaml; cannot be read directly because it's owned by root
+        secret:
+          secretName: {{ template "prompt-proto-service.fullname" . }}-secret
+          defaultMode: 256
+          items:
+            - key: db-auth_file
+              path: db-auth.yaml
+      - name: db-auth-credentials-file
         emptyDir:
           sizeLimit: 10Ki  # Just a text file!
       {{- if .Values.s3.cred_file_auth }}


### PR DESCRIPTION
This PR has Prompt Processing download a `db-auth.yaml` file from the Vault and configure it for use by the service. The deletion of `PGUSER` is conditional on the assumption that `db-auth.yaml` will be used for Butler and Cassandra authentication, with `.pgpass` needed only for connecting to SQL APDBs.

It might be useful to make these blocks conditional on the Vault secret actually containing the `pgpass_file` or `db-auth_file` keys, but I don't know how to do so.