### PR TITLE
DM-44509: Upgrade Butler server, datalinker, and vo-cutouts

### DIFF
--- a/applications/butler/Chart.yaml
+++ b/applications/butler/Chart.yaml
@@ -4,4 +4,4 @@ version: 1.0.0
 description: Server for Butler data abstraction service
 sources:
   - https://github.com/lsst/daf_butler
-appVersion: w.2024.15
+appVersion: w.2024.27

--- a/applications/datalinker/Chart.yaml
+++ b/applications/datalinker/Chart.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 description: IVOA DataLink-based service and data discovery
 sources:
   - https://github.com/lsst-sqre/datalinker
-appVersion: 1.7.1
+appVersion: tickets-DM-44509
 annotations:
   phalanx.lsst.io/docs: |
     - id: "DMTN-238"

--- a/applications/vo-cutouts/Chart.yaml
+++ b/applications/vo-cutouts/Chart.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 description: "Image cutout service complying with IVOA SODA"
 sources:
   - "https://github.com/lsst-sqre/vo-cutouts"
-appVersion: 2.0.0
+appVersion: tickets-DM-44509
 
 dependencies:
   - name: redis

--- a/applications/vo-cutouts/README.md
+++ b/applications/vo-cutouts/README.md
@@ -26,7 +26,7 @@ Image cutout service complying with IVOA SODA
 | config.syncTimeout | string | 60s (1 minute) | Timeout for results from a sync cutout in safir parse_timedelta format |
 | config.timeout | int | 600 (10 minutes) | Timeout for a single cutout job in seconds |
 | cutoutWorker.affinity | object | `{}` | Affinity rules for the cutout worker pod |
-| cutoutWorker.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for cutout workers |
+| cutoutWorker.image.pullPolicy | string | `"Always"` | Pull policy for cutout workers |
 | cutoutWorker.image.repository | string | `"ghcr.io/lsst-sqre/vo-cutouts-worker"` | Stack image to use for cutouts |
 | cutoutWorker.image.tag | string | The appVersion of the chart | Tag of vo-cutouts worker image to use |
 | cutoutWorker.nodeSelector | object | `{}` | Node selection rules for the cutout worker pod |
@@ -50,7 +50,7 @@ Image cutout service complying with IVOA SODA
 | global.butlerServerRepositories | string | Set by Argo CD | Butler repositories accessible via Butler server |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
-| image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the vo-cutouts image |
+| image.pullPolicy | string | `"Always"` | Pull policy for the vo-cutouts image |
 | image.repository | string | `"ghcr.io/lsst-sqre/vo-cutouts"` | vo-cutouts image to use for the frontend and database workers |
 | image.tag | string | The appVersion of the chart | Tag of vo-cutouts image to use |
 | ingress.annotations | object | `{}` | Additional annotations to add to the ingress |

--- a/applications/vo-cutouts/README.md
+++ b/applications/vo-cutouts/README.md
@@ -17,13 +17,13 @@ Image cutout service complying with IVOA SODA
 | cloudsql.instanceConnectionName | string | None, must be set if Cloud SQL is used | Instance connection name for a Cloud SQL PostgreSQL instance |
 | cloudsql.resources | object | See `values.yaml` | Resource limits and requests for the Cloud SQL Proxy container |
 | config.databaseUrl | string | None, must be set if `cloudsql.enabled` is false | URL for the PostgreSQL database if Cloud SQL is not in use |
-| config.lifetime | string | 2592000s (30 days) | Lifetime of job results in safir parse_timedelta format |
+| config.lifetime | string | `"30d"` | Lifetime of job results in Safir `parse_timedelta` format |
 | config.loglevel | string | `"INFO"` | Choose from the text form of Python logging levels |
 | config.pathPrefix | string | `"/api/cutout"` | URL path prefix for the cutout API |
 | config.serviceAccount | string | None, must be set | Google service account with an IAM binding to the `vo-cutouts` Kubernetes service accounts and has the `cloudsql.client` role, access to write to the GCS bucket, and ability to sign URLs as itself |
 | config.slackAlerts | bool | `true` | Whether to send Slack alerts for unexpected failures |
 | config.storageBucketUrl | string | None, must be set | URL for the GCS bucket for results (must start with `gs`) |
-| config.syncTimeout | string | 60s (1 minute) | Timeout for results from a sync cutout in safir parse_timedelta format |
+| config.syncTimeout | string | `"1m"` | Timeout for results from a sync cutout in Safir `parse_timedelta` format |
 | config.timeout | int | 600 (10 minutes) | Timeout for a single cutout job in seconds |
 | cutoutWorker.affinity | object | `{}` | Affinity rules for the cutout worker pod |
 | cutoutWorker.image.pullPolicy | string | `"Always"` | Pull policy for cutout workers |

