### PR TITLE
Enable CloudSQL UWS database for TAP (Initially just for the idfdev SSOTAP service)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,6 +63,12 @@ jobs:
           # Used to query GitHub for the latest Helm release.
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install Helm Unittest Plugin
+        run: helm plugin install https://github.com/quintush/helm-unittest
+
+      - name: Run Helm Unittest
+        run: helm unittest charts/cadc-tap
+
       - uses: lsst-sqre/run-tox@v1
         with:
           python-version: "3.12"

--- a/applications/ssotap/README.md
+++ b/applications/ssotap/README.md
@@ -17,6 +17,7 @@ IVOA TAP service for Solar System Objects
 | cadc-tap.config.pg.username | string | `"dp03"` | Postgres username to use to connect |
 | cadc-tap.config.vaultSecretName | string | `"ssotap"` | Vault secret name: the final key in the vault path |
 | cadc-tap.ingress.path | string | `"ssotap"` |  |
+| cadc-tap.serviceAccount.name | string | `"ssotap"` |  |
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |

--- a/applications/ssotap/secrets-idfdev.yaml
+++ b/applications/ssotap/secrets-idfdev.yaml
@@ -1,11 +1,3 @@
-"google_creds.json":
-  description: >-
-    Google service account credentials used to write async job output to
-    Google Cloud Storage.
-pgpassword:
-  description: >-
-    Password to external PostgreSQL server that contains the Solar System
-    Objects data.
-uwspassword:
+uws-db-password:
   description: >-
     Password to external UWS PostgreSQL server

--- a/applications/ssotap/secrets-idfdev.yaml
+++ b/applications/ssotap/secrets-idfdev.yaml
@@ -1,0 +1,11 @@
+"google_creds.json":
+  description: >-
+    Google service account credentials used to write async job output to
+    Google Cloud Storage.
+pgpassword:
+  description: >-
+    Password to external PostgreSQL server that contains the Solar System
+    Objects data.
+uwspassword:
+  description: >-
+    Password to external UWS PostgreSQL server

--- a/applications/ssotap/values-idfdev.yaml
+++ b/applications/ssotap/values-idfdev.yaml
@@ -1,4 +1,21 @@
 cadc-tap:
+  config:
+    uwsDatabaseUrl: "postgresql://localhost:5432/ssotap"
+    uwsDatabaseUsername: "ssotap"
+    pg:
+      image:
+        repository: "ghcr.io/lsst-sqre/tap-postgres-service"
+        pullPolicy: "Always"
+        tag: "1.16.0"
+
+  uws:
+    enabled: false
+
   tapSchema:
     image:
       repository: "lsstsqre/tap-schema-idfdev-sso"
+
+  cloudsql:
+    enabled: true
+    instanceConnectionName: "science-platform-dev-7696:us-central1:science-platform-dev-e9e11de2"
+    serviceAccount: "ssotap@science-platform-dev-7696.iam.gserviceaccount.com"

--- a/applications/ssotap/values-idfdev.yaml
+++ b/applications/ssotap/values-idfdev.yaml
@@ -1,15 +1,10 @@
 cadc-tap:
   config:
-    uwsDatabaseUrl: "postgresql://localhost:5432/ssotap"
-    uwsDatabaseUsername: "ssotap"
     pg:
       image:
         repository: "ghcr.io/lsst-sqre/tap-postgres-service"
         pullPolicy: "Always"
         tag: "1.16.0"
-
-  uws:
-    enabled: false
 
   tapSchema:
     image:
@@ -19,3 +14,4 @@ cadc-tap:
     enabled: true
     instanceConnectionName: "science-platform-dev-7696:us-central1:science-platform-dev-e9e11de2"
     serviceAccount: "ssotap@science-platform-dev-7696.iam.gserviceaccount.com"
+    database: "ssotap"

--- a/applications/ssotap/values.yaml
+++ b/applications/ssotap/values.yaml
@@ -20,6 +20,10 @@ cadc-tap:
     # -- Vault secret name: the final key in the vault path
     vaultSecretName: "ssotap"
 
+  serviceAccount:
+    # Name of Service Account
+    name: "ssotap"
+
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:

--- a/charts/cadc-tap/README.md
+++ b/charts/cadc-tap/README.md
@@ -13,13 +13,14 @@ IVOA TAP service
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules for the TAP pod |
+| cloudsql.database | string | None, must be set | CloudSQL database name |
 | cloudsql.enabled | bool | `false` | Enable the Cloud SQL Auth Proxy sidecar, used with Cloud SQL databases on Google Cloud |
 | cloudsql.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for Cloud SQL Auth Proxy images |
 | cloudsql.image.repository | string | `"gcr.io/cloudsql-docker/gce-proxy"` | Cloud SQL Auth Proxy image to use |
 | cloudsql.image.tag | string | `"1.35.3"` | Cloud SQL Auth Proxy tag to use |
 | cloudsql.instanceConnectionName | string | `""` | Instance connection name for a Cloud SQL PostgreSQL instance |
 | cloudsql.resources | object | See `values.yaml` | Resource limits and requests for the Cloud SQL Proxy container |
-| cloudsql.serviceAccount | string | None, must be set | The Google service account that has an IAM binding to the `vo-cutouts` Kubernetes service accounts and has the `cloudsql.client` role, access to the GCS bucket, and ability to sign URLs as itself |
+| cloudsql.serviceAccount | string | None, must be set | The Google service account that has an IAM binding to the `cadc-tap` Kubernetes service accounts and has the `cloudsql.client` role, access |
 | config.backend | string | None, must be set to `pg` or `qserv` | What type of backend are we connecting to? |
 | config.datalinkPayloadUrl | string | `"https://github.com/lsst/sdm_schemas/releases/download/2.6.1/datalink-snippets.zip"` | Datalink payload URL |
 | config.gcsBucket | string | `"async-results.lsst.codes"` | Name of GCS bucket in which to store results |
@@ -37,8 +38,6 @@ IVOA TAP service
 | config.qserv.image.repository | string | `"ghcr.io/lsst-sqre/lsst-tap-service"` | TAP image to use |
 | config.qserv.image.tag | string | `"2.2.0"` | Tag of TAP image to use |
 | config.tapSchemaAddress | string | `"cadc-tap-schema-db:3306"` | Address to a MySQL database containing TAP schema data |
-| config.uwsDatabaseUrl | string | `""` | UWS Database URL (if using external UWS) |
-| config.uwsDatabaseUsername | string | `""` | UWS Database Username (if using external UWS) |
 | config.vaultSecretName | string | `""` | Vault secret name, this is appended to the global path to find the vault secrets associated with this deployment. |
 | fullnameOverride | string | `"cadc-tap"` | Override the full name for resources (includes the release name) |
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |
@@ -62,20 +61,19 @@ IVOA TAP service
 | podAnnotations | object | `{}` | Annotations for the TAP pod |
 | replicaCount | int | `1` | Number of pods to start |
 | resources | object | See `values.yaml` | Resource limits and requests for the TAP pod |
