### PR TITLE
DM-44429: Support multiple instruments with separate hinfo deployments.

### DIFF
--- a/applications/consdb/README.md
+++ b/applications/consdb/README.md
@@ -23,10 +23,15 @@ Consolidated Database of Image Metadata
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
-| hinfo.image.repository | string | `"ghcr.io/lsst-dm/consdb-hinfo"` | Image to use in the consdb deployment |
-| hinfo.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
-| image.pullPolicy | string | `"Always"` | Pull policy for the consdb image |
-| image.replicaCount | int | `1` | Number of consdb deployment pods to start |
+| hinfo.image.pullPolicy | string | `"Always"` | Pull policy for the consdb-hinfo image |
+| hinfo.image.repository | string | `"ghcr.io/lsst-dm/consdb-hinfo"` | Image to use in the consdb-hinfo deployment |
+| hinfo.latiss.enable | bool | `false` | Enable deployment of consdb-hinfo for LATISS. |
+| hinfo.latiss.tag | string | `""` | Tag for LATISS deployment. |
+| hinfo.lsstcam.enable | bool | `false` | Enable deployment of consdb-hinfo for LSSTCam. |
+| hinfo.lsstcam.tag | string | `""` | Tag for LSSTCam deployment. |
+| hinfo.lsstcomcam.enable | bool | `false` | Enable deployment of consdb-hinfo for LSSTComCam. |
+| hinfo.lsstcomcam.tag | string | `""` | Tag for LSSTComCam deployment. |
+| hinfo.replicaCount | int | `1` | Number of consdb-hinfo deployment pods to start per instrument |
 | ingress.annotations | object | `{}` | Additional annotations for the ingress rule |
 | kafka.bootstrap | string | `"sasquatch-kafka-bootstrap.sasquatch:9092"` | Kafka bootstrap server |
 | kafka.group_id | string | `"consdb-consumer"` | Name of Kafka consumer group |
@@ -37,7 +42,9 @@ Consolidated Database of Image Metadata
 | lfa.s3EndpointUrl | string | `""` | url |
 | nodeSelector | object | `{}` | Node selection rules for the consdb deployment pod |
 | podAnnotations | object | `{}` | Annotations for the consdb deployment pod |
-| pq.image.repository | string | `"ghcr.io/lsst-dm/consdb-pq"` | Image to use in the consdb deployment |
+| pq.image.pullPolicy | string | `"Always"` | Pull policy for the consdb-hinfo image |
+| pq.image.repository | string | `"ghcr.io/lsst-dm/consdb-pq"` | Image to use in the consdb-pq deployment |
 | pq.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
+| pq.replicaCount | int | `1` | Number of consdb-hinfo deployment pods to start |
 | resources | object | `{}` | Resource limits and requests for the consdb deployment pod |
 | tolerations | list | `[]` | Tolerations for the consdb deployment pod |

--- a/applications/consdb/README.md
+++ b/applications/consdb/README.md
@@ -26,10 +26,13 @@ Consolidated Database of Image Metadata
 | hinfo.image.pullPolicy | string | `"Always"` | Pull policy for the consdb-hinfo image |
 | hinfo.image.repository | string | `"ghcr.io/lsst-dm/consdb-hinfo"` | Image to use in the consdb-hinfo deployment |
 | hinfo.latiss.enable | bool | `false` | Enable deployment of consdb-hinfo for LATISS. |
+| hinfo.latiss.logConfig | string | `"INFO"` | Log configuration for LATISS deployment. |
 | hinfo.latiss.tag | string | `""` | Tag for LATISS deployment. |
 | hinfo.lsstcam.enable | bool | `false` | Enable deployment of consdb-hinfo for LSSTCam. |
+| hinfo.lsstcam.logConfig | string | `"INFO"` | Log configuration for LSSTCam deployment. |
 | hinfo.lsstcam.tag | string | `""` | Tag for LSSTCam deployment. |
 | hinfo.lsstcomcam.enable | bool | `false` | Enable deployment of consdb-hinfo for LSSTComCam. |
