### PR TITLE
DM-44269: Drop name macros from Gafaelfawr chart

### DIFF
--- a/applications/gafaelfawr/README.md
+++ b/applications/gafaelfawr/README.md
@@ -74,7 +74,6 @@ Authentication and identity system
 | config.slackAlerts | bool | `false` | Whether to send certain serious alerts to Slack. If `true`, the `slack-webhook` secret must also be set. |
 | config.tokenLifetime | string | `"30d"` | Session lifetime. Use `w`, `d`, `h`, `m`, and `s` for time intervals. For example, `1d6h23m` is one day, six hours, 23 minutes. |
 | config.updateSchema | bool | `false` | Whether to automatically update the Gafaelfawr database schema |
-| fullnameOverride | string | `""` | Override the full name for resources (includes the release name) |
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
@@ -91,7 +90,6 @@ Authentication and identity system
 | maintenance.podAnnotations | object | `{}` | Annotations for Gafaelfawr maintenance and audit pods |
 | maintenance.resources | object | See `values.yaml` | Resource limits and requests for Gafaelfawr maintenance and audit pods |
 | maintenance.tolerations | list | `[]` | Tolerations for Gafaelfawr maintenance and audit pods |
-| nameOverride | string | `""` | Override the base name for resources |
 | nodeSelector | object | `{}` | Node selector rules for the Gafaelfawr frontend pod |
 | operator.affinity | object | `{}` | Affinity rules for the token management pod |
 | operator.nodeSelector | object | `{}` | Node selection rules for the token management pod |

--- a/applications/gafaelfawr/templates/_helpers.tpl
+++ b/applications/gafaelfawr/templates/_helpers.tpl
@@ -1,30 +1,5 @@
 {{/* vim: set filetype=mustache: */}}
 {{/*
-Expand the name of the chart.
-*/}}
-{{- define "gafaelfawr.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
-{{- end }}
-
-{{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
-*/}}
-{{- define "gafaelfawr.fullname" -}}
-{{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
-{{- end }}
-{{- end }}
-
-{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "gafaelfawr.chart" -}}
@@ -47,7 +22,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Selector labels
 */}}
 {{- define "gafaelfawr.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "gafaelfawr.name" . }}
+app.kubernetes.io/name: "gafaelfawr"
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 

--- a/applications/gafaelfawr/templates/cloudsql-deployment.yaml
+++ b/applications/gafaelfawr/templates/cloudsql-deployment.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: cloud-sql-proxy
+  name: "cloud-sql-proxy"
   labels:
     {{- include "gafaelfawr.labels" . | nindent 4 }}
 spec:
@@ -21,7 +21,7 @@ spec:
         {{- include "gafaelfawr.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: "cloud-sql-proxy"
     spec:
-      serviceAccountName: {{ include "gafaelfawr.fullname" . }}
+      serviceAccountName: "gafaelfawr"
       containers:
         - name: "cloud-sql-proxy"
           command:

--- a/applications/gafaelfawr/templates/cloudsql-networkpolicy.yaml
+++ b/applications/gafaelfawr/templates/cloudsql-networkpolicy.yaml
@@ -15,7 +15,7 @@ spec:
     - Ingress
   ingress:
     # Allow inbound access to the Cloud SQL Proxy from other components except
-    # the frontend.  The frontend, since it's performance-critical and gates
+    # the frontend. The frontend, since it's performance-critical and gates
     # all access to the cluster, continues running its own sidecar.
     - from:
         - podSelector:

--- a/applications/gafaelfawr/templates/configmap-kerberos.yaml
+++ b/applications/gafaelfawr/templates/configmap-kerberos.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "gafaelfawr.fullname" . }}-config-kerberos
+  name: "gafaelfawr-config-kerberos"
   labels:
     {{- include "gafaelfawr.labels" . | nindent 4 }}
 data:

--- a/applications/gafaelfawr/templates/configmap.yaml
+++ b/applications/gafaelfawr/templates/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "gafaelfawr.fullname" . }}-config
+  name: "gafaelfawr-config"
   labels:
     {{- include "gafaelfawr.labels" . | nindent 4 }}
 data:
@@ -12,10 +12,11 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "gafaelfawr.fullname" . }}-config-schema-update
+  name: "gafaelfawr-config-schema-update"
   {{- if .Values.config.updateSchema }}
   annotations:
     helm.sh/hook: "pre-install,pre-upgrade"
+    helm.sh/hook-delete-policy: "hook-succeeded"
     helm.sh/hook-weight: "0"
   {{- end }}
   labels:

--- a/applications/gafaelfawr/templates/cronjob-audit.yaml
+++ b/applications/gafaelfawr/templates/cronjob-audit.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ template "gafaelfawr.fullname" . }}-audit
+  name: "gafaelfawr-audit"
   labels:
     {{- include "gafaelfawr.labels" . | nindent 4 }}
 spec:
@@ -73,14 +73,14 @@ spec:
           volumes:
             - name: "config"
               configMap:
-                name: {{ template "gafaelfawr.fullname" . }}-config
+                name: "gafaelfawr-config"
             {{- if .Values.config.ldap.kerberosConfig }}
             - name: "keytab"
               secret:
-                secretName: {{ template "gafaelfawr.fullname" . }}-keytab
+                secretName: "gafaelfawr-keytab"
             - name: "kerberos-config"
               configMap:
-                name: {{ template "gafaelfawr.fullname" . }}-config-kerberos
+                name: "gafaelfawr-config-kerberos"
             - name: "tmp"
               emptyDir: {}
             {{- end }}

--- a/applications/gafaelfawr/templates/cronjob-maintenance.yaml
+++ b/applications/gafaelfawr/templates/cronjob-maintenance.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ template "gafaelfawr.fullname" . }}-maintenance
+  name: "gafaelfawr-maintenance"
   labels:
     {{- include "gafaelfawr.labels" . | nindent 4 }}
 spec:
@@ -72,14 +72,14 @@ spec:
           volumes:
             - name: "config"
               configMap:
-                name: {{ template "gafaelfawr.fullname" . }}-config
+                name: "gafaelfawr-config"
             {{- if .Values.config.ldap.kerberosConfig }}
             - name: "keytab"
               secret:
-                secretName: {{ template "gafaelfawr.fullname" . }}-keytab
+                secretName: "gafaelfawr-keytab"
             - name: "kerberos-config"
               configMap:
-                name: {{ template "gafaelfawr.fullname" . }}-config-kerberos
+                name: "gafaelfawr-config-kerberos"
             - name: "tmp"
               emptyDir: {}
             {{- end }}

--- a/applications/gafaelfawr/templates/deployment-operator.yaml
+++ b/applications/gafaelfawr/templates/deployment-operator.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "gafaelfawr.fullname" . }}-operator
+  name: "gafaelfawr-operator"
   labels:
     {{- include "gafaelfawr.labels" . | nindent 4 }}
 spec:
@@ -24,7 +24,7 @@ spec:
         app.kubernetes.io/component: "operator"
         gafaelfawr-redis-client: "true"
     spec:
-      serviceAccountName: {{ include "gafaelfawr.fullname" . }}-operator
+      serviceAccountName: "gafaelfawr-operator"
       containers:
         - name: "gafaelfawr"
           command:
@@ -90,14 +90,14 @@ spec:
       volumes:
         - name: "config"
           configMap:
-            name: {{ template "gafaelfawr.fullname" . }}-config
+            name: "gafaelfawr-config"
         {{- if .Values.config.ldap.kerberosConfig }}
         - name: "keytab"
           secret:
-            secretName: {{ template "gafaelfawr.fullname" . }}-keytab
+            secretName: "gafaelfawr-keytab"
         - name: "kerberos-config"
           configMap:
-            name: {{ template "gafaelfawr.fullname" . }}-config-kerberos
+            name: "gafaelfawr-config-kerberos"
         - name: "tmp"
           emptyDir: {}
         {{- end }}

--- a/applications/gafaelfawr/templates/deployment.yaml
+++ b/applications/gafaelfawr/templates/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "gafaelfawr.fullname" . }}
+  name: "gafaelfawr"
   labels:
     {{- include "gafaelfawr.labels" . | nindent 4 }}
 spec:
@@ -23,7 +23,7 @@ spec:
         gafaelfawr-redis-client: "true"
     spec:
       {{- if .Values.cloudsql.enabled }}
-      serviceAccountName: {{ include "gafaelfawr.fullname" . }}
+      serviceAccountName: "gafaelfawr"
       {{- else }}
       automountServiceAccountToken: false
       {{- end }}
@@ -113,14 +113,14 @@ spec:
       volumes:
         - name: "config"
           configMap:
-            name: {{ template "gafaelfawr.fullname" . }}-config
+            name: "gafaelfawr-config"
         {{- if .Values.config.ldap.kerberosConfig }}
         - name: "keytab"
           secret:
-            secretName: {{ template "gafaelfawr.fullname" . }}-keytab
+            secretName: "gafaelfawr-keytab"
         - name: "kerberos-config"
           configMap:
-            name: {{ template "gafaelfawr.fullname" . }}-config-kerberos
+            name: "gafaelfawr-config-kerberos"
         - name: "tmp"
           emptyDir: {}
         {{- end }}

--- a/applications/gafaelfawr/templates/ingress-rewrite.yaml
+++ b/applications/gafaelfawr/templates/ingress-rewrite.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: "/auth/tokens/"
     nginx.ingress.kubernetes.io/use-regex: "true"
-  name: {{ template "gafaelfawr.fullname" . }}-rewrite
+  name: "gafaelfawr-rewrite"
   labels:
     {{- include "gafaelfawr.labels" . | nindent 4 }}
 spec:
@@ -17,6 +17,6 @@ spec:
             pathType: "ImplementationSpecific"
             backend:
               service:
-                name: {{ template "gafaelfawr.fullname" . }}
+                name: "gafaelfawr"
                 port:
                   number: 8080

--- a/applications/gafaelfawr/templates/ingress.yaml
+++ b/applications/gafaelfawr/templates/ingress.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ template "gafaelfawr.fullname" . }}
+  name: "gafaelfawr"
   labels:
     {{- include "gafaelfawr.labels" . | nindent 4 }}
 spec:
@@ -14,21 +14,21 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: {{ template "gafaelfawr.fullname" . }}
+                name: "gafaelfawr"
                 port:
                   number: 8080
           - path: "/login"
             pathType: Exact
             backend:
               service:
-                name: {{ template "gafaelfawr.fullname" . }}
+                name: "gafaelfawr"
                 port:
                   number: 8080
           - path: "/logout"
             pathType: Exact
             backend:
               service:
-                name: {{ template "gafaelfawr.fullname" . }}
+                name: "gafaelfawr"
                 port:
                   number: 8080
           {{- if .Values.config.oidcServer.enabled }}
@@ -36,19 +36,18 @@ spec:
             pathType: Exact
             backend:
               service:
-                name: {{ template "gafaelfawr.fullname" . }}
+                name: "gafaelfawr"
                 port:
                   number: 8080
           - path: "/.well-known/openid-configuration"
             pathType: Exact
             backend:
               service:
-                name: {{ template "gafaelfawr.fullname" . }}
+                name: "gafaelfawr"
                 port:
                   number: 8080
           {{- end }}
-    {{- $context := . }}
-    {{- with $context.Values.ingress.additionalHosts }}
+    {{- with .Values.ingress.additionalHosts }}
     {{- range . }}
     - host: {{ . | quote }}
       http:
@@ -57,7 +56,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: {{ template "gafaelfawr.fullname" $context }}
+                name: "gafaelfawr"
                 port:
                   number: 8080
     {{- end }}

--- a/applications/gafaelfawr/templates/job-schema-update.yaml
+++ b/applications/gafaelfawr/templates/job-schema-update.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ template "gafaelfawr.fullname" . }}-schema-update
+  name: "gafaelfawr-schema-update"
   annotations:
   annotations:
     helm.sh/hook: "pre-install,pre-upgrade"
@@ -23,7 +23,7 @@ spec:
         gafaelfawr-redis-client: "true"
     spec:
       {{- if .Values.cloudsql.enabled }}
-      serviceAccountName: {{ include "gafaelfawr.fullname" . }}-schema-update
+      serviceAccountName: "gafaelfawr-schema-update"
       {{- else }}
       automountServiceAccountToken: false
       {{- end }}
@@ -106,7 +106,7 @@ spec:
       volumes:
         - name: "config"
           configMap:
-            name: {{ template "gafaelfawr.fullname" . }}-config-schema-update
+            name: "gafaelfawr-config-schema-update"
         - name: "lifecycle"
           emptyDir: {}
       {{- with .Values.nodeSelector }}

--- a/applications/gafaelfawr/templates/networkpolicy.yaml
+++ b/applications/gafaelfawr/templates/networkpolicy.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ template "gafaelfawr.fullname" . }}
+  name: "gafaelfawr"
   labels:
     {{- include "gafaelfawr.labels" . | nindent 4 }}
 spec:

--- a/applications/gafaelfawr/templates/service.yaml
+++ b/applications/gafaelfawr/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "gafaelfawr.fullname" . }}
+  name: "gafaelfawr"
   labels:
     {{- include "gafaelfawr.labels" . | nindent 4 }}
 spec:
@@ -13,4 +13,4 @@ spec:
   selector:
     {{- include "gafaelfawr.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: "frontend"
-  sessionAffinity: None
+  sessionAffinity: "None"

--- a/applications/gafaelfawr/templates/serviceaccount-operator.yaml
+++ b/applications/gafaelfawr/templates/serviceaccount-operator.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "gafaelfawr.fullname" . }}-operator
+  name: "gafaelfawr-operator"
   labels:
     {{- include "gafaelfawr.labels" . | nindent 4 }}
   annotations:
@@ -12,7 +12,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "gafaelfawr.fullname" . }}-operator
+  name: "gafaelfawr-operator"
   labels:
     {{- include "gafaelfawr.labels" . | nindent 4 }}
 rules:
@@ -42,14 +42,14 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "gafaelfawr.fullname" . }}-operator
+  name: "gafaelfawr-operator"
   labels:
     {{- include "gafaelfawr.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "gafaelfawr.fullname" . }}-operator
+    name: "gafaelfawr-operator"
     namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "gafaelfawr.fullname" . }}-operator
+  name: "gafaelfawr-operator"

--- a/applications/gafaelfawr/templates/serviceaccount.yaml
+++ b/applications/gafaelfawr/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "gafaelfawr.fullname" . }}
+  name: "gafaelfawr"
   labels:
     {{- include "gafaelfawr.labels" . | nindent 4 }}
   annotations:
@@ -12,12 +12,13 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "gafaelfawr.fullname" . }}-schema-update
+  name: "gafaelfawr-schema-update"
   labels:
     {{- include "gafaelfawr.labels" . | nindent 4 }}
   annotations:
   annotations:
     helm.sh/hook: "pre-install,pre-upgrade"
+    helm.sh/hook-delete-policy: "hook-succeeded"
     helm.sh/hook-weight: "0"
     iam.gke.io/gcp-service-account: {{ required "cloudsql.serviceAccount must be set to a valid Google service account" .Values.cloudsql.serviceAccount | quote }}
 {{- end }}

--- a/applications/gafaelfawr/templates/vault-secrets.yaml
+++ b/applications/gafaelfawr/templates/vault-secrets.yaml
@@ -1,7 +1,7 @@
 apiVersion: ricoberger.de/v1alpha1
 kind: VaultSecret
 metadata:
-  name: {{ template "gafaelfawr.fullname" . }}-secret
+  name: "gafaelfawr-secret"
   labels:
     {{- include "gafaelfawr.labels" . | nindent 4 }}
 spec:
@@ -12,7 +12,7 @@ spec:
 apiVersion: ricoberger.de/v1alpha1
 kind: VaultSecret
 metadata:
-  name: {{ template "gafaelfawr.fullname" . }}-secret-schema-update
+  name: "gafaelfawr-secret-schema-update"
   annotations:
     helm.sh/hook: "pre-install,pre-upgrade"
     helm.sh/hook-weight: "0"
@@ -27,7 +27,7 @@ spec:
 apiVersion: ricoberger.de/v1alpha1
 kind: VaultSecret
 metadata:
-  name: {{ template "gafaelfawr.fullname" . }}-keytab
+  name: "gafaelfawr-keytab"
   labels:
     {{- include "gafaelfawr.labels" . | nindent 4 }}
 spec:

--- a/applications/gafaelfawr/values.yaml
+++ b/applications/gafaelfawr/values.yaml
@@ -1,11 +1,5 @@
 # Default values for Gafaelfawr.
 
-# -- Override the base name for resources
-nameOverride: ""
-
-# -- Override the full name for resources (includes the release name)
-fullnameOverride: ""
-
 # -- Number of web frontend pods to start
 replicaCount: 1
 
@@ -30,17 +24,17 @@ resources:
     cpu: "100m"
     memory: "150Mi"
 
-# -- Annotations for the Gafaelfawr frontend pod
-podAnnotations: {}
+# -- Affinity rules for the Gafaelfawr frontend pod
+affinity: {}
 
 # -- Node selector rules for the Gafaelfawr frontend pod
 nodeSelector: {}
 
+# -- Annotations for the Gafaelfawr frontend pod
+podAnnotations: {}
+
 # -- Tolerations for the Gafaelfawr frontend pod
 tolerations: []
-
-# -- Affinity rules for the Gafaelfawr frontend pod
-affinity: {}
 
 config:
   # -- Where to send the user after they log out


### PR DESCRIPTION
We're moving away from using the standard Helm name manipulation macros and settings, since Phalanx doesn't need them. Drop them from the Gafaelfawr chart.

Add a hook delete policy to the resources created only for the hook in the hope that this will clean them up correctly after hook execution.