### PR TITLE
DM-44544: Add ir2 repo to idfdev Butler server

### DIFF
--- a/applications/butler/README.md
+++ b/applications/butler/README.md
@@ -15,6 +15,7 @@ Server for Butler data abstraction service
 | autoscaling.maxReplicas | int | `100` | Maximum number of butler deployment pods |
 | autoscaling.minReplicas | int | `1` | Minimum number of butler deployment pods |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU utilization of butler deployment pods |
+| config.additionalS3ProfileName | string | No second S3 profile is available. | Profile name identifying a second S3 endpoint and set of credentials to use for accessing files in the datastore. |
 | config.dp02PostgresUri | string | No configuration file for DP02 will be generated. | Postgres connection string pointing to the registry database hosting Data Preview 0.2 data. |
 | config.pathPrefix | string | `"/api/butler"` | The prefix of the path portion of the URL where the Butler service will be exposed.  For example, if the service should be exposed at `https://data.lsst.cloud/api/butler`, this should be set to `/api/butler` |
 | config.pguser | string | Use values specified in per-repository Butler config files. | Postgres username used to connect to the Butler DB |

--- a/applications/butler/secrets.yaml
+++ b/applications/butler/secrets.yaml
@@ -18,3 +18,9 @@
   copy:
     application: nublado
     key: "postgres-credentials.txt"
+"additional-s3-profile":
+  description: >-
+    Credentials and endpoint for a second S3 profile to use, in addition to the
+    default endpoint.  For docs on format see
+    https://github.com/lsst/resources/blob/a34598e125919799d3db4bd8a2363087c3de434e/python/lsst/resources/s3utils.py#L201
+  if: additionalS3ProfileName

--- a/applications/butler/secrets.yaml
+++ b/applications/butler/secrets.yaml
@@ -23,4 +23,4 @@
     Credentials and endpoint for a second S3 profile to use, in addition to the
     default endpoint.  For docs on format see
     https://github.com/lsst/resources/blob/a34598e125919799d3db4bd8a2363087c3de434e/python/lsst/resources/s3utils.py#L201
-  if: additionalS3ProfileName
+  if: config.additionalS3ProfileName

--- a/applications/butler/templates/deployment.yaml
+++ b/applications/butler/templates/deployment.yaml
@@ -65,6 +65,13 @@ spec:
             - name: PGUSER
               value: {{ .Values.config.pguser | quote }}
             {{ end }}
+            {{ if .Values.config.additionalS3ProfileName }}
+            - name: LSST_RESOURCES_S3_PROFILE_{{ .Values.config.additionalS3ProfileName }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "butler.fullname" . }}
+                  key: additional-s3-profile
+            {{ end }}
           volumeMounts:
             - name: "butler-secrets"
               mountPath: "/opt/lsst/butler/secrets"

--- a/applications/butler/values-idfdev.yaml
+++ b/applications/butler/values-idfdev.yaml
@@ -6,3 +6,4 @@ config:
   s3EndpointUrl: "https://storage.googleapis.com"
   repositories:
     dp02: "file:///opt/lsst/butler/config/dp02.yaml"
+    ir2: "s3://butler-us-central1-panda-dev/ir2/butler-ir2.yaml"

--- a/applications/butler/values-idfdev.yaml
+++ b/applications/butler/values-idfdev.yaml
@@ -4,6 +4,7 @@ image:
 config:
   dp02PostgresUri: postgresql://postgres@sqlproxy-butler-int.sqlproxy-cross-project:5432/dp02
   s3EndpointUrl: "https://storage.googleapis.com"
+  additionalS3ProfileName: "ir2"
   repositories:
     dp02: "file:///opt/lsst/butler/config/dp02.yaml"
     ir2: "s3://butler-us-central1-panda-dev/ir2/butler-ir2.yaml"

--- a/applications/butler/values.yaml
+++ b/applications/butler/values.yaml
@@ -92,6 +92,11 @@ config:
   # -- URL for the S3 service where files for datasets are stored by Butler.
   s3EndpointUrl: ""
 
+  # -- Profile name identifying a second S3 endpoint and set of credentials
+  # to use for accessing files in the datastore.
+  # @default -- No second S3 profile is available.
+  additionalS3ProfileName: ""
+
   # -- The prefix of the path portion of the URL where the Butler service will
   # be exposed.  For example, if the service should be exposed at
   # `https://data.lsst.cloud/api/butler`, this should be set to `/api/butler`


### PR DESCRIPTION
We want to use the ir2 repo to test the "hybrid model" where the Butler's database is at Google but the data is at USDF.

Added a configuration option to Butler to allow it to use two different sets of S3 credentials simultaneously.  Added the ir2 repo to data-dev.