### PR TITLE
Add default resource limits/requests to Phalanx core apps

### DIFF
--- a/applications/argocd/README.md
+++ b/applications/argocd/README.md
@@ -21,14 +21,18 @@ Kubernetes application manager
 | argo-cd.controller.metrics.applicationLabels.enabled | bool | `true` | Enable adding additional labels to `argocd_app_labels` metric |
 | argo-cd.controller.metrics.applicationLabels.labels | list | `["name","instance"]` | Labels to add to `argocd_app_labels` metric |
 | argo-cd.controller.metrics.enabled | bool | `true` | Enable controller metrics service |
+| argo-cd.controller.resources | object | `{"limits":{"cpu":"8","memory":"3Gi"},"requests":{"cpu":"1","memory":"1Gi"}}` | Resource limits and requests for the application controller pods |
 | argo-cd.global.logging.format | string | `"json"` | Set the global logging format. Either: `text` or `json` |
 | argo-cd.notifications.metrics.enabled | bool | `true` | Enable notifications metrics service |
+| argo-cd.notifications.resources | object | `{"limits":{"cpu":"100m","memory":"350Mi"},"requests":{"cpu":"5m","memory":"32Mi"}}` | Resource limits and requests for the notifications controller |
 | argo-cd.redis.metrics.enabled | bool | `true` | Enable Redis metrics service |
 | argo-cd.repoServer.metrics.enabled | bool | `true` | Enable repo server metrics service |
+| argo-cd.repoServer.resources | object | `{"limits":{"cpu":"1","memory":"640Mi"},"requests":{"cpu":"200m","memory":"80Mi"}}` | Resource limits and requests for the repo server pods |
 | argo-cd.server.ingress.annotations | object | Configure the `letsencrypt-dns` TLS cert cluster issuer | Annotations to add to the ingress |
 | argo-cd.server.ingress.enabled | bool | `true` | Create an ingress for the Argo CD server |
 | argo-cd.server.ingress.ingressClassName | string | `"nginx"` | Ingress class to use for Argo CD ingress |
 | argo-cd.server.ingress.path | string | `"/argo-cd"` | Paths to route to Argo CD |
 | argo-cd.server.ingress.tls | bool | `true` | Enable TLS management for this ingress. Disable this if TLS should not use a Let's Encrypt TLS certificate. |
 | argo-cd.server.metrics.enabled | bool | `true` | Enable server metrics service |
+| argo-cd.server.resources | object | `{"limits":{"cpu":"1","memory":"500Mi"},"requests":{"cpu":"10m","memory":"64Mi"}}` | Resource limits and requests for the Argo CD server |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |

--- a/applications/argocd/README.md
+++ b/applications/argocd/README.md
@@ -13,6 +13,7 @@ Kubernetes application manager
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| argo-cd.applicationSet.resources | object | See `values.yaml` | Resource limits and requests for the applicationSet server |
 | argo-cd.configs.cm."resource.compareoptions" | string | `"ignoreAggregatedRoles: true\n"` | Configure resource comparison |
 | argo-cd.configs.params."server.basehref" | string | `"/argo-cd"` | Base href for `index.html` when running under a reverse proxy |
 | argo-cd.configs.params."server.insecure" | bool | `true` | Do not use TLS (this is terminated at the ingress) |
@@ -21,18 +22,20 @@ Kubernetes application manager
 | argo-cd.controller.metrics.applicationLabels.enabled | bool | `true` | Enable adding additional labels to `argocd_app_labels` metric |
 | argo-cd.controller.metrics.applicationLabels.labels | list | `["name","instance"]` | Labels to add to `argocd_app_labels` metric |
 | argo-cd.controller.metrics.enabled | bool | `true` | Enable controller metrics service |
-| argo-cd.controller.resources | object | `{"limits":{"cpu":"8","memory":"3Gi"},"requests":{"cpu":"1","memory":"1Gi"}}` | Resource limits and requests for the application controller pods |
+| argo-cd.controller.resources | object | See `values.yaml` | Resource limits and requests for the application controller pods |
+| argo-cd.dex.resources | object | See `values.yaml` | Resource limits and requests for the Dex server |
 | argo-cd.global.logging.format | string | `"json"` | Set the global logging format. Either: `text` or `json` |
 | argo-cd.notifications.metrics.enabled | bool | `true` | Enable notifications metrics service |
