### PR TITLE
Upgrade TAP images / Setup TAP uws on CloudSQL / New cadc libs / Enab…

### DIFF
--- a/applications/alert-stream-broker/README.md
+++ b/applications/alert-stream-broker/README.md
@@ -79,7 +79,7 @@ Alert transmission to community brokers
 | alert-stream-broker.kafkaExporter.logLevel | string | `"warning"` | Log level for Sarama logging |
 | alert-stream-broker.kafkaExporter.topicRegex | string | `".*"` | Kafka topics to monitor |
 | alert-stream-broker.maxBytesRetained | string | `"1000000000000"` | Maximum number of bytes for the replay topic, per partition, per replica. Default is 100GB, but should be lower to not fill storage. |
-| alert-stream-broker.maxMillisecondsRetained | string | `"604800000"` | Maximum amount of time to save simulated alerts in the replay topic, in milliseconds. Default is 7 days. |
+| alert-stream-broker.maxMillisecondsRetained | string | `"1814400000"` | Maximum amount of time to save alerts in the replay topic, in milliseconds. Default is 7 days (604800000). |
 | alert-stream-broker.nameOverride | string | `""` |  |
 | alert-stream-broker.schemaID | int | `1` | Integer ID to use in the prefix of alert data packets. This should be a valid Confluent Schema Registry ID associated with the schema used. |
 | alert-stream-broker.simulatedTopicName | string | `"alerts-simulated"` | Topic used to send simulated alerts to brokers. |
@@ -102,9 +102,9 @@ Alert transmission to community brokers
 | alert-stream-schema-registry.hostname | string | `"usdf-alert-schemas-dev.slac.stanford.edu"` | Hostname for an ingress which sends traffic to the Schema Registry. |
 | alert-stream-schema-registry.name | string | `"alert-schema-registry"` | Name used by the registry, and by its users. |
 | alert-stream-schema-registry.port | int | `8081` | Port where the registry is listening. NOTE: Not actually configurable in strimzi-registry-operator, so this basically cannot be changed. |
-| alert-stream-schema-registry.schemaSync | object | `{"image":{"repository":"lsstdm/lsst_alert_packet","tag":"tickets-DM-41530"},"subject":"alert-packet"}` | Configuration for the Job which injects the most recent alert_packet schema into the Schema Registry |
+| alert-stream-schema-registry.schemaSync | object | `{"image":{"repository":"lsstdm/lsst_alert_packet","tag":"tickets-DM-44470"},"subject":"alert-packet"}` | Configuration for the Job which injects the most recent alert_packet schema into the Schema Registry |
 | alert-stream-schema-registry.schemaSync.image.repository | string | `"lsstdm/lsst_alert_packet"` | Repository of a container which has the alert_packet syncLatestSchemaToRegistry.py program |