+| serviceAccount | object | `{"annotations":{},"create":false,"name":""}` | The service account will allways be created when cloudsql.enabled is set to true In this case the serviceAccount configuration here is required |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.create | bool | `false` | Specifies whether a service account should be created. |
-| serviceAccount.name | string | `"cadc-tap"` |  |
 | tapSchema.affinity | object | `{}` | Affinity rules for the TAP schema database pod |
 | tapSchema.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the TAP schema image |
 | tapSchema.image.repository | string | `"lsstsqre/tap-schema-mock"` | TAP schema image to ue. This must be overridden by each environment with the TAP schema for that environment. |
 | tapSchema.image.tag | string | `"2.6.1"` | Tag of TAP schema image |
 | tapSchema.nodeSelector | object | `{}` | Node selection rules for the TAP schema database pod |
 | tapSchema.podAnnotations | object | `{}` | Annotations for the TAP schema database pod |
-| tapSchema.resources | object | `{}` | Resource limits and requests for the TAP schema database pod |
+| tapSchema.resources | object | See `values.yaml` | Resource limits and requests for the TAP schema database pod |
 | tapSchema.tolerations | list | `[]` | Tolerations for the TAP schema database pod |
 | tolerations | list | `[]` | Tolerations for the TAP pod |
 | uws.affinity | object | `{}` | Affinity rules for the UWS database pod |
-| uws.enabled | bool | `true` |  |
 | uws.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the UWS database image |
 | uws.image.repository | string | `"ghcr.io/lsst-sqre/lsst-tap-uws-db"` | UWS database image to use |
 | uws.image.tag | string | `"2.2.0"` | Tag of UWS database image to use |

--- a/charts/cadc-tap/README.md
+++ b/charts/cadc-tap/README.md
@@ -13,6 +13,13 @@ IVOA TAP service
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules for the TAP pod |
+| cloudsql.enabled | bool | `false` | Enable the Cloud SQL Auth Proxy sidecar, used with Cloud SQL databases on Google Cloud |
+| cloudsql.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for Cloud SQL Auth Proxy images |
+| cloudsql.image.repository | string | `"gcr.io/cloudsql-docker/gce-proxy"` | Cloud SQL Auth Proxy image to use |
+| cloudsql.image.tag | string | `"1.35.3"` | Cloud SQL Auth Proxy tag to use |
+| cloudsql.instanceConnectionName | string | `""` | Instance connection name for a Cloud SQL PostgreSQL instance |
+| cloudsql.resources | object | See `values.yaml` | Resource limits and requests for the Cloud SQL Proxy container |
+| cloudsql.serviceAccount | string | None, must be set | The Google service account that has an IAM binding to the `vo-cutouts` Kubernetes service accounts and has the `cloudsql.client` role, access to the GCS bucket, and ability to sign URLs as itself |
 | config.backend | string | None, must be set to `pg` or `qserv` | What type of backend are we connecting to? |
 | config.datalinkPayloadUrl | string | `"https://github.com/lsst/sdm_schemas/releases/download/2.6.1/datalink-snippets.zip"` | Datalink payload URL |
 | config.gcsBucket | string | `"async-results.lsst.codes"` | Name of GCS bucket in which to store results |
@@ -23,13 +30,15 @@ IVOA TAP service
 | config.pg.host | string | None, must be set if backend is `pg` | Host to connect to |
 | config.pg.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the TAP image |
 | config.pg.image.repository | string | `"ghcr.io/lsst-sqre/tap-postgres-service"` | TAP image to use |
-| config.pg.image.tag | string | `"1.15.0"` | Tag of TAP image to use |
+| config.pg.image.tag | string | `"1.16.0"` | Tag of TAP image to use |
 | config.pg.username | string | None, must be set if backend is `pg` | Username to connect with |
 | config.qserv.host | string | `"mock-db:3306"` (the mock QServ) | QServ hostname:port to connect to |
 | config.qserv.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the TAP image |
 | config.qserv.image.repository | string | `"ghcr.io/lsst-sqre/lsst-tap-service"` | TAP image to use |
 | config.qserv.image.tag | string | `"2.2.0"` | Tag of TAP image to use |
 | config.tapSchemaAddress | string | `"cadc-tap-schema-db:3306"` | Address to a MySQL database containing TAP schema data |
+| config.uwsDatabaseUrl | string | `""` | UWS Database URL (if using external UWS) |
+| config.uwsDatabaseUsername | string | `""` | UWS Database Username (if using external UWS) |
 | config.vaultSecretName | string | `""` | Vault secret name, this is appended to the global path to find the vault secrets associated with this deployment. |
 | fullnameOverride | string | `"cadc-tap"` | Override the full name for resources (includes the release name) |
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |
@@ -53,16 +62,20 @@ IVOA TAP service
 | podAnnotations | object | `{}` | Annotations for the TAP pod |
 | replicaCount | int | `1` | Number of pods to start |
 | resources | object | See `values.yaml` | Resource limits and requests for the TAP pod |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| serviceAccount.create | bool | `false` | Specifies whether a service account should be created. |
+| serviceAccount.name | string | `"cadc-tap"` |  |
 | tapSchema.affinity | object | `{}` | Affinity rules for the TAP schema database pod |
 | tapSchema.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the TAP schema image |
 | tapSchema.image.repository | string | `"lsstsqre/tap-schema-mock"` | TAP schema image to ue. This must be overridden by each environment with the TAP schema for that environment. |
 | tapSchema.image.tag | string | `"2.6.1"` | Tag of TAP schema image |
 | tapSchema.nodeSelector | object | `{}` | Node selection rules for the TAP schema database pod |
 | tapSchema.podAnnotations | object | `{}` | Annotations for the TAP schema database pod |
-| tapSchema.resources | object | See `values.yaml` | Resource limits and requests for the TAP schema database pod |
+| tapSchema.resources | object | `{}` | Resource limits and requests for the TAP schema database pod |
 | tapSchema.tolerations | list | `[]` | Tolerations for the TAP schema database pod |
 | tolerations | list | `[]` | Tolerations for the TAP pod |
 | uws.affinity | object | `{}` | Affinity rules for the UWS database pod |
+| uws.enabled | bool | `true` |  |
 | uws.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the UWS database image |
 | uws.image.repository | string | `"ghcr.io/lsst-sqre/lsst-tap-uws-db"` | UWS database image to use |
 | uws.image.tag | string | `"2.2.0"` | Tag of UWS database image to use |

--- a/charts/cadc-tap/templates/serviceaccount.yaml
+++ b/charts/cadc-tap/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.serviceAccount.name }}
+  name: {{ required "serviceAccount.name must be set" .Values.serviceAccount.name | quote }}
   labels:
     {{- include "cadc-tap.labels" . | nindent 4 }}
   annotations:

--- a/charts/cadc-tap/templates/serviceaccount.yaml
+++ b/charts/cadc-tap/templates/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if or .Values.serviceAccount.create .Values.cloudsql.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name }}
+  labels:
+    {{- include "cadc-tap.labels" . | nindent 4 }}
+  annotations:
+    {{- if .Values.cloudsql.enabled }}
+    iam.gke.io/gcp-service-account: {{ required "cloudsql.serviceAccount must be set to a valid Google service account" .Values.cloudsql.serviceAccount | quote }}
+    {{- end }}
+    {{- with .Values.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/cadc-tap/templates/tap-deployment.yaml
+++ b/charts/cadc-tap/templates/tap-deployment.yaml
@@ -72,7 +72,7 @@ spec:
                 {{- if .Values.cloudsql.enabled }}
                 -Duws.password=$UWS_DB_PASSWORD
                 -Duws.username={{ required "cloudsql.database must be specified" .Values.cloudsql.database }}
-                -Duws.url=jdbc:postgres://localhost:5432/{{ .Values.cloudsql.database }}
+                -Duws.url=jdbc:postgresql://localhost:5432/{{ .Values.cloudsql.database }}
                 {{- else }}
                 -Duws.username=postgres
                 -Duws.url=jdbc:postgresql://{{ template "cadc-tap.fullname" . }}-uws-db/

--- a/charts/cadc-tap/templates/tap-deployment.yaml
+++ b/charts/cadc-tap/templates/tap-deployment.yaml
@@ -70,7 +70,7 @@ spec:
                 -Duws.driverClassName=org.postgresql.Driver
                 -Duws.maxActive=100
                 {{- if .Values.cloudsql.enabled }}
-                -Duws.password=$uwspassword
+                -Duws.password=$UWS_DB_PASSWORD
                 -Duws.username={{ required "cloudsql.database must be specified" .Values.cloudsql.database }}
                 -Duws.url=jdbc:postgres://localhost:5432/{{ .Values.cloudsql.database }}
                 {{- else }}
@@ -79,7 +79,7 @@ spec:
                 {{- end }}
                 {{- if eq .Values.config.backend "pg" }}
                 -Dtap.username={{ .Values.config.pg.username }}
-                -Dtap.password=$pgpassword
+                -Dtap.password=$TAP_DB_PASSWORD
                 -Dtap.url=jdbc:postgresql://{{ .Values.config.pg.host }}/{{ .Values.config.pg.database }}
                 -Dtap.maxActive=100
                 -Dca.nrc.cadc.auth.Authenticator=ca.nrc.cadc.sample.AuthenticatorImpl

--- a/charts/cadc-tap/templates/tap-deployment.yaml
+++ b/charts/cadc-tap/templates/tap-deployment.yaml
@@ -20,8 +20,36 @@ spec:
         {{- include "cadc-tap.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: "server"
     spec:
+      {{- if .Values.cloudsql.enabled }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- else }}
       automountServiceAccountToken: false
+      {{- end }}
       containers:
+        {{- if .Values.cloudsql.enabled }}
+        - name: "cloud-sql-proxy"
+          command:
+            - "/cloud_sql_proxy"
+            - "-ip_address_types=PRIVATE"
+            - "-log_debug_stdout=true"
+            - "-structured_logs=true"
+            - "-instances={{ required "cloudsql.instanceConnectionName must be specified" .Values.cloudsql.instanceConnectionName }}=tcp:5432"
+          image: "{{ .Values.cloudsql.image.repository }}:{{ .Values.cloudsql.image.tag }}"
+          imagePullPolicy: {{ .Values.cloudsql.image.pullPolicy | quote }}
+          {{- with .Values.cloudsql.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+        {{- end }}
         - name: "tap-server"
           {{- if eq .Values.config.backend "pg" }}
           image: "{{ .Values.config.pg.image.repository }}:{{ .Values.config.pg.image.tag }}"
@@ -39,10 +67,16 @@ spec:
                 -Dtapschemauser.driverClassName=com.mysql.cj.jdbc.Driver
                 -Dtapschemauser.url=jdbc:mysql://{{ .Values.config.tapSchemaAddress }}/
                 -Dtapschemauser.maxActive=100
-                -Duws.username=postgres
                 -Duws.driverClassName=org.postgresql.Driver
-                -Duws.url=jdbc:postgresql://{{ template "cadc-tap.fullname" . }}-uws-db/
                 -Duws.maxActive=100
+                {{- if .Values.cloudsql.enabled }}
+                -Duws.password=$uwspassword
+                -Duws.username={{ .Values.config.uwsDatabaseUsername }}
+                -Duws.url=jdbc:{{ .Values.config.uwsDatabaseUrl }}
+                {{- else }}
+                -Duws.username=postgres
+                -Duws.url=jdbc:postgresql://{{ template "cadc-tap.fullname" . }}-uws-db/
+                {{- end }}
                 {{- if eq .Values.config.backend "pg" }}
                 -Dtap.username={{ .Values.config.pg.username }}
                 -Dtap.password=$pgpassword
@@ -50,7 +84,6 @@ spec:
                 -Dtap.maxActive=100
                 -Dca.nrc.cadc.auth.Authenticator=ca.nrc.cadc.sample.AuthenticatorImpl
                 {{- end }}
-
                 {{- if eq .Values.config.backend "qserv" }}
                 -Dqservuser.username=qsmaster
                 -Dqservuser.password=
@@ -73,6 +106,13 @@ spec:
                 secretKeyRef:
                   name: "cadc-tap"
                   key: "pgpassword"
+            {{- end }}
+            {{- if .Values.cloudsql.enabled }}
+            - name: "uwspassword"
+              valueFrom:
+                secretKeyRef:
+                  name: "cadc-tap"
+                  key: "uwspassword"
             {{- end }}
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: "/etc/creds/google_creds.json"

--- a/charts/cadc-tap/templates/tap-deployment.yaml
+++ b/charts/cadc-tap/templates/tap-deployment.yaml
@@ -71,8 +71,8 @@ spec:
                 -Duws.maxActive=100
                 {{- if .Values.cloudsql.enabled }}
                 -Duws.password=$uwspassword
-                -Duws.username={{ .Values.config.uwsDatabaseUsername }}
-                -Duws.url=jdbc:{{ .Values.config.uwsDatabaseUrl }}
+                -Duws.username={{ required "cloudsql.database must be specified" .Values.cloudsql.database }}
+                -Duws.url=jdbc:postgres://localhost:5432/{{ .Values.cloudsql.database }}
                 {{- else }}
                 -Duws.username=postgres
                 -Duws.url=jdbc:postgresql://{{ template "cadc-tap.fullname" . }}-uws-db/
@@ -101,18 +101,18 @@ spec:
                 -Dca.nrc.cadc.util.PropertiesReader.dir=/etc/creds/
                 -Xmx{{ .Values.config.jvmMaxHeapSize }}
             {{- if eq .Values.config.backend "pg" }}
-            - name: "pgpassword"
+            - name: "TAP_DB_PASSWORD"
               valueFrom:
                 secretKeyRef:
                   name: "cadc-tap"
                   key: "pgpassword"
             {{- end }}
             {{- if .Values.cloudsql.enabled }}
-            - name: "uwspassword"
+            - name: "UWS_DB_PASSWORD"
               valueFrom:
                 secretKeyRef:
                   name: "cadc-tap"
-                  key: "uwspassword"
+                  key: "uws-db-password"
             {{- end }}
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: "/etc/creds/google_creds.json"

--- a/charts/cadc-tap/templates/uws-db-deployment.yaml
+++ b/charts/cadc-tap/templates/uws-db-deployment.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.uws.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -49,3 +50,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/charts/cadc-tap/templates/uws-db-deployment.yaml
+++ b/charts/cadc-tap/templates/uws-db-deployment.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.uws.enabled -}}
+{{ if (not .Values.cloudsql.enabled) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/cadc-tap/templates/uws-db-networkpolicy.yaml
+++ b/charts/cadc-tap/templates/uws-db-networkpolicy.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.mockdb.enabled -}}
+{{ if (not .Values.cloudsql.enabled) -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/charts/cadc-tap/templates/uws-db-networkpolicy.yaml
+++ b/charts/cadc-tap/templates/uws-db-networkpolicy.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.mockdb.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -21,3 +22,4 @@ spec:
       ports:
         - protocol: "TCP"
           port: 5432
+{{- end }}

--- a/charts/cadc-tap/templates/uws-db-service.yaml
+++ b/charts/cadc-tap/templates/uws-db-service.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.uws.enabled -}}
+{{ if (not .Values.cloudsql.enabled) -}}
 kind: Service
 apiVersion: v1
 metadata:

--- a/charts/cadc-tap/templates/uws-db-service.yaml
+++ b/charts/cadc-tap/templates/uws-db-service.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.uws.enabled -}}
 kind: Service
 apiVersion: v1
 metadata:
@@ -12,3 +13,4 @@ spec:
   selector:
     {{- include "cadc-tap.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: "uws-db"
+{{- end }}

--- a/charts/cadc-tap/tests/mock-db-networkpolicy_test.yaml
+++ b/charts/cadc-tap/tests/mock-db-networkpolicy_test.yaml
@@ -1,0 +1,22 @@
+suite: Mock-DB Network Policy
+templates:
+  - mock-db-networkpolicy.yaml
+
+tests:
+  - it: should create a Mock-DB Network Policy when mockdb is enabled
+    set:
+      mockdb:
+        enabled: true
+      global:
+        host: "example.com"
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: should not create a Mock-DB Network Policy by default
+    set:
+      global:
+        host: "example.com"
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/cadc-tap/tests/mockdb-deployment_test.yaml
+++ b/charts/cadc-tap/tests/mockdb-deployment_test.yaml
@@ -1,0 +1,24 @@
+suite: MockDB Deployment
+templates:
+  - mock-db-deployment.yaml
+
+tests:
+  - it: should not create a MockDB deployment when mockdb is disabled
+    set:
+      mockdb:
+        enabled: false
+      global:
+        host: "example.com"
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create a MockDB deployment when mockdb is enabled
+    set:
+      mockdb:
+        enabled: true
+      global:
+        host: "example.com"
+    asserts:
+      - hasDocuments:
+          count: 1

--- a/charts/cadc-tap/tests/serviceaccount_test.yaml
+++ b/charts/cadc-tap/tests/serviceaccount_test.yaml
@@ -42,5 +42,3 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
-
-

--- a/charts/cadc-tap/tests/serviceaccount_test.yaml
+++ b/charts/cadc-tap/tests/serviceaccount_test.yaml
@@ -1,0 +1,46 @@
+suite: ServiceAccount
+templates:
+  - serviceaccount.yaml
+
+tests:
+  - it: should create a ServiceAccount when cloudSQL is enabled
+    set:
+      cloudsql:
+        enabled: true
+        instanceConnectionName: "science-platform--xyz:test"
+        serviceAccount: "sa@xyz"
+      global:
+        host: "example.com"
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: cadc-tap
+
+  - it: should create a ServiceAccount when serviceAccount is enabled
+    set:
+      serviceAccount:
+        create: true
+      cloudsql:
+        enabled: false
+      global:
+        host: "example.com"
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: cadc-tap
+
+  - it: should not create a ServiceAccount when uws is enabled
+    set:
+      global:
+        host: "example.com"
+      uws:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+

--- a/charts/cadc-tap/tests/serviceaccount_test.yaml
+++ b/charts/cadc-tap/tests/serviceaccount_test.yaml
@@ -11,17 +11,21 @@ tests:
         serviceAccount: "sa@xyz"
       global:
         host: "example.com"
+      serviceAccount:
+        create: true
+        name: "sa"
     asserts:
       - isKind:
           of: ServiceAccount
       - equal:
           path: metadata.name
-          value: cadc-tap
+          value: sa
 
   - it: should create a ServiceAccount when serviceAccount is enabled
     set:
       serviceAccount:
         create: true
+        name: "sa"
       cloudsql:
         enabled: false
       global:
@@ -31,14 +35,26 @@ tests:
           of: ServiceAccount
       - equal:
           path: metadata.name
-          value: cadc-tap
+          value: sa
 
-  - it: should not create a ServiceAccount when uws is enabled
+  - it: should not create a ServiceAccount when cloudsql is disabled
     set:
       global:
         host: "example.com"
-      uws:
+      cloud:
         enabled: true
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: Test that serviceAccount build fails when cloudsql is enabled but no serviceAccount.name
+    set:
+      cloudsql:
+        enabled: true
+        serviceAccount: "sa@xyz"
+        instanceConnectionName: "science-platform--xyz:test"
+      global:
+        host: "example.com"
+    asserts:
+      - failedTemplate:
+          errorMessage: serviceAccount.name must be set

--- a/charts/cadc-tap/tests/serviceaccount_test.yaml
+++ b/charts/cadc-tap/tests/serviceaccount_test.yaml
@@ -9,6 +9,7 @@ tests:
         enabled: true
         instanceConnectionName: "science-platform--xyz:test"
         serviceAccount: "sa@xyz"
+        database: "mydb"
       global:
         host: "example.com"
       serviceAccount:
@@ -53,6 +54,7 @@ tests:
         enabled: true
         serviceAccount: "sa@xyz"
         instanceConnectionName: "science-platform--xyz:test"
+        database: "mydb"
       global:
         host: "example.com"
     asserts:

--- a/charts/cadc-tap/tests/tap-deployment_test.yaml
+++ b/charts/cadc-tap/tests/tap-deployment_test.yaml
@@ -55,6 +55,7 @@ tests:
         enabled: true
         instanceConnectionName: "science-platform--xyz:test"
         serviceAccount: "sa@xyz"
+        database: "mydb"
       config:
         pg:
           username: "postgres"
@@ -64,17 +65,15 @@ tests:
             repository: "postgres"
             tag: "latest"
             pullPolicy: "IfNotPresent"
-        uwsDatabaseUsername: "cloudsql-user"
-        uwsDatabaseUrl: "cloudsql-instance-url"
       serviceAccount:
         name: "ssotap"
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[1].env[0].value
-          pattern: "-Duws.username=cloudsql-user"
+          pattern: "-Duws.username=mydb"
       - matchRegex:
           path: spec.template.spec.containers[1].env[0].value
-          pattern: "-Duws.url=jdbc:cloudsql-instance-url"
+          pattern: "-Duws.url=jdbc:postgres://localhost:5432/mydb"
       - matchRegex:
           path: spec.template.spec.containers[1].env[0].value
           pattern: "-Duws.password="
@@ -90,6 +89,10 @@ tests:
         enabled: true
         instanceConnectionName: "science-platform--xyz:test"
         serviceAccount: "sa@xyz"
+        database: "mydb"
+      serviceAccount:
+        enabled: true
+        name: "sa"
       config:
         pg:
           username: "postgres"
@@ -99,21 +102,19 @@ tests:
             repository: "postgres"
             tag: "latest"
             pullPolicy: "IfNotPresent"
-        uwsDatabaseUsername: "cloudsql-user"
-        uwsDatabaseUrl: "cloudsql-instance-url"
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[1].env[0].value
-          pattern: "-Duws.username=cloudsql-user"
+          pattern: "-Duws.username=mydb"
       - matchRegex:
           path: spec.template.spec.containers[1].env[0].value
-          pattern: "-Duws.url=jdbc:cloudsql-instance-url"
+          pattern: "-Duws.url=jdbc:postgres://localhost:5432/mydb"
       - matchRegex:
           path: spec.template.spec.containers[1].env[0].value
           pattern: "-Duws.password="
       - equal:
           path: spec.template.spec.serviceAccountName
-          value: "cadc-tap"
+          value: "sa"
 
   - it: should configure UWS database environment variables to use the Chart's Postgres
     set:
@@ -137,6 +138,10 @@ tests:
         enabled: true
         instanceConnectionName: "science-platform--xyz:test"
         serviceAccount: "sa@xyz"
+        database: "mydb"
+      serviceAccount:
+        enabled: true
+        name: "sa"
       config:
         pg:
           username: "postgres"
@@ -146,8 +151,6 @@ tests:
             repository: "postgres"
             tag: "latest"
             pullPolicy: "IfNotPresent"
-        uwsDatabaseUsername: "cloudsql-user"
-        uwsDatabaseUrl: "cloudsql-instance-url"
     asserts:
       - lengthEqual:
           path: spec.template.spec.containers
@@ -180,6 +183,10 @@ tests:
         enabled: true
         instanceConnectionName: "science-platform--xyz:test"
         serviceAccount: "sa@xyz"
+        database: "mydb"
+      serviceAccount:
+        enabled: true
+        name: "sa"
       global:
         host: "example.com"
       config:
@@ -189,21 +196,19 @@ tests:
         gcsBucket: "async-results.lsst.codes"
         gcsBucketUrl: "https://async-results.codes:8080"
         gcsBucketType: "S3"
-        uwsDatabaseUsername: "cloudsql-user"
-        uwsDatabaseUrl: "cloudsql-instance-url"
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[1].env[0].value
-          pattern: "-Duws.username=cloudsql-user"
+          pattern: "-Duws.username=mydb"
       - matchRegex:
           path: spec.template.spec.containers[1].env[0].value
-          pattern: "-Duws.url=jdbc:cloudsql-instance-url"
+          pattern: "-Duws.url=jdbc:postgres://localhost:5432/mydb"
       - matchRegex:
           path: spec.template.spec.containers[1].env[0].value
           pattern: "-Duws.password="
       - equal:
           path: spec.template.spec.serviceAccountName
-          value: "cadc-tap"
+          value: "sa"
       - matchRegex:
           path: spec.template.spec.containers[1].env[0].value
           pattern: "-Dqservuser.username=qsmaster"
@@ -230,3 +235,15 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: cloudsql.instanceConnectionName must be specified
+
+  - it: Test that deployment build fails when cloudsql is enabled but no database
+    set:
+      cloudsql:
+        enabled: true
+        serviceAccount: "sa@xyz"
+        instanceConnectionName: "science-platform--xyz:test"
+      global:
+        host: "example.com"
+    asserts:
+      - failedTemplate:
+          errorMessage: cloudsql.database must be specified

--- a/charts/cadc-tap/tests/tap-deployment_test.yaml
+++ b/charts/cadc-tap/tests/tap-deployment_test.yaml
@@ -230,4 +230,3 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: cloudsql.instanceConnectionName must be specified
-

--- a/charts/cadc-tap/tests/tap-deployment_test.yaml
+++ b/charts/cadc-tap/tests/tap-deployment_test.yaml
@@ -73,7 +73,7 @@ tests:
           pattern: "-Duws.username=mydb"
       - matchRegex:
           path: spec.template.spec.containers[1].env[0].value
-          pattern: "-Duws.url=jdbc:postgres://localhost:5432/mydb"
+          pattern: "-Duws.url=jdbc:postgresql://localhost:5432/mydb"
       - matchRegex:
           path: spec.template.spec.containers[1].env[0].value
           pattern: "-Duws.password="
@@ -108,7 +108,7 @@ tests:
           pattern: "-Duws.username=mydb"
       - matchRegex:
           path: spec.template.spec.containers[1].env[0].value
-          pattern: "-Duws.url=jdbc:postgres://localhost:5432/mydb"
+          pattern: "-Duws.url=jdbc:postgresql://localhost:5432/mydb"
       - matchRegex:
           path: spec.template.spec.containers[1].env[0].value
           pattern: "-Duws.password="
@@ -202,7 +202,7 @@ tests:
           pattern: "-Duws.username=mydb"
       - matchRegex:
           path: spec.template.spec.containers[1].env[0].value
-          pattern: "-Duws.url=jdbc:postgres://localhost:5432/mydb"
+          pattern: "-Duws.url=jdbc:postgresql://localhost:5432/mydb"
       - matchRegex:
           path: spec.template.spec.containers[1].env[0].value
           pattern: "-Duws.password="

--- a/charts/cadc-tap/tests/tap-deployment_test.yaml
+++ b/charts/cadc-tap/tests/tap-deployment_test.yaml
@@ -1,0 +1,233 @@
+suite: TAP deployment
+templates:
+  - tap-deployment.yaml
+
+tests:
+  - it: should configure environment variables correctly for PostgreSQL backend
+    set:
+      global:
+        host: "example.com"
+      config:
+        backend: "pg"
+        pg:
+          username: "postgres"
+          host: "postgres-server"
+          database: "tapdb"
+          image:
+            repository: "postgres"
+            tag: "latest"
+            pullPolicy: "IfNotPresent"
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].env[0].value
+          pattern: "-Dtap.username=postgres"
+      - matchRegex:
+          path: spec.template.spec.containers[0].env[0].value
+          pattern: "-Dtap.url=jdbc:postgresql://postgres-server/tapdb"
+
+  - it: should configure environment variables correctly for Qserv backend
+    set:
+      global:
+        host: "example.com"
+      cloudsql:
+        enabled: false
+      config:
+        backend: "qserv"
+        qserv:
+          host: "mock-db:3306"
+          image:
+            repository: "qserv"
+            tag: "latest"
+            pullPolicy: "IfNotPresent"
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].env[0].value
+          pattern: "-Dqservuser.username=qsmaster"
+      - matchRegex:
+          path: spec.template.spec.containers[0].env[0].value
+          pattern: "-Dqservuser.url=jdbc:mysql://mock-db:3306/"
+
+  - it: should configure UWS database environment variables for Cloud SQL
+    set:
+      global:
+        host: "example.com"
+      cloudsql:
+        enabled: true
+        instanceConnectionName: "science-platform--xyz:test"
+        serviceAccount: "sa@xyz"
+      config:
+        pg:
+          username: "postgres"
+          host: "postgres-server"
+          database: "tapdb"
+          image:
+            repository: "postgres"
+            tag: "latest"
+            pullPolicy: "IfNotPresent"
+        uwsDatabaseUsername: "cloudsql-user"
+        uwsDatabaseUrl: "cloudsql-instance-url"
+      serviceAccount:
+        name: "ssotap"
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[1].env[0].value
+          pattern: "-Duws.username=cloudsql-user"
+      - matchRegex:
+          path: spec.template.spec.containers[1].env[0].value
+          pattern: "-Duws.url=jdbc:cloudsql-instance-url"
+      - matchRegex:
+          path: spec.template.spec.containers[1].env[0].value
+          pattern: "-Duws.password="
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: "ssotap"
+
+  - it: Should configure uws for Cloud SQL as before, but this time serviceAccount not passed in
+    set:
+      global:
+        host: "example.com"
+      cloudsql:
+        enabled: true
+        instanceConnectionName: "science-platform--xyz:test"
+        serviceAccount: "sa@xyz"
+      config:
+        pg:
+          username: "postgres"
+          host: "postgres-server"
+          database: "tapdb"
+          image:
+            repository: "postgres"
+            tag: "latest"
+            pullPolicy: "IfNotPresent"
+        uwsDatabaseUsername: "cloudsql-user"
+        uwsDatabaseUrl: "cloudsql-instance-url"
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[1].env[0].value
+          pattern: "-Duws.username=cloudsql-user"
+      - matchRegex:
+          path: spec.template.spec.containers[1].env[0].value
+          pattern: "-Duws.url=jdbc:cloudsql-instance-url"
+      - matchRegex:
+          path: spec.template.spec.containers[1].env[0].value
+          pattern: "-Duws.password="
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: "cadc-tap"
+
+  - it: should configure UWS database environment variables to use the Chart's Postgres
+    set:
+      global:
+        host: "example.com"
+      cloudsql:
+        enabled: false
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].env[0].value
+          pattern: "-Duws.username=postgres"
+      - matchRegex:
+          path: spec.template.spec.containers[0].env[0].value
+          pattern: "-Duws.url=jdbc:postgresql://cadc-tap-uws-db/"
+
+  - it: should create two containers if cloudsql is enabled
+    set:
+      global:
+        host: "example.com"
+      cloudsql:
+        enabled: true
+        instanceConnectionName: "science-platform--xyz:test"
+        serviceAccount: "sa@xyz"
+      config:
+        pg:
+          username: "postgres"
+          host: "postgres-server"
+          database: "tapdb"
+          image:
+            repository: "postgres"
+            tag: "latest"
+            pullPolicy: "IfNotPresent"
+        uwsDatabaseUsername: "cloudsql-user"
+        uwsDatabaseUrl: "cloudsql-instance-url"
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.containers
+          count: 2
+
+  - it: should setup TAP_SCHEMA database configuration
+    set:
+      global:
+        host: "example.com"
+      cloudsql:
+        enabled: false
+      config:
+        tapSchemaAddress: "tap-schema-address"
+        pg:
+          username: "postgres"
+          host: "postgres-server"
+          database: "tapdb"
+          image:
+            repository: "postgres"
+            tag: "latest"
+            pullPolicy: "IfNotPresent"
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].env[0].value
+          pattern: "-Dtapschemauser.url=jdbc:mysql://tap-schema-address/"
+
+  - it: Create GCS bucket configuration with QServ and CloudSQL UWS database
+    set:
+      cloudsql:
+        enabled: true
+        instanceConnectionName: "science-platform--xyz:test"
+        serviceAccount: "sa@xyz"
+      global:
+        host: "example.com"
+      config:
+        backend: "qserv"
+        qserv:
+          host: "qserv:30040"
+        gcsBucket: "async-results.lsst.codes"
+        gcsBucketUrl: "https://async-results.codes:8080"
+        gcsBucketType: "S3"
+        uwsDatabaseUsername: "cloudsql-user"
+        uwsDatabaseUrl: "cloudsql-instance-url"
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[1].env[0].value
+          pattern: "-Duws.username=cloudsql-user"
+      - matchRegex:
+          path: spec.template.spec.containers[1].env[0].value
+          pattern: "-Duws.url=jdbc:cloudsql-instance-url"
+      - matchRegex:
+          path: spec.template.spec.containers[1].env[0].value
+          pattern: "-Duws.password="
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: "cadc-tap"
+      - matchRegex:
+          path: spec.template.spec.containers[1].env[0].value
+          pattern: "-Dqservuser.username=qsmaster"
+      - matchRegex:
+          path: spec.template.spec.containers[1].env[0].value
+          pattern: "-Dqservuser.url=jdbc:mysql://qserv:30040/"
+      - matchRegex:
+          path: spec.template.spec.containers[1].env[0].value
+          pattern: "-Dgcs_bucket=async-results.lsst.codes"
+      - matchRegex:
+          path: spec.template.spec.containers[1].env[0].value
+          pattern: "-Dgcs_bucket_url=https://async-results.codes:8080"
+      - matchRegex:
+          path: spec.template.spec.containers[1].env[0].value
+          pattern: "-Dgcs_bucket_type=S3"
+
+  - it: Test that deployment build fails when cloudsql is enabled but no instanceConnectionName
+    set:
+      cloudsql:
+        enabled: true
+        serviceAccount: "sa@xyz"
+      global:
+        host: "example.com"
+    asserts:
+      - failedTemplate:
+          errorMessage: cloudsql.instanceConnectionName must be specified
+

