### PR TITLE
DM-44537: Enable minimum token lifetime for Nublado

### DIFF
--- a/applications/nublado/README.md
+++ b/applications/nublado/README.md
@@ -81,12 +81,13 @@ JupyterHub and custom spawner for the Rubin Science Platform
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | hub.internalDatabase | bool | `true` | Whether to use the cluster-internal PostgreSQL server instead of an external server. This is not used directly by the Nublado chart, but controls how the database password is managed. |
+| hub.minimumTokenLifetime | string | `jupyterhub.cull.maxAge` if lab culling is enabled, else none | Minimum remaining token lifetime when spawning a lab. The token cannot be renewed, so it should ideally live as long as the lab does. If the token has less remaining lifetime, the user will be redirected to reauthenticate before spawning a lab. |
 | hub.timeout.startup | int | `90` | Timeout for JupyterLab to start. Currently this sometimes takes over 60 seconds for reasons we don't understand. |
 | jupyterhub.cull.enabled | bool | `true` | Enable the lab culler. |
-| jupyterhub.cull.every | int | 600 (10 minutes) | How frequently to check for idle labs in seconds |
-| jupyterhub.cull.maxAge | int | 5184000 (60 days) | Maximum age of a lab regardless of activity |
+| jupyterhub.cull.every | int | 300 (5 minutes) | How frequently to check for idle labs in seconds |
+| jupyterhub.cull.maxAge | int | 2160000 (25 days) | Maximum age of a lab regardless of activity |
 | jupyterhub.cull.removeNamedServers | bool | `true` | Whether to remove named servers when culling their lab |
-| jupyterhub.cull.timeout | int | 2592000 (30 days) | Default idle timeout before the lab is automatically deleted in seconds |
+| jupyterhub.cull.timeout | int | 432000 (5 days) | Default idle timeout before the lab is automatically deleted in seconds |
 | jupyterhub.cull.users | bool | `true` | Whether to log out the server when culling their lab |
 | jupyterhub.hub.authenticatePrometheus | bool | `false` | Whether to require metrics requests to be authenticated |
 | jupyterhub.hub.baseUrl | string | `"/nb"` | Base URL on which JupyterHub listens |

--- a/applications/nublado/templates/proxy-spawn-ingress.yaml
+++ b/applications/nublado/templates/proxy-spawn-ingress.yaml
@@ -1,0 +1,40 @@
+{{- if (or .Values.hub.minimumTokenLifetime .Values.jupyterhub.cull) }}
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
+metadata:
+  name: "proxy-spawn"
+  labels:
+    {{- include "nublado.labels" . | nindent 4 }}
+config:
+  baseUrl: {{ .Values.global.baseUrl | quote }}
+  scopes:
+    all:
+      - "exec:notebook"
+  loginRedirect: true
+  delegate:
+    {{- if .Values.hub.minimumTokenLifetime }}
+    minimumLifetime: {{ .Values.hub.minimumTokenLifetime }}
+    {{- else }}
+    minimumLifetime: {{ .Values.jupyterhub.cull.maxAge }}
+    {{- end }}
+    notebook: {}
+template:
+  metadata:
+    name: "proxy-spawn"
+    {{- with .Values.proxy.ingress.annotations }}
+    annotations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  spec:
+    rules:
+      - host: {{ .Values.global.host | quote }}
+        http:
+          paths:
+            - path: "{{ .Values.jupyterhub.hub.baseUrl }}/hub/spawn"
+              pathType: "Prefix"
+              backend:
+                service:
+                  name: "proxy-public"
+                  port:
+                    name: "http"
+{{- end }}

--- a/applications/nublado/values-base.yaml
+++ b/applications/nublado/values-base.yaml
@@ -88,12 +88,6 @@ controller:
           volumeName: "auxtel"
 
 jupyterhub:
-  cull:
-    users: false
-    removeNamedServers: false
-    timeout: 432000  # 5 days
-    every: 300  # 5 minutes
-    maxAge: 2160000  # 25 days
   hub:
     db:
       upgrade: true

--- a/applications/nublado/values-ccin2p3.yaml
+++ b/applications/nublado/values-ccin2p3.yaml
@@ -68,7 +68,3 @@ jupyterhub:
     db:
       url: "postgresql://nublado3@postgres.postgres/nublado3"
       upgrade: true
-  cull:
-    timeout: 432000  # 5 days
-    every: 300  # 5 minutes
-    maxAge: 2160000  # 25 days

--- a/applications/nublado/values-idfint.yaml
+++ b/applications/nublado/values-idfint.yaml
@@ -90,19 +90,9 @@ controller:
 
 jupyterhub:
   hub:
-    config:
-      ServerApp:
-        shutdown_no_activity_timeout: 432000
     db:
       url: "postgresql://nublado@cloud-sql-proxy.nublado/nublado"
       upgrade: true
