### PR TITLE
DM-44343: Add mpc-lookup application

### DIFF
--- a/applications/mpc-lookup/.helmignore
+++ b/applications/mpc-lookup/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/applications/mpc-lookup/Chart.yaml
+++ b/applications/mpc-lookup/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+appVersion: 0.1.0
+description: Lookup MPC object by designation
+name: mpc-lookup
+sources:
+- https://github.com/lsst-dm/mpc-lookup
+type: application
+version: 1.0.0

--- a/applications/mpc-lookup/README.md
+++ b/applications/mpc-lookup/README.md
@@ -1,0 +1,28 @@
+# mpc-lookup
+
+Lookup MPC object by designation
+
+## Source Code
+
+* <https://github.com/lsst-dm/mpc-lookup>
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Affinity rules for the mpc-lookup deployment pod |
+| config.logLevel | string | `"INFO"` | Logging level |
+| config.logProfile | string | `"production"` | Logging profile (`production` for JSON, `development` for human-friendly) |
+| config.pathPrefix | string | `"/api/mpc-lookup"` | URL path prefix |
+| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
+| global.host | string | Set by Argo CD | Host name for ingress |
+| global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
+| image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the mpc-lookup image |
+| image.repository | string | `"ghcr.io/lsst-sqre/mpc-lookup"` | Image to use in the mpc-lookup deployment |
+| image.tag | string | The appVersion of the chart | Tag of image to use |
+| ingress.annotations | object | `{}` | Additional annotations for the ingress rule |
+| nodeSelector | object | `{}` | Node selection rules for the mpc-lookup deployment pod |
+| podAnnotations | object | `{}` | Annotations for the mpc-lookup deployment pod |
+| replicaCount | int | `1` | Number of web deployment pods to start |
+| resources | object | See `values.yaml` | Resource limits and requests for the mpc-lookup deployment pod |
+| tolerations | list | `[]` | Tolerations for the mpc-lookup deployment pod |

