### PR TITLE
Enable CloudSQL UWS db on prod

### DIFF
--- a/applications/ssotap/secrets-idfprod.yaml
+++ b/applications/ssotap/secrets-idfprod.yaml
@@ -1,0 +1,3 @@
+uws-db-password:
+  description: >-
+    Password for external UWS PostgreSQL server

--- a/applications/ssotap/values-idfprod.yaml
+++ b/applications/ssotap/values-idfprod.yaml
@@ -2,3 +2,9 @@ cadc-tap:
   tapSchema:
     image:
       repository: "lsstsqre/tap-schema-idfprod-sso"
+
+  cloudsql:
+    enabled: true
+    instanceConnectionName: "science-platform-stable-6994:us-central1:science-platform-stable-0c29612b"
+    serviceAccount: "ssotap@science-platform-stable-6994.iam.gserviceaccount.com"
+    database: "ssotap"

--- a/applications/tap/secrets-idfprod.yaml
+++ b/applications/tap/secrets-idfprod.yaml
@@ -1,0 +1,3 @@
+uws-db-password:
+  description: >-
+    Password for external UWS PostgreSQL server

--- a/applications/tap/values-idfprod.yaml
+++ b/applications/tap/values-idfprod.yaml
@@ -6,3 +6,9 @@ cadc-tap:
   config:
     qserv:
       host: "10.140.1.211:4040"
+
+  cloudsql:
+    enabled: true
+    instanceConnectionName: "science-platform-stable-6994:us-central1:science-platform-stable-0c29612b"
+    serviceAccount: "tap-service@science-platform-stable-6994.iam.gserviceaccount.com"
+    database: "tap"


### PR DESCRIPTION
**Description**

PR to move UWS database to CloudSQL for prod.
These changes have been deployed and tested on dev & int first

**Checklist:**
- Check that databases are available on CloudSQL [Done]
- Create SQL user password for ssotap & tap / Store password in 1pass  [Done]
- Run secrets sync for prod [Done]