### PR TITLE
[DM-45239] Migrate Kafka brokers on USDF to local storage

### DIFF
--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -339,6 +339,7 @@ Rubin Observatory's telemetry service
 | strimzi-kafka.connect.enabled | bool | `false` | Enable Kafka Connect |
 | strimzi-kafka.connect.image | string | `"ghcr.io/lsst-sqre/strimzi-0.40.0-kafka-3.7.0:tickets-DM-43491"` | Custom strimzi-kafka image with connector plugins used by sasquatch |
 | strimzi-kafka.connect.replicas | int | `3` | Number of Kafka Connect replicas to run |
+| strimzi-kafka.cruiseControl | object | `{"enabled":false}` | Configuration for the Kafka Cruise Control |
 | strimzi-kafka.kafka.affinity | object | See `values.yaml` | Affinity for Kafka pod assignment |
 | strimzi-kafka.kafka.config."log.retention.bytes" | string | `"350000000000"` | How much disk space Kafka will ensure is available, set to 70% of the data partition size |
 | strimzi-kafka.kafka.config."log.retention.hours" | int | `48` | Number of days for a topic's data to be retained |
@@ -373,6 +374,7 @@ Rubin Observatory's telemetry service
 | strimzi-kafka.kafkaExporter.resources | object | See `values.yaml` | Kubernetes requests and limits for the Kafka exporter |
 | strimzi-kafka.kafkaExporter.topicRegex | string | `".*"` | Kafka topics to monitor |
 | strimzi-kafka.kraft.enabled | bool | `false` | Enable KRaft mode for Kafka |
+| strimzi-kafka.localStorage | object | `{"enabled":false,"migration":{"enabled":false,"rebalance":false},"size":"1.5Ti","storageClassName":"localdrive"}` | Configuration for deploying Kafka brokers with local storage |
 | strimzi-kafka.mirrormaker2.enabled | bool | `false` | Enable replication in the target (passive) cluster |
 | strimzi-kafka.mirrormaker2.replicas | int | `3` | Number of Mirror Maker replicas to run |
 | strimzi-kafka.mirrormaker2.replication.policy.class | string | `"org.apache.kafka.connect.mirror.IdentityReplicationPolicy"` | Replication policy. |

--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -374,7 +374,7 @@ Rubin Observatory's telemetry service
 | strimzi-kafka.kafkaExporter.resources | object | See `values.yaml` | Kubernetes requests and limits for the Kafka exporter |
 | strimzi-kafka.kafkaExporter.topicRegex | string | `".*"` | Kafka topics to monitor |
 | strimzi-kafka.kraft.enabled | bool | `false` | Enable KRaft mode for Kafka |
-| strimzi-kafka.localStorage | object | `{"enabled":false,"migration":{"enabled":false,"rebalance":false},"size":"1.5Ti","storageClassName":"localdrive"}` | Configuration for deploying Kafka brokers with local storage |
+| strimzi-kafka.localStorage | object | `{"enabled":false,"migration":{"brokers":[0,1,2],"enabled":false,"rebalance":false},"size":"1.5Ti","storageClassName":"localdrive"}` | Configuration for deploying Kafka brokers with local storage |
 | strimzi-kafka.mirrormaker2.enabled | bool | `false` | Enable replication in the target (passive) cluster |
 | strimzi-kafka.mirrormaker2.replicas | int | `3` | Number of Mirror Maker replicas to run |
 | strimzi-kafka.mirrormaker2.replication.policy.class | string | `"org.apache.kafka.connect.mirror.IdentityReplicationPolicy"` | Replication policy. |

--- a/applications/sasquatch/charts/strimzi-kafka/README.md
+++ b/applications/sasquatch/charts/strimzi-kafka/README.md
@@ -52,7 +52,7 @@ A subchart to deploy Strimzi Kafka components for Sasquatch.
 | kafkaExporter.resources | object | See `values.yaml` | Kubernetes requests and limits for the Kafka exporter |
 | kafkaExporter.topicRegex | string | `".*"` | Kafka topics to monitor |
 | kraft.enabled | bool | `false` | Enable KRaft mode for Kafka |
