### PR TITLE
DM-44844: Deploy Cassandra for production Prompt Processing

### DIFF
--- a/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
@@ -47,7 +47,7 @@ prompt-proto-service:
     imageTimeout: '110'
 
   apdb:
-    config: s3://rubin-summit-users/apdb_config/pp_apdb_latiss.py
+    config: s3://rubin-summit-users/apdb_config/sql/pp_apdb_latiss.py
 
   sasquatch:
     endpointUrl: https://usdf-rsp-dev.slac.stanford.edu/sasquatch-rest-proxy

--- a/applications/prompt-proto-service-lsstcomcamsim/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcomcamsim/values-usdfprod-prompt-processing.yaml
@@ -33,7 +33,7 @@ prompt-proto-service:
     topic: rubin-prompt-processing-prod
 
   apdb:
-    config: s3://rubin-summit-users/apdb_config/pp_apdb_lsstcomcamsim.py
+    config: s3://rubin-summit-users/apdb_config/sql/pp_apdb_lsstcomcamsim.py
 
   sasquatch:
     endpointUrl: https://usdf-rsp-dev.slac.stanford.edu/sasquatch-rest-proxy


### PR DESCRIPTION
This PR reflects the new locations of the SQL APDB files. It does not try to migrate to Cassandra, as that can only be done self-consistently on #3427.