--- a/charts/cadc-tap/tests/tap-deployment_test.yaml
+++ b/charts/cadc-tap/tests/tap-deployment_test.yaml
@@ -66,6 +66,7 @@ tests:
             tag: "latest"
             pullPolicy: "IfNotPresent"
       serviceAccount:
+        create: true
         name: "ssotap"
     asserts:
       - matchRegex:
@@ -91,7 +92,7 @@ tests:
         serviceAccount: "sa@xyz"
         database: "mydb"
       serviceAccount:
-        enabled: true
+        create: true
         name: "sa"
       config:
         pg:
@@ -140,7 +141,7 @@ tests:
         serviceAccount: "sa@xyz"
         database: "mydb"
       serviceAccount:
-        enabled: true
+        create: true
         name: "sa"
       config:
         pg:
@@ -185,7 +186,7 @@ tests:
         serviceAccount: "sa@xyz"
         database: "mydb"
       serviceAccount:
-        enabled: true
+        create: true
         name: "sa"
       global:
         host: "example.com"

--- a/charts/cadc-tap/tests/uws-db-networkpolicy_test.yaml
+++ b/charts/cadc-tap/tests/uws-db-networkpolicy_test.yaml
@@ -1,0 +1,22 @@
+suite: UWS DB Network Policy
+templates:
+  - uws-db-networkpolicy.yaml
+
+tests:
+  - it: should not create a UWS Network policy when cloudsql is enabled
+    set:
+      cloudsql:
+        enabled: true
+      global:
+        host: "example.com"
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create a UWS DB Network Policy by default
+    set:
+      global:
+        host: "example.com"
+    asserts:
+      - hasDocuments:
+          count: 1