-| localStorage | object | `{"enabled":false,"migration":{"enabled":false,"rebalance":false},"size":"1.5Ti","storageClassName":"localdrive"}` | Configuration for deploying Kafka brokers with local storage |
+| localStorage | object | `{"enabled":false,"migration":{"brokers":[0,1,2],"enabled":false,"rebalance":false},"size":"1.5Ti","storageClassName":"localdrive"}` | Configuration for deploying Kafka brokers with local storage |
 | mirrormaker2.enabled | bool | `false` | Enable replication in the target (passive) cluster |
 | mirrormaker2.replicas | int | `3` | Number of Mirror Maker replicas to run |
 | mirrormaker2.replication.policy.class | string | `"org.apache.kafka.connect.mirror.IdentityReplicationPolicy"` | Replication policy. |

--- a/applications/sasquatch/charts/strimzi-kafka/README.md
+++ b/applications/sasquatch/charts/strimzi-kafka/README.md
@@ -17,6 +17,7 @@ A subchart to deploy Strimzi Kafka components for Sasquatch.
 | connect.enabled | bool | `false` | Enable Kafka Connect |
 | connect.image | string | `"ghcr.io/lsst-sqre/strimzi-0.40.0-kafka-3.7.0:tickets-DM-43491"` | Custom strimzi-kafka image with connector plugins used by sasquatch |
 | connect.replicas | int | `3` | Number of Kafka Connect replicas to run |
+| cruiseControl | object | `{"enabled":false}` | Configuration for the Kafka Cruise Control |
 | kafka.affinity | object | See `values.yaml` | Affinity for Kafka pod assignment |
 | kafka.config."log.retention.bytes" | string | `"350000000000"` | How much disk space Kafka will ensure is available, set to 70% of the data partition size |
 | kafka.config."log.retention.hours" | int | `48` | Number of days for a topic's data to be retained |
@@ -51,6 +52,7 @@ A subchart to deploy Strimzi Kafka components for Sasquatch.
 | kafkaExporter.resources | object | See `values.yaml` | Kubernetes requests and limits for the Kafka exporter |
 | kafkaExporter.topicRegex | string | `".*"` | Kafka topics to monitor |
 | kraft.enabled | bool | `false` | Enable KRaft mode for Kafka |
+| localStorage | object | `{"enabled":false,"migration":{"enabled":false,"rebalance":false},"size":"1.5Ti","storageClassName":"localdrive"}` | Configuration for deploying Kafka brokers with local storage |
 | mirrormaker2.enabled | bool | `false` | Enable replication in the target (passive) cluster |
 | mirrormaker2.replicas | int | `3` | Number of Mirror Maker replicas to run |
 | mirrormaker2.replication.policy.class | string | `"org.apache.kafka.connect.mirror.IdentityReplicationPolicy"` | Replication policy. |

--- a/applications/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
@@ -79,15 +79,10 @@ spec:
       deleteClaim: false
   template:
     pod:
+      {{- with .Values.localStorage.affinity }}
       affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                - key: local-storage
-                  operator: In
-                  values:
-                  - "true"
+        {{- toYaml . | nindent 10 }}
+      {{- end }}
   {{- with .Values.kafka.resources }}
   resources:
     {{- toYaml . | nindent 6 }}

--- a/applications/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
@@ -100,7 +100,10 @@ metadata:
     strimzi.io/rebalance-auto-approval: "true"
 spec:
   mode: remove-brokers
-  brokers: [0, 1, 2] # Use the node IDs of the existing brokers
+  {{- with .Values.localStorage.migration.brokers }}
+  brokers:
+    {{- toYaml . | nindent 6 }}
+  {{- end }}
 {{- end }}
 ---
 apiVersion: kafka.strimzi.io/v1beta2

