### PR TITLE
Update external IPs for the Kafka brokers at BTS

### DIFF
--- a/applications/sasquatch/values-base.yaml
+++ b/applications/sasquatch/values-base.yaml
@@ -36,11 +36,11 @@ strimzi-kafka:
         loadBalancerIP: "139.229.153.65"
         host: sasquatch-base-kafka-bootstrap.lsst.codes
       brokers:
-        - loadBalancerIP: "139.229.153.66"
+        - loadBalancerIP: "139.229.151.172"
           host: sasquatch-base-kafka-0.lsst.codes
-        - loadBalancerIP: "139.229.153.67"
+        - loadBalancerIP: "139.229.151.173"
           host: sasquatch-base-kafka-1.lsst.codes
-        - loadBalancerIP: "139.229.153.68"
+        - loadBalancerIP: "139.229.151.174"
           host: sasquatch-base-kafka-2.lsst.codes
     resources:
       requests:


### PR DESCRIPTION
The Kafka brokers at BTS got new external IPs, we need to update the external listeners configuration and the DNS records on Route53.