### PR TITLE
DM-44481: Remove now-unneeded Argo CD exclusions

### DIFF
--- a/environments/templates/applications/roundtable/ook.yaml
+++ b/environments/templates/applications/roundtable/ook.yaml
@@ -31,9 +31,4 @@ spec:
       valueFiles:
         - "values.yaml"
         - "values-{{ .Values.name }}.yaml"
-  ignoreDifferences:
-    - kind: "Secret"
-      name: "ook-kafka-user"
-      jsonPointers:
-        - "/data"
 {{- end -}}

--- a/environments/templates/applications/roundtable/squarebot.yaml
+++ b/environments/templates/applications/roundtable/squarebot.yaml
@@ -31,9 +31,4 @@ spec:
       valueFiles:
         - "values.yaml"
         - "values-{{ .Values.name }}.yaml"
-  ignoreDifferences:
-    - kind: "Secret"
-      name: "squarebot-kafka-user"
-      jsonPointers:
-        - "/data"
 {{- end -}}

--- a/environments/templates/applications/roundtable/unfurlbot.yaml
+++ b/environments/templates/applications/roundtable/unfurlbot.yaml
@@ -31,9 +31,4 @@ spec:
       valueFiles:
         - "values.yaml"
         - "values-{{ .Values.name }}.yaml"
-  ignoreDifferences:
-    - kind: "Secret"
-      name: "unfurlbot-kafka-user"
-      jsonPointers:
-        - "/data"
 {{- end -}}


### PR DESCRIPTION
We had previously added Argo CD comparison exclusions for the copied Kafka secrets for Roundtable applications, but the new Kafka TLS management mechanism no longer requires this. Remove them.