--- a/applications/sasquatch/charts/strimzi-kafka/values.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/values.yaml
@@ -303,3 +303,16 @@ mirrormaker2:
 
       # -- Replication policy.
       class: "org.apache.kafka.connect.mirror.IdentityReplicationPolicy"
+
+# -- Configuration for the Kafka Cruise Control
+cruiseControl:
+  enabled: false
+
+# -- Configuration for deploying Kafka brokers with local storage
+localStorage:
+  enabled: false
+  migration:
+    enabled: false
+    rebalance: false
+  size: 1.5Ti
+  storageClassName: localdrive

--- a/applications/sasquatch/charts/strimzi-kafka/values.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/values.yaml
@@ -314,5 +314,9 @@ localStorage:
   migration:
     enabled: false
     rebalance: false
+    brokers:
+      - 0
+      - 1
+      - 2
   size: 1.5Ti
   storageClassName: localdrive

--- a/applications/sasquatch/values-base.yaml
+++ b/applications/sasquatch/values-base.yaml
@@ -105,6 +105,15 @@ strimzi-kafka:
       rebalance: false
     size: 1.5Ti
     storageClassName: localdrive
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: local-storage
+                  operator: In
+                  values:
+                    - "true"
 
 influxdb:
   persistence:

--- a/applications/sasquatch/values-base.yaml
+++ b/applications/sasquatch/values-base.yaml
@@ -103,6 +103,10 @@ strimzi-kafka:
     migration:
       enabled: false
       rebalance: false
+      brokers:
+        - 0
+        - 1
+        - 2
     size: 1.5Ti
     storageClassName: localdrive
     affinity:

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -49,6 +49,33 @@ strimzi-kafka:
     enabled: true
   cruiseControl:
     enabled: true
+  localStorage:
+    enabled: false
+    migration:
+      enabled: true
+      rebalance: false
+    size: 1.5Ti
+    storageClassName: zfs--rubin-efd
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: kubernetes.io/hostname
+                  operator: In
+                  values:
+                    - sdfk8sn005
+                    - sdfk8sn006
+                    - sdfk8sn007
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+                - key: strimzi.io/cluster
+                  operator: In
+                  values:
+                    - sasquatch
+            topologyKey: kubernetes.io/hostname
 
 influxdb:
   enabled: false

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -53,7 +53,7 @@ strimzi-kafka:
     enabled: false
     migration:
       enabled: true
-      rebalance: false
+      rebalance: true
     size: 1.5Ti
     storageClassName: zfs--rubin-efd
     affinity:

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -47,6 +47,8 @@ strimzi-kafka:
     enabled: true
   kafkaController:
     enabled: true
+  cruiseControl:
+    enabled: true
 
 influxdb:
   enabled: false

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -64,8 +64,8 @@ strimzi-kafka:
                 - key: kubernetes.io/hostname
                   operator: In
                   values:
+                    - sdfk8sn004
                     - sdfk8sn005
-                    - sdfk8sn006
                     - sdfk8sn007
       podAntiAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -54,6 +54,10 @@ strimzi-kafka:
     migration:
       enabled: true
       rebalance: true
+      brokers:
+        - 3
+        - 4
+        - 5
     size: 1.5Ti
     storageClassName: zfs--rubin-efd
     affinity:

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -50,10 +50,10 @@ strimzi-kafka:
   cruiseControl:
     enabled: true
   localStorage:
-    enabled: false
+    enabled: true
     migration:
-      enabled: true
-      rebalance: true
+      enabled: false
+      rebalance: false
       brokers:
         - 3
         - 4


### PR DESCRIPTION
We have three nodes with local storage at the USDF prod cluster that are available for Kafka. This PR adds the configuration necessary to create a new `KafkaNodePool` on those nodes and migrate the brokers to the new node pool using Cruise Control. 