### PR TITLE
DM-44481: Test for application/environment config issues

### DIFF
--- a/docs/applications/_summary.rst.jinja
+++ b/docs/applications/_summary.rst.jinja
@@ -36,6 +36,7 @@
    * - Argo CD Project
      - {{ app.project }}
    * - Environments
+     {%- if app.active_environments %}
      - .. list-table::
           {% for env_name in app.active_environments %}
           * - :px-env:`{{ env_name }}`
@@ -46,3 +47,6 @@
             -
             {%- endif %}
           {%- endfor %}
+     {%- else %}
+     -
+     {%- endif %}


### PR DESCRIPTION
Make documentation generation robust against applications not being configured for any environment. Add a test that will fail in this case, and also test that an application is configured for every environment for which it is enabled. This will catch various issues people had during the bootcamp in a more obvious way.