### PR TITLE
DM 44461: Mobu GitHub resource/secret toggle

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,7 +64,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Helm Unittest Plugin
-        run: helm plugin install https://github.com/quintush/helm-unittest
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest
 
       - name: Run Helm Unittest
         run: helm unittest charts/cadc-tap

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,9 +66,8 @@ jobs:
       - name: Install Helm Unittest Plugin
         run: helm plugin install https://github.com/helm-unittest/helm-unittest
 
-      - name: Run Helm Unittest
-        run: helm unittest charts/cadc-tap
-
+      - name: Run Helm Unittest for all applications and charts with a `tests` directory
+        run: helm unittest {applications,charts}/*/tests/..
       - uses: lsst-sqre/run-tox@v1
         with:
           python-version: "3.12"

--- a/applications/mobu/README.md
+++ b/applications/mobu/README.md
@@ -13,6 +13,7 @@ Continuous integration testing
 | affinity | object | `{}` | Affinity rules for the mobu frontend pod |
 | config.autostart | list | `[]` | Autostart specification. Must be a list of mobu flock specifications. Each flock listed will be automatically started when mobu is started. |
 | config.debug | bool | `false` | If set to true, include the output from all flocks in the main mobu log and disable structured JSON logging. |
+| config.githubIntegration | bool | `true` | Whether to enable the GitHub app integration. This should be `false` in envs that are behind a VPN because the integration depends on being able to receive webhook requests from github.com. |
 | config.pathPrefix | string | `"/mobu"` | Prefix for mobu's API routes. |
 | config.slackAlerts | bool | `true` | Whether to send alerts and status to Slack. |
 | fullnameOverride | string | `""` | Override the full name for resources (includes the release name) |

--- a/applications/mobu/secrets.yaml
+++ b/applications/mobu/secrets.yaml
@@ -12,7 +12,10 @@ ALERT_HOOK:
     Slack web hook to which mobu should report failures and daily status.
   if: config.slackAlerts
 github-webhook-secret:
+  if: "config.githubIntegration"
   description: >-
+    This needs to be provided when `config.githubIntegration` is `true`. The
+    value can be found in 1Password; search for "Mobu Github Webhook Secret"
     Some mobu functionality can be triggered by requests from GitHub webhooks
     (like refreshing notebooks when changes are pushed to a repo). These
     webhooks get configured in the GitHub UI, and a "Secret" value must be

--- a/applications/mobu/templates/deployment.yaml
+++ b/applications/mobu/templates/deployment.yaml
@@ -42,11 +42,13 @@ spec:
                 secretKeyRef:
                   name: {{ template "mobu.fullname" . }}-gafaelfawr-token
                   key: "token"
+            {{- if .Values.config.githubIntegration }}
             - name: "MOBU_GITHUB_WEBHOOK_SECRET"
               valueFrom:
                 secretKeyRef:
                   name: {{ template "mobu.fullname" . }}-secret
                   key: "github-webhook-secret"
+            {{- end}}
             - name: "MOBU_PATH_PREFIX"
               value: {{ .Values.config.pathPrefix | quote }}
             {{- if .Values.config.debug }}

--- a/applications/mobu/templates/ingress-webhooks.yaml
+++ b/applications/mobu/templates/ingress-webhooks.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.config.githubIntegration }}
 apiVersion: gafaelfawr.lsst.io/v1alpha1
 kind: GafaelfawrIngress
 metadata:
@@ -27,3 +28,4 @@ template:
                   name: {{ template "mobu.fullname" . }}
                   port:
                     number: 8080
+{{- end }}

--- a/applications/mobu/tests/github_disabled_test.yaml
+++ b/applications/mobu/tests/github_disabled_test.yaml
@@ -1,0 +1,21 @@
+suite: Github Integration Disabled
+set:
+  config:
+    githubIntegration: false
+  global:
+    host: "example.com"
+tests:
+  - it: "Should not create an anonymous ingress"
+    template: "ingress-webhooks.yaml"
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: "Should not inject GitHub secrets into the Deployment env"
+    template: "deployment.yaml"
+    asserts:
+      - notContains:
+          path: "spec.template.spec.containers[0].env"
+          any: true
+          content:
+            name: "MOBU_GITHUB_WEBHOOK_SECRET"

--- a/applications/mobu/tests/github_enabled_test.yaml
+++ b/applications/mobu/tests/github_enabled_test.yaml
@@ -1,0 +1,24 @@
+suite: Github Integration Enabled
+set:
+  # GitHub integration is enabled by default, so no need to set any values
+  global:
+    host: "example.com"
+tests:
+  - it: "Should create an anonymous ingress"
+    template: "ingress-webhooks.yaml"
+    asserts:
+      - containsDocument:
+          kind: "GafaelfawrIngress"
+          apiVersion: gafaelfawr.lsst.io/v1alpha1
+      - equal:
+          path: "config.scopes.anonymous"
+          value: true
+
+  - it: "Should inject GitHub secrets into the Deployment env"
+    template: "deployment.yaml"
+    asserts:
+      - contains:
+          path: "spec.template.spec.containers[0].env"
+          any: true
+          content:
+            name: "MOBU_GITHUB_WEBHOOK_SECRET"

--- a/applications/mobu/values-tucson-teststand.yaml
+++ b/applications/mobu/values-tucson-teststand.yaml
@@ -1,0 +1,3 @@
+config:
+  # Mobu here is behind a VPN and is not reachable by github.com
+  githubIntegration: false

--- a/applications/mobu/values.yaml
+++ b/applications/mobu/values.yaml
@@ -36,6 +36,11 @@ config:
   # -- Prefix for mobu's API routes.
   pathPrefix: "/mobu"
 
+  # -- Whether to enable the GitHub app integration. This should be `false`
+  # in envs that are behind a VPN because the integration depends on being
+  # able to receive webhook requests from github.com.
+  githubIntegration: true
+
 # -- Resource limits and requests for the mobu frontend pod
 # @default -- See `values.yaml`
 resources:


### PR DESCRIPTION
## Changes
Taking some cues from @stvoutsin with this PR description and helm unit tests :grinning: 

### Mobu
* Add mobu chart value (`config.githubIntegration`) to conditionally provision resources and secrets to support environments that are behind a VPN and can't get github webhook requests.

### Repo-wide
* Use latest version of helm unittest plugin ([the repo moved](nittest/blob/254c582c18d52e07541dbe0185eb64befa20a822/README.md?plain=1#L7))
* Run `helm unittest` in all `charts/*` and `applications/*` dirs with tests.

## Testing
* Set `config.githubIntegration` to `false` for mobu in `idfdev`
  * Verified ingress was gone and secrets were not injected into container env
 * New helm unit tests
