### PR TITLE
DM-45101: Increase and tune resource requirements for Noteburst and Times Square

### DIFF
--- a/applications/noteburst/README.md
+++ b/applications/noteburst/README.md
@@ -53,6 +53,8 @@ Noteburst is a notebook execution service for the Rubin Science Platform.
 | redis.tolerations | list | `[]` | Tolerations for the Redis pod |
 | replicaCount | int | `1` | Number of API pods to run |
 | resources | object | See `values.yaml` | Resource requests and limits for noteburst |
+| resources.noteburst | object | `{"limits":{"cpu":"1","memory":"256Mi"},"requests":{"cpu":"2m","memory":"50Mi"}}` | Resource limits and requests for the noteburst FastAPI pods |
+| resources.noteburstWorker | object | `{"limits":{"cpu":"1","memory":"256Mi"},"requests":{"cpu":"2m","memory":"50Mi"}}` | Resource limits and requests for the noteburst arq worker FastAPI pods |
 | service.port | int | `80` | Port of the service to create and map to the ingress |
 | service.type | string | `"ClusterIP"` | Type of service to create |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |

--- a/applications/noteburst/README.md
+++ b/applications/noteburst/README.md
@@ -44,8 +44,8 @@ Noteburst is a notebook execution service for the Rubin Science Platform.
 | podAnnotations | object | `{}` | Annotations for API and worker pods |
 | redis.affinity | object | `{}` | Affinity rules for the Redis pod |
 | redis.nodeSelector | object | `{}` | Node selection rules for the Redis pod |
-| redis.persistence.enabled | bool | `true` | Whether to persist Redis storage and thus tokens. Setting this to false will use `emptyDir` and reset all tokens on every restart. Only use this for a test deployment. |
-| redis.persistence.size | string | `"8Gi"` | Amount of persistent storage to request |
+| redis.persistence.enabled | bool | `true` | Whether to persist Redis storage and thus tokens. Setting this to false will use `emptyDir` and reset data on every restart. Only use this for a test deployment. |
+| redis.persistence.size | string | `"64Gi"` | Amount of persistent storage to request |
 | redis.persistence.storageClass | string | `""` | Class of storage to request |
 | redis.persistence.volumeClaimName | string | `""` | Use an existing PVC, not dynamic provisioning. If this is set, the size, storageClass, and accessMode settings are ignored. |
 | redis.podAnnotations | object | `{}` | Pod annotations for the Redis pod |
@@ -53,8 +53,8 @@ Noteburst is a notebook execution service for the Rubin Science Platform.
 | redis.tolerations | list | `[]` | Tolerations for the Redis pod |
 | replicaCount | int | `1` | Number of API pods to run |
 | resources | object | See `values.yaml` | Resource requests and limits for noteburst |
-| resources.noteburst | object | `{"limits":{"cpu":"1","memory":"256Mi"},"requests":{"cpu":"2m","memory":"50Mi"}}` | Resource limits and requests for the noteburst FastAPI pods |
-| resources.noteburstWorker | object | `{"limits":{"cpu":"1","memory":"256Mi"},"requests":{"cpu":"2m","memory":"50Mi"}}` | Resource limits and requests for the noteburst arq worker FastAPI pods |
+| resources.noteburst | object | `{"limits":{"cpu":"1","memory":"512Mi"},"requests":{"cpu":"2m","memory":"128Mi"}}` | Resource limits and requests for the noteburst FastAPI pods |
+| resources.noteburstWorker | object | `{"limits":{"cpu":"1","memory":"4000Mi"},"requests":{"cpu":"2m","memory":"256Mi"}}` | Resource limits and requests for the noteburst arq worker FastAPI pods |
 | service.port | int | `80` | Port of the service to create and map to the ingress |
 | service.type | string | `"ClusterIP"` | Type of service to create |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |

--- a/applications/noteburst/README.md
+++ b/applications/noteburst/README.md
@@ -45,7 +45,7 @@ Noteburst is a notebook execution service for the Rubin Science Platform.
 | redis.affinity | object | `{}` | Affinity rules for the Redis pod |
 | redis.nodeSelector | object | `{}` | Node selection rules for the Redis pod |
 | redis.persistence.enabled | bool | `true` | Whether to persist Redis storage and thus tokens. Setting this to false will use `emptyDir` and reset data on every restart. Only use this for a test deployment. |
-| redis.persistence.size | string | `"64Gi"` | Amount of persistent storage to request |
+| redis.persistence.size | string | `"8Gi"` | Amount of persistent storage to request |
 | redis.persistence.storageClass | string | `""` | Class of storage to request |
 | redis.persistence.volumeClaimName | string | `""` | Use an existing PVC, not dynamic provisioning. If this is set, the size, storageClass, and accessMode settings are ignored. |
 | redis.podAnnotations | object | `{}` | Pod annotations for the Redis pod |