--- a/charts/cadc-tap/tests/uws-db-networkpolicy_test.yaml
+++ b/charts/cadc-tap/tests/uws-db-networkpolicy_test.yaml
@@ -10,8 +10,8 @@ tests:
         instanceConnectionName: "science-platform--xyz:test"
         serviceAccount: "sa@xyz"
         database: "mydb"
-      serviceAcccount:
-        enabled: true
+      serviceAccount:
+        create: true
         name: "sa"
       global:
         host: "example.com"

--- a/charts/cadc-tap/tests/uws-db-networkpolicy_test.yaml
+++ b/charts/cadc-tap/tests/uws-db-networkpolicy_test.yaml
@@ -7,6 +7,12 @@ tests:
     set:
       cloudsql:
         enabled: true
+        instanceConnectionName: "science-platform--xyz:test"
+        serviceAccount: "sa@xyz"
+        database: "mydb"
+      serviceAcccount:
+        enabled: true
+        name: "sa"
       global:
         host: "example.com"
     asserts:

--- a/charts/cadc-tap/tests/uws-db-service_test.yaml
+++ b/charts/cadc-tap/tests/uws-db-service_test.yaml
@@ -10,8 +10,8 @@ tests:
         instanceConnectionName: "science-platform--xyz:test"
         serviceAccount: "sa@xyz"
         database: "mydb"
