### PR TITLE
Telegraf Kafka chart improvements

### DIFF
--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -402,6 +402,7 @@ Rubin Observatory's telemetry service
 | telegraf-kafka-consumer.image.tag | string | `"latest"` | Telegraf image tag |
 | telegraf-kafka-consumer.imagePullSecrets | list | `[]` | Secret names to use for Docker pulls |
 | telegraf-kafka-consumer.influxdb.database | string | `"telegraf-kafka-consumer-v1"` | Name of the InfluxDB v1 database to write to |
+| telegraf-kafka-consumer.influxdb.url | string | `"http://sasquatch-influxdb.sasquatch:8086"` | URL of the InfluxDB v1 instance to write to |
 | telegraf-kafka-consumer.kafkaConsumers.test.enabled | bool | `false` | Enable the Telegraf Kafka consumer. |
 | telegraf-kafka-consumer.kafkaConsumers.test.fields | list | `[]` | List of Avro fields to be recorded as InfluxDB fields.  If not specified, any Avro field that is not marked as a tag will become an InfluxDB field. |
 | telegraf-kafka-consumer.kafkaConsumers.test.flush_interval | string | `"1s"` | Default data flushing interval to InfluxDB. |

--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -398,8 +398,8 @@ Rubin Observatory's telemetry service
 | telegraf-kafka-consumer.env | list | See `values.yaml` | Telegraf agent enviroment variables |
 | telegraf-kafka-consumer.envFromSecret | string | `""` | Name of the secret with values to be added to the environment. |
 | telegraf-kafka-consumer.image.pullPolicy | string | `"Always"` | Image pull policy |
-| telegraf-kafka-consumer.image.repo | string | `"quay.io/influxdb/telegraf-nightly"` | Telegraf image repository |
-| telegraf-kafka-consumer.image.tag | string | `"latest"` | Telegraf image tag |
+| telegraf-kafka-consumer.image.repo | string | `"docker.io/library/telegraf"` | Telegraf image repository |
+| telegraf-kafka-consumer.image.tag | string | `"1.30.2-alpine"` | Telegraf image tag |
 | telegraf-kafka-consumer.imagePullSecrets | list | `[]` | Secret names to use for Docker pulls |
 | telegraf-kafka-consumer.influxdb.database | string | `"telegraf-kafka-consumer-v1"` | Name of the InfluxDB v1 database to write to |
 | telegraf-kafka-consumer.influxdb.url | string | `"http://sasquatch-influxdb.sasquatch:8086"` | URL of the InfluxDB v1 instance to write to |

--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -403,14 +403,23 @@ Rubin Observatory's telemetry service
 | telegraf-kafka-consumer.imagePullSecrets | list | `[]` | Secret names to use for Docker pulls |
 | telegraf-kafka-consumer.influxdb.database | string | `"telegraf-kafka-consumer-v1"` | Name of the InfluxDB v1 database to write to |
 | telegraf-kafka-consumer.influxdb.url | string | `"http://sasquatch-influxdb.sasquatch:8086"` | URL of the InfluxDB v1 instance to write to |
+| telegraf-kafka-consumer.kafkaConsumers.test.collection_jitter | string | "0s" | Data collection jitter. This is used to jitter the collection by a random amount. Each plugin will sleep for a random time within jitter before collecting. |
+| telegraf-kafka-consumer.kafkaConsumers.test.consumer_fetch_default | string | "20MB" | Maximum amount of data the server should return for a fetch request. |
+| telegraf-kafka-consumer.kafkaConsumers.test.debug | bool | false | Run Telegraf in debug mode. |
 | telegraf-kafka-consumer.kafkaConsumers.test.enabled | bool | `false` | Enable the Telegraf Kafka consumer. |
 | telegraf-kafka-consumer.kafkaConsumers.test.fields | list | `[]` | List of Avro fields to be recorded as InfluxDB fields.  If not specified, any Avro field that is not marked as a tag will become an InfluxDB field. |
