### PR TITLE
DM-45168: Fix a conditional in the rubintv chart

### DIFF
--- a/charts/rubintv/templates/deployment-frontend.yaml
+++ b/charts/rubintv/templates/deployment-frontend.yaml
@@ -31,7 +31,11 @@ spec:
             - name: "SAFIR_PATH_PREFIX"
               value: {{ .Values.frontend.pathPrefix | quote }}
             - name: "AWS_SHARED_CREDENTIALS_FILE"
+{{- if .Values.separateSecrets) }}
               value: /etc/secrets/aws_credentials.ini
+{{- else }}
+              value: /etc/secrets/aws-credentials.ini
+{{- end }}
             {{- if (not .Values.frontend.debug) }}
             - name: "SAFIR_PROFILE"
               value: "production"


### PR DESCRIPTION
The changes for allowing separate secrets accidentally changed behavior without them. Undo that.