-      serviceAcccount:
-        enabled: true
+      serviceAccount:
+        create: true
         name: "sa"
       global:
         host: "example.com"

--- a/charts/cadc-tap/tests/uws-db-service_test.yaml
+++ b/charts/cadc-tap/tests/uws-db-service_test.yaml
@@ -1,0 +1,22 @@
+suite: UWS DB Service
+templates:
+  - uws-db-service.yaml
+
+tests:
+  - it: should not create a UWS DB service when cloudsql is enabled
+    set:
+      cloudsql:
+        enabled: true
+      global:
+        host: "example.com"
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create a UWS DB service by default
+    set:
+      global:
+        host: "example.com"
+    asserts:
+      - hasDocuments:
+          count: 1

--- a/charts/cadc-tap/tests/uws-db-service_test.yaml
+++ b/charts/cadc-tap/tests/uws-db-service_test.yaml
@@ -7,6 +7,12 @@ tests:
     set:
       cloudsql:
         enabled: true
+        instanceConnectionName: "science-platform--xyz:test"
+        serviceAccount: "sa@xyz"
+        database: "mydb"
+      serviceAcccount:
+        enabled: true
+        name: "sa"
       global:
         host: "example.com"
     asserts:

--- a/charts/cadc-tap/tests/uws-deployment_test.yaml
+++ b/charts/cadc-tap/tests/uws-deployment_test.yaml
@@ -12,8 +12,8 @@ tests:
         instanceConnectionName: "science-platform--xyz:test"
         serviceAccount: "sa@xyz"
         database: "mydb"