-| argo-cd.notifications.resources | object | `{"limits":{"cpu":"100m","memory":"350Mi"},"requests":{"cpu":"5m","memory":"32Mi"}}` | Resource limits and requests for the notifications controller |
+| argo-cd.notifications.resources | object | See `values.yaml` | Resource limits and requests for the notifications controller |
 | argo-cd.redis.metrics.enabled | bool | `true` | Enable Redis metrics service |
+| argo-cd.redis.resources | object | See `values.yaml` | Resource limits and requests for the Redis controller |
 | argo-cd.repoServer.metrics.enabled | bool | `true` | Enable repo server metrics service |
-| argo-cd.repoServer.resources | object | `{"limits":{"cpu":"1","memory":"640Mi"},"requests":{"cpu":"200m","memory":"80Mi"}}` | Resource limits and requests for the repo server pods |
+| argo-cd.repoServer.resources | object | See `values.yaml` | Resource limits and requests for the repo server pods |
 | argo-cd.server.ingress.annotations | object | Configure the `letsencrypt-dns` TLS cert cluster issuer | Annotations to add to the ingress |
 | argo-cd.server.ingress.enabled | bool | `true` | Create an ingress for the Argo CD server |
 | argo-cd.server.ingress.ingressClassName | string | `"nginx"` | Ingress class to use for Argo CD ingress |
 | argo-cd.server.ingress.path | string | `"/argo-cd"` | Paths to route to Argo CD |
 | argo-cd.server.ingress.tls | bool | `true` | Enable TLS management for this ingress. Disable this if TLS should not use a Let's Encrypt TLS certificate. |
 | argo-cd.server.metrics.enabled | bool | `true` | Enable server metrics service |
-| argo-cd.server.resources | object | `{"limits":{"cpu":"1","memory":"500Mi"},"requests":{"cpu":"10m","memory":"64Mi"}}` | Resource limits and requests for the Argo CD server |
+| argo-cd.server.resources | object | See `values.yaml` | Resource limits and requests for the Argo CD server |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |

--- a/applications/argocd/values-minikube.yaml
+++ b/applications/argocd/values-minikube.yaml
@@ -7,3 +7,22 @@ argo-cd:
     ingress:
       hostname: "minikube.lsst.codes"
     tls: false
+    resources: {}
+
+  controller:
+    resources: {}
+
+  dex:
+    resources: {}
+
+  applicationSet:
+    resources: {}
+
+  redis:
+    resources: {}
+
+  repoServer:
+    resources: {}
+
+  notifications:
+    resources: {}

--- a/applications/argocd/values.yaml
+++ b/applications/argocd/values.yaml
@@ -49,8 +49,9 @@ argo-cd:
     metrics:
       # -- Enable notifications metrics service
       enabled: true
+
     # -- Resource limits and requests for the notifications controller
-    resources: {}
+    resources:
       limits:
         cpu: "100m"
         memory: "350Mi"
@@ -62,8 +63,9 @@ argo-cd:
     metrics:
       # -- Enable server metrics service
       enabled: true
+
     # -- Resource limits and requests for the Argo CD server
-    resources: {}
+    resources:
       limits:
         cpu: "1"
         memory: "500Mi"

--- a/applications/argocd/values.yaml
+++ b/applications/argocd/values.yaml
@@ -23,21 +23,53 @@ argo-cd:
 
         # -- Labels to add to `argocd_app_labels` metric
         labels: ["name", "instance"]
+    # -- Resource limits and requests for the application controller pods
+    resources:
+      limits:
+        cpu: "8"
+        memory: "3Gi"
+      requests:
+        cpu: "1"
+        memory: "1Gi"
 
   repoServer:
     metrics:
       # -- Enable repo server metrics service
       enabled: true
+    # -- Resource limits and requests for the repo server pods
+    resources:
+      limits:
+        cpu: "1"
+        memory: "640Mi"
+      requests:
+        cpu: "200m"
+        memory: "80Mi"
 
   notifications:
     metrics:
       # -- Enable notifications metrics service
       enabled: true
