### PR TITLE
DM-45251: Switch Squareone and Semaphore's anonymous ingresses to nginx ingress

### DIFF
--- a/applications/semaphore/templates/ingress.yaml
+++ b/applications/semaphore/templates/ingress.yaml
@@ -1,31 +1,19 @@
-{{- if .Values.ingress.enabled -}}
-apiVersion: gafaelfawr.lsst.io/v1alpha1
-kind: GafaelfawrIngress
+apiVersion: networking.k8s.io/v1
+kind: Ingress
 metadata:
-  name: {{ template "semaphore.fullname" . }}
+  name: "semaphore"
   labels:
     {{- include "semaphore.labels" . | nindent 4 }}
-config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
-  scopes:
-    anonymous: true
-template:
-  metadata:
-    name: {{ template "semaphore.fullname" . }}
-    {{- with .Values.ingress.annotations }}
-    annotations:
-      {{- toYaml . | nindent 6 }}
-    {{- end }}
-  spec:
-    rules:
-      - host: {{ required "global.host must be set" .Values.global.host | quote }}
-        http:
-          paths:
-            - path: {{ .Values.ingress.path | quote }}
-              pathType: "Prefix"
-              backend:
-                service:
-                  name: {{ template "semaphore.fullname" . }}
-                  port:
-                    number: 80
-{{- end }}
+spec:
+  ingressClassName: "nginx"
+  rules:
+    - host: {{ required "global.host must be set" .Values.global.host | quote }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.path | quote }}
+            pathType: "Prefix"
+            backend:
+              service:
+                name: "semaphore"
+                port:
+                  number: 80

--- a/applications/squareone/templates/ingress.yaml
+++ b/applications/squareone/templates/ingress.yaml
@@ -1,32 +1,19 @@
-{{- if .Values.ingress.enabled -}}
-{{- $fullName := include "squareone.fullname" . -}}
-apiVersion: gafaelfawr.lsst.io/v1alpha1
-kind: GafaelfawrIngress
+apiVersion: networking.k8s.io/v1
+kind: Ingress
 metadata:
-  name: {{ $fullName }}
+  name: "squareone"
   labels:
     {{- include "squareone.labels" . | nindent 4 }}
-config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
-  scopes:
-    anonymous: true
-template:
-  metadata:
-    name: {{ $fullName }}
-    annotations:
-      {{- with .Values.ingress.annotations }}
-      {{- toYaml . | nindent 6 }}
-      {{- end }}
-  spec:
-    rules:
-      - host: {{ required "global.host must be set" .Values.global.host | quote }}
-        http:
-          paths:
-            - path: "/"
-              pathType: "Prefix"
-              backend:
-                service:
-                  name: {{ $fullName }}
-                  port:
-                    number: 80
-{{- end }}
+spec:
+  ingressClassName: "nginx"
+  rules:
+    - host: {{ required "global.host must be set" .Values.global.host | quote }}
+      http:
+        paths:
+          - path: "/"
+            pathType: "Prefix"
+            backend:
+              service:
+                name: "squareone"
+                port:
+                  number: 80


### PR DESCRIPTION
This switches Semaphore and Squareone's anonymous GafaelfawrIngress to a regular nginx Ingress. This allows Semaphore to continue serving broadcasts even when
there is a Gafaelfawr/CILogon outage.