### PR TITLE
DM-44481: Document time intervals for Nublado

### DIFF
--- a/applications/nublado/README.md
+++ b/applications/nublado/README.md
@@ -29,7 +29,7 @@ JupyterHub and custom spawner for the Rubin Science Platform
 | controller.config.fileserver.creationTimeout | int | `120` | Timeout to wait for Kubernetes to create file servers, in seconds |
 | controller.config.fileserver.deleteTimeout | int | 60 (1 minute) | Timeout for deleting a user's file server from Kubernetes, in seconds |
 | controller.config.fileserver.enabled | bool | `false` | Enable user file servers |
-| controller.config.fileserver.idleTimeout | int | `3600` | Timeout for idle user fileservers, in seconds |
+| controller.config.fileserver.idleTimeout | int | 3600 (1 hour) | Timeout for idle user fileservers, in seconds |
 | controller.config.fileserver.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for file server image |
 | controller.config.fileserver.image.repository | string | `"ghcr.io/lsst-sqre/worblehat"` | File server image to use |
 | controller.config.fileserver.image.tag | string | `"0.1.0"` | Tag of file server image to use |

--- a/applications/nublado/values-base.yaml
+++ b/applications/nublado/values-base.yaml
@@ -90,9 +90,9 @@ jupyterhub:
   cull:
     users: false
     removeNamedServers: false
-    timeout: 432000
-    every: 300
-    maxAge: 2160000
+    timeout: 432000  # 5 days
+    every: 300  # 5 minutes
+    maxAge: 2160000  # 25 days
   hub:
     db:
       upgrade: true

--- a/applications/nublado/values-ccin2p3.yaml
+++ b/applications/nublado/values-ccin2p3.yaml
@@ -13,9 +13,9 @@ controller:
     lab:
       env:
         AUTO_REPO_SPECS: "https://github.com/lsst-sqre/system-test@prod,https://github.com/rubin-dp0/tutorial-notebooks@prod"
-        NO_ACTIVITY_TIMEOUT: "432000"
-        CULL_KERNEL_IDLE_TIMEOUT: "432000"
-        CULL_TERMINAL_INACTIVE_TIMEOUT: "432000"
+        NO_ACTIVITY_TIMEOUT: "432000"  # 5 days
+        CULL_KERNEL_IDLE_TIMEOUT: "432000"  # 5 days
+        CULL_TERMINAL_INACTIVE_TIMEOUT: "432000"  # 5 days
       homedirSchema: "username"
       homedirPrefix: "/sps/lsst/users"
       homedirSuffix: "rsp_home"
@@ -64,14 +64,10 @@ controller:
           volumeName: "sps"
 jupyterhub:
   hub:
-    baseUrl: "/nb"
-    config:
-      ServerApp:
-        shutdown_no_activity_timeout: 432000
     db:
       url: "postgresql://nublado3@postgres.postgres/nublado3"
       upgrade: true
   cull:
-    timeout: 432000
-    every: 300
-    maxAge: 2160000
+    timeout: 432000  # 5 days
+    every: 300  # 5 minutes
+    maxAge: 2160000  # 25 days

--- a/applications/nublado/values-idfint.yaml
+++ b/applications/nublado/values-idfint.yaml
@@ -32,9 +32,7 @@ controller:
         PANDACACHE_URL: "https://usdf-panda-server.slac.stanford.edu:8443/server/panda"
         PANDAMON_URL: "https://usdf-panda-bigmon.slac.stanford.edu:8443/"
         PANDA_CONFIG_ROOT: "~"
-        NO_ACTIVITY_TIMEOUT: "432000"
-        CULL_KERNEL_IDLE_TIMEOUT: "432000"
-        CULL_TERMINAL_INACTIVE_TIMEOUT: "432000"
+        CULL_TERMINAL_INACTIVE_TIMEOUT: "432000"  # 5 days
       initContainers:
         - name: "inithome"
           image:

--- a/applications/nublado/values-idfprod.yaml
+++ b/applications/nublado/values-idfprod.yaml
@@ -17,9 +17,7 @@ controller:
         GOOGLE_APPLICATION_CREDENTIALS: "/opt/lsst/software/jupyterlab/secrets/butler-gcs-idf-creds.json"
         DAF_BUTLER_REPOSITORY_INDEX: "s3://butler-us-central1-repo-locations/data-repos.yaml"
         S3_ENDPOINT_URL: "https://storage.googleapis.com"
-        NO_ACTIVITY_TIMEOUT: "432000"
-        CULL_KERNEL_IDLE_TIMEOUT: "432000"
-        CULL_TERMINAL_INACTIVE_TIMEOUT: "432000"
+        CULL_TERMINAL_INACTIVE_TIMEOUT: "432000"  # 5 days
       initContainers:
         - name: "inithome"
           image:
@@ -81,12 +79,9 @@ jupyterhub:
       url: "postgresql://nublado@cloud-sql-proxy.nublado/nublado"
       upgrade: true
   cull:
-    enabled: true
-    users: false
-    removeNamedServers: false
-    timeout: 432000
-    every: 300
-    maxAge: 2160000
+    timeout: 432000  # 5 days
+    every: 300  # 5 minutes
+    maxAge: 2160000  # 25 days
 hub:
   internalDatabase: false
 cloudsql:

--- a/applications/nublado/values-roe.yaml
+++ b/applications/nublado/values-roe.yaml
@@ -56,6 +56,6 @@ jupyterhub:
     db:
       upgrade: true
   cull:
-    timeout: 432000
-    every: 300
-    maxAge: 2160000
+    timeout: 432000  # 5 days
+    every: 300  # 5 minutes
+    maxAge: 2160000  # 25 days

--- a/applications/nublado/values-summit.yaml
+++ b/applications/nublado/values-summit.yaml
@@ -118,9 +118,9 @@ jupyterhub:
   cull:
     users: false
     removeNamedServers: false
-    timeout: 432000
-    every: 300
-    maxAge: 2160000
+    timeout: 432000  # 5 days
+    every: 300  # 5 minutes
+    maxAge: 2160000  # 25 days
   hub:
     db:
       upgrade: true

--- a/applications/nublado/values-tucson-teststand.yaml
+++ b/applications/nublado/values-tucson-teststand.yaml
@@ -111,11 +111,9 @@ hub:
 
 jupyterhub:
   cull:
-    users: false
-    removeNamedServers: false
-    timeout: 432000
-    every: 300
-    maxAge: 2160000
+    timeout: 432000  # 5 days
+    every: 300  # 5 minutes
+    maxAge: 2160000  # 25 days
   hub:
     db:
       upgrade: true

--- a/applications/nublado/values-usdfdev.yaml
+++ b/applications/nublado/values-usdfdev.yaml
@@ -134,6 +134,6 @@ jupyterhub:
       url: "postgresql://nublado3@postgres.postgres/nublado3"
       upgrade: true
   cull:
-    timeout: 432000
-    every: 300
-    maxAge: 2160000
+    timeout: 432000  # 5 days
+    every: 300  # 5 minutes
+    maxAge: 2160000  # 25 days

--- a/applications/nublado/values-usdfint.yaml
+++ b/applications/nublado/values-usdfint.yaml
@@ -134,9 +134,9 @@ jupyterhub:
       url: "postgresql://nublado3@postgres.postgres/nublado3"
       upgrade: true
   cull:
-    timeout: 432000
-    every: 300
-    maxAge: 2160000
+    timeout: 432000  # 5 days
+    every: 300  # 5 minutes
+    maxAge: 2160000  # 25 days
 
 hub:
   internalDatabase: true

--- a/applications/nublado/values-usdfprod.yaml
+++ b/applications/nublado/values-usdfprod.yaml
@@ -133,6 +133,6 @@ jupyterhub:
       url: "postgresql://nublado3@postgres.postgres/nublado3"
       upgrade: true
   cull:
-    timeout: 432000
-    every: 300
-    maxAge: 2160000
+    timeout: 432000  # 5 days
+    every: 300  # 5 minutes
+    maxAge: 2160000  # 25 days

