### PR TITLE
DM-43180: Filter out old messages in fan-out service

### DIFF
--- a/applications/next-visit-fan-out/README.md
+++ b/applications/next-visit-fan-out/README.md
@@ -15,6 +15,7 @@ Poll next visit events from Kafka, duplicate them, and send them to all applicat
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"us-central1-docker.pkg.dev/prompt-proto/prompt/nextvisit-fanout"` |  |
 | image.tag | string | `""` |  |
+| kafka.expiration | float | `3600` | Maximum message age to consider, in seconds. |
 | kafka.offset | string | `"latest"` |  |
 | kafka.saslMechamism | string | `"SCRAM-SHA-512"` |  |
 | kafka.securityProtocol | string | `"SASL_PLAINTEXT"` |  |

--- a/applications/next-visit-fan-out/templates/deployment.yaml
+++ b/applications/next-visit-fan-out/templates/deployment.yaml
@@ -45,6 +45,8 @@ spec:
               value: {{ .Values.kafka.nextVisitTopic }}
             - name: OFFSET
               value: {{ .Values.kafka.offset }}
+            - name: MESSAGE_EXPIRATION
+              value: '{{ .Values.kafka.expiration }}'
             - name: SASL_MECHANISM
               value: {{ .Values.kafka.saslMechamism }}
             - name: SECURITY_PROTOCOL

--- a/applications/next-visit-fan-out/values-usdfdev-prompt-processing.yaml
+++ b/applications/next-visit-fan-out/values-usdfdev-prompt-processing.yaml
@@ -3,6 +3,8 @@ kafka:
   sasquatchAddress: 10.100.226.209:9094
   consumerGroup: test-group-3
   nextVisitTopic: test.next-visit
+  # Dev processes very old images, set to ~20 years
+  expiration: 600_000_000.0
 
 image:
   repository: ghcr.io/lsst-dm/next_visit_fan_out

--- a/applications/next-visit-fan-out/values.yaml
+++ b/applications/next-visit-fan-out/values.yaml
@@ -11,6 +11,8 @@ kafka:
   offset: latest
   saslMechamism: SCRAM-SHA-512
   securityProtocol: SASL_PLAINTEXT
+  # -- Maximum message age to consider, in seconds.
+  expiration: 3600.0
 
 replicaCount: 1
 


### PR DESCRIPTION
This PR adds a config option to Prompt Processing for rejecting out-of-date messages. It should be merged before lsst-dm/next_visit_fan_out#13.