### PR TITLE
Set custom server header value for TAP ingresses

### DIFF
--- a/charts/cadc-tap/templates/tap-ingress-anonymous.yaml
+++ b/charts/cadc-tap/templates/tap-ingress-anonymous.yaml
@@ -20,6 +20,8 @@ template:
       nginx.ingress.kubernetes.io/proxy-redirect-to: "https://$host/api/{{ .Values.ingress.path }}/"
       nginx.ingress.kubernetes.io/ssl-redirect: "true"
       nginx.ingress.kubernetes.io/use-regex: "true"
+      nginx.ingress.kubernetes.io/server-snippet: |
+        more_set_headers "server: OpenCADC/cadc-rest";
       {{- with .Values.ingress.anonymousAnnotations }}
       {{- toYaml . | indent 4}}
       {{- end }}

--- a/charts/cadc-tap/templates/tap-ingress-authenticated.yaml
+++ b/charts/cadc-tap/templates/tap-ingress-authenticated.yaml
@@ -27,6 +27,8 @@ template:
       nginx.ingress.kubernetes.io/proxy-redirect-to: "https://$host/api/{{ .Values.ingress.path }}/"
       nginx.ingress.kubernetes.io/ssl-redirect: "true"
       nginx.ingress.kubernetes.io/use-regex: "true"
+      nginx.ingress.kubernetes.io/server-snippet: |
+        more_set_headers "server: OpenCADC/cadc-rest";
       {{- with .Values.ingress.authenticatedAnnotations }}
       {{- toYaml . | indent 6 }}
       {{- end }}


### PR DESCRIPTION
**Description**
Taplint expects to find a "Server" header value in HTTP responses to the /capabilities endpoint, so it will produce a warning if it doesn't find it, which will affect the validation rating of the service: 
```
Section CAP: Check TAP and TAPRegExt content of capabilities document
W-CAP-SVR0-1 No HTTP Server header
I-CAP-SVRI-1 HTTP server header "Server: null"
```
I'm not sure if this is only applicable to the /capabilities endpoint. I've also briefly looked for this in the standard, and all I found is the wording similar to: "service SHOULD add a server header". So even though I'm not sure if this is a requirement or not, probably worth adding the header for now as it shouldn't have any other effect on the system.

**Fix**
Add custom headers to the TAP ingresses.
I've used the header value: OpenCADC/cadc-rest to match what cadc return as a server header value.

**Other attempts to fix**
I also tried adding the setting controller.config.allow-backend-server-header to propagate the headers from the TAP tomcat app, but that didn't  work. Not sure if it's worth figuring out why and making it work like this. Open to suggestions though.


**Tests**
Tested with taplint validator
```
Section CAP: Check TAP and TAPRegExt content of capabilities document
I-CAP-SVRI-1 HTTP server header "Server: OpenCADC/cadc-rest"
```
No warnings with above fix 