--- a/applications/noteburst/templates/deployment.yaml
+++ b/applications/noteburst/templates/deployment.yaml
@@ -52,7 +52,7 @@ spec:
               path: /
               port: http
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.resources.noteburst | nindent 12 }}
           envFrom:
             - configMapRef:
                 name: {{ include "noteburst.fullname" . }}

--- a/applications/noteburst/templates/worker-deployment.yaml
+++ b/applications/noteburst/templates/worker-deployment.yaml
@@ -42,7 +42,7 @@ spec:
           command: ["arq"]
           args: ["noteburst.worker.main.WorkerSettings"]
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.resources.noteburstWorker | nindent 12 }}
           envFrom:
             - configMapRef:
                 name: {{ include "noteburst.fullname" . }}-worker

--- a/applications/noteburst/values-usdfdev.yaml
+++ b/applications/noteburst/values-usdfdev.yaml
@@ -1,6 +1,8 @@
 image:
   pullPolicy: Always
 
+replicaCount: 3
+
 config:
   logLevel: "DEBUG"
   worker:

--- a/applications/noteburst/values-usdfdev.yaml
+++ b/applications/noteburst/values-usdfdev.yaml
@@ -10,6 +10,9 @@ config:
     identities:
       - username: "bot-noteburst01"
       - username: "bot-noteburst02"
+      - username: "bot-noteburst03"
+      - username: "bot-noteburst04"
+      - username: "bot-noteburst05"
 
 # Use SSD for Redis storage.
 redis:

--- a/applications/noteburst/values.yaml
+++ b/applications/noteburst/values.yaml
@@ -75,18 +75,18 @@ resources:
   noteburst:
     limits:
       cpu: "1"
-      memory: "256Mi"
+      memory: "512Mi"
     requests:
       cpu: "2m"
-      memory: "50Mi"
+      memory: "128Mi"
   # -- Resource limits and requests for the noteburst arq worker FastAPI pods
   noteburstWorker:
     limits:
       cpu: "1"
-      memory: "256Mi"
+      memory: "4000Mi"
     requests:
       cpu: "2m"
-      memory: "50Mi"
+      memory: "256Mi"
 
 autoscaling:
   enabled: false
@@ -143,12 +143,12 @@ config:
 redis:
   persistence:
     # -- Whether to persist Redis storage and thus tokens. Setting this to
-    # false will use `emptyDir` and reset all tokens on every restart. Only
+    # false will use `emptyDir` and reset data on every restart. Only
     # use this for a test deployment.
     enabled: true
 
     # -- Amount of persistent storage to request
-    size: "8Gi"
+    size: "64Gi"
 
     # -- Class of storage to request
     storageClass: ""
@@ -162,10 +162,10 @@ redis:
   resources:
     limits:
       cpu: "1"
-      memory: "128Mi"
+      memory: "4Gi"
     requests:
       cpu: "2m"
-      memory: "4Mi"
+      memory: "512Mi"
 
   # -- Pod annotations for the Redis pod
   podAnnotations: {}

--- a/applications/noteburst/values.yaml
+++ b/applications/noteburst/values.yaml
@@ -148,7 +148,7 @@ redis:
     enabled: true
 
     # -- Amount of persistent storage to request
-    size: "64Gi"
+    size: "8Gi"
 
     # -- Class of storage to request
     storageClass: ""

--- a/applications/noteburst/values.yaml
+++ b/applications/noteburst/values.yaml
@@ -71,12 +71,22 @@ ingress:
 # -- Resource requests and limits for noteburst
 # @default -- See `values.yaml`
 resources:
-  limits:
-    cpu: "1"
-    memory: "256Mi"
-  requests:
-    cpu: "2m"
-    memory: "50Mi"
+  # -- Resource limits and requests for the noteburst FastAPI pods
+  noteburst:
+    limits:
+      cpu: "1"
+      memory: "256Mi"
+    requests:
+      cpu: "2m"
+      memory: "50Mi"
+  # -- Resource limits and requests for the noteburst arq worker FastAPI pods
+  noteburstWorker:
+    limits:
+      cpu: "1"
+      memory: "256Mi"
+    requests:
+      cpu: "2m"
+      memory: "50Mi"
 
 autoscaling:
   enabled: false

--- a/applications/times-square/README.md
+++ b/applications/times-square/README.md
@@ -48,7 +48,7 @@ An API service for managing and rendering parameterized Jupyter notebooks.
 | redis.affinity | object | `{}` | Affinity rules for the Redis pod |
 | redis.nodeSelector | object | `{}` | Node selection rules for the Redis pod |
 | redis.persistence.enabled | bool | `true` | Whether to persist Redis storage and thus tokens. Setting this to false will use `emptyDir` and reset all tokens on every restart. Only use this for a test deployment. |