-  cull:
-    enabled: true
-    users: false
-    removeNamedServers: false
-    timeout: 432000
-    every: 300
-    maxAge: 2160000
 
 hub:
   internalDatabase: false

--- a/applications/nublado/values-idfprod.yaml
+++ b/applications/nublado/values-idfprod.yaml
@@ -79,12 +79,10 @@ jupyterhub:
     db:
       url: "postgresql://nublado@cloud-sql-proxy.nublado/nublado"
       upgrade: true
-  cull:
-    timeout: 432000  # 5 days
-    every: 300  # 5 minutes
-    maxAge: 2160000  # 25 days
+
 hub:
   internalDatabase: false
+
 cloudsql:
   enabled: true
   instanceConnectionName: "science-platform-stable-6994:us-central1:science-platform-stable-0c29612b"

--- a/applications/nublado/values-roe.yaml
+++ b/applications/nublado/values-roe.yaml
@@ -56,7 +56,3 @@ jupyterhub:
   hub:
     db:
       upgrade: true
-  cull:
-    timeout: 432000  # 5 days
-    every: 300  # 5 minutes
-    maxAge: 2160000  # 25 days

--- a/applications/nublado/values-summit.yaml
+++ b/applications/nublado/values-summit.yaml
@@ -116,12 +116,6 @@ controller:
           volumeName: "lsstdata-base-auxtel"
 
 jupyterhub:
-  cull:
-    users: false
-    removeNamedServers: false
-    timeout: 432000  # 5 days
-    every: 300  # 5 minutes
-    maxAge: 2160000  # 25 days
   hub:
     db:
       upgrade: true

--- a/applications/nublado/values-tucson-teststand.yaml
+++ b/applications/nublado/values-tucson-teststand.yaml
@@ -111,10 +111,6 @@ hub:
   internalDatabase: false
 
 jupyterhub:
-  cull:
-    timeout: 432000  # 5 days
-    every: 300  # 5 minutes
-    maxAge: 2160000  # 25 days
   hub:
     db:
       upgrade: true

--- a/applications/nublado/values-usdfdev.yaml
+++ b/applications/nublado/values-usdfdev.yaml
@@ -136,5 +136,4 @@ jupyterhub:
       upgrade: true
   cull:
     timeout: 432000  # 5 days
-    every: 300  # 5 minutes
     maxAge: 691200  # 8 days

--- a/applications/nublado/values-usdfint.yaml
+++ b/applications/nublado/values-usdfint.yaml
@@ -136,10 +136,10 @@ jupyterhub:
       upgrade: true
   cull:
     timeout: 432000  # 5 days
-    every: 300  # 5 minutes
     maxAge: 691200  # 8 days
 
 hub:
   internalDatabase: true
+
 secrets:
   templateSecrets: true

--- a/applications/nublado/values-usdfprod.yaml
+++ b/applications/nublado/values-usdfprod.yaml
@@ -135,5 +135,4 @@ jupyterhub:
       upgrade: true
   cull:
     timeout: 432000  # 5 days
-    every: 300  # 5 minutes
     maxAge: 691200  # 8 days

--- a/applications/nublado/values.yaml
+++ b/applications/nublado/values.yaml
@@ -348,6 +348,13 @@ hub:
   # controls how the database password is managed.
   internalDatabase: true
 
+  # -- Minimum remaining token lifetime when spawning a lab. The token cannot
+  # be renewed, so it should ideally live as long as the lab does. If the
+  # token has less remaining lifetime, the user will be redirected to
+  # reauthenticate before spawning a lab.
+  # @default -- `jupyterhub.cull.maxAge` if lab culling is enabled, else none
+  minimumTokenLifetime: null
+
   timeout:
     # -- Timeout for JupyterLab to start. Currently this sometimes takes over
     # 60 seconds for reasons we don't understand.
@@ -497,12 +504,12 @@ jupyterhub:
 
     # -- Default idle timeout before the lab is automatically deleted in
     # seconds
-    # @default -- 2592000 (30 days)
-    timeout: 2592000
+    # @default -- 432000 (5 days)
+    timeout: 432000
 
     # -- How frequently to check for idle labs in seconds
-    # @default -- 600 (10 minutes)
-    every: 600
+    # @default -- 300 (5 minutes)
+    every: 300
 
     # -- Whether to log out the server when culling their lab
     users: true
@@ -511,8 +518,8 @@ jupyterhub:
     removeNamedServers: true
 
     # -- Maximum age of a lab regardless of activity
-    # @default -- 5184000 (60 days)
-    maxAge: 5184000
+    # @default -- 2160000 (25 days)
+    maxAge: 2160000
 
   scheduling:
     userScheduler:


### PR DESCRIPTION
Use the Gafaelfawr functionality we added some time back and require a minimum token lifetime when spawning a lab. This lifetime can be explicitly configured or taken from the maxAge lab culler setting.

Change the culler defaults to match the settings we're using for most environments so that the default maxAge is not longer than the default Gafaelfawr token lifetime.