-| alert-stream-schema-registry.schemaSync.image.tag | string | `"tickets-DM-41530"` | Version of the container to use |
+| alert-stream-schema-registry.schemaSync.image.tag | string | `"tickets-DM-44470"` | Version of the container to use |
 | alert-stream-schema-registry.schemaSync.subject | string | `"alert-packet"` | Subject name to use when inserting data into the Schema Registry |
 | alert-stream-schema-registry.schemaTopic | string | `"registry-schemas"` | Name of the topic used by the Schema Registry to store data. |
 | alert-stream-schema-registry.strimziAPIVersion | string | `"v1beta2"` | Version of the Strimzi Custom Resource API. The correct value depends on the deployed version of Strimzi. See [this blog post](https://strimzi.io/blog/2021/04/29/api-conversion/) for more. |

--- a/applications/alert-stream-broker/charts/alert-stream-broker/README.md
+++ b/applications/alert-stream-broker/charts/alert-stream-broker/README.md
@@ -36,7 +36,7 @@ Kafka broker cluster for distributing alerts
 | kafkaExporter.logLevel | string | `"warning"` | Log level for Sarama logging |
 | kafkaExporter.topicRegex | string | `".*"` | Kafka topics to monitor |
 | maxBytesRetained | string | `"1000000000000"` | Maximum number of bytes for the replay topic, per partition, per replica. Default is 100GB, but should be lower to not fill storage. |
-| maxMillisecondsRetained | string | `"604800000"` | Maximum amount of time to save simulated alerts in the replay topic, in milliseconds. Default is 7 days. |
+| maxMillisecondsRetained | string | `"1814400000"` | Maximum amount of time to save alerts in the replay topic, in milliseconds. Default is 7 days (604800000). |
 | nameOverride | string | `""` |  |
 | schemaID | int | `1` | Integer ID to use in the prefix of alert data packets. This should be a valid Confluent Schema Registry ID associated with the schema used. |
 | simulatedTopicName | string | `"alerts-simulated"` | Topic used to send simulated alerts to brokers. |

--- a/applications/alert-stream-broker/charts/alert-stream-broker/templates/kafka-topics.yaml
+++ b/applications/alert-stream-broker/charts/alert-stream-broker/templates/kafka-topics.yaml
@@ -26,6 +26,11 @@ spec:
     cleanup.policy: "delete"
     retention.ms: {{ .Values.maxMillisecondsRetained }} # 7 days
     retention.bytes: {{ .Values.maxBytesRetained }}
+    # The default timestamp is the creation time of the alert.
+    # To get the ingestion rate, we need this to be the log
+    # append time, and the header will contain the producer
+    # timestamp instead
+    message.timestamp.type: 'LogAppendTime'
   partitions: {{ .Values.topicPartitions }}
   replicas: {{ .Values.topicReplicas }}
 ---
@@ -40,6 +45,11 @@ spec:
     cleanup.policy: "delete"
     retention.ms: {{ .Values.maxMillisecondsRetained }} # 7 days
     retention.bytes: {{ .Values.maxBytesRetained }}
+    # The default timestamp is the creation time of the alert.
+    # To get the ingestion rate, we need this to be the log
+    # append time, and the header will contain the producer
+    # timestamp instead
+    message.timestamp.type: 'LogAppendTime'
   partitions: {{ .Values.simulatedTopicPartitions }}
   replicas: {{ .Values.simulatedTopicReplicas }}
 ---
@@ -55,5 +65,10 @@ spec:
     retention.ms: {{ .Values.maxMillisecondsRetained }} # 7 days
     retention.bytes: {{ .Values.maxBytesRetained }}
     compression.type: {{ .Values.devTopicCompression}}
+    # The default timestamp is the creation time of the alert.
+    # To get the ingestion rate, we need this to be the log
+    # append time, and the header will contain the producer
+    # timestamp instead
+    message.timestamp.type: 'LogAppendTime'
   partitions: {{ .Values.devTopicPartitions }}
   replicas: {{ .Values.devTopicReplicas }}

--- a/applications/alert-stream-broker/charts/alert-stream-broker/templates/kafka.yaml
+++ b/applications/alert-stream-broker/charts/alert-stream-broker/templates/kafka.yaml
@@ -30,6 +30,13 @@ spec:
     {{- end }}
     version: {{ .Values.kafka.version }}
     replicas: {{ .Values.kafka.replicas }}
+    resources:
+      requests:
+        memory: 16Gi
+        cpu: "4"
+      limits:
+        memory: 32Gi
+        cpu: "8"
     listeners:
       - name: internal
         port: 9092

--- a/applications/alert-stream-broker/charts/alert-stream-broker/values.yaml
+++ b/applications/alert-stream-broker/charts/alert-stream-broker/values.yaml
@@ -166,9 +166,9 @@ clusterName: alert-broker
 # TLS listener.
 clusterPort: 9092
 
-# -- Maximum amount of time to save simulated alerts in the replay topic, in
-# milliseconds. Default is 7 days.
-maxMillisecondsRetained: "604800000"
+# -- Maximum amount of time to save alerts in the replay topic, in
+# milliseconds. Default is 7 days (604800000).
+maxMillisecondsRetained: "1814400000"
 
 # -- Maximum number of bytes for the replay topic, per partition, per replica.
 # Default is 100GB, but should be lower to not fill storage.

--- a/applications/alert-stream-broker/charts/alert-stream-schema-registry/README.md
+++ b/applications/alert-stream-broker/charts/alert-stream-schema-registry/README.md
@@ -10,9 +10,9 @@ Confluent Schema Registry for managing schema versions for the Alert Stream
 | hostname | string | `"usdf-alert-schemas-dev.slac.stanford.edu"` | Hostname for an ingress which sends traffic to the Schema Registry. |
 | name | string | `"alert-schema-registry"` | Name used by the registry, and by its users. |
 | port | int | `8081` | Port where the registry is listening. NOTE: Not actually configurable in strimzi-registry-operator, so this basically cannot be changed. |
-| schemaSync | object | `{"image":{"repository":"lsstdm/lsst_alert_packet","tag":"tickets-DM-41530"},"subject":"alert-packet"}` | Configuration for the Job which injects the most recent alert_packet schema into the Schema Registry |
+| schemaSync | object | `{"image":{"repository":"lsstdm/lsst_alert_packet","tag":"tickets-DM-44470"},"subject":"alert-packet"}` | Configuration for the Job which injects the most recent alert_packet schema into the Schema Registry |
 | schemaSync.image.repository | string | `"lsstdm/lsst_alert_packet"` | Repository of a container which has the alert_packet syncLatestSchemaToRegistry.py program |
-| schemaSync.image.tag | string | `"tickets-DM-41530"` | Version of the container to use |
+| schemaSync.image.tag | string | `"tickets-DM-44470"` | Version of the container to use |
 | schemaSync.subject | string | `"alert-packet"` | Subject name to use when inserting data into the Schema Registry |
 | schemaTopic | string | `"registry-schemas"` | Name of the topic used by the Schema Registry to store data. |
 | strimziAPIVersion | string | `"v1beta2"` | Version of the Strimzi Custom Resource API. The correct value depends on the deployed version of Strimzi. See [this blog post](https://strimzi.io/blog/2021/04/29/api-conversion/) for more. |

--- a/applications/alert-stream-broker/charts/alert-stream-schema-registry/values.yaml
+++ b/applications/alert-stream-broker/charts/alert-stream-schema-registry/values.yaml
@@ -29,7 +29,7 @@ schemaSync:
     # syncLatestSchemaToRegistry.py program
     repository: lsstdm/lsst_alert_packet
     # -- Version of the container to use
-    tag: tickets-DM-41530
+    tag: tickets-DM-44470
 
   # -- Subject name to use when inserting data into the Schema Registry
   subject: alert-packet

--- a/applications/alert-stream-broker/values-usdfdev-alert-stream-broker.yaml
+++ b/applications/alert-stream-broker/values-usdfdev-alert-stream-broker.yaml
@@ -114,7 +114,7 @@ alert-stream-broker:
   simulatedTopicName: alerts-simulated
   topicPartitions: 400
   topicReplicas: 1
-  simulatedTopicPartitions: 400
+  simulatedTopicPartitions: 45
   simulatedTopicReplicas: 1
   devTopicName: dev-topic
   devTopicPartitions: 10

--- a/applications/argocd/values-idfdev.yaml
+++ b/applications/argocd/values-idfdev.yaml
@@ -42,6 +42,7 @@ argo-cd:
         g, kkoehler@lsst.cloud, role:developer
         g, loi@lsst.cloud, role:developer
         g, roby@lsst.cloud, role:developer
+        g, salnikov@lsst.cloud, role:developer
       scopes: "[email]"
 
   server:

--- a/applications/argocd/values-idfint.yaml
+++ b/applications/argocd/values-idfint.yaml
@@ -44,6 +44,7 @@ argo-cd:
         g, jeremym@lsst.cloud, role:developer
         g, loi@lsst.cloud, role:developer
         g, roby@lsst.cloud, role:developer
+        g, salnikov@lsst.cloud, role:developer
       scopes: "[email]"
 
   server:

--- a/applications/argocd/values-usdfdev-prompt-processing.yaml
+++ b/applications/argocd/values-usdfdev-prompt-processing.yaml
@@ -35,6 +35,7 @@ argo-cd:
         g, hchiang2@slac.stanford.edu, role:admin
         g, ebellm@slac.stanford.edu, role:admin
         g, parejko@slac.stanford.edu, role:admin
+        g, elhoward@slac.stanford.edu, role:admin
       scopes: "[email]"
 
   server:

--- a/applications/consdb/README.md
+++ b/applications/consdb/README.md
@@ -23,10 +23,18 @@ Consolidated Database of Image Metadata
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
-| hinfo.image.repository | string | `"ghcr.io/lsst-dm/consdb-hinfo"` | Image to use in the consdb deployment |
-| hinfo.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
-| image.pullPolicy | string | `"Always"` | Pull policy for the consdb image |
-| image.replicaCount | int | `1` | Number of consdb deployment pods to start |
+| hinfo.image.pullPolicy | string | `"Always"` | Pull policy for the consdb-hinfo image |
+| hinfo.image.repository | string | `"ghcr.io/lsst-dm/consdb-hinfo"` | Image to use in the consdb-hinfo deployment |
+| hinfo.latiss.enable | bool | `false` | Enable deployment of consdb-hinfo for LATISS. |
+| hinfo.latiss.logConfig | string | `"INFO"` | Log configuration for LATISS deployment. |
+| hinfo.latiss.tag | string | `""` | Tag for LATISS deployment. |
+| hinfo.lsstcam.enable | bool | `false` | Enable deployment of consdb-hinfo for LSSTCam. |
+| hinfo.lsstcam.logConfig | string | `"INFO"` | Log configuration for LSSTCam deployment. |
+| hinfo.lsstcam.tag | string | `""` | Tag for LSSTCam deployment. |
+| hinfo.lsstcomcam.enable | bool | `false` | Enable deployment of consdb-hinfo for LSSTComCam. |
+| hinfo.lsstcomcam.logConfig | string | `"INFO"` | Log configuration for LSSTComCam deployment. |
+| hinfo.lsstcomcam.tag | string | `""` | Tag for LSSTComCam deployment. |
+| hinfo.replicaCount | int | `1` | Number of consdb-hinfo deployment pods to start per instrument |
 | ingress.annotations | object | `{}` | Additional annotations for the ingress rule |
 | kafka.bootstrap | string | `"sasquatch-kafka-bootstrap.sasquatch:9092"` | Kafka bootstrap server |
 | kafka.group_id | string | `"consdb-consumer"` | Name of Kafka consumer group |
@@ -37,7 +45,9 @@ Consolidated Database of Image Metadata
 | lfa.s3EndpointUrl | string | `""` | url |
 | nodeSelector | object | `{}` | Node selection rules for the consdb deployment pod |
 | podAnnotations | object | `{}` | Annotations for the consdb deployment pod |
-| pq.image.repository | string | `"ghcr.io/lsst-dm/consdb-pq"` | Image to use in the consdb deployment |
+| pq.image.pullPolicy | string | `"Always"` | Pull policy for the consdb-hinfo image |
+| pq.image.repository | string | `"ghcr.io/lsst-dm/consdb-pq"` | Image to use in the consdb-pq deployment |
 | pq.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
+| pq.replicaCount | int | `1` | Number of consdb-hinfo deployment pods to start |
 | resources | object | `{}` | Resource limits and requests for the consdb deployment pod |
 | tolerations | list | `[]` | Tolerations for the consdb deployment pod |

--- a/applications/consdb/templates/hinfo-deployment.yaml
+++ b/applications/consdb/templates/hinfo-deployment.yaml
@@ -1,12 +1,14 @@
+{{- if .Values.hinfo.latiss.enable }}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: "consdb-hinfo"
+  name: "consdb-hinfo-latiss"
   labels:
     {{- include "consdb.labels" . | nindent 4 }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.hinfo.replicaCount }}
   {{- end }}
   selector:
     matchLabels:
@@ -23,18 +25,22 @@ spec:
     spec:
       automountServiceAccountToken: false
       containers:
-        - name: "consdb-hinfo"
+        - name: "consdb-hinfo-latiss"
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - "all"
             readOnlyRootFilesystem: true
-          image: "{{ .Values.hinfo.image.repository }}:{{ .Values.hinfo.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{ .Values.hinfo.image.repository }}:{{ .Values.hinfo.latiss.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.hinfo.image.pullPolicy }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:
+            - name: "INSTRUMENT"
+              value: "LATISS"
+            - name: "LOG_CONFIG"
+              value: "{{ .Values.hinfo.latiss.logConfig }}"
             - name: "DB_HOST"
               value: "{{ .Values.db.host }}"
             - name: "DB_PASS"
@@ -89,3 +95,200 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}
+{{- if .Values.hinfo.lsstcomcam.enable }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "consdb-hinfo-lsstcomcam"
+  labels:
+    {{- include "consdb.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.hinfo.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "consdb.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        component: hinfo
+        {{- include "consdb.selectorLabels" . | nindent 8 }}
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - name: "consdb-hinfo-lsstcomcam"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+            readOnlyRootFilesystem: true
+          image: "{{ .Values.hinfo.image.repository }}:{{ .Values.hinfo.lsstcomcam.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.hinfo.image.pullPolicy }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          env:
+            - name: "INSTRUMENT"
+              value: "LSSTComCam"
+            - name: "LOG_CONFIG"
+              value: "{{ .Values.hinfo.lsstcomcam.logConfig }}"
+            - name: "DB_HOST"
+              value: "{{ .Values.db.host }}"
+            - name: "DB_PASS"
+              valueFrom:
+                secretKeyRef:
+                  name: consdb
+                  key: "oods-password"
+            - name: "DB_USER"
+              value: "{{ .Values.db.user }}"
+            - name: "DB_NAME"
+              value: "{{ .Values.db.database }}"
+            - name: "AWS_ACCESS_KEY_ID"
+              valueFrom:
+                secretKeyRef:
+                  name: consdb
+                  key: "lfa-key"
+            - name: "AWS_SECRET_ACCESS_KEY"
+              valueFrom:
+                secretKeyRef:
+                  name: consdb
+                  key: "lfa-password"
+            - name: "BUCKET_PREFIX"
+              value: "{{ .Values.lfa.bucket_prefix }}"
+            - name: "S3_ENDPOINT_URL"
+              value: "{{ .Values.lfa.s3EndpointUrl }}"
+            - name: "KAFKA_BOOTSTRAP"
+              value: "{{ .Values.kafka.bootstrap }}"
+            - name: "KAFKA_USERNAME"
+              value: "{{ .Values.kafka.username }}"
+            - name: "KAFKA_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  name: sasquatch
+                  key: "consdb-password"
+            - name: "KAFKA_GROUP_ID"
+              value: "{{ .Values.kafka.group_id }}"
+            - name: "SCHEMA_URL"
+              value: "{{ .Values.kafka.schema_url }}"
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}
+{{- if .Values.hinfo.lsstcam.enable }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "consdb-hinfo-lsstcam"
+  labels:
+    {{- include "consdb.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.hinfo.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "consdb.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        component: hinfo
+        {{- include "consdb.selectorLabels" . | nindent 8 }}
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - name: "consdb-hinfo-lsstcam"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+            readOnlyRootFilesystem: true
+          image: "{{ .Values.hinfo.image.repository }}:{{ .Values.hinfo.lsstcam.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.hinfo.image.pullPolicy }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          env:
+            - name: "INSTRUMENT"
+              value: "LSSTCam"
+            - name: "LOG_CONFIG"
+              value: "{{ .Values.hinfo.lsstcam.logConfig }}"
+            - name: "DB_HOST"
+              value: "{{ .Values.db.host }}"
+            - name: "DB_PASS"
+              valueFrom:
+                secretKeyRef:
+                  name: consdb
+                  key: "oods-password"
+            - name: "DB_USER"
+              value: "{{ .Values.db.user }}"
+            - name: "DB_NAME"
+              value: "{{ .Values.db.database }}"
+            - name: "AWS_ACCESS_KEY_ID"
+              valueFrom:
+                secretKeyRef:
+                  name: consdb
+                  key: "lfa-key"
+            - name: "AWS_SECRET_ACCESS_KEY"
+              valueFrom:
+                secretKeyRef:
+                  name: consdb
+                  key: "lfa-password"
+            - name: "BUCKET_PREFIX"
+              value: "{{ .Values.lfa.bucket_prefix }}"
+            - name: "S3_ENDPOINT_URL"
+              value: "{{ .Values.lfa.s3EndpointUrl }}"
+            - name: "KAFKA_BOOTSTRAP"
+              value: "{{ .Values.kafka.bootstrap }}"
+            - name: "KAFKA_USERNAME"
+              value: "{{ .Values.kafka.username }}"
+            - name: "KAFKA_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  name: sasquatch
+                  key: "consdb-password"
+            - name: "KAFKA_GROUP_ID"
+              value: "{{ .Values.kafka.group_id }}"
+            - name: "SCHEMA_URL"
+              value: "{{ .Values.kafka.schema_url }}"
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/applications/consdb/templates/pq-deployment.yaml
+++ b/applications/consdb/templates/pq-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "consdb.labels" . | nindent 4 }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.pq.replicaCount }}
   {{- end }}
   selector:
     matchLabels:
@@ -31,7 +31,7 @@ spec:
                 - "all"
             readOnlyRootFilesystem: true
           image: "{{ .Values.pq.image.repository }}:{{ .Values.pq.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          imagePullPolicy: {{ .Values.pq.image.pullPolicy }}
           ports:
             - name: http
               containerPort: 8080

--- a/applications/consdb/values-base.yaml
+++ b/applications/consdb/values-base.yaml
@@ -5,8 +5,17 @@ db:
 lfa:
   s3EndpointUrl: "https://s3.ls.lsst.org"
 hinfo:
-  image:
-    tag: "2.0.4"
+  latiss:
+    enable: true
+    tag: "tickets-DM-44551"
+    logConfig: "consdb.hinfo=DEBUG"
+  lsstcomcam:
+    enable: true
+    tag: "tickets-DM-44551"
+    logConfig: "consdb.hinfo=DEBUG"
+  lsstcam:
+    enable: false
+    tag: "tickets-DM-44551"
 pq:
   image:
-    tag: "2.0.3"
+    tag: "main"

--- a/applications/consdb/values-summit.yaml
+++ b/applications/consdb/values-summit.yaml
@@ -1,6 +1,21 @@
 db:
   user: "oods"
   host: "postgresdb01.cp.lsst.org"
-  database: "butler"
+  database: "exposurelog"
 lfa:
   s3EndpointUrl: "https://s3.cp.lsst.org"
+hinfo:
+  latiss:
+    enable: true
+    tag: "tickets-DM-44551"
+    logConfig: "consdb.hinfo=DEBUG"
+  lsstcomcam:
+    enable: true
+    tag: "tickets-DM-44551"
+    logConfig: "consdb.hinfo=DEBUG"
+  lsstcam:
+    enable: false
+    tag: "tickets-DM-44551"
+pq:
+  image:
+    tag: "main"

--- a/applications/consdb/values-usdfdev.yaml
+++ b/applications/consdb/values-usdfdev.yaml
@@ -1,0 +1,17 @@
+db:
+  user: "usdf"
+  host: "usdf-summitdb.slac.stanford.edu"
+  database: "exposurelog"
+hinfo:
+  latiss:
+    enable: false
+    tag: "tickets-DM-44551"
+  lsstcomcam:
+    enable: false
+    tag: "tickets-DM-44551"
+  lsstcam:
+    enable: false
+    tag: "tickets-DM-44551"
+pq:
+  image:
+    tag: "main"

--- a/applications/consdb/values-usdfprod.yaml
+++ b/applications/consdb/values-usdfprod.yaml
@@ -1,10 +1,17 @@
-environment:
-  vaultUrl: "https://vault.slac.stanford.edu"
-
 db:
-  user: "rubin"
-  host: "usdf-butler.slac.stanford.edu"
-  database: "lsstdb1"
-lfa:
-  bucket_prefix: "rubin:"
-  s3EndpointUrl: "https://s3dfrgw.slac.stanford.edu"
+  user: "usdf"
+  host: "usdf-summitdb.slac.stanford.edu"
+  database: "exposurelog"
+hinfo:
+  latiss:
+    enable: false
+    tag: "tickets-DM-44551"
+  lsstcomcam:
+    enable: false
+    tag: "tickets-DM-44551"
+  lsstcam:
+    enable: false
+    tag: "tickets-DM-44551"
+pq:
+  image:
+    tag: "main"

--- a/applications/consdb/values.yaml
+++ b/applications/consdb/values.yaml
@@ -2,22 +2,43 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-image:
-  # -- Number of consdb deployment pods to start
-  replicaCount: 1
-  # -- Pull policy for the consdb image
-  pullPolicy: "Always"
-
 hinfo:
+  # -- Number of consdb-hinfo deployment pods to start per instrument
+  replicaCount: 1
   image:
-    # -- Image to use in the consdb deployment
+    # -- Pull policy for the consdb-hinfo image
+    pullPolicy: "Always"
+    # -- Image to use in the consdb-hinfo deployment
     repository: "ghcr.io/lsst-dm/consdb-hinfo"
-    # -- Overrides the image tag whose default is the chart appVersion.
+  latiss:
+    # -- Enable deployment of consdb-hinfo for LATISS.
+    enable: false
+    # -- Tag for LATISS deployment.
     tag: ""
+    # -- Log configuration for LATISS deployment.
+    logConfig: "INFO"
+  lsstcomcam:
+    # -- Enable deployment of consdb-hinfo for LSSTComCam.
+    enable: false
+    # -- Tag for LSSTComCam deployment.
+    tag: ""
+    # -- Log configuration for LSSTComCam deployment.
+    logConfig: "INFO"
+  lsstcam:
+    # -- Enable deployment of consdb-hinfo for LSSTCam.
+    enable: false
+    # -- Tag for LSSTCam deployment.
+    tag: ""
+    # -- Log configuration for LSSTCam deployment.
+    logConfig: "INFO"
 
 pq:
+  # -- Number of consdb-hinfo deployment pods to start
+  replicaCount: 1
   image:
-    # -- Image to use in the consdb deployment
+    # -- Pull policy for the consdb-hinfo image
+    pullPolicy: "Always"
+    # -- Image to use in the consdb-pq deployment
     repository: "ghcr.io/lsst-dm/consdb-pq"
     # -- Overrides the image tag whose default is the chart appVersion.
     tag: ""

--- a/applications/next-visit-fan-out/README.md
+++ b/applications/next-visit-fan-out/README.md
@@ -15,6 +15,7 @@ Poll next visit events from Kafka, duplicate them, and send them to all applicat
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"us-central1-docker.pkg.dev/prompt-proto/prompt/nextvisit-fanout"` |  |
 | image.tag | string | `""` |  |
+| kafka.expiration | float | `3600` | Maximum message age to consider, in seconds. |
 | kafka.offset | string | `"latest"` |  |
 | kafka.saslMechamism | string | `"SCRAM-SHA-512"` |  |
 | kafka.securityProtocol | string | `"SASL_PLAINTEXT"` |  |

--- a/applications/next-visit-fan-out/templates/deployment.yaml
+++ b/applications/next-visit-fan-out/templates/deployment.yaml
@@ -45,6 +45,8 @@ spec:
               value: {{ .Values.kafka.nextVisitTopic }}
             - name: OFFSET
               value: {{ .Values.kafka.offset }}
+            - name: MESSAGE_EXPIRATION
+              value: '{{ .Values.kafka.expiration }}'
             - name: SASL_MECHANISM
               value: {{ .Values.kafka.saslMechamism }}
             - name: SECURITY_PROTOCOL

--- a/applications/next-visit-fan-out/values-usdfdev-prompt-processing.yaml
+++ b/applications/next-visit-fan-out/values-usdfdev-prompt-processing.yaml
@@ -3,6 +3,8 @@ kafka:
   sasquatchAddress: 10.100.226.209:9094
   consumerGroup: test-group-3
   nextVisitTopic: test.next-visit
+  # Dev processes very old images, set to ~20 years
+  expiration: 600_000_000.0
 
 image:
   repository: ghcr.io/lsst-dm/next_visit_fan_out

--- a/applications/next-visit-fan-out/values.yaml
+++ b/applications/next-visit-fan-out/values.yaml
@@ -11,6 +11,8 @@ kafka:
   offset: latest
   saslMechamism: SCRAM-SHA-512
   securityProtocol: SASL_PLAINTEXT
+  # -- Maximum message age to consider, in seconds.
+  expiration: 3600.0
 
 replicaCount: 1
 

--- a/applications/nublado/Chart.yaml
+++ b/applications/nublado/Chart.yaml
@@ -5,7 +5,7 @@ description: JupyterHub and custom spawner for the Rubin Science Platform
 sources:
   - https://github.com/lsst-sqre/nublado
 home: https://nublado.lsst.io/
-appVersion: 6.1.0
+appVersion: 6.2.0
 
 dependencies:
   - name: jupyterhub

--- a/applications/nublado/values-summit.yaml
+++ b/applications/nublado/values-summit.yaml
@@ -8,8 +8,8 @@ controller:
       numReleases: 0
       numWeeklies: 3
       numDailies: 2
-      cycle: 36
-      recommendedTag: "recommended_c0036"
+      cycle: 37
+      recommendedTag: "recommended_c0037"
     lab:
       extraAnnotations:
         k8s.v1.cni.cncf.io/networks: "kube-system/dds"

--- a/applications/obsenv-management/.helmignore
+++ b/applications/obsenv-management/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/applications/obsenv-management/Chart.yaml
+++ b/applications/obsenv-management/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+version: 1.0.0
+description: Rubin Observatory Environment Management System
+name: obsenv-management
+sources:
+- https://github.com/lsst-ts/obsenv-api
+- https://github.com/lsst-ts/obsenv-ui
+type: application
+dependencies:
+- name: obsenv-api
+  version: 1.0.0
+- name: obsenv-ui
+  version: 1.0.0

--- a/applications/obsenv-management/README.md
+++ b/applications/obsenv-management/README.md
@@ -1,0 +1,43 @@
+# obsenv-management
+
+Rubin Observatory Environment Management System
+
+## Source Code
+
+* <https://github.com/lsst-ts/obsenv-api>
+* <https://github.com/lsst-ts/obsenv-ui>
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
+| global.host | string | Set by Argo CD | Host name for ingress |
+| global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
+| obsenv-api.affinity | object | `{}` | Affinity rules for the obsenv-api deployment pod |
+| obsenv-api.config.logLevel | string | `"INFO"` | Logging level |
+| obsenv-api.config.logProfile | string | `"production"` | Logging profile (`production` for JSON, `development` for human-friendly) |
+| obsenv-api.config.pathPrefix | string | `"/obsenv-api"` | URL path prefix |
+| obsenv-api.config.useFakeObsenvManager | bool | `false` | Use fake obsenv management system |
+| obsenv-api.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the obsenv-api image |
+| obsenv-api.image.repository | string | `"rubincr.lsst.org/obsenv-api"` | Image to use in the obsenv-api deployment |
+| obsenv-api.image.tag | string | The appVersion of the chart | Tag of image to use |
+| obsenv-api.ingress.annotations | object | `{}` | Additional annotations for the ingress rule |
+| obsenv-api.nodeSelector | object | `{}` | Node selection rules for the obsenv-api deployment pod |
+| obsenv-api.podAnnotations | object | `{}` | Annotations for the obsenv-api deployment pod |
+| obsenv-api.replicaCount | int | `1` | Number of web deployment pods to start |
+| obsenv-api.resources | object | See `values.yaml` | Resource limits and requests for the obsenv-api deployment pod |
+| obsenv-api.tolerations | list | `[]` | Tolerations for the obsenv-api deployment pod |
+| obsenv-ui.affinity | object | `{}` | Affinity rules for the obsenv-ui deployment pod |
+| obsenv-ui.config.logLevel | string | `"INFO"` | Logging level |
+| obsenv-ui.config.logProfile | string | `"production"` | Logging profile (`production` for JSON, `development` for human-friendly) |
+| obsenv-ui.config.pathPrefix | string | `"/obsenv-ui"` | URL path prefix |
+| obsenv-ui.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the obsenv-ui image |
+| obsenv-ui.image.repository | string | `"rubincr.lsst.org/obsenv-ui"` | Image to use in the obsenv-ui deployment |
+| obsenv-ui.image.tag | string | The appVersion of the chart | Tag of image to use |
+| obsenv-ui.ingress.annotations | object | `{}` | Additional annotations for the ingress rule |
+| obsenv-ui.nodeSelector | object | `{}` | Node selection rules for the obsenv-ui deployment pod |
+| obsenv-ui.podAnnotations | object | `{}` | Annotations for the obsenv-ui deployment pod |
+| obsenv-ui.replicaCount | int | `1` | Number of web deployment pods to start |
+| obsenv-ui.resources | object | See `values.yaml` | Resource limits and requests for the obsenv-ui deployment pod |
+| obsenv-ui.tolerations | list | `[]` | Tolerations for the obsenv-ui deployment pod |

--- a/applications/obsenv-management/charts/obsenv-api/Chart.yaml
+++ b/applications/obsenv-management/charts/obsenv-api/Chart.yaml
@@ -1,0 +1,5 @@
+name: obsenv-api
+apiVersion: v2
+version: 1.0.0
+description: Helm chart for the Observatory Environment Management API.
+appVersion: "0.1.0"

--- a/applications/obsenv-management/charts/obsenv-api/README.md
+++ b/applications/obsenv-management/charts/obsenv-api/README.md
@@ -1,0 +1,22 @@
+# obsenv-api
+
+Helm chart for the Observatory Environment Management API.
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Affinity rules for the obsenv-api deployment pod |
+| config.logLevel | string | `"INFO"` | Logging level |
+| config.logProfile | string | `"production"` | Logging profile (`production` for JSON, `development` for human-friendly) |
+| config.pathPrefix | string | `"/obsenv-api"` | URL path prefix |
+| config.useFakeObsenvManager | bool | `false` | Use fake obsenv management system |
+| image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the obsenv-api image |
+| image.repository | string | `"rubincr.lsst.org/obsenv-api"` | Image to use in the obsenv-api deployment |
+| image.tag | string | The appVersion of the chart | Tag of image to use |
+| ingress.annotations | object | `{}` | Additional annotations for the ingress rule |
+| nodeSelector | object | `{}` | Node selection rules for the obsenv-api deployment pod |
+| podAnnotations | object | `{}` | Annotations for the obsenv-api deployment pod |
+| replicaCount | int | `1` | Number of web deployment pods to start |
+| resources | object | See `values.yaml` | Resource limits and requests for the obsenv-api deployment pod |
+| tolerations | list | `[]` | Tolerations for the obsenv-api deployment pod |

--- a/applications/obsenv-management/charts/obsenv-api/templates/_helpers.tpl
+++ b/applications/obsenv-management/charts/obsenv-api/templates/_helpers.tpl
@@ -1,0 +1,26 @@
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "obsenv-api.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "obsenv-api.labels" -}}
+helm.sh/chart: {{ include "obsenv-api.chart" . }}
+{{ include "obsenv-api.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "obsenv-api.selectorLabels" -}}
+app.kubernetes.io/name: "obsenv-api"
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/applications/obsenv-management/charts/obsenv-api/templates/configmap.yaml
+++ b/applications/obsenv-management/charts/obsenv-api/templates/configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "obsenv-api"
+  labels:
+    {{- include "obsenv-api.labels" . | nindent 4 }}
+data:
+  OBSENV_API_LOG_LEVEL: {{ .Values.config.logLevel | quote }}
+  OBSENV_API_PATH_PREFIX: {{ .Values.config.pathPrefix | quote }}
+  OBSENV_API_PROFILE: {{ .Values.config.logProfile | quote }}
+  OBSENV_API_USE_FAKE_OBSENV_MANAGER: {{ .Values.config.useFakeObsenvManager | quote }}

--- a/applications/obsenv-management/charts/obsenv-api/templates/deployment.yaml
+++ b/applications/obsenv-management/charts/obsenv-api/templates/deployment.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "obsenv-api"
+  labels:
+    {{- include "obsenv-api.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "obsenv-api.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "obsenv-api.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      automountServiceAccountToken: false
+      containers:
+        - name: {{ .Chart.Name }}
+          envFrom:
+            - configMapRef:
+                name: "obsenv-api"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: "http"
+              containerPort: 8080
+              protocol: "TCP"
+          readinessProbe:
+            httpGet:
+              path: "/"
+              port: "http"
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+            readOnlyRootFilesystem: true
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 72091
+        runAsGroup: 72089

--- a/applications/obsenv-management/charts/obsenv-api/templates/networkpolicy.yaml
+++ b/applications/obsenv-management/charts/obsenv-api/templates/networkpolicy.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: "obsenv-api"
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "obsenv-api.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - "Ingress"
+    - "Egress"
+  ingress:
+    - from:
+      - podSelector:
+          matchLabels:
+            app.kubernetes.io/name: obsenv-ui
+  egress:
+    - to:
+      - podSelector:
+          matchLabels:
+            app.kubernetes.io/name: obsenv-ui

--- a/applications/obsenv-management/charts/obsenv-api/templates/service.yaml
+++ b/applications/obsenv-management/charts/obsenv-api/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "obsenv-api"
+  labels:
+    {{- include "obsenv-api.labels" . | nindent 4 }}
+spec:
+  type: "ClusterIP"
+  ports:
+    - port: 8080
+      targetPort: "http"
+      protocol: "TCP"
+      name: "http"
+  selector:
+    {{- include "obsenv-api.selectorLabels" . | nindent 4 }}

--- a/applications/obsenv-management/charts/obsenv-api/values.yaml
+++ b/applications/obsenv-management/charts/obsenv-api/values.yaml
@@ -1,0 +1,47 @@
+# -- Number of web deployment pods to start
+replicaCount: 1
+
+image:
+  # -- Image to use in the obsenv-api deployment
+  repository: "rubincr.lsst.org/obsenv-api"
+
+  # -- Pull policy for the obsenv-api image
+  pullPolicy: "IfNotPresent"
+
+  # -- Tag of image to use
+  # @default -- The appVersion of the chart
+  tag: null
+
+config:
+  # -- Logging level
+  logLevel: "INFO"
+
+  # -- Logging profile (`production` for JSON, `development` for
+  # human-friendly)
+  logProfile: "production"
+
+  # -- URL path prefix
+  pathPrefix: "/obsenv-api"
+
+  # -- Use fake obsenv management system
+  useFakeObsenvManager: false
+
+ingress:
+  # -- Additional annotations for the ingress rule
+  annotations: {}
+
+# -- Affinity rules for the obsenv-api deployment pod
+affinity: {}
+
+# -- Node selection rules for the obsenv-api deployment pod
+nodeSelector: {}
+
+# -- Annotations for the obsenv-api deployment pod
+podAnnotations: {}
+
+# -- Resource limits and requests for the obsenv-api deployment pod
+# @default -- See `values.yaml`
+resources: {}
+
+# -- Tolerations for the obsenv-api deployment pod
+tolerations: []

--- a/applications/obsenv-management/charts/obsenv-ui/Chart.yaml
+++ b/applications/obsenv-management/charts/obsenv-ui/Chart.yaml
@@ -1,0 +1,5 @@
+name: obsenv-ui
+apiVersion: v2
+version: 1.0.0
+description: Helm chart for the Observatory Environment Management UI.
+appVersion: "0.1.0"

--- a/applications/obsenv-management/charts/obsenv-ui/README.md
+++ b/applications/obsenv-management/charts/obsenv-ui/README.md
@@ -1,0 +1,21 @@
+# obsenv-ui
+
+Helm chart for the Observatory Environment Management UI.
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Affinity rules for the obsenv-ui deployment pod |
+| config.logLevel | string | `"INFO"` | Logging level |
+| config.logProfile | string | `"production"` | Logging profile (`production` for JSON, `development` for human-friendly) |
+| config.pathPrefix | string | `"/obsenv-ui"` | URL path prefix |
+| image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the obsenv-ui image |
+| image.repository | string | `"rubincr.lsst.org/obsenv-ui"` | Image to use in the obsenv-ui deployment |
+| image.tag | string | The appVersion of the chart | Tag of image to use |
+| ingress.annotations | object | `{}` | Additional annotations for the ingress rule |
+| nodeSelector | object | `{}` | Node selection rules for the obsenv-ui deployment pod |
+| podAnnotations | object | `{}` | Annotations for the obsenv-ui deployment pod |
+| replicaCount | int | `1` | Number of web deployment pods to start |
+| resources | object | See `values.yaml` | Resource limits and requests for the obsenv-ui deployment pod |
+| tolerations | list | `[]` | Tolerations for the obsenv-ui deployment pod |

--- a/applications/obsenv-management/charts/obsenv-ui/templates/_helpers.tpl
+++ b/applications/obsenv-management/charts/obsenv-ui/templates/_helpers.tpl
@@ -1,0 +1,26 @@
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "obsenv-ui.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "obsenv-ui.labels" -}}
+helm.sh/chart: {{ include "obsenv-ui.chart" . }}
+{{ include "obsenv-ui.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "obsenv-ui.selectorLabels" -}}
+app.kubernetes.io/name: "obsenv-ui"
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/applications/obsenv-management/charts/obsenv-ui/templates/configmap.yaml
+++ b/applications/obsenv-management/charts/obsenv-ui/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "obsenv-ui"
+  labels:
+    {{- include "obsenv-ui.labels" . | nindent 4 }}
+data:
+  BASE_URL: {{ .Values.global.basePath | quote }}
+  OBSENV_API: "obsenv-api:8080"

--- a/applications/obsenv-management/charts/obsenv-ui/templates/deployment.yaml
+++ b/applications/obsenv-management/charts/obsenv-ui/templates/deployment.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "obsenv-ui"
+  labels:
+    {{- include "obsenv-ui.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "obsenv-ui.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "obsenv-ui.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      automountServiceAccountToken: false
+      containers:
+        - name: {{ .Chart.Name }}
+          envFrom:
+            - configMapRef:
+                name: "obsenv-ui"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: "http"
+              containerPort: 8080
+              protocol: "TCP"
+          readinessProbe:
+            httpGet:
+              path: "/"
+              port: "http"
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+            readOnlyRootFilesystem: true
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        runAsGroup: 1001

--- a/applications/obsenv-management/charts/obsenv-ui/templates/ingress.yaml
+++ b/applications/obsenv-management/charts/obsenv-ui/templates/ingress.yaml
@@ -1,0 +1,30 @@
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
+metadata:
+  name: "obsenv-ui"
+  labels:
+    {{- include "obsenv-ui.labels" . | nindent 4 }}
+config:
+  baseUrl: {{ .Values.global.baseUrl | quote }}
+  scopes:
+    all:
+      - "exec:internal-tools"
+template:
+  metadata:
+    name: "obsenv-ui"
+    {{- with .Values.ingress.annotations }}
+    annotations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  spec:
+    rules:
+      - host: {{ required "global.host must be set" .Values.global.host | quote }}
+        http:
+          paths:
+            - path: {{ .Values.config.pathPrefix | quote }}
+              pathType: "Prefix"
+              backend:
+                service:
+                  name: "obsenv-ui"
+                  port:
+                    number: 3000

--- a/applications/obsenv-management/charts/obsenv-ui/templates/networkpolicy.yaml
+++ b/applications/obsenv-management/charts/obsenv-ui/templates/networkpolicy.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: "obsenv-ui"
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "obsenv-ui.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - "Ingress"
+    - "Egress"
+  ingress:
+    - from:
+      - podSelector:
+          matchLabels:
+            app.kubernetes.io/name: obsenv-api
+  egress:
+    - to:
+      - podSelector:
+          matchLabels:
+            app.kubernetes.io/name: obsenv-api

--- a/applications/obsenv-management/charts/obsenv-ui/templates/service.yaml
+++ b/applications/obsenv-management/charts/obsenv-ui/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "obsenv-ui"
+  labels:
+    {{- include "obsenv-ui.labels" . | nindent 4 }}
+spec:
+  type: "ClusterIP"
+  ports:
+    - port: 3000
+      targetPort: "http"
+      protocol: "TCP"
+      name: "http"
+  selector:
+    {{- include "obsenv-ui.selectorLabels" . | nindent 4 }}

--- a/applications/obsenv-management/charts/obsenv-ui/values.yaml
+++ b/applications/obsenv-management/charts/obsenv-ui/values.yaml
@@ -1,0 +1,44 @@
+# -- Number of web deployment pods to start
+replicaCount: 1
+
+image:
+  # -- Image to use in the obsenv-ui deployment
+  repository: "rubincr.lsst.org/obsenv-ui"
+
+  # -- Pull policy for the obsenv-ui image
+  pullPolicy: "IfNotPresent"
+
+  # -- Tag of image to use
+  # @default -- The appVersion of the chart
+  tag: null
+
+config:
+  # -- Logging level
+  logLevel: "INFO"
+
+  # -- Logging profile (`production` for JSON, `development` for
+  # human-friendly)
+  logProfile: "production"
+
+  # -- URL path prefix
+  pathPrefix: "/obsenv-ui"
+
+ingress:
+  # -- Additional annotations for the ingress rule
+  annotations: {}
+
+# -- Affinity rules for the obsenv-ui deployment pod
+affinity: {}
+
+# -- Node selection rules for the obsenv-ui deployment pod
+nodeSelector: {}
+
+# -- Annotations for the obsenv-ui deployment pod
+podAnnotations: {}
+
+# -- Resource limits and requests for the obsenv-ui deployment pod
+# @default -- See `values.yaml`
+resources: {}
+
+# -- Tolerations for the obsenv-ui deployment pod
+tolerations: []

--- a/applications/obsenv-management/values-tucson-teststand.yaml
+++ b/applications/obsenv-management/values-tucson-teststand.yaml
@@ -1,0 +1,3 @@
+obsenv-api:
+  config:
+    useFakeObsenvManager: true

--- a/applications/obsenv-management/values.yaml
+++ b/applications/obsenv-management/values.yaml
@@ -1,0 +1,14 @@
+# The following will be set by parameters injected by Argo CD and should not
+# be set in the individual environment values files.
+global:
+  # -- Base URL for the environment
+  # @default -- Set by Argo CD
+  baseUrl: null
+
+  # -- Host name for ingress
+  # @default -- Set by Argo CD
+  host: null
+
+  # -- Base path for Vault secrets
+  # @default -- Set by Argo CD
+  vaultSecretsPath: null

--- a/applications/portal/values-idfprod.yaml
+++ b/applications/portal/values-idfprod.yaml
@@ -9,4 +9,5 @@ config:
 
 resources:
   limits:
-    memory: "30Gi"
+    cpu: "6"
+    memory: "90Gi"

--- a/applications/prompt-proto-service-hsc-gpu/README.md
+++ b/applications/prompt-proto-service-hsc-gpu/README.md
@@ -18,6 +18,9 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.alerts.topic | string | `"alert-stream-test"` | Topic name where alerts will be sent |
 | prompt-proto-service.alerts.username | string | `"kafka-admin"` | Username for sending alerts to the alert stream |
 | prompt-proto-service.apdb.config | string | None, must be set | URL to a serialized APDB configuration, or the "label:" prefix followed by the indexed name of such a config. |
+| prompt-proto-service.cache.baseSize | int | `3` | The default number of datasets of each type to keep. The pipeline only needs one of most dataset types (one bias, one flat, etc.), so this is roughly the number of visits that fit in the cache. |
+| prompt-proto-service.cache.patchesPerImage | int | `4` | A factor by which to multiply `baseSize` for templates and other patch-based datasets. |
+| prompt-proto-service.cache.refcatsPerImage | int | `4` | A factor by which to multiply `baseSize` for refcat datasets. |
 | prompt-proto-service.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
 | prompt-proto-service.image.repository | string | `"ghcr.io/lsst-dm/prompt-service"` | Image to use in the PP deployment |
 | prompt-proto-service.image.tag | string | `"latest"` | Overrides the image tag whose default is the chart appVersion. |
@@ -31,8 +34,8 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.instrument.skymap | string | `"hsc_rings_v1"` | Skymap to use with the instrument |
 | prompt-proto-service.knative.cpuLimit | string | `"1"` | The maximum cpu cores. |
 | prompt-proto-service.knative.cpuRequest | string | `"1"` | The cpu cores requested. |
-| prompt-proto-service.knative.ephemeralStorageLimit | string | `"20Gi"` | The maximum storage space allowed for each container (mostly local Butler). |
-| prompt-proto-service.knative.ephemeralStorageRequest | string | `"20Gi"` | The storage space reserved for each container (mostly local Butler). |
+| prompt-proto-service.knative.ephemeralStorageLimit | string | `"5Gi"` | The maximum storage space allowed for each container (mostly local Butler). |
+| prompt-proto-service.knative.ephemeralStorageRequest | string | `"5Gi"` | The storage space reserved for each container (mostly local Butler). |
 | prompt-proto-service.knative.gpu | bool | `true` | GPUs enabled. |
 | prompt-proto-service.knative.gpuRequest | string | `"1"` | The number of GPUs to request. |
 | prompt-proto-service.knative.idleTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service (seconds). |

--- a/applications/prompt-proto-service-hsc-gpu/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-hsc-gpu/values-usdfdev-prompt-processing.yaml
@@ -25,7 +25,7 @@ prompt-proto-service:
     topic: prompt-processing-dev
 
   apdb:
-    config: s3://rubin-pp-dev-users/apdb_config/pp_apdb_hsc-dev.py
+    config: s3://rubin-pp-dev-users/apdb_config/sql/pp_apdb_hsc-dev.py
 
   sasquatch:
     endpointUrl: https://usdf-rsp-dev.slac.stanford.edu/sasquatch-rest-proxy

--- a/applications/prompt-proto-service-hsc-gpu/values.yaml
+++ b/applications/prompt-proto-service-hsc-gpu/values.yaml
@@ -43,6 +43,15 @@ prompt-proto-service:
     # @default -- None, must be set
     calibRepo: ""
 
+  cache:
+    # -- The default number of datasets of each type to keep.
+    # The pipeline only needs one of most dataset types (one bias, one flat, etc.), so this is roughly the number of visits that fit in the cache.
+    baseSize: 3
+    # -- A factor by which to multiply `baseSize` for refcat datasets.
+    refcatsPerImage: 4
+    # -- A factor by which to multiply `baseSize` for templates and other patch-based datasets.
+    patchesPerImage: 4
+
   s3:
     # -- Bucket containing the incoming raw images
     # @default -- None, must be set
@@ -104,9 +113,9 @@ prompt-proto-service:
     # -- The maximum cpu cores.
     cpuLimit: "1"
     # -- The storage space reserved for each container (mostly local Butler).
-    ephemeralStorageRequest: "20Gi"
+    ephemeralStorageRequest: "5Gi"
     # -- The maximum storage space allowed for each container (mostly local Butler).
-    ephemeralStorageLimit: "20Gi"
+    ephemeralStorageLimit: "5Gi"
     # -- GPUs enabled.
     gpu: true
     # -- The number of GPUs to request.

--- a/applications/prompt-proto-service-hsc/README.md
+++ b/applications/prompt-proto-service-hsc/README.md
@@ -18,6 +18,9 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.alerts.topic | string | `"alert-stream-test"` | Topic name where alerts will be sent |
 | prompt-proto-service.alerts.username | string | `"kafka-admin"` | Username for sending alerts to the alert stream |
 | prompt-proto-service.apdb.config | string | None, must be set | URL to a serialized APDB configuration, or the "label:" prefix followed by the indexed name of such a config. |
+| prompt-proto-service.cache.baseSize | int | `3` | The default number of datasets of each type to keep. The pipeline only needs one of most dataset types (one bias, one flat, etc.), so this is roughly the number of visits that fit in the cache. |
+| prompt-proto-service.cache.patchesPerImage | int | `4` | A factor by which to multiply `baseSize` for templates and other patch-based datasets. |
+| prompt-proto-service.cache.refcatsPerImage | int | `4` | A factor by which to multiply `baseSize` for refcat datasets. |
 | prompt-proto-service.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
 | prompt-proto-service.image.repository | string | `"ghcr.io/lsst-dm/prompt-service"` | Image to use in the PP deployment |
 | prompt-proto-service.image.tag | string | `"latest"` | Overrides the image tag whose default is the chart appVersion. |
@@ -31,8 +34,8 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.instrument.skymap | string | `"hsc_rings_v1"` | Skymap to use with the instrument |
 | prompt-proto-service.knative.cpuLimit | string | `"1"` | The maximum cpu cores. |
 | prompt-proto-service.knative.cpuRequest | string | `"1"` | The cpu cores requested. |
-| prompt-proto-service.knative.ephemeralStorageLimit | string | `"20Gi"` | The maximum storage space allowed for each container (mostly local Butler). |
-| prompt-proto-service.knative.ephemeralStorageRequest | string | `"20Gi"` | The storage space reserved for each container (mostly local Butler). |
+| prompt-proto-service.knative.ephemeralStorageLimit | string | `"5Gi"` | The maximum storage space allowed for each container (mostly local Butler). |
+| prompt-proto-service.knative.ephemeralStorageRequest | string | `"5Gi"` | The storage space reserved for each container (mostly local Butler). |
 | prompt-proto-service.knative.gpu | bool | `false` | GPUs enabled. |
 | prompt-proto-service.knative.gpuRequest | string | `"0"` | The number of GPUs to request. |
 | prompt-proto-service.knative.idleTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service (seconds). |

--- a/applications/prompt-proto-service-hsc/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-hsc/values-usdfdev-prompt-processing.yaml
@@ -26,7 +26,7 @@ prompt-proto-service:
     topic: prompt-processing-dev
 
   apdb:
-    config: s3://rubin-pp-dev-users/apdb_config/pp_apdb_hsc-dev.py
+    config: s3://rubin-pp-dev-users/apdb_config/sql/pp_apdb_hsc-dev.py
 
   sasquatch:
     endpointUrl: https://usdf-rsp-dev.slac.stanford.edu/sasquatch-rest-proxy

--- a/applications/prompt-proto-service-hsc/values.yaml
+++ b/applications/prompt-proto-service-hsc/values.yaml
@@ -43,6 +43,15 @@ prompt-proto-service:
     # @default -- None, must be set
     calibRepo: ""
 
+  cache:
+    # -- The default number of datasets of each type to keep.
+    # The pipeline only needs one of most dataset types (one bias, one flat, etc.), so this is roughly the number of visits that fit in the cache.
+    baseSize: 3
+    # -- A factor by which to multiply `baseSize` for refcat datasets.
+    refcatsPerImage: 4
+    # -- A factor by which to multiply `baseSize` for templates and other patch-based datasets.
+    patchesPerImage: 4
+
   s3:
     # -- Bucket containing the incoming raw images
     # @default -- None, must be set
@@ -104,9 +113,9 @@ prompt-proto-service:
     # -- The maximum cpu cores.
     cpuLimit: "1"
     # -- The storage space reserved for each container (mostly local Butler).
-    ephemeralStorageRequest: "20Gi"
+    ephemeralStorageRequest: "5Gi"
     # -- The maximum storage space allowed for each container (mostly local Butler).
-    ephemeralStorageLimit: "20Gi"
+    ephemeralStorageLimit: "5Gi"
     # -- GPUs enabled.
     gpu: false
     # -- The number of GPUs to request.

--- a/applications/prompt-proto-service-latiss/README.md
+++ b/applications/prompt-proto-service-latiss/README.md
@@ -18,6 +18,9 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.alerts.topic | string | `"alert-stream-test"` | Topic name where alerts will be sent |
 | prompt-proto-service.alerts.username | string | `"kafka-admin"` | Username for sending alerts to the alert stream |
 | prompt-proto-service.apdb.config | string | None, must be set | URL to a serialized APDB configuration, or the "label:" prefix followed by the indexed name of such a config. |
+| prompt-proto-service.cache.baseSize | int | `3` | The default number of datasets of each type to keep. The pipeline only needs one of most dataset types (one bias, one flat, etc.), so this is roughly the number of visits that fit in the cache. |
+| prompt-proto-service.cache.patchesPerImage | int | `6` | A factor by which to multiply `baseSize` for templates and other patch-based datasets. |
+| prompt-proto-service.cache.refcatsPerImage | int | `4` | A factor by which to multiply `baseSize` for refcat datasets. |
 | prompt-proto-service.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
 | prompt-proto-service.image.repository | string | `"ghcr.io/lsst-dm/prompt-service"` | Image to use in the PP deployment |
 | prompt-proto-service.image.tag | string | `"latest"` | Overrides the image tag whose default is the chart appVersion. |
@@ -31,8 +34,8 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.instrument.skymap | string | `"latiss_v1"` | Skymap to use with the instrument |
 | prompt-proto-service.knative.cpuLimit | string | `"1"` | The maximum cpu cores. |
 | prompt-proto-service.knative.cpuRequest | string | `"1"` | The cpu cores requested. |
-| prompt-proto-service.knative.ephemeralStorageLimit | string | `"20Gi"` | The maximum storage space allowed for each container (mostly local Butler). |
-| prompt-proto-service.knative.ephemeralStorageRequest | string | `"20Gi"` | The storage space reserved for each container (mostly local Butler). |
+| prompt-proto-service.knative.ephemeralStorageLimit | string | `"5Gi"` | The maximum storage space allowed for each container (mostly local Butler). |
+| prompt-proto-service.knative.ephemeralStorageRequest | string | `"5Gi"` | The storage space reserved for each container (mostly local Butler). |
 | prompt-proto-service.knative.gpu | bool | `false` | GPUs enabled. |
 | prompt-proto-service.knative.gpuRequest | string | `"0"` | The number of GPUs to request. |
 | prompt-proto-service.knative.idleTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service (seconds). |

--- a/applications/prompt-proto-service-latiss/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfdev-prompt-processing.yaml
@@ -26,7 +26,7 @@ prompt-proto-service:
     topic: prompt-processing-dev
 
   apdb:
-    config: s3://rubin-pp-dev-users/apdb_config/pp_apdb_latiss-dev.py
+    config: s3://rubin-pp-dev-users/apdb_config/cassandra/pp_apdb_latiss-dev.py
 
   sasquatch:
     endpointUrl: https://usdf-rsp-dev.slac.stanford.edu/sasquatch-rest-proxy

--- a/applications/prompt-proto-service-latiss/values.yaml
+++ b/applications/prompt-proto-service-latiss/values.yaml
@@ -44,6 +44,15 @@ prompt-proto-service:
     # @default -- None, must be set
     calibRepo: ""
 
+  cache:
+    # -- The default number of datasets of each type to keep.
+    # The pipeline only needs one of most dataset types (one bias, one flat, etc.), so this is roughly the number of visits that fit in the cache.
+    baseSize: 3
+    # -- A factor by which to multiply `baseSize` for refcat datasets.
+    refcatsPerImage: 4
+    # -- A factor by which to multiply `baseSize` for templates and other patch-based datasets.
+    patchesPerImage: 6
+
   s3:
     # -- Bucket containing the incoming raw images
     # @default -- None, must be set
@@ -104,9 +113,9 @@ prompt-proto-service:
     # -- The maximum cpu cores.
     cpuLimit: "1"
     # -- The storage space reserved for each container (mostly local Butler).
-    ephemeralStorageRequest: "20Gi"
+    ephemeralStorageRequest: "5Gi"
     # -- The maximum storage space allowed for each container (mostly local Butler).
-    ephemeralStorageLimit: "20Gi"
+    ephemeralStorageLimit: "5Gi"
     # -- GPUs enabled.
     gpu: false
     # -- The number of GPUs to request.

--- a/applications/prompt-proto-service-lsstcam/README.md
+++ b/applications/prompt-proto-service-lsstcam/README.md
@@ -18,6 +18,9 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.alerts.topic | string | `"alert-stream-test"` | Topic name where alerts will be sent |
 | prompt-proto-service.alerts.username | string | `"kafka-admin"` | Username for sending alerts to the alert stream |
 | prompt-proto-service.apdb.config | string | None, must be set | URL to a serialized APDB configuration, or the "label:" prefix followed by the indexed name of such a config. |
+| prompt-proto-service.cache.baseSize | int | `3` | The default number of datasets of each type to keep. The pipeline only needs one of most dataset types (one bias, one flat, etc.), so this is roughly the number of visits that fit in the cache. |
+| prompt-proto-service.cache.patchesPerImage | int | `4` | A factor by which to multiply `baseSize` for templates and other patch-based datasets. |
+| prompt-proto-service.cache.refcatsPerImage | int | `4` | A factor by which to multiply `baseSize` for refcat datasets. |
 | prompt-proto-service.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
 | prompt-proto-service.image.repository | string | `"ghcr.io/lsst-dm/prompt-service"` | Image to use in the PP deployment |
 | prompt-proto-service.image.tag | string | `"latest"` | Overrides the image tag whose default is the chart appVersion. |
@@ -31,8 +34,8 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.instrument.skymap | string | `""` | Skymap to use with the instrument |
 | prompt-proto-service.knative.cpuLimit | string | `"1"` | The maximum cpu cores. |
 | prompt-proto-service.knative.cpuRequest | string | `"1"` | The cpu cores requested. |
-| prompt-proto-service.knative.ephemeralStorageLimit | string | `"20Gi"` | The maximum storage space allowed for each container (mostly local Butler). |
-| prompt-proto-service.knative.ephemeralStorageRequest | string | `"20Gi"` | The storage space reserved for each container (mostly local Butler). |
+| prompt-proto-service.knative.ephemeralStorageLimit | string | `"5Gi"` | The maximum storage space allowed for each container (mostly local Butler). |
+| prompt-proto-service.knative.ephemeralStorageRequest | string | `"5Gi"` | The storage space reserved for each container (mostly local Butler). |
 | prompt-proto-service.knative.gpu | bool | `false` | GPUs enabled. |
 | prompt-proto-service.knative.gpuRequest | string | `"0"` | The number of GPUs to request. |
 | prompt-proto-service.knative.idleTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service (seconds). |

--- a/applications/prompt-proto-service-lsstcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcam/values.yaml
@@ -43,6 +43,15 @@ prompt-proto-service:
     # @default -- None, must be set
     calibRepo: ""
 
+  cache:
+    # -- The default number of datasets of each type to keep.
+    # The pipeline only needs one of most dataset types (one bias, one flat, etc.), so this is roughly the number of visits that fit in the cache.
+    baseSize: 3
+    # -- A factor by which to multiply `baseSize` for refcat datasets.
+    refcatsPerImage: 4
+    # -- A factor by which to multiply `baseSize` for templates and other patch-based datasets.
+    patchesPerImage: 4
+
   s3:
     # -- Bucket containing the incoming raw images
     # @default -- None, must be set
@@ -104,9 +113,9 @@ prompt-proto-service:
     # -- The maximum cpu cores.
     cpuLimit: "1"
     # -- The storage space reserved for each container (mostly local Butler).
-    ephemeralStorageRequest: "20Gi"
+    ephemeralStorageRequest: "5Gi"
     # -- The maximum storage space allowed for each container (mostly local Butler).
-    ephemeralStorageLimit: "20Gi"
+    ephemeralStorageLimit: "5Gi"
     # -- GPUs enabled.
     gpu: false
     # -- The number of GPUs to request.

--- a/applications/prompt-proto-service-lsstcomcam/README.md
+++ b/applications/prompt-proto-service-lsstcomcam/README.md
@@ -18,6 +18,9 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.alerts.topic | string | `"alert-stream-test"` | Topic name where alerts will be sent |
 | prompt-proto-service.alerts.username | string | `"kafka-admin"` | Username for sending alerts to the alert stream |
 | prompt-proto-service.apdb.config | string | None, must be set | URL to a serialized APDB configuration, or the "label:" prefix followed by the indexed name of such a config. |
+| prompt-proto-service.cache.baseSize | int | `3` | The default number of datasets of each type to keep. The pipeline only needs one of most dataset types (one bias, one flat, etc.), so this is roughly the number of visits that fit in the cache. |
+| prompt-proto-service.cache.patchesPerImage | int | `4` | A factor by which to multiply `baseSize` for templates and other patch-based datasets. |
+| prompt-proto-service.cache.refcatsPerImage | int | `4` | A factor by which to multiply `baseSize` for refcat datasets. |
 | prompt-proto-service.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
 | prompt-proto-service.image.repository | string | `"ghcr.io/lsst-dm/prompt-service"` | Image to use in the PP deployment |
 | prompt-proto-service.image.tag | string | `"latest"` | Overrides the image tag whose default is the chart appVersion. |
@@ -31,8 +34,8 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.instrument.skymap | string | `""` | Skymap to use with the instrument |
 | prompt-proto-service.knative.cpuLimit | string | `"1"` | The maximum cpu cores. |
 | prompt-proto-service.knative.cpuRequest | string | `"1"` | The cpu cores requested. |
-| prompt-proto-service.knative.ephemeralStorageLimit | string | `"20Gi"` | The maximum storage space allowed for each container (mostly local Butler). |
-| prompt-proto-service.knative.ephemeralStorageRequest | string | `"20Gi"` | The storage space reserved for each container (mostly local Butler). |
+| prompt-proto-service.knative.ephemeralStorageLimit | string | `"5Gi"` | The maximum storage space allowed for each container (mostly local Butler). |
+| prompt-proto-service.knative.ephemeralStorageRequest | string | `"5Gi"` | The storage space reserved for each container (mostly local Butler). |
 | prompt-proto-service.knative.gpu | bool | `false` | GPUs enabled. |
 | prompt-proto-service.knative.gpuRequest | string | `"0"` | The number of GPUs to request. |
 | prompt-proto-service.knative.idleTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service (seconds). |

--- a/applications/prompt-proto-service-lsstcomcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/values.yaml
@@ -43,6 +43,15 @@ prompt-proto-service:
     # @default -- None, must be set
     calibRepo: ""
 
+  cache:
+    # -- The default number of datasets of each type to keep.
+    # The pipeline only needs one of most dataset types (one bias, one flat, etc.), so this is roughly the number of visits that fit in the cache.
+    baseSize: 3
+    # -- A factor by which to multiply `baseSize` for refcat datasets.
+    refcatsPerImage: 4
+    # -- A factor by which to multiply `baseSize` for templates and other patch-based datasets.
+    patchesPerImage: 4
+
   s3:
     # -- Bucket containing the incoming raw images
     # @default -- None, must be set
@@ -104,9 +113,9 @@ prompt-proto-service:
     # -- The maximum cpu cores.
     cpuLimit: "1"
     # -- The storage space reserved for each container (mostly local Butler).
-    ephemeralStorageRequest: "20Gi"
+    ephemeralStorageRequest: "5Gi"
     # -- The maximum storage space allowed for each container (mostly local Butler).
-    ephemeralStorageLimit: "20Gi"
+    ephemeralStorageLimit: "5Gi"
     # -- GPUs enabled.
     gpu: false
     # -- The number of GPUs to request.

--- a/applications/prompt-proto-service-lsstcomcamsim/README.md
+++ b/applications/prompt-proto-service-lsstcomcamsim/README.md
@@ -18,6 +18,9 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.alerts.topic | string | `"alert-stream-test"` | Topic name where alerts will be sent |
 | prompt-proto-service.alerts.username | string | `"kafka-admin"` | Username for sending alerts to the alert stream |
 | prompt-proto-service.apdb.config | string | None, must be set | URL to a serialized APDB configuration, or the "label:" prefix followed by the indexed name of such a config. |
+| prompt-proto-service.cache.baseSize | int | `3` | The default number of datasets of each type to keep. The pipeline only needs one of most dataset types (one bias, one flat, etc.), so this is roughly the number of visits that fit in the cache. |
+| prompt-proto-service.cache.patchesPerImage | int | `16` | A factor by which to multiply `baseSize` for templates and other patch-based datasets. |
+| prompt-proto-service.cache.refcatsPerImage | int | `6` | A factor by which to multiply `baseSize` for refcat datasets. |
 | prompt-proto-service.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
 | prompt-proto-service.image.repository | string | `"ghcr.io/lsst-dm/prompt-service"` | Image to use in the PP deployment |
 | prompt-proto-service.image.tag | string | `"latest"` | Overrides the image tag whose default is the chart appVersion. |
@@ -31,8 +34,8 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.instrument.skymap | string | `"ops_rehersal_prep_2k_v1"` | Skymap to use with the instrument |
 | prompt-proto-service.knative.cpuLimit | string | `"1"` | The maximum cpu cores. |
 | prompt-proto-service.knative.cpuRequest | string | `"1"` | The cpu cores requested. |
-| prompt-proto-service.knative.ephemeralStorageLimit | string | `"20Gi"` | The maximum storage space allowed for each container (mostly local Butler). |
-| prompt-proto-service.knative.ephemeralStorageRequest | string | `"20Gi"` | The storage space reserved for each container (mostly local Butler). |
+| prompt-proto-service.knative.ephemeralStorageLimit | string | `"5Gi"` | The maximum storage space allowed for each container (mostly local Butler). |
+| prompt-proto-service.knative.ephemeralStorageRequest | string | `"5Gi"` | The storage space reserved for each container (mostly local Butler). |
 | prompt-proto-service.knative.gpu | bool | `false` | GPUs enabled. |
 | prompt-proto-service.knative.gpuRequest | string | `"0"` | The number of GPUs to request. |
 | prompt-proto-service.knative.idleTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service (seconds). |

--- a/applications/prompt-proto-service-lsstcomcamsim/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcomcamsim/values-usdfdev-prompt-processing.yaml
@@ -27,7 +27,7 @@ prompt-proto-service:
     topic: prompt-processing-dev
 
   apdb:
-    config: s3://rubin-pp-dev-users/apdb_config/pp_apdb_lsstcomcamsim-dev.py
+    config: s3://rubin-pp-dev-users/apdb_config/cassandra/pp_apdb_lsstcomcamsim-dev.py
 
   sasquatch:
     endpointUrl: https://usdf-rsp-dev.slac.stanford.edu/sasquatch-rest-proxy

--- a/applications/prompt-proto-service-lsstcomcamsim/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcomcamsim/values-usdfprod-prompt-processing.yaml
@@ -3,9 +3,7 @@ prompt-proto-service:
   podAnnotations:
     # Expect to need roughly n_detector × request_latency / survey_cadence pods
     # For a 30 s ComCam survey with 500 s latency, this is 150
-    # Request 2× as workaround for DM-41834
-    # TODO DM-40193: Scaled down from 400 to avoid hitting global ephemeral storage limits.
-    autoscaling.knative.dev/max-scale: "150"
+    autoscaling.knative.dev/max-scale: "200"
     # Update this field if using latest or static image tag in dev
     revision: "1"
 
@@ -45,12 +43,6 @@ prompt-proto-service:
   logLevel: timer.lsst.activator=DEBUG
 
   knative:
-    # TODO DM-40193: Scaled down from 50Gi to avoid hitting global ephemeral storage limits.
-    # A value below 10 GiB is only viable if cacheAny is false.
-    ephemeralStorageRequest: "5Gi"
-    ephemeralStorageLimit: "5Gi"
     memoryLimit: "16Gi"
-
-  cacheAny: false
 
   fullnameOverride: "prompt-proto-service-lsstcomcamsim"

--- a/applications/prompt-proto-service-lsstcomcamsim/values.yaml
+++ b/applications/prompt-proto-service-lsstcomcamsim/values.yaml
@@ -44,6 +44,15 @@ prompt-proto-service:
     # @default -- None, must be set
     calibRepo: ""
 
+  cache:
+    # -- The default number of datasets of each type to keep.
+    # The pipeline only needs one of most dataset types (one bias, one flat, etc.), so this is roughly the number of visits that fit in the cache.
+    baseSize: 3
+    # -- A factor by which to multiply `baseSize` for refcat datasets.
+    refcatsPerImage: 6
+    # -- A factor by which to multiply `baseSize` for templates and other patch-based datasets.
+    patchesPerImage: 16
+
   s3:
     # -- Bucket containing the incoming raw images
     # @default -- None, must be set
@@ -104,9 +113,9 @@ prompt-proto-service:
     # -- The maximum cpu cores.
     cpuLimit: "1"
     # -- The storage space reserved for each container (mostly local Butler).
-    ephemeralStorageRequest: "20Gi"
+    ephemeralStorageRequest: "5Gi"
     # -- The maximum storage space allowed for each container (mostly local Butler).
-    ephemeralStorageLimit: "20Gi"
+    ephemeralStorageLimit: "5Gi"
     # -- GPUs enabled.
     gpu: false
     # -- The number of GPUs to request.

--- a/applications/ssotap/secrets-idfint.yaml
+++ b/applications/ssotap/secrets-idfint.yaml
@@ -1,0 +1,3 @@
+uws-db-password:
+  description: >-
+    Password to external UWS PostgreSQL server

--- a/applications/ssotap/values-idfdev.yaml
+++ b/applications/ssotap/values-idfdev.yaml
@@ -1,11 +1,4 @@
 cadc-tap:
-  config:
-    pg:
-      image:
-        repository: "ghcr.io/lsst-sqre/tap-postgres-service"
-        pullPolicy: "Always"
-        tag: "1.16.0"
-
   tapSchema:
     image:
       repository: "lsstsqre/tap-schema-idfdev-sso"

--- a/applications/ssotap/values-idfint.yaml
+++ b/applications/ssotap/values-idfint.yaml
@@ -2,3 +2,9 @@ cadc-tap:
   tapSchema:
     image:
       repository: "lsstsqre/tap-schema-idfint-sso"
+
+  cloudsql:
+    enabled: true
+    instanceConnectionName: "science-platform-int-dc5d:us-central1:science-platform-int-8f439af2"
+    serviceAccount: "ssotap@science-platform-int-dc5d.iam.gserviceaccount.com"
+    database: "ssotap"

--- a/applications/tap/README.md
+++ b/applications/tap/README.md
@@ -14,6 +14,7 @@ IVOA TAP service
 | cadc-tap.config.backend | string | `"qserv"` | What type of backend? |
 | cadc-tap.config.vaultSecretName | string | `"tap"` | Vault secret name: the final key in the vault path |
 | cadc-tap.ingress.path | string | `"tap"` |  |
+| cadc-tap.serviceAccount.name | string | `"tap"` |  |
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |

--- a/applications/tap/secrets-idfdev.yaml
+++ b/applications/tap/secrets-idfdev.yaml
@@ -1,0 +1,3 @@
+uws-db-password:
+  description: >-
+    Password to external UWS PostgreSQL server

--- a/applications/tap/secrets-idfint.yaml
+++ b/applications/tap/secrets-idfint.yaml
@@ -1,0 +1,3 @@
+uws-db-password:
+  description: >-
+    Password to external UWS PostgreSQL server

--- a/applications/tap/values-idfdev.yaml
+++ b/applications/tap/values-idfdev.yaml
@@ -7,3 +7,9 @@ cadc-tap:
     qserv:
       host: "10.140.1.211:4040"
       # Change to 134.79.23.209:4040 to point to USDF qserv
+
+  cloudsql:
+    enabled: true
+    instanceConnectionName: "science-platform-dev-7696:us-central1:science-platform-dev-e9e11de2"
+    serviceAccount: "tap-service@science-platform-dev-7696.iam.gserviceaccount.com"
+    database: "tap"

--- a/applications/tap/values-idfint.yaml
+++ b/applications/tap/values-idfint.yaml
@@ -5,4 +5,18 @@ cadc-tap:
 
   config:
     qserv:
+<<<<<<< HEAD
       host: "10.140.1.211:4040"
+
+  cloudsql:
+    enabled: true
+    instanceConnectionName: "science-platform-int-dc5d:us-central1:science-platform-int-8f439af2"
+    serviceAccount: "tap-service@science-platform-int-dc5d.iam.gserviceaccount.com"
+    database: "tap"
+=======
+      host: "134.79.23.227:4040"
+<<<<<<< HEAD
+>>>>>>> 9d31aa29 (Repoint data-int tap to usdf-prod.)
+=======
+      jdbcParams: "?enabledTLSProtocols=TLSv1.2"
+>>>>>>> 9561c90f (Add TLS parameters for TAP connections to qserv.)

--- a/applications/tap/values-usdfdev.yaml
+++ b/applications/tap/values-usdfdev.yaml
@@ -6,6 +6,7 @@ cadc-tap:
   config:
     qserv:
       host: "172.24.49.51:4040"
+      jdbcParams: "?enabledTLSProtocols=TLSv1.2"
 
     gcsBucket: "rubin:rubin-qserv"
     gcsBucketUrl: "https://s3dfrgw.slac.stanford.edu"

--- a/applications/tap/values-usdfint.yaml
+++ b/applications/tap/values-usdfint.yaml
@@ -6,6 +6,7 @@ cadc-tap:
   config:
     qserv:
       host: "172.24.49.51:4040"
+      jdbcParams: "?enabledTLSProtocols=TLSv1.2"
 
     gcsBucket: "rubin:rubin-qserv"
     gcsBucketUrl: "https://s3dfrgw.slac.stanford.edu"

--- a/applications/tap/values-usdfprod.yaml
+++ b/applications/tap/values-usdfprod.yaml
@@ -6,6 +6,7 @@ cadc-tap:
   config:
     qserv:
       host: "172.24.49.51:4040"
+      jdbcParams: "?enabledTLSProtocols=TLSv1.2"
 
     gcsBucket: "rubin:rubin-qserv"
     gcsBucketUrl: "https://s3dfrgw.slac.stanford.edu"

--- a/applications/tap/values.yaml
+++ b/applications/tap/values.yaml
@@ -10,6 +10,10 @@ cadc-tap:
     # -- Vault secret name: the final key in the vault path
     vaultSecretName: "tap"
 
+  serviceAccount:
+    # Name of Service Account
+    name: "tap"
+
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:

--- a/applications/vo-cutouts/README.md
+++ b/applications/vo-cutouts/README.md
@@ -56,7 +56,7 @@ Image cutout service complying with IVOA SODA
 | ingress.annotations | object | `{}` | Additional annotations to add to the ingress |
 | redis.affinity | object | `{}` | Affinity rules for the Redis pod |
 | redis.config.secretKey | string | `"redis-password"` | Key inside secret from which to get the Redis password (do not change) |
-| redis.config.secretName | string | `"vo-cutouts-secret"` | Name of secret containing Redis password (may require changing if fullnameOverride is set) |
+| redis.config.secretName | string | `"vo-cutouts"` | Name of secret containing Redis password |
 | redis.nodeSelector | object | `{}` | Node selection rules for the Redis pod |
 | redis.persistence.accessMode | string | `"ReadWriteOnce"` | Access mode of storage to request |
 | redis.persistence.enabled | bool | `true` | Whether to persist Redis storage and thus tokens. Setting this to false will use `emptyDir` and reset all tokens on every restart. Only use this for a test deployment. |

--- a/applications/vo-cutouts/values.yaml
+++ b/applications/vo-cutouts/values.yaml
@@ -174,9 +174,8 @@ databaseWorker:
 
 redis:
   config:
-    # -- Name of secret containing Redis password (may require changing if
-    # fullnameOverride is set)
-    secretName: "vo-cutouts-secret"
+    # -- Name of secret containing Redis password
+    secretName: "vo-cutouts"
 
     # -- Key inside secret from which to get the Redis password (do not
     # change)

--- a/charts/cadc-tap/README.md
+++ b/charts/cadc-tap/README.md
@@ -31,12 +31,17 @@ IVOA TAP service
 | config.pg.host | string | None, must be set if backend is `pg` | Host to connect to |
 | config.pg.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the TAP image |
 | config.pg.image.repository | string | `"ghcr.io/lsst-sqre/tap-postgres-service"` | TAP image to use |
-| config.pg.image.tag | string | `"1.16.0"` | Tag of TAP image to use |
+| config.pg.image.tag | string | `"1.17.2"` | Tag of TAP image to use |
 | config.pg.username | string | None, must be set if backend is `pg` | Username to connect with |
 | config.qserv.host | string | `"mock-db:3306"` (the mock QServ) | QServ hostname:port to connect to |
 | config.qserv.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the TAP image |
 | config.qserv.image.repository | string | `"ghcr.io/lsst-sqre/lsst-tap-service"` | TAP image to use |
+<<<<<<< HEAD
+| config.qserv.image.tag | string | `"2.3.0"` | Tag of TAP image to use |
+=======
 | config.qserv.image.tag | string | `"2.2.0"` | Tag of TAP image to use |
+| config.qserv.jdbcParams | string | `""` | Extra JDBC connection parameters |
+>>>>>>> 9561c90f (Add TLS parameters for TAP connections to qserv.)
 | config.tapSchemaAddress | string | `"cadc-tap-schema-db:3306"` | Address to a MySQL database containing TAP schema data |
 | config.vaultSecretName | string | `""` | Vault secret name, this is appended to the global path to find the vault secrets associated with this deployment. |
 | fullnameOverride | string | `"cadc-tap"` | Override the full name for resources (includes the release name) |
@@ -76,7 +81,7 @@ IVOA TAP service
 | uws.affinity | object | `{}` | Affinity rules for the UWS database pod |
 | uws.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the UWS database image |
 | uws.image.repository | string | `"ghcr.io/lsst-sqre/lsst-tap-uws-db"` | UWS database image to use |
-| uws.image.tag | string | `"2.2.0"` | Tag of UWS database image to use |
+| uws.image.tag | string | `"2.3.0"` | Tag of UWS database image to use |
 | uws.nodeSelector | object | `{}` | Node selection rules for the UWS database pod |
 | uws.podAnnotations | object | `{}` | Annotations for the UWS databse pod |
 | uws.resources | object | See `values.yaml` | Resource limits and requests for the UWS database pod |

--- a/charts/cadc-tap/templates/configmap.yaml
+++ b/charts/cadc-tap/templates/configmap.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cadc-tap-config
+  labels:
+    {{- include "cadc-tap.labels" . | nindent 4 }}
+data:
+  cadc-registry.properties: |
+    ivo://ivoa.net/sso#OpenID = {{ .Values.global.baseUrl }}/auth/cadc
+  catalina.properties: |
+    # tomcat properties
+    tomcat.connector.connectionTimeout=20000
+    tomcat.connector.keepAliveTimeout=120000
+    tomcat.connector.secure=false
+    tomcat.connector.scheme=http
+    tomcat.connector.proxyName={{ .Values.global.host }}
+    tomcat.connector.proxyPort=80
+
+    # authentication provider
+    ca.nrc.cadc.auth.IdentityManager=org.opencadc.auth.StandardIdentityManager

--- a/charts/cadc-tap/templates/tap-deployment.yaml
+++ b/charts/cadc-tap/templates/tap-deployment.yaml
@@ -82,23 +82,20 @@ spec:
                 -Dtap.password=$TAP_DB_PASSWORD
                 -Dtap.url=jdbc:postgresql://{{ .Values.config.pg.host }}/{{ .Values.config.pg.database }}
                 -Dtap.maxActive=100
-                -Dca.nrc.cadc.auth.Authenticator=ca.nrc.cadc.sample.AuthenticatorImpl
                 {{- end }}
                 {{- if eq .Values.config.backend "qserv" }}
                 -Dqservuser.username=qsmaster
                 -Dqservuser.password=
                 -Dqservuser.driverClassName=com.mysql.cj.jdbc.Driver
-                -Dqservuser.url=jdbc:mysql://{{ .Values.config.qserv.host }}/
+                -Dqservuser.url=jdbc:mysql://{{ .Values.config.qserv.host }}/{{ .Values.config.qserv.jdbcParams }}
                 -Dqservuser.maxActive=100
-                -Dca.nrc.cadc.auth.Authenticator=org.opencadc.tap.impl.AuthenticatorImpl
                 {{- end }}
-                -Dca.nrc.cadc.reg.client.RegistryClient.local=true
                 -Dgafaelfawr_url={{ .Values.global.baseUrl }}/auth/api/v1/user-info
                 -Dgcs_bucket={{ .Values.config.gcsBucket }}
                 -Dgcs_bucket_url={{ .Values.config.gcsBucketUrl }}
                 -Dgcs_bucket_type={{ .Values.config.gcsBucketType }}
                 -Dbase_url={{ .Values.global.baseUrl }}
-                -Dca.nrc.cadc.util.PropertiesReader.dir=/etc/creds/
+                -Dca.nrc.cadc.util.PropertiesReader.dir=/config/
                 -Xmx{{ .Values.config.jvmMaxHeapSize }}
             {{- if eq .Values.config.backend "pg" }}
             - name: "TAP_DB_PASSWORD"
@@ -142,6 +139,8 @@ spec:
               readOnly: true
             - name: "tmp"
               mountPath: "/tmp"
+            - name: "config-volume"
+              mountPath: "/config"
           livenessProbe:
             failureThreshold: 3
             httpGet:
@@ -155,9 +154,12 @@ spec:
       volumes:
         - name: "google-creds"
           secret:
-            secretName: cadc-tap
+            secretName: "cadc-tap"
         - name: "tmp"
           emptyDir: {}
+        - name: "config-volume"
+          configMap:
+            name: "cadc-tap-config"
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/cadc-tap/values.yaml
+++ b/charts/cadc-tap/values.yaml
@@ -71,12 +71,15 @@ config:
       pullPolicy: "IfNotPresent"
 
       # -- Tag of TAP image to use
-      tag: "1.16.0"
+      tag: "1.17.2"
 
   qserv:
     # -- QServ hostname:port to connect to
     # @default -- `"mock-db:3306"` (the mock QServ)
     host: "mock-db:3306"
+
+    # -- Extra JDBC connection parameters
+    jdbcParams: ""
 
     image:
       # -- TAP image to use
@@ -86,7 +89,7 @@ config:
       pullPolicy: "IfNotPresent"
 
       # -- Tag of TAP image to use
-      tag: "2.2.0"
+      tag: "2.3.0"
 
   # -- Address to a MySQL database containing TAP schema data
   tapSchemaAddress: "cadc-tap-schema-db:3306"
@@ -188,7 +191,7 @@ uws:
     pullPolicy: "IfNotPresent"
 
     # -- Tag of UWS database image to use
-    tag: "2.2.0"
+    tag: "2.3.0"
 
   # -- Resource limits and requests for the UWS database pod
   # @default -- See `values.yaml`

--- a/charts/prompt-proto-service/README.md
+++ b/charts/prompt-proto-service/README.md
@@ -18,8 +18,10 @@ Event-driven processing of camera images
 | alerts.topic | string | alert-stream-test | Topic name where alerts will be sent |
 | alerts.username | string | `"kafka-admin"` | Username for sending alerts to the alert stream |
 | apdb.config | string | None, must be set | URL to a serialized APDB configuration, or the "label:" prefix followed by the indexed name of such a config. |
-| cacheAny | bool | `true` | Whether or not any pipeline inputs should be cached between runs of a pod. This is a temporary flag that should only be unset in specific circumstances. |
-| cacheCalibs | bool | `true` | Whether or not calibs should be cached between runs of a pod. This is a temporary flag that should only be unset in specific circumstances, and only in the development environment. It only has an effect if `cacheAny` is true. |
+| cache.baseSize | int | `3` | The default number of datasets of each type to keep. The pipeline only needs one of most dataset types (one bias, one flat, etc.), so this is roughly the number of visits that fit in the cache. |
+| cache.patchesPerImage | int | `4` | A factor by which to multiply `baseSize` for templates and other patch-based datasets. |
+| cache.refcatsPerImage | int | `4` | A factor by which to multiply `baseSize` for refcat datasets. |
+| cacheCalibs | bool | `true` | Whether or not calibs should be cached between runs of a pod. This is a temporary flag that should only be unset in specific circumstances, and only in the development environment. |
 | containerConcurrency | int | `1` | The number of Knative requests that can be handled simultaneously by one container |
 | fullnameOverride | string | `"prompt-proto-service"` | Override the full name for resources (includes the release name) |
 | image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
@@ -36,8 +38,8 @@ Event-driven processing of camera images
 | instrument.skymap | string | `""` | Skymap to use with the instrument |
 | knative.cpuLimit | string | `"1"` | The maximum cpu cores. |
 | knative.cpuRequest | string | `"1"` | The cpu cores requested. |
-| knative.ephemeralStorageLimit | string | `"20Gi"` | The maximum storage space allowed for each container (mostly local Butler). |
-| knative.ephemeralStorageRequest | string | `"20Gi"` | The storage space reserved for each container (mostly local Butler). |
+| knative.ephemeralStorageLimit | string | `"5Gi"` | The maximum storage space allowed for each container (mostly local Butler). |
+| knative.ephemeralStorageRequest | string | `"5Gi"` | The storage space reserved for each container (mostly local Butler). |
 | knative.gpu | bool | `false` | GPUs enabled. |
 | knative.gpuRequest | string | `"0"` | The number of GPUs to request. |
 | knative.idleTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service (seconds). |

--- a/charts/prompt-proto-service/templates/prompt-proto-service.yaml
+++ b/charts/prompt-proto-service/templates/prompt-proto-service.yaml
@@ -110,10 +110,14 @@ spec:
           value: "/tmp-butler"
         - name: SERVICE_LOG_LEVELS
           value: {{ .Values.logLevel }}
+        - name: LOCAL_REPO_CACHE_SIZE
+          value: '{{ .Values.cache.baseSize }}'
+        - name: REFCATS_PER_IMAGE
+          value: '{{ .Values.cache.refcatsPerImage }}'
+        - name: PATCHES_PER_IMAGE
+          value: '{{ .Values.cache.patchesPerImage }}'
         - name: DEBUG_CACHE_CALIBS
           value: {{ if .Values.cacheCalibs }}'1'{{ else }}'0'{{ end }}
-        - name: DEBUG_CACHE_INPUTS
-          value: {{ if .Values.cacheAny }}'1'{{ else }}'0'{{ end }}
         volumeMounts:
         - mountPath: /tmp-butler
           name: ephemeral

--- a/charts/prompt-proto-service/values.yaml
+++ b/charts/prompt-proto-service/values.yaml
@@ -45,6 +45,15 @@ instrument:
   # @default -- None, must be set
   calibRepo: ""
 
+cache:
+  # -- The default number of datasets of each type to keep.
+  # The pipeline only needs one of most dataset types (one bias, one flat, etc.), so this is roughly the number of visits that fit in the cache.
+  baseSize: 3
+  # -- A factor by which to multiply `baseSize` for refcat datasets.
+  refcatsPerImage: 4
+  # -- A factor by which to multiply `baseSize` for templates and other patch-based datasets.
+  patchesPerImage: 4
+
 s3:
   # -- Bucket containing the incoming raw images
   # @default -- None, must be set
@@ -107,9 +116,9 @@ knative:
   # -- The maximum cpu cores.
   cpuLimit: "1"
   # -- The storage space reserved for each container (mostly local Butler).
-  ephemeralStorageRequest: "20Gi"
+  ephemeralStorageRequest: "5Gi"
   # -- The maximum storage space allowed for each container (mostly local Butler).
-  ephemeralStorageLimit: "20Gi"
+  ephemeralStorageLimit: "5Gi"
   # -- GPUs enabled.
   gpu: false
   # -- The number of GPUs to request.
@@ -136,11 +145,7 @@ containerConcurrency: 1
 
 # -- Whether or not calibs should be cached between runs of a pod.
 # This is a temporary flag that should only be unset in specific circumstances, and only in the development environment.
-# It only has an effect if `cacheAny` is true.
 cacheCalibs: true
-# -- Whether or not any pipeline inputs should be cached between runs of a pod.
-# This is a temporary flag that should only be unset in specific circumstances.
-cacheAny: true
 
 # -- Kubernetes YAML configs for extra container volume(s).
 # Any volumes required by other config options are automatically handled by the Helm chart.

--- a/charts/rubintv/templates/deployment-frontend.yaml
+++ b/charts/rubintv/templates/deployment-frontend.yaml
@@ -59,7 +59,7 @@ spec:
             capabilities:
               drop:
                 - ALL
-            readOnlyRootFilesystem: true
+            readOnlyRootFilesystem: false
           volumeMounts:
             - name: {{ $.Release.Name }}-secrets
               mountPath: "/etc/secrets"

--- a/docs/applications/consdb/index.rst
+++ b/docs/applications/consdb/index.rst
@@ -4,11 +4,12 @@
 consdb — Populate the consolidated database
 ###########################################
 
-There are two parts to the consolidated database:
-  - use the header information from the header service to populate the
-    ``visit`` table
-  - in USDF sumarise other EFD data into the ``summary`` table per visit
-
+There are two parts to the consolidated database application here:
+  - The ``hinfo`` service populates the ``exposure`` and ``visit`` tables,
+    as well as related tables like ``ccdexposure``.
+  - The ``pqserver`` service responds to publish and query requests from
+    clients, allowing insertion into fixed and flexible metadata tables
+    and querying of all tables and views.
 
 .. jinja:: consdb
    :file: applications/_summary.rst.jinja

--- a/docs/applications/obsenv-management/index.rst
+++ b/docs/applications/obsenv-management/index.rst
@@ -1,0 +1,16 @@
+.. px-app:: obsenv-management
+
+###################################################################
+obsenv-management — Rubin Observatory Environment Management System
+###################################################################
+
+.. jinja:: obsenv-management
+   :file: applications/_summary.rst.jinja
+
+Guides
+======
+
+.. toctree::
+   :maxdepth: 1
+
+   values

--- a/docs/applications/obsenv-management/values.md
+++ b/docs/applications/obsenv-management/values.md
@@ -1,0 +1,12 @@
+```{px-app-values} obsenv-management
+```
+
+# obsenv-management Helm values reference
+
+Helm values reference table for the {px-app}`obsenv-management` application.
+
+```{include} ../../../applications/obsenv-management/README.md
+---
+start-after: "## Values"
+---
+```

--- a/docs/applications/telescope.rst
+++ b/docs/applications/telescope.rst
@@ -15,6 +15,7 @@ Argo CD project: ``telescope``
    control-system-test/index
    eas/index
    love/index
+   obsenv-management/index
    obssys/index
    simonyitel/index
    uws/index

--- a/environments/README.md
+++ b/environments/README.md
@@ -34,6 +34,7 @@
 | applications.next-visit-fan-out | bool | `false` | Enable the next-visit-fan-out application |
 | applications.noteburst | bool | `false` | Enable the noteburst application (required by times-square) |
 | applications.nublado | bool | `false` | Enable the nublado application (v3 of the Notebook Aspect) |
+| applications.obsenv-management | bool | `false` | Enable the obsenv-management application |
 | applications.obsloctap | bool | `false` | Enable the obsloctap application |
 | applications.obssys | bool | `false` | Enable the obssys control system application |
 | applications.onepassword-connect | bool | `false` | Enable the onepassword-connect application |

--- a/environments/templates/applications/telescope/obsenv-management.yaml
+++ b/environments/templates/applications/telescope/obsenv-management.yaml
@@ -1,0 +1,34 @@
+{{- if (index .Values "applications" "obsenv-management") -}}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "obsenv-management"
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: "obsenv-management"
+  namespace: "argocd"
+  finalizers:
+    - "resources-finalizer.argocd.argoproj.io"
+spec:
+  destination:
+    namespace: "obsenv-management"
+    server: "https://kubernetes.default.svc"
+  project: "telescope"
+  source:
+    path: "applications/obsenv-management"
+    repoURL: {{ .Values.repoUrl | quote }}
+    targetRevision: {{ .Values.targetRevision | quote }}
+    helm:
+      parameters:
+        - name: "global.host"
+          value: {{ .Values.fqdn | quote }}
+        - name: "global.baseUrl"
+          value: "https://{{ .Values.fqdn }}"
+        - name: "global.vaultSecretsPath"
+          value: {{ .Values.vaultPathPrefix | quote }}
+      valueFiles:
+        - "values.yaml"
+        - "values-{{ .Values.name }}.yaml"
+{{- end -}}

--- a/environments/values-tucson-teststand.yaml
+++ b/environments/values-tucson-teststand.yaml
@@ -20,6 +20,7 @@ applications:
   mobu: true
   narrativelog: true
   nublado: true
+  obsenv-management: true
   obssys: true
   portal: true
   sasquatch: true

--- a/environments/values.yaml
+++ b/environments/values.yaml
@@ -129,6 +129,9 @@ applications:
   # -- Enable the nublado application (v3 of the Notebook Aspect)
   nublado: false
 
+  # -- Enable the obsenv-management application
+  obsenv-management: false
+
   # -- Enable the obssys control system application
   obssys: false
 


### PR DESCRIPTION
**Description**
This PR addresses the tasks of creating & enabling the use of CloudSQL (Postgres) as the backend database for UWS, for both the tap & ssotap applications. It also upgrades the versions of the lsst-tap-service & tap-postgres images, to newer ones which include upgrades to the cadc libraries, enabling automated UWS creation through the application on initialisation of the tomcat app & switching to using cadc-tap tomcat as the base image.
This change for the cadc upgrades also come with the use of a configmap to pass in some properties, which is mounted on /config which the cadc-tap expects to find for the properties.

**Backwards Compatibility**
Changes should not require any changes from the users of phalanx. Changes to the idf values for tap & ssotap are included in PR

**Related Jira Issues**
- https://rubinobs.atlassian.net/browse/DM-44524
- https://rubinobs.atlassian.net/browse/DM-44607
- https://rubinobs.atlassian.net/browse/DM-44746

**How was this tested**
- Manual validation (sync & async queries to data & TAP_SCHEMA via pyvo & firefly portal)
- taplint validator
- helm unittest

**Related changes (Not in PR)**
- Changed idf_deploy to enable creation of ssotap & tap CloudSQL databases on int & dev
- Updated lsst-tap-service & tap-postgres (Upgrading cadc-tap libs & enabling automated uws table create, switch to using cadc-tap tomcat base image)
- phalanx secrets sync on int & dev (PENDING)

**Notes for review**
- We have different setups for phalanx installations (cloudsql, non-cloudsql uws, qserv / pg databases for data). Is this likely to break anything for other envs that I haven't tested?