### PR TITLE
DM-44481: Add new applications to the doc index

### DIFF
--- a/docs/developers/helm-chart/add-application.rst
+++ b/docs/developers/helm-chart/add-application.rst
@@ -26,9 +26,6 @@ This should explain the purpose of the application and which environments should
 
 The :file:`values.md` file generally does not need to be modified.
 
-Add the new application to the appropriate :file:`docs/applications/{project}.rst` file, where *project* is the Argo CD project of your application (the value that you passed to ``--project`` when creating the application originally).
-Please maintain the alphabetical sorting of the applications.
-
 Configure other Phalanx applications
 ====================================
 

--- a/tests/cli/application_test.py
+++ b/tests/cli/application_test.py
@@ -50,9 +50,7 @@ def test_add_helm_repos(mock_helm: MockHelmCommand) -> None:
 def test_create(tmp_path: Path) -> None:
     config_path = tmp_path / "phalanx"
     shutil.copytree(str(phalanx_test_path()), str(config_path))
-    (config_path / "docs").mkdir()
     app_docs_path = config_path / "docs" / "applications"
-    app_docs_path.mkdir()
     apps_path = config_path / "applications"
 
     # Add three new applications that sort at the start, in the middle, and at
@@ -116,6 +114,12 @@ def test_create(tmp_path: Path) -> None:
     assert (app_docs_path / "hips" / "values.md").exists()
     assert (app_docs_path / "zzz-other-app" / "index.rst").exists()
     assert (app_docs_path / "zzz-other-app" / "values.md").exists()
+
+    # Check that the applications were added to the indices.
+    index = (app_docs_path / "infrastructure.rst").read_text()
+    assert index == read_output_data("docs", "infrastructure.rst")
+    index = (app_docs_path / "rsp.rst").read_text()
+    assert index == read_output_data("docs", "rsp.rst")
 
     # Enable all of these applications for the minikube environment so that we
     # can load them with the normal tools.
@@ -221,9 +225,6 @@ def test_create_errors(tmp_path: Path) -> None:
 def test_create_prompt(tmp_path: Path) -> None:
     config_path = tmp_path / "phalanx"
     shutil.copytree(str(phalanx_test_path()), str(config_path))
-    (config_path / "docs").mkdir()
-    app_docs_path = config_path / "docs" / "applications"
-    app_docs_path.mkdir()
 
     # Add an application, prompting for the description.
     result = run_cli(

--- a/tests/data/input/docs/applications/infrastructure.rst
+++ b/tests/data/input/docs/applications/infrastructure.rst
@@ -1,0 +1,21 @@
+######################
+Cluster infrastructure
+######################
+
+These applications provide the core functionality of a Phalanx environment.
+Access to write operations on these Argo CD applications is often restricted only to environment administrators.
+
+Argo CD project: ``infrastructure``
+
+.. toctree::
+   :maxdepth: 1
+
+   argocd/index
+   cert-manager/index
+   ingress-nginx/index
+   gafaelfawr/index
+   mobu/index
+   postgres/index
+   strimzi/index
+   strimzi-access-operator/index
+   vault-secrets-operator/index

--- a/tests/data/input/docs/applications/rsp.rst
+++ b/tests/data/input/docs/applications/rsp.rst
@@ -1,0 +1,27 @@
+######################
+Rubin Science Platform
+######################
+
+These applications constitute the Rubin Science Platform, which provides a portal, user notebooks, and IVOA-compatible APIs for astronomers.
+
+Argo CD project: ``rsp``
+
+.. toctree::
+   :maxdepth: 1
+
+   butler/index
+   datalinker/index
+   filestore-backup/index
+   jira-data-proxy/index
+   livetap/index
+   noteburst/index
+   nublado/index
+   portal/index
+   semaphore/index
+   siav2/index
+   sqlproxy-cross-project/index
+   squareone/index
+   ssotap/index
+   tap/index
+   times-square/index
+   vo-cutouts/index

--- a/tests/data/output/docs/infrastructure.rst
+++ b/tests/data/output/docs/infrastructure.rst
@@ -1,0 +1,22 @@
+######################
+Cluster infrastructure
+######################
+
+These applications provide the core functionality of a Phalanx environment.
+Access to write operations on these Argo CD applications is often restricted only to environment administrators.
+
+Argo CD project: ``infrastructure``
+
+.. toctree::
+   :maxdepth: 1
+
+   aaa-new-app/index
+   argocd/index
+   cert-manager/index
+   ingress-nginx/index
+   gafaelfawr/index
+   mobu/index
+   postgres/index
+   strimzi/index
+   strimzi-access-operator/index
+   vault-secrets-operator/index

--- a/tests/data/output/docs/rsp.rst
+++ b/tests/data/output/docs/rsp.rst
@@ -1,0 +1,29 @@
+######################
+Rubin Science Platform
+######################
+
+These applications constitute the Rubin Science Platform, which provides a portal, user notebooks, and IVOA-compatible APIs for astronomers.
+
+Argo CD project: ``rsp``
+
+.. toctree::
+   :maxdepth: 1
+
+   butler/index
+   datalinker/index
+   filestore-backup/index
+   hips/index
+   jira-data-proxy/index
+   livetap/index
+   noteburst/index
+   nublado/index
+   portal/index
+   semaphore/index
+   siav2/index
+   sqlproxy-cross-project/index
+   squareone/index
+   ssotap/index
+   tap/index
+   times-square/index
+   vo-cutouts/index
+   zzz-other-app/index


### PR DESCRIPTION
Now that we know the project for each new application and the documentation indices are separated by project, we can add new applications to the relevant documentation index automatically. Add that support.