### PR TITLE
TAP async results redirect fix (TAP Image upgrades)

### DIFF
--- a/charts/cadc-tap/README.md
+++ b/charts/cadc-tap/README.md
@@ -31,7 +31,7 @@ IVOA TAP service
 | config.pg.host | string | None, must be set if backend is `pg` | Host to connect to |
 | config.pg.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the TAP image |
 | config.pg.image.repository | string | `"ghcr.io/lsst-sqre/tap-postgres-service"` | TAP image to use |
-| config.pg.image.tag | string | `"1.18.0"` | Tag of TAP image to use |
+| config.pg.image.tag | string | `"1.18.1"` | Tag of TAP image to use |
 | config.pg.username | string | None, must be set if backend is `pg` | Username to connect with |
 | config.qserv.host | string | `"mock-db:3306"` (the mock QServ) | QServ hostname:port to connect to |
 | config.qserv.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the TAP image |

--- a/charts/cadc-tap/README.md
+++ b/charts/cadc-tap/README.md
@@ -31,12 +31,12 @@ IVOA TAP service
 | config.pg.host | string | None, must be set if backend is `pg` | Host to connect to |
 | config.pg.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the TAP image |
 | config.pg.image.repository | string | `"ghcr.io/lsst-sqre/tap-postgres-service"` | TAP image to use |
-| config.pg.image.tag | string | `"1.18.1"` | Tag of TAP image to use |
+| config.pg.image.tag | string | `"1.18.4"` | Tag of TAP image to use |
 | config.pg.username | string | None, must be set if backend is `pg` | Username to connect with |
 | config.qserv.host | string | `"mock-db:3306"` (the mock QServ) | QServ hostname:port to connect to |
 | config.qserv.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the TAP image |
 | config.qserv.image.repository | string | `"ghcr.io/lsst-sqre/lsst-tap-service"` | TAP image to use |
-| config.qserv.image.tag | string | `"2.4.0"` | Tag of TAP image to use |
+| config.qserv.image.tag | string | `"2.4.4"` | Tag of TAP image to use |
 | config.qserv.jdbcParams | string | `""` | Extra JDBC connection parameters |
 | config.tapSchemaAddress | string | `"cadc-tap-schema-db:3306"` | Address to a MySQL database containing TAP schema data |
 | config.vaultSecretName | string | `""` | Vault secret name, this is appended to the global path to find the vault secrets associated with this deployment. |
@@ -77,7 +77,7 @@ IVOA TAP service
 | uws.affinity | object | `{}` | Affinity rules for the UWS database pod |
 | uws.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the UWS database image |
 | uws.image.repository | string | `"ghcr.io/lsst-sqre/lsst-tap-uws-db"` | UWS database image to use |
-| uws.image.tag | string | `"2.4.0"` | Tag of UWS database image to use |
+| uws.image.tag | string | `"2.4.4"` | Tag of UWS database image to use |
 | uws.nodeSelector | object | `{}` | Node selection rules for the UWS database pod |
 | uws.podAnnotations | object | `{}` | Annotations for the UWS databse pod |
 | uws.resources | object | See `values.yaml` | Resource limits and requests for the UWS database pod |

--- a/charts/cadc-tap/README.md
+++ b/charts/cadc-tap/README.md
@@ -31,12 +31,12 @@ IVOA TAP service
 | config.pg.host | string | None, must be set if backend is `pg` | Host to connect to |
 | config.pg.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the TAP image |
 | config.pg.image.repository | string | `"ghcr.io/lsst-sqre/tap-postgres-service"` | TAP image to use |
-| config.pg.image.tag | string | `"1.17.3"` | Tag of TAP image to use |
+| config.pg.image.tag | string | `"1.18.0"` | Tag of TAP image to use |
 | config.pg.username | string | None, must be set if backend is `pg` | Username to connect with |
 | config.qserv.host | string | `"mock-db:3306"` (the mock QServ) | QServ hostname:port to connect to |
 | config.qserv.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the TAP image |
 | config.qserv.image.repository | string | `"ghcr.io/lsst-sqre/lsst-tap-service"` | TAP image to use |
-| config.qserv.image.tag | string | `"2.3.1"` | Tag of TAP image to use |
+| config.qserv.image.tag | string | `"2.4.0"` | Tag of TAP image to use |
 | config.qserv.jdbcParams | string | `""` | Extra JDBC connection parameters |
 | config.tapSchemaAddress | string | `"cadc-tap-schema-db:3306"` | Address to a MySQL database containing TAP schema data |
 | config.vaultSecretName | string | `""` | Vault secret name, this is appended to the global path to find the vault secrets associated with this deployment. |
@@ -77,7 +77,7 @@ IVOA TAP service
 | uws.affinity | object | `{}` | Affinity rules for the UWS database pod |
 | uws.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the UWS database image |
 | uws.image.repository | string | `"ghcr.io/lsst-sqre/lsst-tap-uws-db"` | UWS database image to use |
-| uws.image.tag | string | `"2.3.1"` | Tag of UWS database image to use |
+| uws.image.tag | string | `"2.4.0"` | Tag of UWS database image to use |
 | uws.nodeSelector | object | `{}` | Node selection rules for the UWS database pod |
 | uws.podAnnotations | object | `{}` | Annotations for the UWS databse pod |
 | uws.resources | object | See `values.yaml` | Resource limits and requests for the UWS database pod |

