### PR TITLE
DM-44503: Bump Butler server version

### DIFF
--- a/applications/butler/Chart.yaml
+++ b/applications/butler/Chart.yaml
@@ -4,4 +4,4 @@ version: 1.0.0
 description: Server for Butler data abstraction service
 sources:
   - https://github.com/lsst/daf_butler
-appVersion: w.2024.15
+appVersion: w.2024.26

--- a/applications/datalinker/Chart.yaml
+++ b/applications/datalinker/Chart.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 description: IVOA DataLink-based service and data discovery
 sources:
   - https://github.com/lsst-sqre/datalinker
-appVersion: 1.7.1
+appVersion: 2.0.0
 annotations:
   phalanx.lsst.io/docs: |
     - id: "DMTN-238"

--- a/applications/vo-cutouts/Chart.yaml
+++ b/applications/vo-cutouts/Chart.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 description: "Image cutout service complying with IVOA SODA"
 sources:
   - "https://github.com/lsst-sqre/vo-cutouts"
-appVersion: 2.0.0
+appVersion: 3.0.0
 
 dependencies:
   - name: redis


### PR DESCRIPTION
This release includes a breaking change to the REST API which should have been deployed at the same time as commit 468b395e5c4dda80b88c35585ac3c656c896e6ed but wasn't.