-| telegraf-kafka-consumer.kafkaConsumers.test.flush_interval | string | `"1s"` | Default data flushing interval to InfluxDB. |
-| telegraf-kafka-consumer.kafkaConsumers.test.interval | string | `"1s"` | Data collection interval for the Kafka consumer. |
+| telegraf-kafka-consumer.kafkaConsumers.test.flush_interval | string | "1s" | Data flushing interval for all outputs. Don’t set this below interval. Maximum flush_interval is flush_interval + flush_jitter |
+| telegraf-kafka-consumer.kafkaConsumers.test.flush_jitter | string | "0s" | Jitter the flush interval by a random amount. This is primarily to avoid large write spikes for users running a large number of telegraf instances. |
+| telegraf-kafka-consumer.kafkaConsumers.test.interval | string | "1s" | Data collection interval for the Kafka consumer. |
+| telegraf-kafka-consumer.kafkaConsumers.test.max_processing_time | string | "5s" | Maximum processing time for a single message. |
+| telegraf-kafka-consumer.kafkaConsumers.test.metric_batch_size | int | 1000 | Sends metrics to the output in batches of at most metric_batch_size metrics. |
+| telegraf-kafka-consumer.kafkaConsumers.test.metric_buffer_limit | int | 10000 | Caches metric_buffer_limit metrics for each output, and flushes this buffer on a successful write. This should be a multiple of metric_batch_size and could not be less than 2 times metric_batch_size. |
+| telegraf-kafka-consumer.kafkaConsumers.test.offset | string | `"oldest"` | Kafka consumer offset. Possible values are `oldest` and `newest`. |
+| telegraf-kafka-consumer.kafkaConsumers.test.precision | string | "1us" | Data precision. |
 | telegraf-kafka-consumer.kafkaConsumers.test.replicaCount | int | `1` | Number of Telegraf Kafka consumer replicas. Increase this value to increase the consumer throughput. |
 | telegraf-kafka-consumer.kafkaConsumers.test.tags | list | `[]` | List of Avro fields to be recorded as InfluxDB tags.  The Avro fields specified as tags will be converted to strings before ingestion into InfluxDB. |
 | telegraf-kafka-consumer.kafkaConsumers.test.timestamp_field | string | `"private_efdStamp"` | Avro field to be used as the InfluxDB timestamp (optional).  If unspecified or set to the empty string, Telegraf will use the time it received the measurement. |