+| hinfo.lsstcomcam.logConfig | string | `"INFO"` | Log configuration for LSSTComCam deployment. |
 | hinfo.lsstcomcam.tag | string | `""` | Tag for LSSTComCam deployment. |
 | hinfo.replicaCount | int | `1` | Number of consdb-hinfo deployment pods to start per instrument |
 | ingress.annotations | object | `{}` | Additional annotations for the ingress rule |

--- a/applications/consdb/templates/hinfo-deployment.yaml
+++ b/applications/consdb/templates/hinfo-deployment.yaml
@@ -1,12 +1,14 @@
+{{- if .Values.hinfo.latiss.enable }}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: "consdb-hinfo"
+  name: "consdb-hinfo-latiss"
   labels:
     {{- include "consdb.labels" . | nindent 4 }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.hinfo.replicaCount }}
   {{- end }}
   selector:
     matchLabels:
@@ -23,18 +25,20 @@ spec:
     spec:
       automountServiceAccountToken: false
       containers:
-        - name: "consdb-hinfo"
+        - name: "consdb-hinfo-latiss"
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - "all"
             readOnlyRootFilesystem: true
-          image: "{{ .Values.hinfo.image.repository }}:{{ .Values.hinfo.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{ .Values.hinfo.image.repository }}:{{ .Values.hinfo.latiss.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.hinfo.image.pullPolicy }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:
+            - name: "INSTRUMENT"
+              value: "LATISS"
             - name: "DB_HOST"
               value: "{{ .Values.db.host }}"
             - name: "DB_PASS"
