### PR TITLE
Switch Prompt Processing LATISS-prod to Cassandra.

### DIFF
--- a/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
@@ -54,7 +54,7 @@ prompt-proto-service:
     imageTimeout: 110
 
   apdb:
-    config: s3://rubin-summit-users/apdb_config/sql/pp_apdb_latiss.py
+    config: s3://rubin-summit-users/apdb_config/cassandra/pp_apdb_latiss.py
 
   sasquatch:
     endpointUrl: https://usdf-rsp-dev.slac.stanford.edu/sasquatch-rest-proxy


### PR DESCRIPTION
This is a non-canonical config located on the old embargo rack. Once LATISS is switched over to new embargo, the file can be removed. (The S3 URL is the same on both racks.)