### PR TITLE
tickets/PREOPS-5192: Update phalanx config for schedview-snapshot to use its own vault secret

### DIFF
--- a/applications/schedview-snapshot/README.md
+++ b/applications/schedview-snapshot/README.md
@@ -27,5 +27,5 @@ Dashboard for examination of scheduler snapshots
 | nodeSelector | object | `{}` | Node selection rules for the schedview-snapshot deployment pod |
 | podAnnotations | object | `{}` | Annotations for the schedview-snapshot deployment pod |
 | replicaCount | int | `1` | Number of web deployment pods to start |
-| resources | object | `{}` | Resource limits and requests for the schedview-snapshot deployment pod |
+| resources | object | `{"limits":{"cpu":2,"memory":"8Gi"},"requests":{"cpu":1,"memory":"4Gi"}}` | Resource limits and requests for the schedview-snapshot deployment pod |
 | tolerations | list | `[]` | Tolerations for the schedview-snapshot deployment pod |

--- a/applications/schedview-snapshot/secrets.yaml
+++ b/applications/schedview-snapshot/secrets.yaml
@@ -1,9 +1,6 @@
-# Follow the example of plot-navigator, but only getting the aws-credentials
-
 "aws-credentials.ini":
   description: >-
     Cloud storage for access to the LFA, from which scheduler snapshots
     can be loaded.
-  copy:
-    application: nublado
-    key: "aws-credentials.ini"
+  onepassword:
+    encoded: true

--- a/applications/schedview-snapshot/templates/deployment.yaml
+++ b/applications/schedview-snapshot/templates/deployment.yaml
@@ -29,7 +29,6 @@ spec:
               drop:
                 - "all"
             readOnlyRootFilesystem: true
-          privileged: false
           securityContext:
             privileged: false
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/applications/schedview-snapshot/templates/deployment.yaml
+++ b/applications/schedview-snapshot/templates/deployment.yaml
@@ -29,6 +29,7 @@ spec:
               drop:
                 - "all"
             readOnlyRootFilesystem: true
+          privileged: false
           securityContext:
             privileged: false
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/applications/schedview-snapshot/templates/deployment.yaml
+++ b/applications/schedview-snapshot/templates/deployment.yaml
@@ -29,7 +29,6 @@ spec:
               drop:
                 - "all"
             readOnlyRootFilesystem: true
-          securityContext:
             privileged: false
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/applications/schedview-snapshot/templates/deployment.yaml
+++ b/applications/schedview-snapshot/templates/deployment.yaml
@@ -29,7 +29,8 @@ spec:
               drop:
                 - "all"
             readOnlyRootFilesystem: true
-          privileged: false
+          securityContext:
+            privileged: false
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:

--- a/applications/schedview-snapshot/templates/deployment.yaml
+++ b/applications/schedview-snapshot/templates/deployment.yaml
@@ -29,6 +29,7 @@ spec:
               drop:
                 - "all"
             readOnlyRootFilesystem: true
+          privileged: false
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:

--- a/applications/schedview-snapshot/templates/deployment.yaml
+++ b/applications/schedview-snapshot/templates/deployment.yaml
@@ -80,9 +80,11 @@ spec:
       {{- end }}
       volumes:
         - name: tmp
-          emptyDir: {}
+          emptyDir:
+            sizeLimit: "16Gi"
         - name: slashdatcache
-          emptyDir: {}
+          emptyDir:
+            sizeLimit: "16Gi"
         - name: schedview-snapshot-secrets
           secret:
             secretName: schedview-snapshot

--- a/applications/schedview-snapshot/values-usdfint.yaml
+++ b/applications/schedview-snapshot/values-usdfint.yaml
@@ -1,3 +1,8 @@
 image:
   # -- Overrides the image tag whose default is the chart appVersion.
   tag: "v0.12.0"
+
+resources:
+  limits:
+    cpu: 2.0
+    memory: "8Gi"

--- a/applications/schedview-snapshot/values-usdfint.yaml
+++ b/applications/schedview-snapshot/values-usdfint.yaml
@@ -6,3 +6,6 @@ resources:
   limits:
     cpu: 2.0
     memory: "8Gi"
+  requests:
+    cpu: 1.0
+    memory: "4Gi"

--- a/applications/schedview-snapshot/values.yaml
+++ b/applications/schedview-snapshot/values.yaml
@@ -37,7 +37,13 @@ autoscaling:
 podAnnotations: {}
 
 # -- Resource limits and requests for the schedview-snapshot deployment pod
-resources: {}
+resources:
+  limits:
+    cpu: 2.0
+    memory: "8Gi"
+  requests:
+    cpu: 1.0
+    memory: "4Gi"
 
 # -- Node selection rules for the schedview-snapshot deployment pod
 nodeSelector: {}


### PR DESCRIPTION
There were a few "policy violation" events that got shown by ArgoCD on usdf-int that commits here address (or attempt to address) as well. See the slack thread [here](https://lsstc.slack.com/archives/C027902HL8H/p1717442595254499).