### PR TITLE
Revert new version of datalinker and vo-cutouts

### DIFF
--- a/applications/datalinker/Chart.yaml
+++ b/applications/datalinker/Chart.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 description: IVOA DataLink-based service and data discovery
 sources:
   - https://github.com/lsst-sqre/datalinker
-appVersion: 2.0.0
+appVersion: 1.7.1
 annotations:
   phalanx.lsst.io/docs: |
     - id: "DMTN-238"

--- a/applications/vo-cutouts/Chart.yaml
+++ b/applications/vo-cutouts/Chart.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 description: "Image cutout service complying with IVOA SODA"
 sources:
   - "https://github.com/lsst-sqre/vo-cutouts"
-appVersion: 3.0.0
+appVersion: 2.0.0
 
 dependencies:
   - name: redis


### PR DESCRIPTION
Revert 468b395e5c4dda80b88c35585ac3c656c896e6ed.  These changes should have been deployed at the same time as a new release of Butler server due to a REST API backwards compatibility break.