+    # -- Resource limits and requests for the notifications controller
+    resources: {}
+      limits:
+        cpu: "100m"
+        memory: "350Mi"
+      requests:
+        cpu: "5m"
+        memory: "32Mi"
 
   server:
     metrics:
       # -- Enable server metrics service
       enabled: true
+    # -- Resource limits and requests for the Argo CD server
+    resources: {}
+      limits:
+        cpu: "1"
+        memory: "500Mi"
+      requests:
+        cpu: "10m"
+        memory: "64Mi"
 
     ingress:
       # -- Create an ingress for the Argo CD server

--- a/applications/argocd/values.yaml
+++ b/applications/argocd/values.yaml
@@ -12,6 +12,16 @@ argo-cd:
       # -- Enable Redis metrics service
       enabled: true
 
+    # -- Resource limits and requests for the Redis controller
+    # @default -- See `values.yaml`
+    resources:
+      limits:
+        cpu: "1"
+        memory: "50Mi"
+      requests:
+        cpu: "2m"
+        memory: "10Mi"
+
   controller:
     metrics:
       # -- Enable controller metrics service
@@ -23,7 +33,9 @@ argo-cd:
 
         # -- Labels to add to `argocd_app_labels` metric
         labels: ["name", "instance"]
+
     # -- Resource limits and requests for the application controller pods
+    # @default -- See `values.yaml`
     resources:
       limits:
         cpu: "8"
@@ -32,11 +44,37 @@ argo-cd:
         cpu: "1"
         memory: "1Gi"
 
+  dex:
+
+    # -- Resource limits and requests for the Dex server
+    # @default -- See `values.yaml`
+    resources:
+      limits:
+        cpu: "1"
+        memory: "400Mi"
+      requests:
+        cpu: "5m"
+        memory: "30Mi"
+
+  applicationSet:
+
+    # -- Resource limits and requests for the applicationSet server
+    # @default -- See `values.yaml`
+    resources:
+      limits:
+        cpu: "1"
+        memory: "128Mi"
+      requests:
+        cpu: "3m"
+        memory: "30Mi"
+
   repoServer:
     metrics:
       # -- Enable repo server metrics service
       enabled: true
+
     # -- Resource limits and requests for the repo server pods
+    # @default -- See `values.yaml`
     resources:
       limits:
         cpu: "1"
@@ -51,6 +89,7 @@ argo-cd:
       enabled: true
 
     # -- Resource limits and requests for the notifications controller
+    # @default -- See `values.yaml`
     resources:
       limits:
         cpu: "100m"
@@ -65,6 +104,7 @@ argo-cd:
       enabled: true
 
     # -- Resource limits and requests for the Argo CD server
+    # @default -- See `values.yaml`
     resources:
       limits:
         cpu: "1"

--- a/applications/cert-manager/README.md
+++ b/applications/cert-manager/README.md
@@ -15,7 +15,9 @@ TLS certificate manager
 | cert-manager.cainjector.extraArgs | list | `["--logging-format=json"]` | Additional arguments to the CA injector |
 | cert-manager.extraArgs | list | `["--logging-format=json","--dns01-recursive-nameservers-only","--dns01-recursive-nameservers=8.8.8.8:53,1.1.1.1:53"]` | Additional arguments to the main cert-manager pod |
 | cert-manager.installCRDs | bool | `true` | Whether to install CRDs |
+| cert-manager.resources | object | `{"limits":{"cpu":"1","memory":"256Mi"},"requests":{"cpu":"50m","memory":"64Mi"}}` | requests and limits for the cert-manager controller |
 | cert-manager.webhook.extraArgs | list | `["--logging-format=json"]` | Additional arguments to the webhook pod |
+| cert-manager.webhook.resources | object | `{"limits":{"cpu":"100m","memory":"256Mi"},"requests":{"cpu":"10m","memory":"32Mi"}}` | requests and limits for the webhook pod |
 | config.createIssuer | bool | `true` | Whether to create a Let's Encrypt DNS-based cluster issuer |
 | config.email | string | sqre-admin | Contact email address registered with Let's Encrypt |
 | config.route53.awsAccessKeyId | string | None, must be set if `createIssuer` is true | AWS access key ID for Route 53 (must match `aws-secret-access-key` in Vault secret referenced by `config.vaultSecretPath`) |