--- a/applications/mpc-lookup/templates/_helpers.tpl
+++ b/applications/mpc-lookup/templates/_helpers.tpl
@@ -1,0 +1,26 @@
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "mpc-lookup.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "mpc-lookup.labels" -}}
+helm.sh/chart: {{ include "mpc-lookup.chart" . }}
+{{ include "mpc-lookup.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "mpc-lookup.selectorLabels" -}}
+app.kubernetes.io/name: "mpc-lookup"
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/applications/mpc-lookup/templates/configmap.yaml
+++ b/applications/mpc-lookup/templates/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "mpc-lookup"
+  labels:
+    {{- include "mpc-lookup.labels" . | nindent 4 }}
+data:
+  MPC_LOOKUP_LOG_LEVEL: {{ .Values.config.logLevel | quote }}
+  MPC_LOOKUP_PATH_PREFIX: {{ .Values.config.pathPrefix | quote }}
+  MPC_LOOKUP_PROFILE: {{ .Values.config.logProfile | quote }}

--- a/applications/mpc-lookup/templates/deployment.yaml
+++ b/applications/mpc-lookup/templates/deployment.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "mpc-lookup"
+  labels:
+    {{- include "mpc-lookup.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "mpc-lookup.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "mpc-lookup.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      automountServiceAccountToken: false
+      containers:
+        - name: {{ .Chart.Name }}
+          envFrom:
+            - configMapRef:
+                name: "mpc-lookup"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: "http"
+              containerPort: 8080
+              protocol: "TCP"
+          readinessProbe:
+            httpGet:
+              path: "/"
+              port: "http"
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+            readOnlyRootFilesystem: true
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000

--- a/applications/mpc-lookup/templates/ingress.yaml
+++ b/applications/mpc-lookup/templates/ingress.yaml
@@ -1,0 +1,30 @@
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
+metadata:
+  name: "mpc-lookup"
+  labels:
+    {{- include "mpc-lookup.labels" . | nindent 4 }}
+config:
+  baseUrl: {{ .Values.global.baseUrl | quote }}
+  scopes:
+    all:
+      - "read:image"
+template:
+  metadata:
+    name: "mpc-lookup"
+    {{- with .Values.ingress.annotations }}
+    annotations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  spec:
+    rules:
+      - host: {{ required "global.host must be set" .Values.global.host | quote }}
+        http:
+          paths:
+            - path: {{ .Values.config.pathPrefix | quote }}
+              pathType: "Prefix"
+              backend:
+                service:
+                  name: "mpc-lookup"
+                  port:
+                    number: 8080

--- a/applications/mpc-lookup/templates/networkpolicy.yaml
+++ b/applications/mpc-lookup/templates/networkpolicy.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: "mpc-lookup"
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "mpc-lookup.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - "Ingress"
+  ingress:
+    # Allow inbound access from pods (in any namespace) labeled
+    # gafaelfawr.lsst.io/ingress: true.
+    - from:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              gafaelfawr.lsst.io/ingress: "true"
+      ports:
+        - protocol: "TCP"
+          port: 8080

--- a/applications/mpc-lookup/templates/service.yaml
+++ b/applications/mpc-lookup/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "mpc-lookup"
+  labels:
+    {{- include "mpc-lookup.labels" . | nindent 4 }}
+spec:
+  type: "ClusterIP"
+  ports:
+    - port: 8080
+      targetPort: "http"
+      protocol: "TCP"
+      name: "http"
+  selector:
+    {{- include "mpc-lookup.selectorLabels" . | nindent 4 }}

--- a/applications/mpc-lookup/values.yaml
+++ b/applications/mpc-lookup/values.yaml
@@ -1,0 +1,63 @@
+# Default values for mpc-lookup.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# -- Number of web deployment pods to start
+replicaCount: 1
+
+image:
+  # -- Image to use in the mpc-lookup deployment
+  repository: "ghcr.io/lsst-sqre/mpc-lookup"
+
+  # -- Pull policy for the mpc-lookup image
+  pullPolicy: "IfNotPresent"
+
+  # -- Tag of image to use
+  # @default -- The appVersion of the chart
+  tag: null
+
+config:
+  # -- Logging level
+  logLevel: "INFO"
+
+  # -- Logging profile (`production` for JSON, `development` for
+  # human-friendly)
+  logProfile: "production"
+
+  # -- URL path prefix
+  pathPrefix: "/api/mpc-lookup"
+
+ingress:
+  # -- Additional annotations for the ingress rule
+  annotations: {}
+
+# -- Affinity rules for the mpc-lookup deployment pod
+affinity: {}
+
+# -- Node selection rules for the mpc-lookup deployment pod
+nodeSelector: {}
+
+# -- Annotations for the mpc-lookup deployment pod
+podAnnotations: {}
+
+# -- Resource limits and requests for the mpc-lookup deployment pod
+# @default -- See `values.yaml`
+resources: {}
+
+# -- Tolerations for the mpc-lookup deployment pod
+tolerations: []
+
+# The following will be set by parameters injected by Argo CD and should not
+# be set in the individual environment values files.
+global:
+  # -- Base URL for the environment
+  # @default -- Set by Argo CD
+  baseUrl: null
+
+  # -- Host name for ingress
+  # @default -- Set by Argo CD
+  host: null
+
+  # -- Base path for Vault secrets
+  # @default -- Set by Argo CD
+  vaultSecretsPath: null

--- a/docs/applications/mpc-lookup/index.rst
+++ b/docs/applications/mpc-lookup/index.rst
@@ -1,0 +1,19 @@
+.. px-app:: mpc-lookup
+
+#############################################
+mpc-lookup — Lookup MPC object by designation
+#############################################
+
+This application provides a simple service for looking up Minor Planet Center
+(MPC) objects by their designation. Given a valid designation string, the endpoint will automatically redirect to the page for the object on the MPC webpage. The service will also automatically strip out an erroneous prepended string which is present in the DP0.3 designation column.
+
+.. jinja:: mpc-lookup
+   :file: applications/_summary.rst.jinja
+
+Guides
+======
+
+.. toctree::
+   :maxdepth: 1
+
+   values

--- a/docs/applications/mpc-lookup/values.md
+++ b/docs/applications/mpc-lookup/values.md
@@ -1,0 +1,12 @@
+```{px-app-values} mpc-lookup
+```
+
+# mpc-lookup Helm values reference
+
+Helm values reference table for the {px-app}`mpc-lookup` application.
+
+```{include} ../../../applications/mpc-lookup/README.md
+---
+start-after: "## Values"
+---
+```

--- a/docs/applications/rsp.rst
+++ b/docs/applications/rsp.rst
@@ -15,6 +15,7 @@ Argo CD project: ``rsp``
    hips/index
    jira-data-proxy/index
    livetap/index
+   mpc-lookup/index
    noteburst/index
    nublado/index
    portal/index

--- a/environments/README.md
+++ b/environments/README.md
@@ -30,6 +30,7 @@
 | applications.love | bool | `false` | Enable the love control system application |
 | applications.mobu | bool | `false` | Enable the mobu application |
 | applications.monitoring | bool | `false` | Enable the monitoring application |
+| applications.mpc-lookup | bool | `false` | Enable the mpc-lookup application |
 | applications.narrativelog | bool | `false` | Enable the narrativelog application |
 | applications.next-visit-fan-out | bool | `false` | Enable the next-visit-fan-out application |
 | applications.noteburst | bool | `false` | Enable the noteburst application (required by times-square) |

--- a/environments/templates/applications/rsp/mpc-lookup.yaml
+++ b/environments/templates/applications/rsp/mpc-lookup.yaml
@@ -1,0 +1,34 @@
+{{- if (index .Values "applications" "mpc-lookup") -}}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "mpc-lookup"
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: "mpc-lookup"
+  namespace: "argocd"
+  finalizers:
+    - "resources-finalizer.argocd.argoproj.io"
+spec:
+  destination:
+    namespace: "mpc-lookup"
+    server: "https://kubernetes.default.svc"
+  project: "rsp"
+  source:
+    path: "applications/mpc-lookup"
+    repoURL: {{ .Values.repoUrl | quote }}
+    targetRevision: {{ .Values.targetRevision | quote }}
+    helm:
+      parameters:
+        - name: "global.host"
+          value: {{ .Values.fqdn | quote }}
+        - name: "global.baseUrl"
+          value: "https://{{ .Values.fqdn }}"
+        - name: "global.vaultSecretsPath"
+          value: {{ .Values.vaultPathPrefix | quote }}
+      valueFiles:
+        - "values.yaml"
+        - "values-{{ .Values.name }}.yaml"
+{{- end -}}

--- a/environments/values-idfdev.yaml
+++ b/environments/values-idfdev.yaml
@@ -19,6 +19,7 @@ applications:
   filestore-backup: true
   hips: true
   jira-data-proxy: true
+  mpc-lookup: true
   mobu: true
   noteburst: true
   nublado: true

--- a/environments/values-idfint.yaml
+++ b/environments/values-idfint.yaml
@@ -18,6 +18,7 @@ applications:
   datalinker: true
   filestore-backup: true
   hips: true
+  mpc-lookup: true
   mobu: true
   nublado: true
   plot-navigator: true

--- a/environments/values.yaml
+++ b/environments/values.yaml
@@ -117,6 +117,9 @@ applications:
   # -- Enable the monitoring application
   monitoring: false
 
+  # -- Enable the mpc-lookup application
+  mpc-lookup: false
+
   # -- Enable the narrativelog application
   narrativelog: false
 


### PR DESCRIPTION
This adds an application for looking up a Minor Planet Center (MPC) object by its designation. A redirect to the object's page on the MPC website is provided. The prepending string "2011 ", present in the fullDesignation column in the DP0.3 dataset, is automatically stripped off before performing the lookup. If the object appears to be synthetic, an HTML page is returned to indicate this.