@@ -89,3 +93,196 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}
+{{- if .Values.hinfo.lsstcomcam.enable }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "consdb-hinfo-lsstcomcam"
+  labels:
+    {{- include "consdb.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.hinfo.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "consdb.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        component: hinfo
+        {{- include "consdb.selectorLabels" . | nindent 8 }}
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - name: "consdb-hinfo-lsstcomcam"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+            readOnlyRootFilesystem: true
+          image: "{{ .Values.hinfo.image.repository }}:{{ .Values.hinfo.lsstcomcam.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.hinfo.image.pullPolicy }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          env:
+            - name: "INSTRUMENT"
+              value: "LSSTComCam"
+            - name: "DB_HOST"
+              value: "{{ .Values.db.host }}"
+            - name: "DB_PASS"
+              valueFrom:
+                secretKeyRef:
+                  name: consdb
+                  key: "oods-password"
+            - name: "DB_USER"
+              value: "{{ .Values.db.user }}"
+            - name: "DB_NAME"
+              value: "{{ .Values.db.database }}"
+            - name: "AWS_ACCESS_KEY_ID"
+              valueFrom:
+                secretKeyRef:
+                  name: consdb
+                  key: "lfa-key"
+            - name: "AWS_SECRET_ACCESS_KEY"
+              valueFrom:
+                secretKeyRef:
+                  name: consdb
+                  key: "lfa-password"
+            - name: "BUCKET_PREFIX"
+              value: "{{ .Values.lfa.bucket_prefix }}"
+            - name: "S3_ENDPOINT_URL"
+              value: "{{ .Values.lfa.s3EndpointUrl }}"
+            - name: "KAFKA_BOOTSTRAP"
+              value: "{{ .Values.kafka.bootstrap }}"
+            - name: "KAFKA_USERNAME"
+              value: "{{ .Values.kafka.username }}"
+            - name: "KAFKA_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  name: sasquatch
+                  key: "consdb-password"
+            - name: "KAFKA_GROUP_ID"
+              value: "{{ .Values.kafka.group_id }}"
+            - name: "SCHEMA_URL"
+              value: "{{ .Values.kafka.schema_url }}"
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}
+{{- if .Values.hinfo.lsstcam.enable }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "consdb-hinfo-lsstcam"
+  labels:
+    {{- include "consdb.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.hinfo.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "consdb.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        component: hinfo
+        {{- include "consdb.selectorLabels" . | nindent 8 }}
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - name: "consdb-hinfo-lsstcam"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+            readOnlyRootFilesystem: true
+          image: "{{ .Values.hinfo.image.repository }}:{{ .Values.hinfo.lsstcam.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.hinfo.image.pullPolicy }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          env:
+            - name: "INSTRUMENT"
+              value: "LSSTCam"
+            - name: "DB_HOST"
+              value: "{{ .Values.db.host }}"
+            - name: "DB_PASS"
+              valueFrom:
+                secretKeyRef:
+                  name: consdb
+                  key: "oods-password"
+            - name: "DB_USER"
+              value: "{{ .Values.db.user }}"
+            - name: "DB_NAME"
+              value: "{{ .Values.db.database }}"
+            - name: "AWS_ACCESS_KEY_ID"
+              valueFrom:
+                secretKeyRef:
+                  name: consdb
+                  key: "lfa-key"
+            - name: "AWS_SECRET_ACCESS_KEY"
+              valueFrom:
+                secretKeyRef:
+                  name: consdb
+                  key: "lfa-password"
+            - name: "BUCKET_PREFIX"
+              value: "{{ .Values.lfa.bucket_prefix }}"
+            - name: "S3_ENDPOINT_URL"
+              value: "{{ .Values.lfa.s3EndpointUrl }}"
+            - name: "KAFKA_BOOTSTRAP"
+              value: "{{ .Values.kafka.bootstrap }}"
+            - name: "KAFKA_USERNAME"
+              value: "{{ .Values.kafka.username }}"
+            - name: "KAFKA_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  name: sasquatch
+                  key: "consdb-password"
+            - name: "KAFKA_GROUP_ID"
+              value: "{{ .Values.kafka.group_id }}"
+            - name: "SCHEMA_URL"
+              value: "{{ .Values.kafka.schema_url }}"
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/applications/consdb/templates/hinfo-deployment.yaml
+++ b/applications/consdb/templates/hinfo-deployment.yaml
@@ -39,6 +39,8 @@ spec:
           env:
             - name: "INSTRUMENT"
               value: "LATISS"
+            - name: "LOG_CONFIG"
+              value: "{{ .Values.hinfo.latiss.logConfig }}"
             - name: "DB_HOST"
               value: "{{ .Values.db.host }}"
             - name: "DB_PASS"
@@ -135,6 +137,8 @@ spec:
           env:
             - name: "INSTRUMENT"
               value: "LSSTComCam"
+            - name: "LOG_CONFIG"
+              value: "{{ .Values.hinfo.lsstcomcam.logConfig }}"
             - name: "DB_HOST"
               value: "{{ .Values.db.host }}"
             - name: "DB_PASS"
@@ -231,6 +235,8 @@ spec:
           env:
             - name: "INSTRUMENT"
               value: "LSSTCam"
+            - name: "LOG_CONFIG"
+              value: "{{ .Values.hinfo.lsstcam.logConfig }}"
             - name: "DB_HOST"
               value: "{{ .Values.db.host }}"
             - name: "DB_PASS"

--- a/applications/consdb/templates/pq-deployment.yaml
+++ b/applications/consdb/templates/pq-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "consdb.labels" . | nindent 4 }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.pq.replicaCount }}
   {{- end }}
   selector:
     matchLabels:
@@ -31,7 +31,7 @@ spec:
                 - "all"
             readOnlyRootFilesystem: true
           image: "{{ .Values.pq.image.repository }}:{{ .Values.pq.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          imagePullPolicy: {{ .Values.pq.image.pullPolicy }}
           ports:
             - name: http
               containerPort: 8080

--- a/applications/consdb/values-base.yaml
+++ b/applications/consdb/values-base.yaml
@@ -18,4 +18,4 @@ hinfo:
     tag: "tickets-DM-44551"
 pq:
   image:
-    tag: "tickets-DM-44551"
+    tag: "main"

--- a/applications/consdb/values-base.yaml
+++ b/applications/consdb/values-base.yaml
@@ -8,9 +8,11 @@ hinfo:
   latiss:
     enable: true
     tag: "tickets-DM-44551"
+    logConfig: "consdb.hinfo=DEBUG"
   lsstcomcam:
     enable: true
     tag: "tickets-DM-44551"
+    logConfig: "consdb.hinfo=DEBUG"
   lsstcam:
     enable: false
     tag: "tickets-DM-44551"

--- a/applications/consdb/values-base.yaml
+++ b/applications/consdb/values-base.yaml
@@ -5,8 +5,15 @@ db:
 lfa:
   s3EndpointUrl: "https://s3.ls.lsst.org"
 hinfo:
-  image:
-    tag: "2.0.4"
+  latiss:
+    enable: true
+    tag: "tickets-DM-44551"
+  lsstcomcam:
+    enable: true
+    tag: "tickets-DM-44551"
+  lsstcam:
+    enable: false
+    tag: "tickets-DM-44551"
 pq:
   image:
-    tag: "2.0.3"
+    tag: "tickets-DM-44551"

--- a/applications/consdb/values-summit.yaml
+++ b/applications/consdb/values-summit.yaml
@@ -18,4 +18,4 @@ hinfo:
     tag: "tickets-DM-44551"
 pq:
   image:
-    tag: "tickets-DM-44387"
+    tag: "main"

--- a/applications/consdb/values-summit.yaml
+++ b/applications/consdb/values-summit.yaml
@@ -8,9 +8,11 @@ hinfo:
   latiss:
     enable: true
     tag: "tickets-DM-44551"
+    logConfig: "consdb.hinfo=DEBUG"
   lsstcomcam:
     enable: true
     tag: "tickets-DM-44551"
+    logConfig: "consdb.hinfo=DEBUG"
   lsstcam:
     enable: false
     tag: "tickets-DM-44551"

--- a/applications/consdb/values-summit.yaml
+++ b/applications/consdb/values-summit.yaml
@@ -4,3 +4,16 @@ db:
   database: "butler"
 lfa:
   s3EndpointUrl: "https://s3.cp.lsst.org"
+hinfo:
+  latiss:
+    enable: true
+    tag: "tickets-DM-44551"
+  lsstcomcam:
+    enable: true
+    tag: "tickets-DM-44551"
+  lsstcam:
+    enable: false
+    tag: "tickets-DM-44551"
+pq:
+  image:
+    tag: "tickets-DM-44387"

--- a/applications/consdb/values-usdfdev.yaml
+++ b/applications/consdb/values-usdfdev.yaml
@@ -14,4 +14,4 @@ hinfo:
     tag: "tickets-DM-44551"
 pq:
   image:
-    tag: "tickets-DM-44387"
+    tag: "main"

--- a/applications/consdb/values-usdfdev.yaml
+++ b/applications/consdb/values-usdfdev.yaml
@@ -1,0 +1,17 @@
+db:
+  user: "rubin"
+  host: "usdf-butler.slac.stanford.edu"
+  database: "lsstdb1"
+hinfo:
+  latiss:
+    enable: false
+    tag: "tickets-DM-44551"
+  lsstcomcam:
+    enable: false
+    tag: "tickets-DM-44551"
+  lsstcam:
+    enable: false
+    tag: "tickets-DM-44551"
+pq:
+  image:
+    tag: "tickets-DM-44387"

--- a/applications/consdb/values-usdfprod.yaml
+++ b/applications/consdb/values-usdfprod.yaml
@@ -14,4 +14,4 @@ hinfo:
     tag: "tickets-DM-44551"
 pq:
   image:
-    tag: "tickets-DM-44387"
+    tag: "main"

--- a/applications/consdb/values-usdfprod.yaml
+++ b/applications/consdb/values-usdfprod.yaml
@@ -1,10 +1,17 @@
-environment:
-  vaultUrl: "https://vault.slac.stanford.edu"
-
 db:
   user: "rubin"
   host: "usdf-butler.slac.stanford.edu"
   database: "lsstdb1"
-lfa:
-  bucket_prefix: "rubin:"
-  s3EndpointUrl: "https://s3dfrgw.slac.stanford.edu"
+hinfo:
+  latiss:
+    enable: false
+    tag: "tickets-DM-44551"
+  lsstcomcam:
+    enable: false
+    tag: "tickets-DM-44551"
+  lsstcam:
+    enable: false
+    tag: "tickets-DM-44551"
+pq:
+  image:
+    tag: "tickets-DM-44387"

--- a/applications/consdb/values.yaml
+++ b/applications/consdb/values.yaml
@@ -2,22 +2,37 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-image:
-  # -- Number of consdb deployment pods to start
-  replicaCount: 1
-  # -- Pull policy for the consdb image
-  pullPolicy: "Always"
-
 hinfo:
+  # -- Number of consdb-hinfo deployment pods to start per instrument
+  replicaCount: 1
   image:
-    # -- Image to use in the consdb deployment
+    # -- Pull policy for the consdb-hinfo image
+    pullPolicy: "Always"
+    # -- Image to use in the consdb-hinfo deployment
     repository: "ghcr.io/lsst-dm/consdb-hinfo"
-    # -- Overrides the image tag whose default is the chart appVersion.
+  latiss:
+    # -- Enable deployment of consdb-hinfo for LATISS.
+    enable: false
+    # -- Tag for LATISS deployment.
+    tag: ""
+  lsstcomcam:
+    # -- Enable deployment of consdb-hinfo for LSSTComCam.
+    enable: false
+    # -- Tag for LSSTComCam deployment.
+    tag: ""
+  lsstcam:
+    # -- Enable deployment of consdb-hinfo for LSSTCam.
+    enable: false
+    # -- Tag for LSSTCam deployment.
     tag: ""
 
 pq:
+  # -- Number of consdb-hinfo deployment pods to start
+  replicaCount: 1
   image:
-    # -- Image to use in the consdb deployment
+    # -- Pull policy for the consdb-hinfo image
+    pullPolicy: "Always"
+    # -- Image to use in the consdb-pq deployment
     repository: "ghcr.io/lsst-dm/consdb-pq"
     # -- Overrides the image tag whose default is the chart appVersion.
     tag: ""

--- a/applications/consdb/values.yaml
+++ b/applications/consdb/values.yaml
@@ -15,16 +15,22 @@ hinfo:
     enable: false
     # -- Tag for LATISS deployment.
     tag: ""
+    # -- Log configuration for LATISS deployment.
+    logConfig: "INFO"
   lsstcomcam:
     # -- Enable deployment of consdb-hinfo for LSSTComCam.
     enable: false
     # -- Tag for LSSTComCam deployment.
     tag: ""
+    # -- Log configuration for LSSTComCam deployment.
+    logConfig: "INFO"
   lsstcam:
     # -- Enable deployment of consdb-hinfo for LSSTCam.
     enable: false
     # -- Tag for LSSTCam deployment.
     tag: ""
+    # -- Log configuration for LSSTCam deployment.
+    logConfig: "INFO"
 
 pq:
   # -- Number of consdb-hinfo deployment pods to start

--- a/docs/applications/consdb/index.rst
+++ b/docs/applications/consdb/index.rst
@@ -4,11 +4,12 @@
 consdb — Populate the consolidated database
 ###########################################
 
-There are two parts to the consolidated database:
-  - use the header information from the header service to populate the
-    ``visit`` table
-  - in USDF sumarise other EFD data into the ``summary`` table per visit
-
+There are two parts to the consolidated database application here:
+  - The ``hinfo`` service populates the ``exposure`` and ``visit`` tables,
+    as well as related tables like ``ccdexposure``.
+  - The ``pqserver`` service responds to publish and query requests from
+    clients, allowing insertion into fixed and flexible metadata tables
+    and querying of all tables and views.
 
 .. jinja:: consdb
    :file: applications/_summary.rst.jinja


### PR DESCRIPTION
One deployment per HeaderService topic; each deployment can support multiple instruments seen on that topic (e.g. LSSTComCamSim and LSSTComCam).  Each deployment can be enabled or disabled separately, and each can use a different tag of the consdb-hinfo container.