--- a/applications/cert-manager/README.md
+++ b/applications/cert-manager/README.md
@@ -15,9 +15,9 @@ TLS certificate manager
 | cert-manager.cainjector.extraArgs | list | `["--logging-format=json"]` | Additional arguments to the CA injector |
 | cert-manager.extraArgs | list | `["--logging-format=json","--dns01-recursive-nameservers-only","--dns01-recursive-nameservers=8.8.8.8:53,1.1.1.1:53"]` | Additional arguments to the main cert-manager pod |
 | cert-manager.installCRDs | bool | `true` | Whether to install CRDs |
-| cert-manager.resources | object | `{"limits":{"cpu":"1","memory":"256Mi"},"requests":{"cpu":"50m","memory":"64Mi"}}` | requests and limits for the cert-manager controller |
+| cert-manager.resources | object | See `values.yaml` | Resource requests and limits for the cert-manager controller |
 | cert-manager.webhook.extraArgs | list | `["--logging-format=json"]` | Additional arguments to the webhook pod |
-| cert-manager.webhook.resources | object | `{"limits":{"cpu":"100m","memory":"256Mi"},"requests":{"cpu":"10m","memory":"32Mi"}}` | requests and limits for the webhook pod |
+| cert-manager.webhook.resources | object | See `values.yaml` | Resource requests and limits for the webhook pod |
 | config.createIssuer | bool | `true` | Whether to create a Let's Encrypt DNS-based cluster issuer |
 | config.email | string | sqre-admin | Contact email address registered with Let's Encrypt |
 | config.route53.awsAccessKeyId | string | None, must be set if `createIssuer` is true | AWS access key ID for Route 53 (must match `aws-secret-access-key` in Vault secret referenced by `config.vaultSecretPath`) |

--- a/applications/cert-manager/values-minikube.yaml
+++ b/applications/cert-manager/values-minikube.yaml
@@ -1,2 +1,6 @@
 config:
   createIssuer: false
+cert-manager:
+  resources: {}
+  webhook:
+    resources: {}

--- a/applications/cert-manager/values.yaml
+++ b/applications/cert-manager/values.yaml
@@ -32,10 +32,28 @@ cert-manager:
     extraArgs:
       - "--logging-format=json"
 
+  # -- requests and limits for the cert-manager controller
+  resources:
+    limits:
+      cpu: "1"
+      memory: "256Mi"
+    requests:
+      cpu: "50m"
+      memory: "64Mi"
+
   webhook:
     # -- Additional arguments to the webhook pod
     extraArgs:
       - "--logging-format=json"
+    # -- requests and limits for the webhook pod
+    resources:
+      limits:
+        cpu: "100m"
+        memory: "256Mi"
+      requests:
+        cpu: "10m"
+        memory: "32Mi"
+
 
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.

--- a/applications/cert-manager/values.yaml
+++ b/applications/cert-manager/values.yaml
@@ -32,7 +32,8 @@ cert-manager:
     extraArgs:
       - "--logging-format=json"
 
-  # -- requests and limits for the cert-manager controller
+  # -- Resource requests and limits for the cert-manager controller
+  # @default -- See `values.yaml`
   resources:
     limits:
       cpu: "1"
@@ -45,7 +46,9 @@ cert-manager:
     # -- Additional arguments to the webhook pod
     extraArgs:
       - "--logging-format=json"
-    # -- requests and limits for the webhook pod
+
+    # -- Resource requests and limits for the webhook pod
+    # @default -- See `values.yaml`
     resources:
       limits:
         cpu: "100m"

--- a/applications/gafaelfawr/values-minikube.yaml
+++ b/applications/gafaelfawr/values-minikube.yaml
@@ -3,6 +3,8 @@ redis:
   persistence:
     enabled: false
 
+resources: {}
+
 config:
   internalDatabase: true
   updateSchema: true

--- a/applications/ingress-nginx/README.md
+++ b/applications/ingress-nginx/README.md
@@ -21,6 +21,6 @@ Ingress controller
 | ingress-nginx.controller.config.use-forwarded-headers | string | `"true"` | Enable the `X-Forwarded-For` processing |
 | ingress-nginx.controller.metrics.enabled | bool | `true` | Enable metrics reporting via Prometheus |
 | ingress-nginx.controller.podLabels | object | See `values.yaml` | Add labels used by `NetworkPolicy` objects to restrict access to the ingress and thus ensure that auth subrequest handlers run |