--- a/applications/vo-cutouts/README.md
+++ b/applications/vo-cutouts/README.md
@@ -17,13 +17,13 @@ Image cutout service complying with IVOA SODA
 | cloudsql.instanceConnectionName | string | None, must be set if Cloud SQL is used | Instance connection name for a Cloud SQL PostgreSQL instance |
 | cloudsql.resources | object | See `values.yaml` | Resource limits and requests for the Cloud SQL Proxy container |
 | config.databaseUrl | string | None, must be set if `cloudsql.enabled` is false | URL for the PostgreSQL database if Cloud SQL is not in use |
-| config.lifetime | string | 2592000 (30 days) | Lifetime of job results in seconds (quote so that Helm doesn't turn it into a floating point number) |
+| config.lifetime | string | 2592000s (30 days) | Lifetime of job results in safir parse_timedelta format |
 | config.loglevel | string | `"INFO"` | Choose from the text form of Python logging levels |
 | config.pathPrefix | string | `"/api/cutout"` | URL path prefix for the cutout API |
 | config.serviceAccount | string | None, must be set | Google service account with an IAM binding to the `vo-cutouts` Kubernetes service accounts and has the `cloudsql.client` role, access to write to the GCS bucket, and ability to sign URLs as itself |
 | config.slackAlerts | bool | `true` | Whether to send Slack alerts for unexpected failures |
 | config.storageBucketUrl | string | None, must be set | URL for the GCS bucket for results (must start with `gs`) |
-| config.syncTimeout | int | 60 (1 minute) | Timeout for results from a sync cutout in seconds |
+| config.syncTimeout | string | 60s (1 minute) | Timeout for results from a sync cutout in safir parse_timedelta format |
 | config.timeout | int | 600 (10 minutes) | Timeout for a single cutout job in seconds |
 | cutoutWorker.affinity | object | `{}` | Affinity rules for the cutout worker pod |
 | cutoutWorker.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for cutout workers |

--- a/applications/vo-cutouts/values.yaml
+++ b/applications/vo-cutouts/values.yaml
@@ -13,10 +13,9 @@ config:
   # @default -- None, must be set if `cloudsql.enabled` is false
   databaseUrl: null
 
-  # -- Lifetime of job results in seconds (quote so that Helm doesn't turn it
-  # into a floating point number)
-  # @default -- 2592000 (30 days)
-  lifetime: "2592000"
+  # -- Lifetime of job results in safir parse_timedelta format
+  # @default -- 2592000s (30 days)
+  lifetime: "2592000s"
 
   # -- Google service account with an IAM binding to the `vo-cutouts`
   # Kubernetes service accounts and has the `cloudsql.client` role, access
@@ -31,9 +30,9 @@ config:
   # @default -- None, must be set
   storageBucketUrl: null
 
-  # -- Timeout for results from a sync cutout in seconds
-  # @default -- 60 (1 minute)
-  syncTimeout: 60
+  # -- Timeout for results from a sync cutout in safir parse_timedelta format
+  # @default -- 60s (1 minute)
+  syncTimeout: "60s"
 
   # -- Timeout for a single cutout job in seconds
   # @default -- 600 (10 minutes)

--- a/applications/vo-cutouts/values.yaml
+++ b/applications/vo-cutouts/values.yaml
@@ -43,7 +43,7 @@ image:
   repository: "ghcr.io/lsst-sqre/vo-cutouts"
 
   # -- Pull policy for the vo-cutouts image
-  pullPolicy: "IfNotPresent"
+  pullPolicy: "Always"
 
   # -- Tag of vo-cutouts image to use
   # @default -- The appVersion of the chart
@@ -121,7 +121,7 @@ cutoutWorker:
     tag: null
 
     # -- Pull policy for cutout workers
-    pullPolicy: "IfNotPresent"
+    pullPolicy: "Always"
 
   # -- Resource limits and requests for the cutout worker pod
   # @default -- See `values.yaml`

--- a/applications/vo-cutouts/values.yaml
+++ b/applications/vo-cutouts/values.yaml
@@ -13,9 +13,8 @@ config:
   # @default -- None, must be set if `cloudsql.enabled` is false
   databaseUrl: null
 
-  # -- Lifetime of job results in safir parse_timedelta format
-  # @default -- 2592000s (30 days)
-  lifetime: "2592000s"
+  # -- Lifetime of job results in Safir `parse_timedelta` format
+  lifetime: "30d"
 
   # -- Google service account with an IAM binding to the `vo-cutouts`
   # Kubernetes service accounts and has the `cloudsql.client` role, access
@@ -30,9 +29,9 @@ config:
   # @default -- None, must be set
   storageBucketUrl: null
 
-  # -- Timeout for results from a sync cutout in safir parse_timedelta format
-  # @default -- 60s (1 minute)
-  syncTimeout: "60s"
+  # -- Timeout for results from a sync cutout in Safir `parse_timedelta`
+  # format
+  syncTimeout: "1m"
 
   # -- Timeout for a single cutout job in seconds
   # @default -- 600 (10 minutes)


### PR DESCRIPTION
The new release of Butler server includes backwards-incompatible changes to the REST API, so datalinker and vo-cutouts need new versions with an updated client library simultaneously.