### PR TITLE
DM-45168: Ignore accessors that return forbidden

### DIFF
--- a/docs/documenteer.toml
+++ b/docs/documenteer.toml
@@ -43,6 +43,7 @@ rst_epilog_file = "_rst_epilog.rst"
 
 [sphinx.intersphinx.projects]
 click = "https://click.palletsprojects.com/en/8.1.x/"
+hvac = "https://hvac.readthedocs.io/en/stable/"
 python = "https://docs.python.org/3/"
 safir = "https://safir.lsst.io/"
 sphinx = "https://www.sphinx-doc.org/en/master/"

--- a/src/phalanx/storage/vault.py
+++ b/src/phalanx/storage/vault.py
@@ -281,6 +281,12 @@ class VaultClient:
         VaultTokenMetadata or None
             Metadata for the token, or `None` if no token exists with that
             accessor.
+
+        Raises
+        ------
+        hvac.exceptions.Forbidden
+            Raised if the caller doesn't have access to retrieve this
+            accessor.
         """
         try:
             r = self._vault.auth.token.lookup_accessor(accessor)


### PR DESCRIPTION
We have one Vault token accessor that returns Forbidden for all attempted requests. Not sure what's going on with that, but it shouldn't block creating new write tokens, so ignore accessors that raise Forbidden. Hopefully this won't cause too many problems.