-| ingress-nginx.controller.resources | object | `{"limits":{"cpu":"4","memory":"5Gi"},"requests":{"cpu":"80m","memory":"500Mi"}}` | Resource requests and limits for ingress-nginx controller |
+| ingress-nginx.controller.resources | object | See `values.yaml` | Resource requests and limits for ingress-nginx controller |
 | ingress-nginx.controller.service.externalTrafficPolicy | string | `"Local"` | Force traffic routing policy to Local so that the external IP in `X-Forwarded-For` will be correct |
 | vaultCertificate.enabled | bool | `false` | Whether to get the ingress TLS certificate from Vault instead of Let's Encrypt |

--- a/applications/ingress-nginx/README.md
+++ b/applications/ingress-nginx/README.md
@@ -21,5 +21,6 @@ Ingress controller
 | ingress-nginx.controller.config.use-forwarded-headers | string | `"true"` | Enable the `X-Forwarded-For` processing |
 | ingress-nginx.controller.metrics.enabled | bool | `true` | Enable metrics reporting via Prometheus |
 | ingress-nginx.controller.podLabels | object | See `values.yaml` | Add labels used by `NetworkPolicy` objects to restrict access to the ingress and thus ensure that auth subrequest handlers run |
+| ingress-nginx.controller.resources | object | `{"limits":{"cpu":"4","memory":"5Gi"},"requests":{"cpu":"80m","memory":"500Mi"}}` | Resource requests and limits for ingress-nginx controller |
 | ingress-nginx.controller.service.externalTrafficPolicy | string | `"Local"` | Force traffic routing policy to Local so that the external IP in `X-Forwarded-For` will be correct |
 | vaultCertificate.enabled | bool | `false` | Whether to get the ingress TLS certificate from Vault instead of Let's Encrypt |

--- a/applications/ingress-nginx/values-minikube.yaml
+++ b/applications/ingress-nginx/values-minikube.yaml
@@ -1,5 +1,6 @@
 ingress-nginx:
   controller:
+    resources: {}
     service:
       externalTrafficPolicy: null
       type: ClusterIP

--- a/applications/ingress-nginx/values.yaml
+++ b/applications/ingress-nginx/values.yaml
@@ -44,6 +44,15 @@ ingress-nginx:
       # -- Enable metrics reporting via Prometheus
       enabled: true
 
+    # -- Resource requests and limits for ingress-nginx controller
+    resources:
+      limits:
+        cpu: "4"
+        memory: "5Gi"
+      requests:
+        cpu: "80m"
+        memory: "500Mi"
+
     service:
       # -- Force traffic routing policy to Local so that the external IP in
       # `X-Forwarded-For` will be correct

--- a/applications/ingress-nginx/values.yaml
+++ b/applications/ingress-nginx/values.yaml
@@ -45,6 +45,7 @@ ingress-nginx:
       enabled: true
 
     # -- Resource requests and limits for ingress-nginx controller
+    # @default -- See `values.yaml`
     resources:
       limits:
         cpu: "4"

--- a/applications/mobu/README.md
+++ b/applications/mobu/README.md
@@ -26,5 +26,5 @@ Continuous integration testing
 | nameOverride | string | `""` | Override the base name for resources |
 | nodeSelector | object | `{}` | Node selector rules for the mobu frontend pod |
 | podAnnotations | object | `{}` | Annotations for the mobu frontend pod |
-| resources | object | `{"limits":{"cpu":"1","memory":"3.5Gi"},"requests":{"cpu":"50m","memory":"1Gi"}}` | Resource limits and requests for the mobu frontend pod |
+| resources | object | See `values.yaml` | Resource limits and requests for the mobu frontend pod |
 | tolerations | list | `[]` | Tolerations for the mobu frontend pod |