-      serviceAcccount:
-        enabled: true
+      serviceAccount:
+        create: true
         name: "sa"
     asserts:
       - hasDocuments:

--- a/charts/cadc-tap/tests/uws-deployment_test.yaml
+++ b/charts/cadc-tap/tests/uws-deployment_test.yaml
@@ -1,0 +1,24 @@
+suite: UWS Deployment
+templates:
+  - uws-db-deployment.yaml
+
+tests:
+  - it: should not create a UWS deployment when uws is disabled
+    set:
+      uws:
+        enabled: false
+      global:
+        host: "example.com"
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create a UWS deployment when uws is enabled
+    set:
+      uws:
+        enabled: true
+      global:
+        host: "example.com"
+    asserts:
+      - hasDocuments:
+          count: 1

--- a/charts/cadc-tap/tests/uws-deployment_test.yaml
+++ b/charts/cadc-tap/tests/uws-deployment_test.yaml
@@ -3,20 +3,21 @@ templates:
   - uws-db-deployment.yaml
 
 tests:
-  - it: should not create a UWS deployment when uws is disabled
+  - it: should not be created when cloudsql is enabled
     set:
-      uws:
-        enabled: false
       global:
         host: "example.com"
+      cloudsql:
+        enabled: true
+        instanceConnectionName: "science-platform--xyz:test"
+        serviceAccount: "sa@xyz"
+        database: "mydb"
     asserts:
       - hasDocuments:
           count: 0
 
-  - it: should create a UWS deployment when uws is enabled
+  - it: should create a UWS deployment when cloudsql is note enabled (off by default)
     set:
-      uws:
-        enabled: true
       global:
         host: "example.com"
     asserts:

--- a/charts/cadc-tap/tests/uws-deployment_test.yaml
+++ b/charts/cadc-tap/tests/uws-deployment_test.yaml
@@ -12,6 +12,9 @@ tests:
         instanceConnectionName: "science-platform--xyz:test"
         serviceAccount: "sa@xyz"
         database: "mydb"
+      serviceAcccount:
+        enabled: true
+        name: "sa"
     asserts:
       - hasDocuments:
           count: 0

--- a/charts/cadc-tap/values.yaml
+++ b/charts/cadc-tap/values.yaml
@@ -71,7 +71,7 @@ config:
       pullPolicy: "IfNotPresent"
 
       # -- Tag of TAP image to use
-      tag: "1.15.0"
+      tag: "1.16.0"
 
   qserv:
     # -- QServ hostname:port to connect to
@@ -90,6 +90,12 @@ config:
 
   # -- Address to a MySQL database containing TAP schema data
   tapSchemaAddress: "cadc-tap-schema-db:3306"
+
+  # -- UWS Database URL (if using external UWS)
+  uwsDatabaseUrl: ""
+
+  # -- UWS Database Username (if using external UWS)
+  uwsDatabaseUsername: ""
 
   # -- Datalink payload URL
   datalinkPayloadUrl: "https://github.com/lsst/sdm_schemas/releases/download/2.6.1/datalink-snippets.zip"
