### PR TITLE
Change Sasquatch Kafka min.insync.replicas setting to 2

### DIFF
--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -345,7 +345,7 @@ Rubin Observatory's telemetry service
 | strimzi-kafka.kafka.config."message.max.bytes" | int | `10485760` | The largest record batch size allowed by Kafka |
 | strimzi-kafka.kafka.config."offsets.retention.minutes" | int | `2880` | Number of minutes for a consumer group's offsets to be retained |
 | strimzi-kafka.kafka.config."replica.fetch.max.bytes" | int | `10485760` | The number of bytes of messages to attempt to fetch for each partition |
-| strimzi-kafka.kafka.disruption_tolerance | int | `0` | Number of down brokers that the system can tolerate |
+| strimzi-kafka.kafka.disruption_tolerance | int | `1` | Number of down brokers that the system can tolerate |
 | strimzi-kafka.kafka.externalListener.bootstrap.annotations | object | `{}` | Annotations that will be added to the Ingress, Route, or Service resource |
 | strimzi-kafka.kafka.externalListener.bootstrap.host | string | Do not configure TLS | Name used for TLS hostname verification |
 | strimzi-kafka.kafka.externalListener.bootstrap.loadBalancerIP | string | Do not request a load balancer IP | Request this load balancer IP. See `values.yaml` for more discussion |

--- a/applications/sasquatch/charts/strimzi-kafka/README.md
+++ b/applications/sasquatch/charts/strimzi-kafka/README.md
@@ -23,7 +23,7 @@ A subchart to deploy Strimzi Kafka components for Sasquatch.
 | kafka.config."message.max.bytes" | int | `10485760` | The largest record batch size allowed by Kafka |
 | kafka.config."offsets.retention.minutes" | int | `2880` | Number of minutes for a consumer group's offsets to be retained |
 | kafka.config."replica.fetch.max.bytes" | int | `10485760` | The number of bytes of messages to attempt to fetch for each partition |
-| kafka.disruption_tolerance | int | `0` | Number of down brokers that the system can tolerate |
+| kafka.disruption_tolerance | int | `1` | Number of down brokers that the system can tolerate |
 | kafka.externalListener.bootstrap.annotations | object | `{}` | Annotations that will be added to the Ingress, Route, or Service resource |
 | kafka.externalListener.bootstrap.host | string | Do not configure TLS | Name used for TLS hostname verification |
 | kafka.externalListener.bootstrap.loadBalancerIP | string | Do not request a load balancer IP | Request this load balancer IP. See `values.yaml` for more discussion |

--- a/applications/sasquatch/charts/strimzi-kafka/values.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/values.yaml
@@ -17,7 +17,7 @@ kafka:
   replicas: 3
 
   # -- Number of down brokers that the system can tolerate
-  disruption_tolerance: 0
+  disruption_tolerance: 1
 
   storage:
     # -- Size of the backing storage disk for each of the Kafka brokers


### PR DESCRIPTION
- Make this the default configuration, which means that we allow one Kafka broker to fail and we improve the Kafka consumer's performance requiring that the messages are replicated to at least 2 brokers before being available for consumption.