--- a/applications/mobu/README.md
+++ b/applications/mobu/README.md
@@ -26,5 +26,5 @@ Continuous integration testing
 | nameOverride | string | `""` | Override the base name for resources |
 | nodeSelector | object | `{}` | Node selector rules for the mobu frontend pod |
 | podAnnotations | object | `{}` | Annotations for the mobu frontend pod |
-| resources | object | `{}` | Resource limits and requests for the mobu frontend pod |
+| resources | object | `{"limits":{"cpu":"1","memory":"3.5Gi"},"requests":{"cpu":"50m","memory":"1Gi"}}` | Resource limits and requests for the mobu frontend pod |
 | tolerations | list | `[]` | Tolerations for the mobu frontend pod |

--- a/applications/mobu/values-minikube.yaml
+++ b/applications/mobu/values-minikube.yaml
@@ -1,2 +1,3 @@
 config:
   slackAlerts: false
+resources: {}

--- a/applications/mobu/values.yaml
+++ b/applications/mobu/values.yaml
@@ -37,7 +37,13 @@ config:
   pathPrefix: "/mobu"
 
 # -- Resource limits and requests for the mobu frontend pod
-resources: {}
+resources:
+  limits:
+    cpu: "1"
+    memory: "3.5Gi"
+  requests:
+    cpu: "50m"
+    memory: "1Gi"
 
 # -- Annotations for the mobu frontend pod
 podAnnotations: {}

--- a/applications/mobu/values.yaml
+++ b/applications/mobu/values.yaml
@@ -37,6 +37,7 @@ config:
   pathPrefix: "/mobu"
 
 # -- Resource limits and requests for the mobu frontend pod
+# @default -- See `values.yaml`
 resources:
   limits:
     cpu: "1"