--- a/charts/cadc-tap/templates/tap-deployment.yaml
+++ b/charts/cadc-tap/templates/tap-deployment.yaml
@@ -95,6 +95,7 @@ spec:
                 -Dgcs_bucket_url={{ .Values.config.gcsBucketUrl }}
                 -Dgcs_bucket_type={{ .Values.config.gcsBucketType }}
                 -Dbase_url={{ .Values.global.baseUrl }}
+                -Dpath_prefix=/api/{{ .Values.ingress.path }}
                 -Dca.nrc.cadc.util.PropertiesReader.dir=/config/
                 -Xmx{{ .Values.config.jvmMaxHeapSize }}
             {{- if eq .Values.config.backend "pg" }}

--- a/charts/cadc-tap/templates/tap-ingress-anonymous.yaml
+++ b/charts/cadc-tap/templates/tap-ingress-anonymous.yaml
@@ -20,7 +20,7 @@ template:
       nginx.ingress.kubernetes.io/proxy-redirect-to: "https://$host/api/{{ .Values.ingress.path }}/"
       nginx.ingress.kubernetes.io/ssl-redirect: "true"
       nginx.ingress.kubernetes.io/use-regex: "true"
-      nginx.ingress.kubernetes.io/server-snippet: |
+      nginx.ingress.kubernetes.io/configuration-snippet: |
         more_set_headers "server: OpenCADC/cadc-rest";
       {{- with .Values.ingress.anonymousAnnotations }}
       {{- toYaml . | indent 4}}

--- a/charts/cadc-tap/templates/tap-ingress-authenticated.yaml
+++ b/charts/cadc-tap/templates/tap-ingress-authenticated.yaml
@@ -27,7 +27,7 @@ template:
       nginx.ingress.kubernetes.io/proxy-redirect-to: "https://$host/api/{{ .Values.ingress.path }}/"
       nginx.ingress.kubernetes.io/ssl-redirect: "true"
       nginx.ingress.kubernetes.io/use-regex: "true"
-      nginx.ingress.kubernetes.io/server-snippet: |
+      nginx.ingress.kubernetes.io/configuration-snippet: |
         more_set_headers "server: OpenCADC/cadc-rest";
       {{- with .Values.ingress.authenticatedAnnotations }}
       {{- toYaml . | indent 6 }}

--- a/charts/cadc-tap/values.yaml
+++ b/charts/cadc-tap/values.yaml
@@ -71,7 +71,7 @@ config:
       pullPolicy: "IfNotPresent"
 
       # -- Tag of TAP image to use
-      tag: "1.18.1"
+      tag: "1.18.4"
 
   qserv:
     # -- QServ hostname:port to connect to
@@ -89,7 +89,7 @@ config:
       pullPolicy: "IfNotPresent"
 
       # -- Tag of TAP image to use
-      tag: "2.4.0"
+      tag: "2.4.4"
 
   # -- Address to a MySQL database containing TAP schema data
   tapSchemaAddress: "cadc-tap-schema-db:3306"
@@ -191,7 +191,7 @@ uws:
     pullPolicy: "IfNotPresent"
 
     # -- Tag of UWS database image to use
-    tag: "2.4.0"
+    tag: "2.4.4"
 
   # -- Resource limits and requests for the UWS database pod
   # @default -- See `values.yaml`

--- a/charts/cadc-tap/values.yaml
+++ b/charts/cadc-tap/values.yaml
@@ -71,7 +71,7 @@ config:
       pullPolicy: "IfNotPresent"
 
       # -- Tag of TAP image to use
-      tag: "1.17.3"
+      tag: "1.18.0"
 
   qserv:
     # -- QServ hostname:port to connect to
@@ -89,7 +89,7 @@ config:
       pullPolicy: "IfNotPresent"
 
       # -- Tag of TAP image to use
-      tag: "2.3.1"
+      tag: "2.4.0"
 
   # -- Address to a MySQL database containing TAP schema data
   tapSchemaAddress: "cadc-tap-schema-db:3306"
@@ -191,7 +191,7 @@ uws:
     pullPolicy: "IfNotPresent"
 
     # -- Tag of UWS database image to use
-    tag: "2.3.1"
+    tag: "2.4.0"
 
   # -- Resource limits and requests for the UWS database pod
   # @default -- See `values.yaml`

--- a/charts/cadc-tap/values.yaml
+++ b/charts/cadc-tap/values.yaml
@@ -71,7 +71,7 @@ config:
       pullPolicy: "IfNotPresent"
 
       # -- Tag of TAP image to use
-      tag: "1.18.0"
+      tag: "1.18.1"
 
   qserv:
     # -- QServ hostname:port to connect to


### PR DESCRIPTION
**Description**

Changes how TAP async results are handled. Introduce a results servlet, so that the uws/results/result endpoint links to that instead of the external Google bucket/CDN. The previous approach lead to an issue when trying to use pyvo to query asynchronously using the "CredentialStore" class for authentication, as the auth headers were sent to the Google CDN at the step of fetching the results, leading to an error HTTP response.

The changes in phalanx are upgrades to the Docker images for tap-postgres & lsst-tap-service, where these changes are applied.
The TAP service image upgrades also include upgrading the Capabilites generating code, to match the CADC upstream changes.

One additional change is to add a path_prefix, which is used by both the results and the capabilities servlet.

**How was this tested**

Deployed & tested on dev
- pyvo async & sync queries
- taplint validation

**Potential issues**

Has not been tested on environments that use S3 bucket subdirectories, I've added a JUnit test for this case, but that's one type of environment I'm less confident will not break. 