### PR TITLE
DM-44481: Use null instead of the empty string in starters

### DIFF
--- a/starters/empty/values.yaml
+++ b/starters/empty/values.yaml
@@ -7,12 +7,12 @@
 global:
   # -- Base URL for the environment
   # @default -- Set by Argo CD
-  baseUrl: ""
+  baseUrl: null
 
   # -- Host name for ingress
   # @default -- Set by Argo CD
-  host: ""
+  host: null
 
   # -- Base path for Vault secrets
   # @default -- Set by Argo CD
-  vaultSecretsPath: ""
+  vaultSecretsPath: null

--- a/starters/fastapi-safir/values.yaml
+++ b/starters/fastapi-safir/values.yaml
@@ -12,8 +12,9 @@ image:
   # -- Pull policy for the <CHARTNAME> image
   pullPolicy: "IfNotPresent"
 
-  # -- Overrides the image tag whose default is the chart appVersion.
-  tag: ""
+  # -- Tag of image to use
+  # @default -- The appVersion of the chart
+  tag: null
 
 config:
   # -- Logging level
@@ -51,12 +52,12 @@ tolerations: []
 global:
   # -- Base URL for the environment
   # @default -- Set by Argo CD
-  baseUrl: ""
+  baseUrl: null
 
   # -- Host name for ingress
   # @default -- Set by Argo CD
-  host: ""
+  host: null
 
   # -- Base path for Vault secrets
   # @default -- Set by Argo CD
-  vaultSecretsPath: ""
+  vaultSecretsPath: null

--- a/starters/web-service/values.yaml
+++ b/starters/web-service/values.yaml
@@ -12,8 +12,9 @@ image:
   # -- Pull policy for the <CHARTNAME> image
   pullPolicy: "IfNotPresent"
 
-  # -- Overrides the image tag whose default is the chart appVersion.
-  tag: ""
+  # -- Tag of image to use
+  # @default -- The appVersion of the chart
+  tag: null
 
 ingress:
   # -- Additional annotations for the ingress rule
@@ -40,12 +41,12 @@ tolerations: []
 global:
   # -- Base URL for the environment
   # @default -- Set by Argo CD
-  baseUrl: ""
+  baseUrl: null
 
   # -- Host name for ingress
   # @default -- Set by Argo CD
-  host: ""
+  host: null
 
   # -- Base path for Vault secrets
   # @default -- Set by Argo CD
-  vaultSecretsPath: ""
+  vaultSecretsPath: null


### PR DESCRIPTION
null in YAML is a more accurate representation of an unset value and, for applications that use part of the values file directly as a configuration file for the application, will translate into the more-useful None value in Python.

Fix the documentation comment for image.tag to specify a default.