@@ -158,14 +164,7 @@ tapSchema:
     tag: "2.6.1"
 
   # -- Resource limits and requests for the TAP schema database pod
-  # @default -- See `values.yaml`
-  resources:
-    limits:
-      cpu: "1"
-      memory: "1Gi"
-    requests:
-      cpu: "5m"
-      memory: "400Mi"
+  resources: {}
 
   # -- Annotations for the TAP schema database pod
   podAnnotations: {}
@@ -180,6 +179,8 @@ tapSchema:
   affinity: {}
 
 uws:
+  # --
+  enabled: true
   image:
     # -- UWS database image to use
     repository: "ghcr.io/lsst-sqre/lsst-tap-uws-db"
@@ -211,6 +212,51 @@ uws:
 
   # -- Affinity rules for the UWS database pod
   affinity: {}
+
+cloudsql:
+  # -- Enable the Cloud SQL Auth Proxy sidecar, used with Cloud SQL databases
+  # on Google Cloud
+  enabled: false
+
+  image:
+    # -- Cloud SQL Auth Proxy image to use
+    repository: "gcr.io/cloudsql-docker/gce-proxy"
+
+    # -- Cloud SQL Auth Proxy tag to use
+    tag: "1.35.3"
+
+    # -- Pull policy for Cloud SQL Auth Proxy images
+    pullPolicy: "IfNotPresent"
+
+  # -- Instance connection name for a Cloud SQL PostgreSQL instance
+  instanceConnectionName: ""
+
+  # -- The Google service account that has an IAM binding to the `vo-cutouts`
+  # Kubernetes service accounts and has the `cloudsql.client` role, access
+  # to the GCS bucket, and ability to sign URLs as itself
+  # @default -- None, must be set
+  serviceAccount: ""
+
+  # -- Resource limits and requests for the Cloud SQL Proxy container
+  # @default -- See `values.yaml`
+  resources:
+    limits:
+      cpu: "100m"
+      memory: "20Mi"
+    requests:
+      cpu: "5m"
+      memory: "7Mi"
+
+serviceAccount:
+  # -- Specifies whether a service account should be created.
+  create: false
+
+  # -- Annotations to add to the service account
+  annotations: {}
+
+  # The name of the service account to use.
+  # @default -- Generated using the fullname template
+  name: "cadc-tap"
 
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.

--- a/charts/cadc-tap/values.yaml
+++ b/charts/cadc-tap/values.yaml
@@ -91,12 +91,6 @@ config:
   # -- Address to a MySQL database containing TAP schema data
   tapSchemaAddress: "cadc-tap-schema-db:3306"
 
-  # -- UWS Database URL (if using external UWS)
-  uwsDatabaseUrl: ""
-
-  # -- UWS Database Username (if using external UWS)
-  uwsDatabaseUsername: ""
-
   # -- Datalink payload URL
   datalinkPayloadUrl: "https://github.com/lsst/sdm_schemas/releases/download/2.6.1/datalink-snippets.zip"
 
@@ -164,7 +158,14 @@ tapSchema:
     tag: "2.6.1"
 
   # -- Resource limits and requests for the TAP schema database pod
-  resources: {}
+  # @default -- See `values.yaml`
+  resources:
+    limits:
+      cpu: "1"
+      memory: "1Gi"
+    requests:
+      cpu: "5m"
+      memory: "400Mi"
 
   # -- Annotations for the TAP schema database pod
   podAnnotations: {}
@@ -179,8 +180,6 @@ tapSchema:
   affinity: {}
 
 uws:
-  # --
-  enabled: true
   image:
     # -- UWS database image to use
     repository: "ghcr.io/lsst-sqre/lsst-tap-uws-db"
@@ -231,11 +230,14 @@ cloudsql:
   # -- Instance connection name for a Cloud SQL PostgreSQL instance
   instanceConnectionName: ""
 
-  # -- The Google service account that has an IAM binding to the `vo-cutouts`
+  # -- The Google service account that has an IAM binding to the `cadc-tap`
   # Kubernetes service accounts and has the `cloudsql.client` role, access
-  # to the GCS bucket, and ability to sign URLs as itself
   # @default -- None, must be set
   serviceAccount: ""
+
+  # -- CloudSQL database name
+  # @default -- None, must be set
+  database: ""
 
   # -- Resource limits and requests for the Cloud SQL Proxy container
   # @default -- See `values.yaml`
@@ -247,6 +249,8 @@ cloudsql:
       cpu: "5m"
       memory: "7Mi"
 
+# -- The service account will allways be created when cloudsql.enabled is set to true
+# In this case the serviceAccount configuration here is required
 serviceAccount:
   # -- Specifies whether a service account should be created.
   create: false
@@ -255,8 +259,8 @@ serviceAccount:
   annotations: {}
 
   # The name of the service account to use.
-  # @default -- Generated using the fullname template
-  name: "cadc-tap"
+  # @default -- None, must be set if service account creation is enabled
+  name: ""
 
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.


### PR DESCRIPTION
## PR Summary:

This PR addresses Jira issue DM-44524: Move the UWS database for SSO-TAP to CloudSQL
A summary of the changes introduced to enable the feature:

### Changes to cadc-tap chart:
  - Add optional cloudsql configuration to values
  - Add optional UWS database / username configuration to values
  - Optional serviceaccount.yaml / Used when cloudsql is enabled
  - Make uws optional (add enabled: true | false).
  - Make UWS (uws database that get's deployed as part of cadc-tap until now) resources optional, only deployed when uws enabled
  - Add cloudsql proxy container option to tap-deployment / Deployed if cloudsql is enabled
  - Add Helm unit tests that use: https://github.com/helm-unittest/helm-unittest/
  
### Changes to applications/ssotap:
  - Set serviceAccount in values to default to "ssotap"
  - Enable cloudsql / Disable uws for idfdev. Set parameters so that CloudSQL is used for UWS (using Proxy) / Use tap-postgres image 1.16.0 (which includes auto-initialisation)
  - Add secrets-idfdev.yaml (new secret for UWS CloudSQL database for idfdev)
  
### Changes to github CI workflow:
  - Enable Helm unittest to be run

## Other relevant changes:
- A Postgres database has been created in GCP CloudSQL, named "ssotap" for idfdev
- A secret to store the password for this database has been stored in OnePass   
  
## How was this tested:
- Helm chart unit tests for cadc-tap
- Tested sync & async queries to ssotap with the following scenarios:
   - Empty cloudsql ssotap UWS database
   - Non-empty cloudsql ssotap UWS database
   - cloudsql disabled / uws enabled 
  
## Detailed Description

Detailed description of steps taken, design decisions, as well as some question and potential issues found can be found here:
https://github.com/stvoutsin/rub-notes/wiki/DM%E2%80%9044427-%E2%80%90-Enable-CloudSQL-UWS-database-for-SSO-TAP-service 
  
  
## Other info:
The changes should be backwards compatible, i.e. no changes should be required to any of the other tap or ssotap applications. If there are I've missed something and should correct.