-| redis.persistence.size | string | `"8Gi"` | Amount of persistent storage to request |
+| redis.persistence.size | string | `"64Gi"` | Amount of persistent storage to request |
 | redis.persistence.storageClass | string | `""` | Class of storage to request |
 | redis.persistence.volumeClaimName | string | `""` | Use an existing PVC, not dynamic provisioning. If this is set, the size, storageClass, and accessMode settings are ignored. |
 | redis.podAnnotations | object | `{}` | Pod annotations for the Redis pod |

--- a/applications/times-square/README.md
+++ b/applications/times-square/README.md
@@ -48,7 +48,7 @@ An API service for managing and rendering parameterized Jupyter notebooks.
 | redis.affinity | object | `{}` | Affinity rules for the Redis pod |
 | redis.nodeSelector | object | `{}` | Node selection rules for the Redis pod |
 | redis.persistence.enabled | bool | `true` | Whether to persist Redis storage and thus tokens. Setting this to false will use `emptyDir` and reset all tokens on every restart. Only use this for a test deployment. |
-| redis.persistence.size | string | `"64Gi"` | Amount of persistent storage to request |
+| redis.persistence.size | string | `"8Gi"` | Amount of persistent storage to request |
 | redis.persistence.storageClass | string | `""` | Class of storage to request |
 | redis.persistence.volumeClaimName | string | `""` | Use an existing PVC, not dynamic provisioning. If this is set, the size, storageClass, and accessMode settings are ignored. |
 | redis.podAnnotations | object | `{}` | Pod annotations for the Redis pod |

--- a/applications/times-square/templates/deployment.yaml
+++ b/applications/times-square/templates/deployment.yaml
@@ -82,7 +82,7 @@ spec:
               path: /
               port: http
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.resources.timesSquare | nindent 12 }}
           envFrom:
             - configMapRef:
                 name: {{ include "times-square.fullname" . }}

--- a/applications/times-square/templates/worker-deployment.yaml
+++ b/applications/times-square/templates/worker-deployment.yaml
@@ -72,7 +72,7 @@ spec:
           command: ["arq"]
           args: ["timessquare.worker.main.WorkerSettings"]
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.resources.timesSquareWorker | nindent 12 }}
           envFrom:
             - configMapRef:
                 name: {{ include "times-square.fullname" . }}

--- a/applications/times-square/values-usdfdev.yaml
+++ b/applications/times-square/values-usdfdev.yaml
@@ -1,3 +1,6 @@
+replicaCount:
+  api: 2
+  worker: 2
 image:
   pullPolicy: Always
 config:

--- a/applications/times-square/values.yaml
+++ b/applications/times-square/values.yaml
@@ -175,7 +175,7 @@ redis:
     enabled: true
 
     # -- Amount of persistent storage to request
-    size: "64Gi"
+    size: "8Gi"
 
     # -- Class of storage to request
     storageClass: ""

--- a/applications/times-square/values.yaml
+++ b/applications/times-square/values.yaml
@@ -62,12 +62,20 @@ ingress:
 # -- Resource limits and requests for the times-square deployment pod
 # @default -- see `values.yaml`
 resources:
-  limits:
-    cpu: "1"
-    memory: "1Gi"
-  requests:
-    cpu: "2m"
-    memory: "100Mi"
+  timesSquare:
+    limits:
+      cpu: "1"
+      memory: "1Gi"
+    requests:
+      cpu: "2m"
+      memory: "100Mi"
+  timesSquareWorker:
+    limits:
+      cpu: "1"
+      memory: "1Gi"
+    requests:
+      cpu: "2m"
+      memory: "256Mi"
 
 autoscaling:
   # -- Enable autoscaling of times-square deployment
@@ -147,10 +155,10 @@ cloudsql:
     resources:
       limits:
         cpu: "1"
-        memory: "50Mi"
+        memory: "4Gi"
       requests:
         cpu: "1m"
-        memory: "8Mi"
+        memory: "512Mi"
 
   # -- Instance connection name for a Cloud SQL PostgreSQL instance
   instanceConnectionName: ""
@@ -167,7 +175,7 @@ redis:
     enabled: true
 
     # -- Amount of persistent storage to request
-    size: "8Gi"
+    size: "64Gi"
 
     # -- Class of storage to request
     storageClass: ""


### PR DESCRIPTION
- The resource allocations for FastAPI front ends and arq backend workers are now separately tuneable for Times Square and Noteburst
- Resource allocations for the app pods as well as their redis databases are generally increased to provide better performance and reliability.