### PR TITLE
DM-44468: Cache authentication for Portal and Nublado

### DIFF
--- a/applications/ingress-nginx/README.md
+++ b/applications/ingress-nginx/README.md
@@ -22,4 +22,4 @@ Ingress controller
 | ingress-nginx.controller.metrics.enabled | bool | `true` | Enable metrics reporting via Prometheus |
 | ingress-nginx.controller.podLabels | object | See `values.yaml` | Add labels used by `NetworkPolicy` objects to restrict access to the ingress and thus ensure that auth subrequest handlers run |
 | ingress-nginx.controller.service.externalTrafficPolicy | string | `"Local"` | Force traffic routing policy to Local so that the external IP in `X-Forwarded-For` will be correct |
-| vaultCertificate.enabled | bool | `false` | Whether to store ingress TLS certificate via vault-secrets-operator. Typically the `squareone` application owns it instead in an RSP. |
+| vaultCertificate.enabled | bool | `false` | Whether to get the ingress TLS certificate from Vault instead of Let's Encrypt |

--- a/applications/ingress-nginx/values.yaml
+++ b/applications/ingress-nginx/values.yaml
@@ -57,8 +57,8 @@ ingress-nginx:
       hub.jupyter.org/network-access-proxy-http: "true"
 
 vaultCertificate:
-  # -- Whether to store ingress TLS certificate via vault-secrets-operator.
-  # Typically the `squareone` application owns it instead in an RSP.
+  # -- Whether to get the ingress TLS certificate from Vault instead of Let's
+  # Encrypt
   enabled: false
 
 # The following will be set by parameters injected by Argo CD and should not

--- a/applications/nublado/README.md
+++ b/applications/nublado/README.md
@@ -110,5 +110,5 @@ JupyterHub and custom spawner for the Rubin Science Platform
 | jupyterhub.proxy.service.type | string | `"ClusterIP"` | Only expose the proxy to the cluster, overriding the default of exposing the proxy directly to the Internet |
 | jupyterhub.scheduling.userPlaceholder.enabled | bool | `false` | Whether to spawn placeholder pods representing fake users to force autoscaling in advance of running out of resources |
 | jupyterhub.scheduling.userScheduler.enabled | bool | `false` | Whether the user scheduler should be enabled |
-| proxy.ingress.annotations | object | Increase `proxy-read-timeout` and `proxy-send-timeout` to 5m | Additional annotations to add to the proxy ingress (also used to talk to JupyterHub and all user labs) |
+| proxy.ingress.annotations | object | Increase `proxy-read-timeout` and `proxy-send-timeout` to | Additional annotations to add to the proxy ingress (also used to talk to JupyterHub and all user labs) 5m, enable authentication caching |
 | secrets.templateSecrets | bool | `false` | Whether to use the new secrets management mechanism. If enabled, the Vault nublado secret will be split into a nublado secret for JupyterHub and a nublado-lab-secret secret used as a source for secret values for the user's lab. |

--- a/applications/nublado/values.yaml
+++ b/applications/nublado/values.yaml
@@ -358,8 +358,10 @@ proxy:
   ingress:
     # -- Additional annotations to add to the proxy ingress (also used to talk
     # to JupyterHub and all user labs)
-    # @default -- Increase `proxy-read-timeout` and `proxy-send-timeout` to 5m
+    # @default -- Increase `proxy-read-timeout` and `proxy-send-timeout` to
+    # 5m, enable authentication caching
     annotations:
+      nginx.ingress.kubernetes.io/auth-cache-key: "$http_cookie$http_authorization"
       nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
       nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
 

--- a/applications/portal/templates/ingress.yaml
+++ b/applications/portal/templates/ingress.yaml
@@ -22,6 +22,7 @@ template:
     name: {{ include "portal.fullname" . }}
     annotations:
       nginx.ingress.kubernetes.io/affinity: "cookie"
+      nginx.ingress.kubernetes.io/auth-cache-key: "$http_cookie$http_authorization"
       nginx.ingress.kubernetes.io/client-header-buffer-size: "24k"
       nginx.ingress.kubernetes.io/proxy-body-size: "0m"
       nginx.ingress.kubernetes.io/proxy-cookie-path: "/suit /portal/app"


### PR DESCRIPTION
Cache authentication for up to five minutes, using a cache key that invalidates the cache if the Cookie or Authorization headers have changed, for Portal and the Nublado proxy ingress. We want to avoid forcing Gafaelfawr to validate every HTTP request for interactive web sites that may load a large number of ancillary resources.