--- a/applications/nublado/values.yaml
+++ b/applications/nublado/values.yaml
@@ -8,7 +8,7 @@ controller:
   # service account that has an IAM binding to the `nublado-controller`
   # Kubernetes service account and has the Artifact Registry reader role
   # @default -- None, must be set when using Google Artifact Registry
-  googleServiceAccount: ""
+  googleServiceAccount: null
 
   image:
     # -- Nublado controller image to use
@@ -19,7 +19,7 @@ controller:
 
     # -- Tag of Nublado controller image to use
     # @default -- The appVersion of the chart
-    tag: ""
+    tag: null
 
   ingress:
     # -- Additional annotations to add for the Nublado controller ingress
@@ -75,6 +75,7 @@ controller:
       deleteTimeout: 60
 
       # -- Timeout for idle user fileservers, in seconds
+      # @default -- 3600 (1 hour)
       idleTimeout: 3600
 
       image:
@@ -167,12 +168,12 @@ controller:
       env:
         API_ROUTE: "/api"
         AUTO_REPO_SPECS: "https://github.com/lsst-sqre/system-test@prod"
-        CULL_KERNEL_IDLE_TIMEOUT: "432000"  # These might be set from group?
+        CULL_KERNEL_IDLE_TIMEOUT: "432000"  # 5 days
         CULL_KERNEL_CONNECTED: "True"
-        CULL_KERNEL_INTERVAL: "300"
+        CULL_KERNEL_INTERVAL: "300"  # 5 minutes
         FIREFLY_ROUTE: "/portal/app"
         HUB_ROUTE: "/nb/hub"
-        NO_ACTIVITY_TIMEOUT: "432000"  # Also from group?
+        NO_ACTIVITY_TIMEOUT: "432000"  # 5 days
         RSP_SITE_TYPE: "science"
         TAP_ROUTE: "/api/tap"
 
@@ -362,8 +363,8 @@ proxy:
     # 5m, enable authentication caching
     annotations:
       nginx.ingress.kubernetes.io/auth-cache-key: "$http_cookie$http_authorization"
-      nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
-      nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
+      nginx.ingress.kubernetes.io/proxy-read-timeout: "300"  # 5 minutes
+      nginx.ingress.kubernetes.io/proxy-send-timeout: "300"  # 5 minutes
 
 # Configuration for Nublado secrets management.
 secrets:
@@ -477,9 +478,9 @@ jupyterhub:
         # each user's lab environment in its own namespace
         interNamespaceAccessLabels: "accept"
 
-        # This currently causes Minikube deployment in GH-actions to fail.
+        # This currently causes Minikube deployment in GitHub Actions to fail.
         # We want it sometime but it's not critical; it will help with
-        # scale-down
+        # scale-down.
         # pdb:
         #   enabled: true
         #   minAvailable: 1
@@ -567,7 +568,7 @@ cloudsql:
   # `cloud-sql-proxy` Kubernetes service account and has the `cloudsql.client`
   # role
   # @default -- None, must be set if Cloud SQL Auth Proxy is enabled
-  serviceAccount: ""
+  serviceAccount: null
 
   # -- Tolerations for the Cloud SQL Auth Proxy pod
   tolerations: []
@@ -577,12 +578,12 @@ cloudsql:
 global:
   # -- Base URL for the environment
   # @default -- Set by Argo CD
-  baseUrl: ""
+  baseUrl: null
 
   # -- Host name for ingress
   # @default -- Set by Argo CD
-  host: ""
+  host: null
 
   # -- Base path for Vault secrets
   # @default -- Set by Argo CD
-  vaultSecretsPath: ""
+  vaultSecretsPath: null


### PR DESCRIPTION
Several times in the Nublado configuration related to culling were given in number of seconds with no human-readable equivalent. Add comments with the human-readable time.

Remove some cull override settings that should be safe to keep at the defaults (we don't use named servers, and it should be fine to remove the user on cull), and remove some obsolete settings that should no longer be needed. Change defaults for unset settings to null instead of the empty string.