### PR TITLE
Increase fixed Prompt Processing size for ComCamSim.

### DIFF
--- a/applications/prompt-proto-service-lsstcomcamsim/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcomcamsim/values-usdfprod-prompt-processing.yaml
@@ -4,8 +4,8 @@ prompt-proto-service:
     # Expect to need roughly n_detector × request_latency / survey_cadence pods
     # For a 30 s ComCam survey with 500 s latency, this is 150
     # HACK: disable autoscaling as an OR4 workaround for DM-41829
-    autoscaling.knative.dev/min-scale: "100"
-    autoscaling.knative.dev/max-scale: "100"
+    autoscaling.knative.dev/min-scale: "150"
+    autoscaling.knative.dev/max-scale: "150"
     # Update this field if using latest or static image tag in dev
     revision: "1"
 


### PR DESCRIPTION
This PR increases the service size from 100 pods to 150; experience from the first night suggests that 120 is (barely) sufficient, but that we can afford 150.