--- a/applications/postgres/README.md
+++ b/applications/postgres/README.md
@@ -17,5 +17,5 @@ Postgres RDBMS for LSP
 | image.tag | string | The appVersion of the chart | Tag of postgres image to use |
 | postgresStorageClass | string | `"standard"` | Storage class for postgres volume.  Set to appropriate value for your deployment: at GKE, "standard" (if you want SSD, "premium-rwo", but if you want a good database maybe it's better to use a cloud database?), on Rubin Observatory Rancher, "rook-ceph-block", elsewhere probably "standard" |
 | postgresVolumeSize | string | `"1Gi"` | Volume size for postgres.  It can generally be very small |
-| resources | object | `{"limits":{"cpu":"1","memory":"128Mi"},"requests":{"cpu":"60m","memory":"32Mi"}}` | Resource requests and limits for postgres pod |
+| resources | object | See `values.yaml` | Resource requests and limits for postgres pod |
 | volumeName | string | `""` | Volume name for postgres, if you use an existing volume that isn't automatically created from the PVC by the storage driver. |

--- a/applications/postgres/README.md
+++ b/applications/postgres/README.md
@@ -17,4 +17,5 @@ Postgres RDBMS for LSP
 | image.tag | string | The appVersion of the chart | Tag of postgres image to use |
 | postgresStorageClass | string | `"standard"` | Storage class for postgres volume.  Set to appropriate value for your deployment: at GKE, "standard" (if you want SSD, "premium-rwo", but if you want a good database maybe it's better to use a cloud database?), on Rubin Observatory Rancher, "rook-ceph-block", elsewhere probably "standard" |
 | postgresVolumeSize | string | `"1Gi"` | Volume size for postgres.  It can generally be very small |
+| resources | object | `{"limits":{"cpu":"1","memory":"128Mi"},"requests":{"cpu":"60m","memory":"32Mi"}}` | Resource requests and limits for postgres pod |
 | volumeName | string | `""` | Volume name for postgres, if you use an existing volume that isn't automatically created from the PVC by the storage driver. |

--- a/applications/postgres/values-minikube.yaml
+++ b/applications/postgres/values-minikube.yaml
@@ -3,3 +3,4 @@ gafaelfawr_db:
   user: "gafaelfawr"
   db: "gafaelfawr"
 postgresStorageClass: "standard"
+resources: {}

--- a/applications/postgres/values.yaml
+++ b/applications/postgres/values.yaml
@@ -17,6 +17,7 @@ image:
   tag: ""
 
 # -- Resource requests and limits for postgres pod
+# @default -- See `values.yaml`
 resources:
   limits:
     cpu: "1"

--- a/applications/postgres/values.yaml
+++ b/applications/postgres/values.yaml
@@ -21,7 +21,7 @@ image:
 resources:
   limits:
     cpu: "1"
-    memory: "128Mi"
+    memory: "1200Mi"
   requests:
     cpu: "60m"
     memory: "32Mi"

--- a/applications/postgres/values.yaml
+++ b/applications/postgres/values.yaml
@@ -16,6 +16,15 @@ image:
   # @default -- The appVersion of the chart
   tag: ""
 
+# -- Resource requests and limits for postgres pod
+resources:
+  limits:
+    cpu: "1"
+    memory: "128Mi"
+  requests:
+    cpu: "60m"
+    memory: "32Mi"
+
 # -- Volume size for postgres.  It can generally be very small
 postgresVolumeSize: "1Gi"
 

--- a/applications/strimzi-access-operator/README.md
+++ b/applications/strimzi-access-operator/README.md
@@ -11,7 +11,7 @@ Strimzi Access Operator
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | image.repository | string | `"ghcr.io/lsst-sqre/kafka-access-operator"` | Image repository |
 | image.tag | string | The appVersion of the chart | Tag of the image |
-| resources | object | `{"limits":{"cpu":"50m","memory":"384Mi"},"requests":{"cpu":"5m","memory":"180Mi"}}` | Resource requests and limits for strimzi-access-operator |
+| resources | object | See `values.yaml` | Resource requests and limits for strimzi-access-operator |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created. |
 | serviceAccount.name | string | `""` |  |

--- a/applications/strimzi-access-operator/README.md
+++ b/applications/strimzi-access-operator/README.md
@@ -11,6 +11,7 @@ Strimzi Access Operator
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | image.repository | string | `"ghcr.io/lsst-sqre/kafka-access-operator"` | Image repository |
 | image.tag | string | The appVersion of the chart | Tag of the image |
+| resources | object | `{"limits":{"cpu":"50m","memory":"384Mi"},"requests":{"cpu":"5m","memory":"180Mi"}}` | Resource requests and limits for strimzi-access-operator |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created. |
 | serviceAccount.name | string | `""` |  |

--- a/applications/strimzi-access-operator/values.yaml
+++ b/applications/strimzi-access-operator/values.yaml
@@ -10,6 +10,7 @@ image:
   tag: ""
 
 # -- Resource requests and limits for strimzi-access-operator
+# @default -- See `values.yaml`
 resources:
   limits:
     cpu: "50m"

--- a/applications/strimzi-access-operator/values.yaml
+++ b/applications/strimzi-access-operator/values.yaml
@@ -9,6 +9,15 @@ image:
   # @default -- The appVersion of the chart
   tag: ""
 
+# -- Resource requests and limits for strimzi-access-operator
+resources:
+  limits:
+    cpu: "50m"
+    memory: "384Mi"
+  requests:
+    cpu: "5m"
+    memory: "180Mi"
+
 serviceAccount:
   # -- Specifies whether a service account should be created.
   create: true

--- a/applications/strimzi/README.md
+++ b/applications/strimzi/README.md
@@ -8,7 +8,4 @@ Strimzi Kafka Operator
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| strimzi-cluster-operator.resources.limits.cpu | string | `"1"` |  |
-| strimzi-cluster-operator.resources.limits.memory | string | `"1Gi"` |  |
-| strimzi-cluster-operator.resources.requests.cpu | string | `"20m"` |  |
-| strimzi-cluster-operator.resources.requests.memory | string | `"450Mi"` |  |
+| strimzi-cluster-operator | object | See `values.yaml` | Resource limits and requests for the strimzi-cluster-operator pod |

--- a/applications/strimzi/README.md
+++ b/applications/strimzi/README.md
@@ -4,3 +4,11 @@ Strimzi Kafka Operator
 
 **Homepage:** <https://strimzi.io>
 
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| strimzi-cluster-operator.resources.limits.cpu | string | `"1"` |  |
+| strimzi-cluster-operator.resources.limits.memory | string | `"1Gi"` |  |
+| strimzi-cluster-operator.resources.requests.cpu | string | `"20m"` |  |
+| strimzi-cluster-operator.resources.requests.memory | string | `"450Mi"` |  |

--- a/applications/strimzi/values.yaml
+++ b/applications/strimzi/values.yaml
@@ -1,0 +1,8 @@
+strimzi-cluster-operator:
+  resources:
+    limits:
+      cpu: "1"
+      memory: "1Gi"
+    requests:
+      cpu: "20m"
+      memory: "450Mi"

--- a/applications/strimzi/values.yaml
+++ b/applications/strimzi/values.yaml
@@ -1,3 +1,5 @@
+# -- Resource limits and requests for the strimzi-cluster-operator pod
+# @default -- See `values.yaml`
 strimzi-cluster-operator:
   resources:
     limits:

--- a/applications/vault-secrets-operator/README.md
+++ b/applications/vault-secrets-operator/README.md
@@ -9,7 +9,7 @@
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | vault-secrets-operator.environmentVars | list | Use a Vault AppRole (see `values.yaml` for details) | Additional environment variables used to configure the operator |
-| vault-secrets-operator.resources | object | `{"limits":{"cpu":"300m","memory":"300Mi"},"requests":{"cpu":"20m","memory":"30Mi"}}` | Resource requests and limits for vault-secrets-operator |
+| vault-secrets-operator.resources | object | See `values.yaml` | Resource requests and limits for vault-secrets-operator |
 | vault-secrets-operator.serviceAccount.createSecret | bool | `false` | Disable creation of a secret for the service account. It shouldn't be needed and it conflicts with the secret we create that contains the credentials for talking to Vault. |
 | vault-secrets-operator.vault.address | string | Set by Argo CD | URL of the underlying Vault implementation |
 | vault-secrets-operator.vault.authMethod | string | `"approle"` | Authentication method to use |

--- a/applications/vault-secrets-operator/README.md
+++ b/applications/vault-secrets-operator/README.md
@@ -9,6 +9,7 @@
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | vault-secrets-operator.environmentVars | list | Use a Vault AppRole (see `values.yaml` for details) | Additional environment variables used to configure the operator |
+| vault-secrets-operator.resources | object | `{"limits":{"cpu":"300m","memory":"300Mi"},"requests":{"cpu":"20m","memory":"30Mi"}}` | Resource requests and limits for vault-secrets-operator |
 | vault-secrets-operator.serviceAccount.createSecret | bool | `false` | Disable creation of a secret for the service account. It shouldn't be needed and it conflicts with the secret we create that contains the credentials for talking to Vault. |
 | vault-secrets-operator.vault.address | string | Set by Argo CD | URL of the underlying Vault implementation |
 | vault-secrets-operator.vault.authMethod | string | `"approle"` | Authentication method to use |

--- a/applications/vault-secrets-operator/values-minikube.yaml
+++ b/applications/vault-secrets-operator/values-minikube.yaml
@@ -14,3 +14,4 @@ vault-secrets-operator:
     # not-yet-expired tokens in Vault from GitHub Actions CI tests.
     - name: "VAULT_TOKEN_MAX_TTL"
       value: "3600"
+  resources: {}

--- a/applications/vault-secrets-operator/values.yaml
+++ b/applications/vault-secrets-operator/values.yaml
@@ -16,6 +16,7 @@ vault-secrets-operator:
           key: "VAULT_SECRET_ID"
 
   # -- Resource requests and limits for vault-secrets-operator
+  # @default -- See `values.yaml`
   resources:
     limits:
       cpu: "300m"

--- a/applications/vault-secrets-operator/values.yaml
+++ b/applications/vault-secrets-operator/values.yaml
@@ -15,6 +15,14 @@ vault-secrets-operator:
           name: "vault-credentials"
           key: "VAULT_SECRET_ID"
 
+  # -- Resource requests and limits for vault-secrets-operator
+  resources:
+    limits:
+      cpu: "300m"
+      memory: "300Mi"
+    requests:
+      cpu: "20m"
+      memory: "30Mi"
   serviceAccount:
     # -- Disable creation of a secret for the service account. It shouldn't be
     # needed and it conflicts with the secret we create that contains the


### PR DESCRIPTION
For our core applications, add reasonably-sane (but not tight) requests/limits for all of them.

Site-specific overrides to follow eventually.