-| telegraf-kafka-consumer.kafkaConsumers.test.timestamp_format | string | `"unix"` | Timestamp format. Possible values are `unix` (the default if unset), `unix_ms`, `unix_us`, and `unix_ns`.  At Rubin, use `unix` timestamp format for SAL timestamps. |
+| telegraf-kafka-consumer.kafkaConsumers.test.timestamp_format | string | `"unix"` | Timestamp format. Possible values are `unix` (the default if unset) a timestamp in seconds since the Unix epoch, `unix_ms` (milliseconds), `unix_us` (microsseconds), or `unix_ns` (nanoseconds). |
 | telegraf-kafka-consumer.kafkaConsumers.test.topicRegexps | string | `"[ \".*Test\" ]\n"` | List of regular expressions to specify the Kafka topics consumed by this agent. |
 | telegraf-kafka-consumer.kafkaConsumers.test.union_field_separator | string | `""` | Union field separator: if a single Avro field is flattened into more than one InfluxDB field (e.g. an array `a`, with four members, would yield `a0`, `a1`, `a2`, `a3`; if the field separator were `_`, these would be `a_0`...`a_3`. |
 | telegraf-kafka-consumer.kafkaConsumers.test.union_mode | string | `"nullable"` | Union mode: this can be one of `flatten`, `nullable`, or `any`. See `values.yaml` for extensive discussion. |

--- a/applications/sasquatch/charts/telegraf-kafka-consumer/README.md
+++ b/applications/sasquatch/charts/telegraf-kafka-consumer/README.md
@@ -16,6 +16,7 @@ Telegraf is an agent written in Go for collecting, processing, aggregating, and 
 | image.tag | string | `"latest"` | Telegraf image tag |
 | imagePullSecrets | list | `[]` | Secret names to use for Docker pulls |
 | influxdb.database | string | `"telegraf-kafka-consumer-v1"` | Name of the InfluxDB v1 database to write to |
+| influxdb.url | string | `"http://sasquatch-influxdb.sasquatch:8086"` | URL of the InfluxDB v1 instance to write to |
 | kafkaConsumers.test.enabled | bool | `false` | Enable the Telegraf Kafka consumer. |
 | kafkaConsumers.test.fields | list | `[]` | List of Avro fields to be recorded as InfluxDB fields.  If not specified, any Avro field that is not marked as a tag will become an InfluxDB field. |
 | kafkaConsumers.test.flush_interval | string | `"1s"` | Default data flushing interval to InfluxDB. |

--- a/applications/sasquatch/charts/telegraf-kafka-consumer/README.md
+++ b/applications/sasquatch/charts/telegraf-kafka-consumer/README.md
@@ -17,14 +17,23 @@ Telegraf is an agent written in Go for collecting, processing, aggregating, and 
 | imagePullSecrets | list | `[]` | Secret names to use for Docker pulls |
 | influxdb.database | string | `"telegraf-kafka-consumer-v1"` | Name of the InfluxDB v1 database to write to |
 | influxdb.url | string | `"http://sasquatch-influxdb.sasquatch:8086"` | URL of the InfluxDB v1 instance to write to |
+| kafkaConsumers.test.collection_jitter | string | "0s" | Data collection jitter. This is used to jitter the collection by a random amount. Each plugin will sleep for a random time within jitter before collecting. |
+| kafkaConsumers.test.consumer_fetch_default | string | "20MB" | Maximum amount of data the server should return for a fetch request. |
+| kafkaConsumers.test.debug | bool | false | Run Telegraf in debug mode. |
 | kafkaConsumers.test.enabled | bool | `false` | Enable the Telegraf Kafka consumer. |
 | kafkaConsumers.test.fields | list | `[]` | List of Avro fields to be recorded as InfluxDB fields.  If not specified, any Avro field that is not marked as a tag will become an InfluxDB field. |
-| kafkaConsumers.test.flush_interval | string | `"1s"` | Default data flushing interval to InfluxDB. |
-| kafkaConsumers.test.interval | string | `"1s"` | Data collection interval for the Kafka consumer. |
+| kafkaConsumers.test.flush_interval | string | "1s" | Data flushing interval for all outputs. Don’t set this below interval. Maximum flush_interval is flush_interval + flush_jitter |
+| kafkaConsumers.test.flush_jitter | string | "0s" | Jitter the flush interval by a random amount. This is primarily to avoid large write spikes for users running a large number of telegraf instances. |
+| kafkaConsumers.test.interval | string | "1s" | Data collection interval for the Kafka consumer. |
+| kafkaConsumers.test.max_processing_time | string | "5s" | Maximum processing time for a single message. |
+| kafkaConsumers.test.metric_batch_size | int | 1000 | Sends metrics to the output in batches of at most metric_batch_size metrics. |
+| kafkaConsumers.test.metric_buffer_limit | int | 10000 | Caches metric_buffer_limit metrics for each output, and flushes this buffer on a successful write. This should be a multiple of metric_batch_size and could not be less than 2 times metric_batch_size. |
+| kafkaConsumers.test.offset | string | `"oldest"` | Kafka consumer offset. Possible values are `oldest` and `newest`. |
+| kafkaConsumers.test.precision | string | "1us" | Data precision. |
 | kafkaConsumers.test.replicaCount | int | `1` | Number of Telegraf Kafka consumer replicas. Increase this value to increase the consumer throughput. |
 | kafkaConsumers.test.tags | list | `[]` | List of Avro fields to be recorded as InfluxDB tags.  The Avro fields specified as tags will be converted to strings before ingestion into InfluxDB. |
 | kafkaConsumers.test.timestamp_field | string | `"private_efdStamp"` | Avro field to be used as the InfluxDB timestamp (optional).  If unspecified or set to the empty string, Telegraf will use the time it received the measurement. |
-| kafkaConsumers.test.timestamp_format | string | `"unix"` | Timestamp format. Possible values are `unix` (the default if unset), `unix_ms`, `unix_us`, and `unix_ns`.  At Rubin, use `unix` timestamp format for SAL timestamps. |
+| kafkaConsumers.test.timestamp_format | string | `"unix"` | Timestamp format. Possible values are `unix` (the default if unset) a timestamp in seconds since the Unix epoch, `unix_ms` (milliseconds), `unix_us` (microsseconds), or `unix_ns` (nanoseconds). |
 | kafkaConsumers.test.topicRegexps | string | `"[ \".*Test\" ]\n"` | List of regular expressions to specify the Kafka topics consumed by this agent. |
 | kafkaConsumers.test.union_field_separator | string | `""` | Union field separator: if a single Avro field is flattened into more than one InfluxDB field (e.g. an array `a`, with four members, would yield `a0`, `a1`, `a2`, `a3`; if the field separator were `_`, these would be `a_0`...`a_3`. |
 | kafkaConsumers.test.union_mode | string | `"nullable"` | Union mode: this can be one of `flatten`, `nullable`, or `any`. See `values.yaml` for extensive discussion. |

--- a/applications/sasquatch/charts/telegraf-kafka-consumer/README.md
+++ b/applications/sasquatch/charts/telegraf-kafka-consumer/README.md
@@ -12,8 +12,8 @@ Telegraf is an agent written in Go for collecting, processing, aggregating, and 
 | env | list | See `values.yaml` | Telegraf agent enviroment variables |
 | envFromSecret | string | `""` | Name of the secret with values to be added to the environment. |
 | image.pullPolicy | string | `"Always"` | Image pull policy |
-| image.repo | string | `"quay.io/influxdb/telegraf-nightly"` | Telegraf image repository |
-| image.tag | string | `"latest"` | Telegraf image tag |
+| image.repo | string | `"docker.io/library/telegraf"` | Telegraf image repository |
+| image.tag | string | `"1.30.2-alpine"` | Telegraf image tag |
 | imagePullSecrets | list | `[]` | Secret names to use for Docker pulls |
 | influxdb.database | string | `"telegraf-kafka-consumer-v1"` | Name of the InfluxDB v1 database to write to |
 | influxdb.url | string | `"http://sasquatch-influxdb.sasquatch:8086"` | URL of the InfluxDB v1 instance to write to |

--- a/applications/sasquatch/charts/telegraf-kafka-consumer/templates/configmap.yaml
+++ b/applications/sasquatch/charts/telegraf-kafka-consumer/templates/configmap.yaml
@@ -10,17 +10,15 @@ metadata:
 data:
   telegraf.conf: |+
     [agent]
-      collection_jitter = "0s"
-      debug = true
-      flush_interval = {{ default "1s" $value.flush_interval | quote }}
-      flush_jitter = "0s"
       interval = {{ default "1s" $value.interval | quote }}
-      logfile = ""
-      metric_batch_size = {{ default 1000 $value.metric_batch_size }}
-      metric_buffer_limit = 10000
-      omit_hostname = true
-      quiet = false
       round_interval = true
+      metric_batch_size = {{ default 1000 $value.metric_batch_size }}
+      metric_buffer_limit = {{ default 10000 $value.metric_buffer_limit }}
+      collection_jitter = {{ default "0s" $value.collection_jitter | quote }}
+      flush_interval = {{ default "1s" $value.flush_interval | quote }}
+      flush_jitter = {{ default "0s" $value.flush_jitter | quote }}
+      debug = {{ default false $value.debug }}
+      omit_hostname = true
 
     [[outputs.influxdb]]
       urls = [
@@ -31,38 +29,30 @@ data:
       password = "${INFLUXDB_PASSWORD}"
 
     [[inputs.kafka_consumer]]
-      avro_schema_registry = "http://sasquatch-schema-registry.sasquatch:8081"
-      {{- with $value.union_mode }}
-      avro_union_mode = {{- $value.union_mode | quote }}
-      {{- end }}
-      {{- with $value.timestamp_field }}
-      avro_timestamp = {{- $value.timestamp_field | quote }}
-      {{- end }}
-      {{- with $value.timestamp_format }}
-      avro_timestamp_format = {{- $value.timestamp_format | quote }}
-      {{- end }}
-      {{- with $value.union_field_separator }}
-      avro_field_separator = {{- $value.union_field_separator | quote }}
-      {{- end }}
-      {{- with $value.fields }}
-      avro_fields = {{- toYaml . }}
-      {{- end }}
-      {{- with $value.tags }}
-      avro_tags = {{- toYaml . }}
-      {{- end }}
       brokers = [
         "sasquatch-kafka-brokers.sasquatch:9092"
       ]
       consumer_group = "telegraf-kafka-consumer-{{ $key }}"
-      data_format = "avro"
-      max_processing_time = "5s"
       sasl_mechanism = "SCRAM-SHA-512"
       sasl_password = "$TELEGRAF_PASSWORD"
       sasl_username = "telegraf"
+      data_format = "avro"
+      avro_schema_registry = "http://sasquatch-schema-registry.sasquatch:8081"
+      avro_timestamp = {{ default "private_efdStamp" $value.timestamp_field | quote }}
+      avro_timestamp_format = {{ default "unix" $value.timestamp_format | quote }}
+      avro_union_mode = {{ default "nullable" $value.union_mode | quote }}
+      avro_field_separator = {{ default "" $value.union_field_separator | quote }}
+      {{ with $value.fields }}
+      avro_fields = {{ $value.fields }}
+      {{ end }}
+      {{ with $value.tags }}
+      avro_tags = {{ $value.tags }}
+      {{ end }}
       topic_regexps = {{ $value.topicRegexps }}
-      offset = "oldest"
-      consumer_fetch_default = "20MB"
-      precision = "1us"
+      offset = {{ default "oldest" $value.offset | quote }}
+      precision = {{ default "1us" $value.precision | quote }}
+      max_processing_time = {{ default "5s" $value.max_processing_time | quote }}
+      consumer_fetch_default = {{ default "20MB" $value.consumer_fetch_default | quote }}
 
     [[inputs.internal]]
       collect_memstats = false

--- a/applications/sasquatch/charts/telegraf-kafka-consumer/templates/configmap.yaml
+++ b/applications/sasquatch/charts/telegraf-kafka-consumer/templates/configmap.yaml
@@ -60,7 +60,7 @@ data:
       sasl_password = "$TELEGRAF_PASSWORD"
       sasl_username = "telegraf"
       topic_regexps = {{ $value.topicRegexps }}
-      offset = "newest"
+      offset = "oldest"
       consumer_fetch_default = "20MB"
       precision = "1us"
 

--- a/applications/sasquatch/charts/telegraf-kafka-consumer/templates/configmap.yaml
+++ b/applications/sasquatch/charts/telegraf-kafka-consumer/templates/configmap.yaml
@@ -24,7 +24,7 @@ data:
 
     [[outputs.influxdb]]
       urls = [
-        "http://sasquatch-influxdb.sasquatch:8086"
+        {{ $.Values.influxdb.url | quote }}
       ]
       database = {{ $.Values.influxdb.database | quote }}
       username = "${INFLUXDB_USER}"

--- a/applications/sasquatch/charts/telegraf-kafka-consumer/values.yaml
+++ b/applications/sasquatch/charts/telegraf-kafka-consumer/values.yaml
@@ -61,16 +61,51 @@ kafkaConsumers:
     replicaCount: 1
 
     # -- Data collection interval for the Kafka consumer.
+    # @default -- "1s"
     interval: "1s"
 
-    # -- Default data flushing interval to InfluxDB.
+    # -- Sends metrics to the output in batches of at most metric_batch_size
+    # metrics.
+    # @default -- 1000
+    metric_batch_size: 1000
+
+    # -- Caches metric_buffer_limit metrics for each output, and flushes this
+    # buffer on a successful write. This should be a multiple of metric_batch_size
+    # and could not be less than 2 times metric_batch_size.
+    # @default -- 10000
+    metric_buffer_limit: 10000
+
+    # -- Data collection jitter. This is used to jitter the collection by a
+    # random amount. Each plugin will sleep for a random time within jitter
+    # before collecting.
+    # @default -- "0s"
+    collection_jitter: "0s"
+
+    # -- Data flushing interval for all outputs.
+    # Don’t set this below interval.
+    # Maximum flush_interval is flush_interval + flush_jitter
+    # @default -- "1s"
     flush_interval: "1s"
 
-    # -- Union field separator: if a single Avro field is flattened into more
-    # than one InfluxDB field (e.g. an array `a`, with four members, would
-    # yield `a0`, `a1`, `a2`, `a3`; if the field separator were `_`, these
-    # would be `a_0`...`a_3`.
-    union_field_separator: ""
+    # -- Jitter the flush interval by a random amount. This is primarily to
+    # avoid large write spikes for users running a large number of telegraf
+    # instances.
+    # @default -- "0s"
+    flush_jitter: "0s"
+
+    # -- Run Telegraf in debug mode.
+    # @default -- false
+    debug: false
+
+    # -- Timestamp format. Possible values are `unix` (the default if unset) a
+    # timestamp in seconds since the Unix epoch, `unix_ms` (milliseconds),
+    # `unix_us` (microsseconds), or `unix_ns` (nanoseconds).
+    timestamp_format: "unix"
+
+    # -- Avro field to be used as the InfluxDB timestamp (optional).  If
+    # unspecified or set to the empty string, Telegraf will use the time it
+    # received the measurement.
+    timestamp_field: "private_efdStamp"
 
     # Union mode.
     #
@@ -104,30 +139,41 @@ kafkaConsumers:
     # `values.yaml` for extensive discussion.
     union_mode: "nullable"
 
-    # -- Timestamp format. Possible values are `unix` (the default if unset),
-    # `unix_ms`, `unix_us`, and `unix_ns`.  At Rubin, use `unix` timestamp
-    # format for SAL timestamps.
-    timestamp_format: "unix"
-
-    # -- Avro field to be used as the InfluxDB timestamp (optional).  If
-    # unspecified or set to the empty string, Telegraf will use the time it
-    # received the measurement.
-    timestamp_field: "private_efdStamp"
-
-    # -- List of Avro fields to be recorded as InfluxDB tags.  The Avro fields
-    # specified as tags will be converted to strings before ingestion into
-    # InfluxDB.
-    tags: []
+    # -- Union field separator: if a single Avro field is flattened into more
+    # than one InfluxDB field (e.g. an array `a`, with four members, would
+    # yield `a0`, `a1`, `a2`, `a3`; if the field separator were `_`, these
+    # would be `a_0`...`a_3`.
+    union_field_separator: ""
 
     # -- List of Avro fields to be recorded as InfluxDB fields.  If not
     # specified, any Avro field that is not marked as a tag will become an
     # InfluxDB field.
     fields: []
 
+    # -- List of Avro fields to be recorded as InfluxDB tags.  The Avro fields
+    # specified as tags will be converted to strings before ingestion into
+    # InfluxDB.
+    tags: []
+
     # -- List of regular expressions to specify the Kafka topics consumed by
     # this agent.
     topicRegexps: |
       [ ".*Test" ]
+
+    # -- Kafka consumer offset. Possible values are `oldest` and `newest`.
+    offset: "oldest"
+
+    # -- Data precision.
+    # @default -- "1us"
+    precision: "1us"
+
+    # -- Maximum processing time for a single message.
+    # @default -- "5s"
+    max_processing_time: "5s"
+
+    # -- Maximum amount of data the server should return for a fetch request.
+    # @default -- "20MB"
+    consumer_fetch_default: "20MB"
 
 influxdb:
   # -- URL of the InfluxDB v1 instance to write to
@@ -140,10 +186,10 @@ influxdb:
 resources:
   limits:
     cpu: "1"
-    memory: "160Mi"
+    memory: "1Gi"
   requests:
-    cpu: "8m"
-    memory: "75Mi"
+    cpu: "1"
+    memory: "1Gi"
 
 # -- Node labels for pod assignment
 nodeSelector: {}

--- a/applications/sasquatch/charts/telegraf-kafka-consumer/values.yaml
+++ b/applications/sasquatch/charts/telegraf-kafka-consumer/values.yaml
@@ -5,10 +5,10 @@ enabled: false
 
 image:
   # -- Telegraf image repository
-  repo: "quay.io/influxdb/telegraf-nightly"
+  repo: "docker.io/library/telegraf"
 
   # -- Telegraf image tag
-  tag: "latest"
+  tag: "1.30.2-alpine"
 
   # -- Image pull policy
   pullPolicy: "Always"

--- a/applications/sasquatch/charts/telegraf-kafka-consumer/values.yaml
+++ b/applications/sasquatch/charts/telegraf-kafka-consumer/values.yaml
@@ -130,6 +130,8 @@ kafkaConsumers:
       [ ".*Test" ]
 
 influxdb:
+  # -- URL of the InfluxDB v1 instance to write to
+  url: "http://sasquatch-influxdb.sasquatch:8086"
   # -- Name of the InfluxDB v1 database to write to
   database: "telegraf-kafka-consumer-v1"
 

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -174,7 +174,7 @@ kafka-connect-manager-enterprise:
         topicsRegex: ".*MTVMS"
       enterprise-lasertracker:
         enabled: true
-        repairerConnector: false
+        repairerConnector: true
         topicsRegex: ".*LaserTracker"
       enterprise-lsstcam:
         enabled: true

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -118,7 +118,7 @@ kafka-connect-manager-enterprise:
       enterprise-eas:
         enabled: true
         repairerConnector: false
-        topicsRegex: ".*DIMM|.*DSM|.*ESS|.*HVAC|.*WeatherForecast"
+        topicsRegex: ".*DIMM|.*DSM|.*EPM|.*ESS|.*HVAC|.*WeatherForecast"
       enterprise-m1m3:
         enabled: true
         repairerConnector: false

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -181,6 +181,54 @@ kafka-connect-manager-enterprise:
         repairerConnector: false
         topicsRegex: ".*MTCamera|.*MTHeaderService|.*MTOODS"
 
+telegraf-kafka-consumer:
+  enabled: true
+  influxdb:
+    url: "http://sasquatch-influxdb-enterprise-data.sasquatch:8086"
+    database: "efd"
+  kafkaConsumers:
+    auxtel:
+      enabled: true
+      replicaCount: 1
+      interval: "1s"
+      flush_interval: "1s"
+      union_mode: "nullable"
+      timestamp_format: "unix"
+      timestamp_field: "private_efdStamp"
+      topicRegexps: |
+        [ "lsst.sal.ATAOS", "lsst.sal.ATDome", "lsst.sal.ATDomeTrajectory", "lsst.sal.ATHexapod", "lsst.sal.ATPneumatics", "lsst.sal.ATPtg", "lsst.sal.ATMCS" ]
+    latiss:
+      enabled: true
+      replicaCount: 1
+      interval: "1s"
+      flush_interval: "1s"
+      union_mode: "nullable"
+      timestamp_format: "unix"
+      timestamp_field: "private_efdStamp"
+      topicRegexps: |
+        [ "lsst.sal.ATCamera", "lsst.sal.ATHeaderService", "lsst.sal.ATOODS", "lsst.sal.ATSpectrograph" ]
+    test:
+      enabled: true
+      replicaCount: 1
+      interval: "1s"
+      flush_interval: "1s"
+      union_mode: "nullable"
+      timestamp_format: "unix"
+      timestamp_field: "private_efdStamp"
+      topicRegexps: |
+        [ "lsst.sal.Test" ]
+    lasertracker:
+      enabled: true
+      replicaCount: 1
+      interval: "1s"
+      flush_interval: "1s"
+      union_mode: "nullable"
+      timestamp_format: "unix"
+      timestamp_field: "private_efdStamp"
+      topicRegexps: |
+        [ "lsst.sal.LaserTracker" ]
+
+
 kafdrop:
   ingress:
     enabled: true

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -102,10 +102,6 @@ kafka-connect-manager-enterprise:
     # Enable here the same connectors that are enabled at the summit to
     # persist the same data at InfluxDB Enterprise at USDF
     connectors:
-      enterprise-auxtel:
-        enabled: true
-        repairerConnector: false
-        topicsRegex: ".*ATAOS|.*ATDome|.*ATDomeTrajectory|.*ATHexapod|.*ATPneumatics|.*ATPtg|.*ATMCS"
       enterprise-maintel:
         enabled: true
         repairerConnector: false
@@ -122,11 +118,7 @@ kafka-connect-manager-enterprise:
       enterprise-eas:
         enabled: true
         repairerConnector: false
-        topicsRegex: ".*DIMM|.*DSM|.*EPM|.*ESS|.*HVAC|.*WeatherForecast"
-      enterprise-latiss:
-        enabled: true
-        repairerConnector: false
-        topicsRegex: ".*ATCamera|.*ATHeaderService|.*ATOODS|.*ATSpectrograph"
+        topicsRegex: ".*DIMM|.*DSM|.*ESS|.*HVAC|.*WeatherForecast"
       enterprise-m1m3:
         enabled: true
         repairerConnector: false
@@ -144,10 +136,6 @@ kafka-connect-manager-enterprise:
         enabled: true
         repairerConnector: false
         topicsRegex: ".*OCPS"
-      enterprise-test:
-        enabled: true
-        repairerConnector: false
-        topicsRegex: "lsst.sal.Test"
       enterprise-pmd:
         enabled: true
         repairerConnector: false
@@ -172,10 +160,6 @@ kafka-connect-manager-enterprise:
         enabled: true
         repairerConnector: false
         topicsRegex: ".*MTVMS"
-      enterprise-lasertracker:
-        enabled: true
-        repairerConnector: true
-        topicsRegex: ".*LaserTracker"
       enterprise-lsstcam:
         enabled: true
         repairerConnector: false
@@ -227,7 +211,6 @@ telegraf-kafka-consumer:
       timestamp_field: "private_efdStamp"
       topicRegexps: |
         [ "lsst.sal.LaserTracker" ]
-
 
 kafdrop:
   ingress:


### PR DESCRIPTION
- Replace auxtel, latiss, lasertracker InfluxDB Sink connectors with corresponding Telegraf Kafka connectors
- Add new eas connectors 