### PR TITLE
Prompt Processing: ComCamSim Utilization Percentage

### DIFF
--- a/applications/prompt-proto-service-lsstcomcamsim/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcomcamsim/values-usdfprod-prompt-processing.yaml
@@ -6,6 +6,7 @@ prompt-proto-service:
     # HACK: disable autoscaling as an OR4 workaround for DM-41829
     autoscaling.knative.dev/min-scale: "150"
     autoscaling.knative.dev/max-scale: "150"
+    autoscaling.knative.dev/target-utilization-percentage: "100"
     # Update this field if using latest or static image tag in dev
     revision: "1"
 


### PR DESCRIPTION
Adjust target utilization percentage to attempt to get higher utilization or running pods.  We saw 60% utilization of running pods.