### PR TITLE
DM-40434: Prompt Processing continues processing after timeout or termination

### DIFF
--- a/applications/prompt-proto-service-hsc-gpu/README.md
+++ b/applications/prompt-proto-service-hsc-gpu/README.md
@@ -39,10 +39,10 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.knative.extraTimeout | int | `10` | To acommodate scheduling problems, Knative waits for a request for twice `worker.timeout`. This parameter adds extra time to that minimum (seconds). |
 | prompt-proto-service.knative.gpu | bool | `true` | GPUs enabled. |
 | prompt-proto-service.knative.gpuRequest | int | `1` | The number of GPUs to request. |
-| prompt-proto-service.knative.idleTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service (seconds). |
+| prompt-proto-service.knative.idleTimeout | int | `0` | Maximum time that a container can send nothing to Knative (seconds). This is only useful if the container runs async workers. If 0, idle timeout is ignored. |
 | prompt-proto-service.knative.memoryLimit | string | `"8Gi"` | The maximum memory limit. |
 | prompt-proto-service.knative.memoryRequest | string | `"2Gi"` | The minimum memory to request. |
-| prompt-proto-service.knative.responseStartTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service after initial submission (seconds). |
+| prompt-proto-service.knative.responseStartTimeout | int | `0` | Maximum time that a container can send nothing to Knative after initial submission (seconds). This is only useful if the container runs async workers. If 0, idle timeout is ignored. |
 | prompt-proto-service.logLevel | string | log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
 | prompt-proto-service.podAnnotations | object | See the `values.yaml` file. | Annotations for the prompt-proto-service pod |
 | prompt-proto-service.registry.centralRepoFile | bool | `false` | If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted. |

--- a/applications/prompt-proto-service-hsc-gpu/README.md
+++ b/applications/prompt-proto-service-hsc-gpu/README.md
@@ -54,5 +54,6 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.sasquatch.endpointUrl | string | `""` | Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload. This is a preliminary implementation of Sasquatch support, and this parameter may be deprecated if we instead support `SasquatchDatastore` in the future. |
 | prompt-proto-service.sasquatch.namespace | string | `"lsst.prompt"` | Namespace in the Sasquatch system with which to associate metrics. |
 | prompt-proto-service.tolerations | list | `[{"effect":"NoSchedule","key":"nvidia.com/gpu"}]` | Tolerations for the prompt processing pods |
+| prompt-proto-service.worker.grace_period | int | `45` | When Knative shuts down a pod, the time its workers have to abort processing and save intermediate results (seconds). |
 | prompt-proto-service.worker.restart | int | `0` | The number of requests to process before rebooting a worker. If 0, workers process requests indefinitely. |
 | prompt-proto-service.worker.timeout | int | `900` | Maximum time that a worker can process a next_visit request (seconds). |

--- a/applications/prompt-proto-service-hsc-gpu/README.md
+++ b/applications/prompt-proto-service-hsc-gpu/README.md
@@ -36,13 +36,13 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.knative.cpuRequest | int | `1` | The cpu cores requested. |
 | prompt-proto-service.knative.ephemeralStorageLimit | string | `"5Gi"` | The maximum storage space allowed for each container (mostly local Butler). |
 | prompt-proto-service.knative.ephemeralStorageRequest | string | `"5Gi"` | The storage space reserved for each container (mostly local Butler). |
+| prompt-proto-service.knative.extraTimeout | int | `10` | To acommodate scheduling problems, Knative waits for a request for twice `worker.timeout`. This parameter adds extra time to that minimum (seconds). |
 | prompt-proto-service.knative.gpu | bool | `true` | GPUs enabled. |
 | prompt-proto-service.knative.gpuRequest | int | `1` | The number of GPUs to request. |
 | prompt-proto-service.knative.idleTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service (seconds). |
 | prompt-proto-service.knative.memoryLimit | string | `"8Gi"` | The maximum memory limit. |
 | prompt-proto-service.knative.memoryRequest | string | `"2Gi"` | The minimum memory to request. |
 | prompt-proto-service.knative.responseStartTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service after initial submission (seconds). |
-| prompt-proto-service.knative.timeout | int | `900` | Maximum time that a container can respond to a next_visit request (seconds). |
 | prompt-proto-service.logLevel | string | log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
 | prompt-proto-service.podAnnotations | object | See the `values.yaml` file. | Annotations for the prompt-proto-service pod |
 | prompt-proto-service.registry.centralRepoFile | bool | `false` | If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted. |

--- a/applications/prompt-proto-service-hsc-gpu/README.md
+++ b/applications/prompt-proto-service-hsc-gpu/README.md
@@ -55,3 +55,4 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.sasquatch.namespace | string | `"lsst.prompt"` | Namespace in the Sasquatch system with which to associate metrics. |
 | prompt-proto-service.tolerations | list | `[{"effect":"NoSchedule","key":"nvidia.com/gpu"}]` | Tolerations for the prompt processing pods |
 | prompt-proto-service.worker.restart | int | `0` | The number of requests to process before rebooting a worker. If 0, workers process requests indefinitely. |
+| prompt-proto-service.worker.timeout | int | `900` | Maximum time that a worker can process a next_visit request (seconds). |

--- a/applications/prompt-proto-service-hsc-gpu/values.yaml
+++ b/applications/prompt-proto-service-hsc-gpu/values.yaml
@@ -31,6 +31,8 @@ prompt-proto-service:
     restart: 0
     # -- Maximum time that a worker can process a next_visit request (seconds).
     timeout: 900
+    # -- When Knative shuts down a pod, the time its workers have to abort processing and save intermediate results (seconds).
+    grace_period: 45
 
   instrument:
     # -- The "short" name of the instrument

--- a/applications/prompt-proto-service-hsc-gpu/values.yaml
+++ b/applications/prompt-proto-service-hsc-gpu/values.yaml
@@ -131,8 +131,9 @@ prompt-proto-service:
     memoryRequest: "2Gi"
     # -- The maximum memory limit.
     memoryLimit: "8Gi"
-    # -- Maximum time that a container can respond to a next_visit request (seconds).
-    timeout: 900
+    # -- To acommodate scheduling problems, Knative waits for a request for twice `worker.timeout`.
+    # This parameter adds extra time to that minimum (seconds).
+    extraTimeout: 10
     # -- Maximum time that a container can send nothing to the fanout service (seconds).
     idleTimeout: 900
     # -- Maximum time that a container can send nothing to the fanout service after initial submission (seconds).

--- a/applications/prompt-proto-service-hsc-gpu/values.yaml
+++ b/applications/prompt-proto-service-hsc-gpu/values.yaml
@@ -134,10 +134,14 @@ prompt-proto-service:
     # -- To acommodate scheduling problems, Knative waits for a request for twice `worker.timeout`.
     # This parameter adds extra time to that minimum (seconds).
     extraTimeout: 10
-    # -- Maximum time that a container can send nothing to the fanout service (seconds).
-    idleTimeout: 900
-    # -- Maximum time that a container can send nothing to the fanout service after initial submission (seconds).
-    responseStartTimeout: 900
+    # -- Maximum time that a container can send nothing to Knative (seconds).
+    # This is only useful if the container runs async workers.
+    # If 0, idle timeout is ignored.
+    idleTimeout: 0
+    # -- Maximum time that a container can send nothing to Knative after initial submission (seconds).
+    # This is only useful if the container runs async workers.
+    # If 0, idle timeout is ignored.
+    responseStartTimeout: 0
 
   # -- Kubernetes YAML configs for extra container volume(s).
   # Any volumes required by other config options are automatically handled by the Helm chart.

--- a/applications/prompt-proto-service-hsc-gpu/values.yaml
+++ b/applications/prompt-proto-service-hsc-gpu/values.yaml
@@ -29,6 +29,8 @@ prompt-proto-service:
     # -- The number of requests to process before rebooting a worker.
     # If 0, workers process requests indefinitely.
     restart: 0
+    # -- Maximum time that a worker can process a next_visit request (seconds).
+    timeout: 900
 
   instrument:
     # -- The "short" name of the instrument

--- a/applications/prompt-proto-service-hsc/README.md
+++ b/applications/prompt-proto-service-hsc/README.md
@@ -39,10 +39,10 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.knative.extraTimeout | int | `10` | To acommodate scheduling problems, Knative waits for a request for twice `worker.timeout`. This parameter adds extra time to that minimum (seconds). |
 | prompt-proto-service.knative.gpu | bool | `false` | GPUs enabled. |
 | prompt-proto-service.knative.gpuRequest | int | `0` | The number of GPUs to request. |
-| prompt-proto-service.knative.idleTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service (seconds). |
+| prompt-proto-service.knative.idleTimeout | int | `0` | Maximum time that a container can send nothing to Knative (seconds). This is only useful if the container runs async workers. If 0, idle timeout is ignored. |
 | prompt-proto-service.knative.memoryLimit | string | `"8Gi"` | The maximum memory limit. |
 | prompt-proto-service.knative.memoryRequest | string | `"2Gi"` | The minimum memory to request. |
-| prompt-proto-service.knative.responseStartTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service after initial submission (seconds). |
+| prompt-proto-service.knative.responseStartTimeout | int | `0` | Maximum time that a container can send nothing to Knative after initial submission (seconds). This is only useful if the container runs async workers. If 0, idle timeout is ignored. |
 | prompt-proto-service.logLevel | string | log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
 | prompt-proto-service.podAnnotations | object | See the `values.yaml` file. | Annotations for the prompt-proto-service pod |
 | prompt-proto-service.registry.centralRepoFile | bool | `false` | If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted. |

--- a/applications/prompt-proto-service-hsc/README.md
+++ b/applications/prompt-proto-service-hsc/README.md
@@ -55,3 +55,4 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.sasquatch.namespace | string | `"lsst.prompt"` | Namespace in the Sasquatch system with which to associate metrics. |
 | prompt-proto-service.tolerations | list | `[]` | Tolerations for the prompt processing pods |
 | prompt-proto-service.worker.restart | int | `0` | The number of requests to process before rebooting a worker. If 0, workers process requests indefinitely. |
+| prompt-proto-service.worker.timeout | int | `900` | Maximum time that a worker can process a next_visit request (seconds). |

--- a/applications/prompt-proto-service-hsc/README.md
+++ b/applications/prompt-proto-service-hsc/README.md
@@ -36,13 +36,13 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.knative.cpuRequest | int | `1` | The cpu cores requested. |
 | prompt-proto-service.knative.ephemeralStorageLimit | string | `"5Gi"` | The maximum storage space allowed for each container (mostly local Butler). |
 | prompt-proto-service.knative.ephemeralStorageRequest | string | `"5Gi"` | The storage space reserved for each container (mostly local Butler). |
+| prompt-proto-service.knative.extraTimeout | int | `10` | To acommodate scheduling problems, Knative waits for a request for twice `worker.timeout`. This parameter adds extra time to that minimum (seconds). |
 | prompt-proto-service.knative.gpu | bool | `false` | GPUs enabled. |
 | prompt-proto-service.knative.gpuRequest | int | `0` | The number of GPUs to request. |
 | prompt-proto-service.knative.idleTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service (seconds). |
 | prompt-proto-service.knative.memoryLimit | string | `"8Gi"` | The maximum memory limit. |
 | prompt-proto-service.knative.memoryRequest | string | `"2Gi"` | The minimum memory to request. |
 | prompt-proto-service.knative.responseStartTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service after initial submission (seconds). |
-| prompt-proto-service.knative.timeout | int | `900` | Maximum time that a container can respond to a next_visit request (seconds). |
 | prompt-proto-service.logLevel | string | log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
 | prompt-proto-service.podAnnotations | object | See the `values.yaml` file. | Annotations for the prompt-proto-service pod |
 | prompt-proto-service.registry.centralRepoFile | bool | `false` | If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted. |

--- a/applications/prompt-proto-service-hsc/README.md
+++ b/applications/prompt-proto-service-hsc/README.md
@@ -54,5 +54,6 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.sasquatch.endpointUrl | string | `""` | Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload. This is a preliminary implementation of Sasquatch support, and this parameter may be deprecated if we instead support `SasquatchDatastore` in the future. |
 | prompt-proto-service.sasquatch.namespace | string | `"lsst.prompt"` | Namespace in the Sasquatch system with which to associate metrics. |
 | prompt-proto-service.tolerations | list | `[]` | Tolerations for the prompt processing pods |
+| prompt-proto-service.worker.grace_period | int | `45` | When Knative shuts down a pod, the time its workers have to abort processing and save intermediate results (seconds). |
 | prompt-proto-service.worker.restart | int | `0` | The number of requests to process before rebooting a worker. If 0, workers process requests indefinitely. |
 | prompt-proto-service.worker.timeout | int | `900` | Maximum time that a worker can process a next_visit request (seconds). |

--- a/applications/prompt-proto-service-hsc/values.yaml
+++ b/applications/prompt-proto-service-hsc/values.yaml
@@ -31,6 +31,8 @@ prompt-proto-service:
     restart: 0
     # -- Maximum time that a worker can process a next_visit request (seconds).
     timeout: 900
+    # -- When Knative shuts down a pod, the time its workers have to abort processing and save intermediate results (seconds).
+    grace_period: 45
 
   instrument:
     # -- The "short" name of the instrument

--- a/applications/prompt-proto-service-hsc/values.yaml
+++ b/applications/prompt-proto-service-hsc/values.yaml
@@ -131,8 +131,9 @@ prompt-proto-service:
     memoryRequest: "2Gi"
     # -- The maximum memory limit.
     memoryLimit: "8Gi"
-    # -- Maximum time that a container can respond to a next_visit request (seconds).
-    timeout: 900
+    # -- To acommodate scheduling problems, Knative waits for a request for twice `worker.timeout`.
+    # This parameter adds extra time to that minimum (seconds).
+    extraTimeout: 10
     # -- Maximum time that a container can send nothing to the fanout service (seconds).
     idleTimeout: 900
     # -- Maximum time that a container can send nothing to the fanout service after initial submission (seconds).

--- a/applications/prompt-proto-service-hsc/values.yaml
+++ b/applications/prompt-proto-service-hsc/values.yaml
@@ -134,10 +134,14 @@ prompt-proto-service:
     # -- To acommodate scheduling problems, Knative waits for a request for twice `worker.timeout`.
     # This parameter adds extra time to that minimum (seconds).
     extraTimeout: 10
-    # -- Maximum time that a container can send nothing to the fanout service (seconds).
-    idleTimeout: 900
-    # -- Maximum time that a container can send nothing to the fanout service after initial submission (seconds).
-    responseStartTimeout: 900
+    # -- Maximum time that a container can send nothing to Knative (seconds).
+    # This is only useful if the container runs async workers.
+    # If 0, idle timeout is ignored.
+    idleTimeout: 0
+    # -- Maximum time that a container can send nothing to Knative after initial submission (seconds).
+    # This is only useful if the container runs async workers.
+    # If 0, idle timeout is ignored.
+    responseStartTimeout: 0
 
   # -- Kubernetes YAML configs for extra container volume(s).
   # Any volumes required by other config options are automatically handled by the Helm chart.

--- a/applications/prompt-proto-service-hsc/values.yaml
+++ b/applications/prompt-proto-service-hsc/values.yaml
@@ -29,6 +29,8 @@ prompt-proto-service:
     # -- The number of requests to process before rebooting a worker.
     # If 0, workers process requests indefinitely.
     restart: 0
+    # -- Maximum time that a worker can process a next_visit request (seconds).
+    timeout: 900
 
   instrument:
     # -- The "short" name of the instrument

--- a/applications/prompt-proto-service-latiss/README.md
+++ b/applications/prompt-proto-service-latiss/README.md
@@ -39,10 +39,10 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.knative.extraTimeout | int | `10` | To acommodate scheduling problems, Knative waits for a request for twice `worker.timeout`. This parameter adds extra time to that minimum (seconds). |
 | prompt-proto-service.knative.gpu | bool | `false` | GPUs enabled. |
 | prompt-proto-service.knative.gpuRequest | int | `0` | The number of GPUs to request. |
-| prompt-proto-service.knative.idleTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service (seconds). |
+| prompt-proto-service.knative.idleTimeout | int | `0` | Maximum time that a container can send nothing to Knative (seconds). This is only useful if the container runs async workers. If 0, idle timeout is ignored. |
 | prompt-proto-service.knative.memoryLimit | string | `"8Gi"` | The maximum memory limit. |
 | prompt-proto-service.knative.memoryRequest | string | `"2Gi"` | The minimum memory to request. |
-| prompt-proto-service.knative.responseStartTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service after initial submission (seconds). |
+| prompt-proto-service.knative.responseStartTimeout | int | `0` | Maximum time that a container can send nothing to Knative after initial submission (seconds). This is only useful if the container runs async workers. If 0, idle timeout is ignored. |
 | prompt-proto-service.logLevel | string | log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
 | prompt-proto-service.podAnnotations | object | See the `values.yaml` file. | Annotations for the prompt-proto-service pod |
 | prompt-proto-service.registry.centralRepoFile | bool | `false` | If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted. |

--- a/applications/prompt-proto-service-latiss/README.md
+++ b/applications/prompt-proto-service-latiss/README.md
@@ -36,13 +36,13 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.knative.cpuRequest | int | `1` | The cpu cores requested. |
 | prompt-proto-service.knative.ephemeralStorageLimit | string | `"5Gi"` | The maximum storage space allowed for each container (mostly local Butler). |
 | prompt-proto-service.knative.ephemeralStorageRequest | string | `"5Gi"` | The storage space reserved for each container (mostly local Butler). |
+| prompt-proto-service.knative.extraTimeout | int | `10` | To acommodate scheduling problems, Knative waits for a request for twice `worker.timeout`. This parameter adds extra time to that minimum (seconds). |
 | prompt-proto-service.knative.gpu | bool | `false` | GPUs enabled. |
 | prompt-proto-service.knative.gpuRequest | int | `0` | The number of GPUs to request. |
 | prompt-proto-service.knative.idleTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service (seconds). |
 | prompt-proto-service.knative.memoryLimit | string | `"8Gi"` | The maximum memory limit. |
 | prompt-proto-service.knative.memoryRequest | string | `"2Gi"` | The minimum memory to request. |
 | prompt-proto-service.knative.responseStartTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service after initial submission (seconds). |
-| prompt-proto-service.knative.timeout | int | `900` | Maximum time that a container can respond to a next_visit request (seconds). |
 | prompt-proto-service.logLevel | string | log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
 | prompt-proto-service.podAnnotations | object | See the `values.yaml` file. | Annotations for the prompt-proto-service pod |
 | prompt-proto-service.registry.centralRepoFile | bool | `false` | If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted. |

--- a/applications/prompt-proto-service-latiss/README.md
+++ b/applications/prompt-proto-service-latiss/README.md
@@ -54,3 +54,4 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.sasquatch.endpointUrl | string | `""` | Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload. This is a preliminary implementation of Sasquatch support, and this parameter may be deprecated if we instead support `SasquatchDatastore` in the future. |
 | prompt-proto-service.sasquatch.namespace | string | `"lsst.prompt"` | Namespace in the Sasquatch system with which to associate metrics. |
 | prompt-proto-service.worker.restart | int | `0` | The number of requests to process before rebooting a worker. If 0, workers process requests indefinitely. |
+| prompt-proto-service.worker.timeout | int | `900` | Maximum time that a worker can process a next_visit request (seconds). |

--- a/applications/prompt-proto-service-latiss/README.md
+++ b/applications/prompt-proto-service-latiss/README.md
@@ -53,5 +53,6 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.sasquatch.auth_env | bool | `true` | If set, this application's Vault secret must contain a `sasquatch_token` key containing the authentication token for `sasquatch.endpointUrl`. Leave unset to attempt anonymous access. |
 | prompt-proto-service.sasquatch.endpointUrl | string | `""` | Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload. This is a preliminary implementation of Sasquatch support, and this parameter may be deprecated if we instead support `SasquatchDatastore` in the future. |
 | prompt-proto-service.sasquatch.namespace | string | `"lsst.prompt"` | Namespace in the Sasquatch system with which to associate metrics. |
+| prompt-proto-service.worker.grace_period | int | `45` | When Knative shuts down a pod, the time its workers have to abort processing and save intermediate results (seconds). |
 | prompt-proto-service.worker.restart | int | `0` | The number of requests to process before rebooting a worker. If 0, workers process requests indefinitely. |
 | prompt-proto-service.worker.timeout | int | `900` | Maximum time that a worker can process a next_visit request (seconds). |

--- a/applications/prompt-proto-service-latiss/values.yaml
+++ b/applications/prompt-proto-service-latiss/values.yaml
@@ -30,6 +30,8 @@ prompt-proto-service:
     # -- The number of requests to process before rebooting a worker.
     # If 0, workers process requests indefinitely.
     restart: 0
+    # -- Maximum time that a worker can process a next_visit request (seconds).
+    timeout: 900
 
   instrument:
     # -- The "short" name of the instrument

--- a/applications/prompt-proto-service-latiss/values.yaml
+++ b/applications/prompt-proto-service-latiss/values.yaml
@@ -131,8 +131,9 @@ prompt-proto-service:
     memoryRequest: "2Gi"
     # -- The maximum memory limit.
     memoryLimit: "8Gi"
-    # -- Maximum time that a container can respond to a next_visit request (seconds).
-    timeout: 900
+    # -- To acommodate scheduling problems, Knative waits for a request for twice `worker.timeout`.
+    # This parameter adds extra time to that minimum (seconds).
+    extraTimeout: 10
     # -- Maximum time that a container can send nothing to the fanout service (seconds).
     idleTimeout: 900
     # -- Maximum time that a container can send nothing to the fanout service after initial submission (seconds).

--- a/applications/prompt-proto-service-latiss/values.yaml
+++ b/applications/prompt-proto-service-latiss/values.yaml
@@ -32,6 +32,8 @@ prompt-proto-service:
     restart: 0
     # -- Maximum time that a worker can process a next_visit request (seconds).
     timeout: 900
+    # -- When Knative shuts down a pod, the time its workers have to abort processing and save intermediate results (seconds).
+    grace_period: 45
 
   instrument:
     # -- The "short" name of the instrument

--- a/applications/prompt-proto-service-latiss/values.yaml
+++ b/applications/prompt-proto-service-latiss/values.yaml
@@ -134,10 +134,14 @@ prompt-proto-service:
     # -- To acommodate scheduling problems, Knative waits for a request for twice `worker.timeout`.
     # This parameter adds extra time to that minimum (seconds).
     extraTimeout: 10
-    # -- Maximum time that a container can send nothing to the fanout service (seconds).
-    idleTimeout: 900
-    # -- Maximum time that a container can send nothing to the fanout service after initial submission (seconds).
-    responseStartTimeout: 900
+    # -- Maximum time that a container can send nothing to Knative (seconds).
+    # This is only useful if the container runs async workers.
+    # If 0, idle timeout is ignored.
+    idleTimeout: 0
+    # -- Maximum time that a container can send nothing to Knative after initial submission (seconds).
+    # This is only useful if the container runs async workers.
+    # If 0, idle timeout is ignored.
+    responseStartTimeout: 0
 
   # -- Kubernetes YAML configs for extra container volume(s).
   # Any volumes required by other config options are automatically handled by the Helm chart.

--- a/applications/prompt-proto-service-lsstcam/README.md
+++ b/applications/prompt-proto-service-lsstcam/README.md
@@ -39,10 +39,10 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.knative.extraTimeout | int | `10` | To acommodate scheduling problems, Knative waits for a request for twice `worker.timeout`. This parameter adds extra time to that minimum (seconds). |
 | prompt-proto-service.knative.gpu | bool | `false` | GPUs enabled. |
 | prompt-proto-service.knative.gpuRequest | int | `0` | The number of GPUs to request. |
-| prompt-proto-service.knative.idleTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service (seconds). |
+| prompt-proto-service.knative.idleTimeout | int | `0` | Maximum time that a container can send nothing to Knative (seconds). This is only useful if the container runs async workers. If 0, idle timeout is ignored. |
 | prompt-proto-service.knative.memoryLimit | string | `"8Gi"` | The maximum memory limit. |
 | prompt-proto-service.knative.memoryRequest | string | `"2Gi"` | The minimum memory to request. |
-| prompt-proto-service.knative.responseStartTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service after initial submission (seconds). |
+| prompt-proto-service.knative.responseStartTimeout | int | `0` | Maximum time that a container can send nothing to Knative after initial submission (seconds). This is only useful if the container runs async workers. If 0, idle timeout is ignored. |
 | prompt-proto-service.logLevel | string | log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
 | prompt-proto-service.podAnnotations | object | See the `values.yaml` file. | Annotations for the prompt-proto-service pod |
 | prompt-proto-service.registry.centralRepoFile | bool | `false` | If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted. |

--- a/applications/prompt-proto-service-lsstcam/README.md
+++ b/applications/prompt-proto-service-lsstcam/README.md
@@ -36,13 +36,13 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.knative.cpuRequest | int | `1` | The cpu cores requested. |
 | prompt-proto-service.knative.ephemeralStorageLimit | string | `"5Gi"` | The maximum storage space allowed for each container (mostly local Butler). |
 | prompt-proto-service.knative.ephemeralStorageRequest | string | `"5Gi"` | The storage space reserved for each container (mostly local Butler). |
+| prompt-proto-service.knative.extraTimeout | int | `10` | To acommodate scheduling problems, Knative waits for a request for twice `worker.timeout`. This parameter adds extra time to that minimum (seconds). |
 | prompt-proto-service.knative.gpu | bool | `false` | GPUs enabled. |
 | prompt-proto-service.knative.gpuRequest | int | `0` | The number of GPUs to request. |
 | prompt-proto-service.knative.idleTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service (seconds). |
 | prompt-proto-service.knative.memoryLimit | string | `"8Gi"` | The maximum memory limit. |
 | prompt-proto-service.knative.memoryRequest | string | `"2Gi"` | The minimum memory to request. |
 | prompt-proto-service.knative.responseStartTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service after initial submission (seconds). |
-| prompt-proto-service.knative.timeout | int | `900` | Maximum time that a container can respond to a next_visit request (seconds). |
 | prompt-proto-service.logLevel | string | log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
 | prompt-proto-service.podAnnotations | object | See the `values.yaml` file. | Annotations for the prompt-proto-service pod |
 | prompt-proto-service.registry.centralRepoFile | bool | `false` | If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted. |

--- a/applications/prompt-proto-service-lsstcam/README.md
+++ b/applications/prompt-proto-service-lsstcam/README.md
@@ -54,3 +54,4 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.sasquatch.endpointUrl | string | `""` | Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload. This is a preliminary implementation of Sasquatch support, and this parameter may be deprecated if we instead support `SasquatchDatastore` in the future. |
 | prompt-proto-service.sasquatch.namespace | string | `"lsst.prompt"` | Namespace in the Sasquatch system with which to associate metrics. |
 | prompt-proto-service.worker.restart | int | `0` | The number of requests to process before rebooting a worker. If 0, workers process requests indefinitely. |
+| prompt-proto-service.worker.timeout | int | `900` | Maximum time that a worker can process a next_visit request (seconds). |

--- a/applications/prompt-proto-service-lsstcam/README.md
+++ b/applications/prompt-proto-service-lsstcam/README.md
@@ -53,5 +53,6 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.sasquatch.auth_env | bool | `true` | If set, this application's Vault secret must contain a `sasquatch_token` key containing the authentication token for `sasquatch.endpointUrl`. Leave unset to attempt anonymous access. |
 | prompt-proto-service.sasquatch.endpointUrl | string | `""` | Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload. This is a preliminary implementation of Sasquatch support, and this parameter may be deprecated if we instead support `SasquatchDatastore` in the future. |
 | prompt-proto-service.sasquatch.namespace | string | `"lsst.prompt"` | Namespace in the Sasquatch system with which to associate metrics. |
+| prompt-proto-service.worker.grace_period | int | `45` | When Knative shuts down a pod, the time its workers have to abort processing and save intermediate results (seconds). |
 | prompt-proto-service.worker.restart | int | `0` | The number of requests to process before rebooting a worker. If 0, workers process requests indefinitely. |
 | prompt-proto-service.worker.timeout | int | `900` | Maximum time that a worker can process a next_visit request (seconds). |

--- a/applications/prompt-proto-service-lsstcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcam/values.yaml
@@ -31,6 +31,8 @@ prompt-proto-service:
     restart: 0
     # -- Maximum time that a worker can process a next_visit request (seconds).
     timeout: 900
+    # -- When Knative shuts down a pod, the time its workers have to abort processing and save intermediate results (seconds).
+    grace_period: 45
 
   instrument:
     # -- The "short" name of the instrument

--- a/applications/prompt-proto-service-lsstcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcam/values.yaml
@@ -131,8 +131,9 @@ prompt-proto-service:
     memoryRequest: "2Gi"
     # -- The maximum memory limit.
     memoryLimit: "8Gi"
-    # -- Maximum time that a container can respond to a next_visit request (seconds).
-    timeout: 900
+    # -- To acommodate scheduling problems, Knative waits for a request for twice `worker.timeout`.
+    # This parameter adds extra time to that minimum (seconds).
+    extraTimeout: 10
     # -- Maximum time that a container can send nothing to the fanout service (seconds).
     idleTimeout: 900
     # -- Maximum time that a container can send nothing to the fanout service after initial submission (seconds).

--- a/applications/prompt-proto-service-lsstcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcam/values.yaml
@@ -134,10 +134,14 @@ prompt-proto-service:
     # -- To acommodate scheduling problems, Knative waits for a request for twice `worker.timeout`.
     # This parameter adds extra time to that minimum (seconds).
     extraTimeout: 10
-    # -- Maximum time that a container can send nothing to the fanout service (seconds).
-    idleTimeout: 900
-    # -- Maximum time that a container can send nothing to the fanout service after initial submission (seconds).
-    responseStartTimeout: 900
+    # -- Maximum time that a container can send nothing to Knative (seconds).
+    # This is only useful if the container runs async workers.
+    # If 0, idle timeout is ignored.
+    idleTimeout: 0
+    # -- Maximum time that a container can send nothing to Knative after initial submission (seconds).
+    # This is only useful if the container runs async workers.
+    # If 0, idle timeout is ignored.
+    responseStartTimeout: 0
 
   # -- Kubernetes YAML configs for extra container volume(s).
   # Any volumes required by other config options are automatically handled by the Helm chart.

--- a/applications/prompt-proto-service-lsstcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcam/values.yaml
@@ -29,6 +29,8 @@ prompt-proto-service:
     # -- The number of requests to process before rebooting a worker.
     # If 0, workers process requests indefinitely.
     restart: 0
+    # -- Maximum time that a worker can process a next_visit request (seconds).
+    timeout: 900
 
   instrument:
     # -- The "short" name of the instrument

--- a/applications/prompt-proto-service-lsstcomcam/README.md
+++ b/applications/prompt-proto-service-lsstcomcam/README.md
@@ -39,10 +39,10 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.knative.extraTimeout | int | `10` | To acommodate scheduling problems, Knative waits for a request for twice `worker.timeout`. This parameter adds extra time to that minimum (seconds). |
 | prompt-proto-service.knative.gpu | bool | `false` | GPUs enabled. |
 | prompt-proto-service.knative.gpuRequest | int | `0` | The number of GPUs to request. |
-| prompt-proto-service.knative.idleTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service (seconds). |
+| prompt-proto-service.knative.idleTimeout | int | `0` | Maximum time that a container can send nothing to Knative (seconds). This is only useful if the container runs async workers. If 0, idle timeout is ignored. |
 | prompt-proto-service.knative.memoryLimit | string | `"8Gi"` | The maximum memory limit. |
 | prompt-proto-service.knative.memoryRequest | string | `"2Gi"` | The minimum memory to request. |
-| prompt-proto-service.knative.responseStartTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service after initial submission (seconds). |
+| prompt-proto-service.knative.responseStartTimeout | int | `0` | Maximum time that a container can send nothing to Knative after initial submission (seconds). This is only useful if the container runs async workers. If 0, idle timeout is ignored. |
 | prompt-proto-service.logLevel | string | log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
 | prompt-proto-service.podAnnotations | object | See the `values.yaml` file. | Annotations for the prompt-proto-service pod |
 | prompt-proto-service.registry.centralRepoFile | bool | `false` | If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted. |

--- a/applications/prompt-proto-service-lsstcomcam/README.md
+++ b/applications/prompt-proto-service-lsstcomcam/README.md
@@ -36,13 +36,13 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.knative.cpuRequest | int | `1` | The cpu cores requested. |
 | prompt-proto-service.knative.ephemeralStorageLimit | string | `"5Gi"` | The maximum storage space allowed for each container (mostly local Butler). |
 | prompt-proto-service.knative.ephemeralStorageRequest | string | `"5Gi"` | The storage space reserved for each container (mostly local Butler). |
+| prompt-proto-service.knative.extraTimeout | int | `10` | To acommodate scheduling problems, Knative waits for a request for twice `worker.timeout`. This parameter adds extra time to that minimum (seconds). |
 | prompt-proto-service.knative.gpu | bool | `false` | GPUs enabled. |
 | prompt-proto-service.knative.gpuRequest | int | `0` | The number of GPUs to request. |
 | prompt-proto-service.knative.idleTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service (seconds). |
 | prompt-proto-service.knative.memoryLimit | string | `"8Gi"` | The maximum memory limit. |
 | prompt-proto-service.knative.memoryRequest | string | `"2Gi"` | The minimum memory to request. |
 | prompt-proto-service.knative.responseStartTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service after initial submission (seconds). |
-| prompt-proto-service.knative.timeout | int | `900` | Maximum time that a container can respond to a next_visit request (seconds). |
 | prompt-proto-service.logLevel | string | log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
 | prompt-proto-service.podAnnotations | object | See the `values.yaml` file. | Annotations for the prompt-proto-service pod |
 | prompt-proto-service.registry.centralRepoFile | bool | `false` | If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted. |

--- a/applications/prompt-proto-service-lsstcomcam/README.md
+++ b/applications/prompt-proto-service-lsstcomcam/README.md
@@ -54,3 +54,4 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.sasquatch.endpointUrl | string | `""` | Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload. This is a preliminary implementation of Sasquatch support, and this parameter may be deprecated if we instead support `SasquatchDatastore` in the future. |
 | prompt-proto-service.sasquatch.namespace | string | `"lsst.prompt"` | Namespace in the Sasquatch system with which to associate metrics. |
 | prompt-proto-service.worker.restart | int | `0` | The number of requests to process before rebooting a worker. If 0, workers process requests indefinitely. |
+| prompt-proto-service.worker.timeout | int | `900` | Maximum time that a worker can process a next_visit request (seconds). |

--- a/applications/prompt-proto-service-lsstcomcam/README.md
+++ b/applications/prompt-proto-service-lsstcomcam/README.md
@@ -53,5 +53,6 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.sasquatch.auth_env | bool | `true` | If set, this application's Vault secret must contain a `sasquatch_token` key containing the authentication token for `sasquatch.endpointUrl`. Leave unset to attempt anonymous access. |
 | prompt-proto-service.sasquatch.endpointUrl | string | `""` | Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload. This is a preliminary implementation of Sasquatch support, and this parameter may be deprecated if we instead support `SasquatchDatastore` in the future. |
 | prompt-proto-service.sasquatch.namespace | string | `"lsst.prompt"` | Namespace in the Sasquatch system with which to associate metrics. |
+| prompt-proto-service.worker.grace_period | int | `45` | When Knative shuts down a pod, the time its workers have to abort processing and save intermediate results (seconds). |
 | prompt-proto-service.worker.restart | int | `0` | The number of requests to process before rebooting a worker. If 0, workers process requests indefinitely. |
 | prompt-proto-service.worker.timeout | int | `900` | Maximum time that a worker can process a next_visit request (seconds). |

--- a/applications/prompt-proto-service-lsstcomcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/values.yaml
@@ -31,6 +31,8 @@ prompt-proto-service:
     restart: 0
     # -- Maximum time that a worker can process a next_visit request (seconds).
     timeout: 900
+    # -- When Knative shuts down a pod, the time its workers have to abort processing and save intermediate results (seconds).
+    grace_period: 45
 
   instrument:
     # -- The "short" name of the instrument

--- a/applications/prompt-proto-service-lsstcomcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/values.yaml
@@ -131,8 +131,9 @@ prompt-proto-service:
     memoryRequest: "2Gi"
     # -- The maximum memory limit.
     memoryLimit: "8Gi"
-    # -- Maximum time that a container can respond to a next_visit request (seconds).
-    timeout: 900
+    # -- To acommodate scheduling problems, Knative waits for a request for twice `worker.timeout`.
+    # This parameter adds extra time to that minimum (seconds).
+    extraTimeout: 10
     # -- Maximum time that a container can send nothing to the fanout service (seconds).
     idleTimeout: 900
     # -- Maximum time that a container can send nothing to the fanout service after initial submission (seconds).

--- a/applications/prompt-proto-service-lsstcomcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/values.yaml
@@ -134,10 +134,14 @@ prompt-proto-service:
     # -- To acommodate scheduling problems, Knative waits for a request for twice `worker.timeout`.
     # This parameter adds extra time to that minimum (seconds).
     extraTimeout: 10
-    # -- Maximum time that a container can send nothing to the fanout service (seconds).
-    idleTimeout: 900
-    # -- Maximum time that a container can send nothing to the fanout service after initial submission (seconds).
-    responseStartTimeout: 900
+    # -- Maximum time that a container can send nothing to Knative (seconds).
+    # This is only useful if the container runs async workers.
+    # If 0, idle timeout is ignored.
+    idleTimeout: 0
+    # -- Maximum time that a container can send nothing to Knative after initial submission (seconds).
+    # This is only useful if the container runs async workers.
+    # If 0, idle timeout is ignored.
+    responseStartTimeout: 0
 
   # -- Kubernetes YAML configs for extra container volume(s).
   # Any volumes required by other config options are automatically handled by the Helm chart.

--- a/applications/prompt-proto-service-lsstcomcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/values.yaml
@@ -29,6 +29,8 @@ prompt-proto-service:
     # -- The number of requests to process before rebooting a worker.
     # If 0, workers process requests indefinitely.
     restart: 0
+    # -- Maximum time that a worker can process a next_visit request (seconds).
+    timeout: 900
 
   instrument:
     # -- The "short" name of the instrument

--- a/applications/prompt-proto-service-lsstcomcamsim/README.md
+++ b/applications/prompt-proto-service-lsstcomcamsim/README.md
@@ -39,10 +39,10 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.knative.extraTimeout | int | `10` | To acommodate scheduling problems, Knative waits for a request for twice `worker.timeout`. This parameter adds extra time to that minimum (seconds). |
 | prompt-proto-service.knative.gpu | bool | `false` | GPUs enabled. |
 | prompt-proto-service.knative.gpuRequest | int | `0` | The number of GPUs to request. |
-| prompt-proto-service.knative.idleTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service (seconds). |
+| prompt-proto-service.knative.idleTimeout | int | `0` | Maximum time that a container can send nothing to Knative (seconds). This is only useful if the container runs async workers. If 0, idle timeout is ignored. |
 | prompt-proto-service.knative.memoryLimit | string | `"8Gi"` | The maximum memory limit. |
 | prompt-proto-service.knative.memoryRequest | string | `"2Gi"` | The minimum memory to request. |
-| prompt-proto-service.knative.responseStartTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service after initial submission (seconds). |
+| prompt-proto-service.knative.responseStartTimeout | int | `0` | Maximum time that a container can send nothing to Knative after initial submission (seconds). This is only useful if the container runs async workers. If 0, idle timeout is ignored. |
 | prompt-proto-service.logLevel | string | log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
 | prompt-proto-service.podAnnotations | object | See the `values.yaml` file. | Annotations for the prompt-proto-service pod |
 | prompt-proto-service.registry.centralRepoFile | bool | `false` | If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted. |

--- a/applications/prompt-proto-service-lsstcomcamsim/README.md
+++ b/applications/prompt-proto-service-lsstcomcamsim/README.md
@@ -36,13 +36,13 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.knative.cpuRequest | int | `1` | The cpu cores requested. |
 | prompt-proto-service.knative.ephemeralStorageLimit | string | `"5Gi"` | The maximum storage space allowed for each container (mostly local Butler). |
 | prompt-proto-service.knative.ephemeralStorageRequest | string | `"5Gi"` | The storage space reserved for each container (mostly local Butler). |
+| prompt-proto-service.knative.extraTimeout | int | `10` | To acommodate scheduling problems, Knative waits for a request for twice `worker.timeout`. This parameter adds extra time to that minimum (seconds). |
 | prompt-proto-service.knative.gpu | bool | `false` | GPUs enabled. |
 | prompt-proto-service.knative.gpuRequest | int | `0` | The number of GPUs to request. |
 | prompt-proto-service.knative.idleTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service (seconds). |
 | prompt-proto-service.knative.memoryLimit | string | `"8Gi"` | The maximum memory limit. |
 | prompt-proto-service.knative.memoryRequest | string | `"2Gi"` | The minimum memory to request. |
 | prompt-proto-service.knative.responseStartTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service after initial submission (seconds). |
-| prompt-proto-service.knative.timeout | int | `900` | Maximum time that a container can respond to a next_visit request (seconds). |
 | prompt-proto-service.logLevel | string | log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
 | prompt-proto-service.podAnnotations | object | See the `values.yaml` file. | Annotations for the prompt-proto-service pod |
 | prompt-proto-service.registry.centralRepoFile | bool | `false` | If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted. |

--- a/applications/prompt-proto-service-lsstcomcamsim/README.md
+++ b/applications/prompt-proto-service-lsstcomcamsim/README.md
@@ -54,3 +54,4 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.sasquatch.endpointUrl | string | `""` | Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload. This is a preliminary implementation of Sasquatch support, and this parameter may be deprecated if we instead support `SasquatchDatastore` in the future. |
 | prompt-proto-service.sasquatch.namespace | string | `"lsst.prompt"` | Namespace in the Sasquatch system with which to associate metrics. |
 | prompt-proto-service.worker.restart | int | `0` | The number of requests to process before rebooting a worker. If 0, workers process requests indefinitely. |
+| prompt-proto-service.worker.timeout | int | `900` | Maximum time that a worker can process a next_visit request (seconds). |

--- a/applications/prompt-proto-service-lsstcomcamsim/README.md
+++ b/applications/prompt-proto-service-lsstcomcamsim/README.md
@@ -53,5 +53,6 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.sasquatch.auth_env | bool | `true` | If set, this application's Vault secret must contain a `sasquatch_token` key containing the authentication token for `sasquatch.endpointUrl`. Leave unset to attempt anonymous access. |
 | prompt-proto-service.sasquatch.endpointUrl | string | `""` | Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload. This is a preliminary implementation of Sasquatch support, and this parameter may be deprecated if we instead support `SasquatchDatastore` in the future. |
 | prompt-proto-service.sasquatch.namespace | string | `"lsst.prompt"` | Namespace in the Sasquatch system with which to associate metrics. |
+| prompt-proto-service.worker.grace_period | int | `45` | When Knative shuts down a pod, the time its workers have to abort processing and save intermediate results (seconds). |
 | prompt-proto-service.worker.restart | int | `0` | The number of requests to process before rebooting a worker. If 0, workers process requests indefinitely. |
 | prompt-proto-service.worker.timeout | int | `900` | Maximum time that a worker can process a next_visit request (seconds). |

--- a/applications/prompt-proto-service-lsstcomcamsim/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcomcamsim/values-usdfprod-prompt-processing.yaml
@@ -8,6 +8,10 @@ prompt-proto-service:
     # Update this field if using latest or static image tag in dev
     revision: "1"
 
+  worker:
+    # Embargo rack allows fast cleanup.
+    grace_period: 20
+
   image:
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.

--- a/applications/prompt-proto-service-lsstcomcamsim/values.yaml
+++ b/applications/prompt-proto-service-lsstcomcamsim/values.yaml
@@ -30,6 +30,8 @@ prompt-proto-service:
     # -- The number of requests to process before rebooting a worker.
     # If 0, workers process requests indefinitely.
     restart: 0
+    # -- Maximum time that a worker can process a next_visit request (seconds).
+    timeout: 900
 
   instrument:
     # -- The "short" name of the instrument

--- a/applications/prompt-proto-service-lsstcomcamsim/values.yaml
+++ b/applications/prompt-proto-service-lsstcomcamsim/values.yaml
@@ -131,8 +131,9 @@ prompt-proto-service:
     memoryRequest: "2Gi"
     # -- The maximum memory limit.
     memoryLimit: "8Gi"
-    # -- Maximum time that a container can respond to a next_visit request (seconds).
-    timeout: 900
+    # -- To acommodate scheduling problems, Knative waits for a request for twice `worker.timeout`.
+    # This parameter adds extra time to that minimum (seconds).
+    extraTimeout: 10
     # -- Maximum time that a container can send nothing to the fanout service (seconds).
     idleTimeout: 900
     # -- Maximum time that a container can send nothing to the fanout service after initial submission (seconds).

--- a/applications/prompt-proto-service-lsstcomcamsim/values.yaml
+++ b/applications/prompt-proto-service-lsstcomcamsim/values.yaml
@@ -32,6 +32,8 @@ prompt-proto-service:
     restart: 0
     # -- Maximum time that a worker can process a next_visit request (seconds).
     timeout: 900
+    # -- When Knative shuts down a pod, the time its workers have to abort processing and save intermediate results (seconds).
+    grace_period: 45
 
   instrument:
     # -- The "short" name of the instrument

--- a/applications/prompt-proto-service-lsstcomcamsim/values.yaml
+++ b/applications/prompt-proto-service-lsstcomcamsim/values.yaml
@@ -134,10 +134,14 @@ prompt-proto-service:
     # -- To acommodate scheduling problems, Knative waits for a request for twice `worker.timeout`.
     # This parameter adds extra time to that minimum (seconds).
     extraTimeout: 10
-    # -- Maximum time that a container can send nothing to the fanout service (seconds).
-    idleTimeout: 900
-    # -- Maximum time that a container can send nothing to the fanout service after initial submission (seconds).
-    responseStartTimeout: 900
+    # -- Maximum time that a container can send nothing to Knative (seconds).
+    # This is only useful if the container runs async workers.
+    # If 0, idle timeout is ignored.
+    idleTimeout: 0
+    # -- Maximum time that a container can send nothing to Knative after initial submission (seconds).
+    # This is only useful if the container runs async workers.
+    # If 0, idle timeout is ignored.
+    responseStartTimeout: 0
 
   # -- Kubernetes YAML configs for extra container volume(s).
   # Any volumes required by other config options are automatically handled by the Helm chart.

--- a/charts/prompt-proto-service/README.md
+++ b/charts/prompt-proto-service/README.md
@@ -40,13 +40,13 @@ Event-driven processing of camera images
 | knative.cpuRequest | int | `1` | The cpu cores requested. |
 | knative.ephemeralStorageLimit | string | `"5Gi"` | The maximum storage space allowed for each container (mostly local Butler). |
 | knative.ephemeralStorageRequest | string | `"5Gi"` | The storage space reserved for each container (mostly local Butler). |
+| knative.extraTimeout | int | `10` | To acommodate scheduling problems, Knative waits for a request for twice `worker.timeout`. This parameter adds extra time to that minimum (seconds). |
 | knative.gpu | bool | `false` | GPUs enabled. |
 | knative.gpuRequest | int | `0` | The number of GPUs to request. |
 | knative.idleTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service (seconds). |
 | knative.memoryLimit | string | `"8Gi"` | The maximum memory limit. |
 | knative.memoryRequest | string | `"2Gi"` | The minimum memory to request. |
 | knative.responseStartTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service after initial submission (seconds). |
-| knative.timeout | int | `900` | Maximum time that a container can respond to a next_visit request (seconds). |
 | logLevel | string | log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
 | nameOverride | string | `""` | Override the base name for resources |
 | nodeSelector | object | `{}` |  |

--- a/charts/prompt-proto-service/README.md
+++ b/charts/prompt-proto-service/README.md
@@ -60,5 +60,6 @@ Event-driven processing of camera images
 | sasquatch.endpointUrl | string | `""` | Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload. This is a preliminary implementation of Sasquatch support, and this parameter may be deprecated if we instead support `SasquatchDatastore` in the future. |
 | sasquatch.namespace | string | `"lsst.prompt"` | Namespace in the Sasquatch system with which to associate metrics. |
 | tolerations | list | `[]` |  |
+| worker.grace_period | int | `45` | When Knative shuts down a pod, the time its workers have to abort processing and save intermediate results (seconds). |
 | worker.restart | int | `0` | The number of requests to process before rebooting a worker. If 0, workers process requests indefinitely. |
 | worker.timeout | int | `900` | Maximum time that a worker can process a next_visit request (seconds). |

--- a/charts/prompt-proto-service/README.md
+++ b/charts/prompt-proto-service/README.md
@@ -43,10 +43,10 @@ Event-driven processing of camera images
 | knative.extraTimeout | int | `10` | To acommodate scheduling problems, Knative waits for a request for twice `worker.timeout`. This parameter adds extra time to that minimum (seconds). |
 | knative.gpu | bool | `false` | GPUs enabled. |
 | knative.gpuRequest | int | `0` | The number of GPUs to request. |
-| knative.idleTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service (seconds). |
+| knative.idleTimeout | int | `0` | Maximum time that a container can send nothing to Knative (seconds). This is only useful if the container runs async workers. If 0, idle timeout is ignored. |
 | knative.memoryLimit | string | `"8Gi"` | The maximum memory limit. |
 | knative.memoryRequest | string | `"2Gi"` | The minimum memory to request. |
-| knative.responseStartTimeout | int | `900` | Maximum time that a container can send nothing to the fanout service after initial submission (seconds). |
+| knative.responseStartTimeout | int | `0` | Maximum time that a container can send nothing to Knative after initial submission (seconds). This is only useful if the container runs async workers. If 0, startup timeout is ignored. |
 | logLevel | string | log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
 | nameOverride | string | `""` | Override the base name for resources |
 | nodeSelector | object | `{}` |  |

--- a/charts/prompt-proto-service/README.md
+++ b/charts/prompt-proto-service/README.md
@@ -61,3 +61,4 @@ Event-driven processing of camera images
 | sasquatch.namespace | string | `"lsst.prompt"` | Namespace in the Sasquatch system with which to associate metrics. |
 | tolerations | list | `[]` |  |
 | worker.restart | int | `0` | The number of requests to process before rebooting a worker. If 0, workers process requests indefinitely. |
+| worker.timeout | int | `900` | Maximum time that a worker can process a next_visit request (seconds). |

--- a/charts/prompt-proto-service/templates/prompt-proto-service.yaml
+++ b/charts/prompt-proto-service/templates/prompt-proto-service.yaml
@@ -42,6 +42,8 @@ spec:
         env:
         - name: WORKER_RESTART_FREQ
           value: {{ .Values.worker.restart | toString | quote }}
+        - name: WORKER_TIMEOUT
+          value: {{ .Values.worker.timeout | toString | quote }}
         - name: RUBIN_INSTRUMENT
           value: {{ .Values.instrument.name }}
         - name: PREPROCESSING_PIPELINES_CONFIG

--- a/charts/prompt-proto-service/templates/prompt-proto-service.yaml
+++ b/charts/prompt-proto-service/templates/prompt-proto-service.yaml
@@ -206,5 +206,5 @@ spec:
       {{- end }}
       enableServiceLinks: true
       timeoutSeconds: {{ $knative_timeout }}
-      idleTimeoutSeconds: {{ .Values.knative.idleTimeout }}
-      responseStartTimeoutSeconds: {{ .Values.knative.responseStartTimeout }}
+      idleTimeoutSeconds: {{ with .Values.knative.idleTimeout }}{{ . }}{{ else }}{{ $knative_timeout }}{{ end }}
+      responseStartTimeoutSeconds: {{ with .Values.knative.responseStartTimeout }}{{ . }}{{ else }}{{ $knative_timeout }}{{ end }}

--- a/charts/prompt-proto-service/templates/prompt-proto-service.yaml
+++ b/charts/prompt-proto-service/templates/prompt-proto-service.yaml
@@ -44,6 +44,8 @@ spec:
           value: {{ .Values.worker.restart | toString | quote }}
         - name: WORKER_TIMEOUT
           value: {{ .Values.worker.timeout | toString | quote }}
+        {{- /* Knative not configured for timeouts longer than 1200 seconds, and shouldn't need to be. */ -}}
+        {{- $knative_timeout := minf 1200 (addf (mulf 2 (coalesce .Values.worker.timeout 600)) .Values.knative.extraTimeout) }}
         - name: RUBIN_INSTRUMENT
           value: {{ .Values.instrument.name }}
         - name: PREPROCESSING_PIPELINES_CONFIG
@@ -203,6 +205,6 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       enableServiceLinks: true
-      timeoutSeconds: {{ .Values.knative.timeout }}
+      timeoutSeconds: {{ $knative_timeout }}
       idleTimeoutSeconds: {{ .Values.knative.idleTimeout }}
       responseStartTimeoutSeconds: {{ .Values.knative.responseStartTimeout }}

--- a/charts/prompt-proto-service/templates/prompt-proto-service.yaml
+++ b/charts/prompt-proto-service/templates/prompt-proto-service.yaml
@@ -44,6 +44,8 @@ spec:
           value: {{ .Values.worker.restart | toString | quote }}
         - name: WORKER_TIMEOUT
           value: {{ .Values.worker.timeout | toString | quote }}
+        - name: WORKER_GRACE_PERIOD
+          value: {{ .Values.worker.grace_period | toString | quote }}
         {{- /* Knative not configured for timeouts longer than 1200 seconds, and shouldn't need to be. */ -}}
         {{- $knative_timeout := minf 1200 (addf (mulf 2 (coalesce .Values.worker.timeout 600)) .Values.knative.extraTimeout) }}
         - name: RUBIN_INSTRUMENT

--- a/charts/prompt-proto-service/values.yaml
+++ b/charts/prompt-proto-service/values.yaml
@@ -134,8 +134,9 @@ knative:
   memoryRequest: "2Gi"
   # -- The maximum memory limit.
   memoryLimit: "8Gi"
-  # -- Maximum time that a container can respond to a next_visit request (seconds).
-  timeout: 900
+  # -- To acommodate scheduling problems, Knative waits for a request for twice `worker.timeout`.
+  # This parameter adds extra time to that minimum (seconds).
+  extraTimeout: 10
   # -- Maximum time that a container can send nothing to the fanout service (seconds).
   idleTimeout: 900
   # -- Maximum time that a container can send nothing to the fanout service after initial submission (seconds).

--- a/charts/prompt-proto-service/values.yaml
+++ b/charts/prompt-proto-service/values.yaml
@@ -137,10 +137,14 @@ knative:
   # -- To acommodate scheduling problems, Knative waits for a request for twice `worker.timeout`.
   # This parameter adds extra time to that minimum (seconds).
   extraTimeout: 10
-  # -- Maximum time that a container can send nothing to the fanout service (seconds).
-  idleTimeout: 900
-  # -- Maximum time that a container can send nothing to the fanout service after initial submission (seconds).
-  responseStartTimeout: 900
+  # -- Maximum time that a container can send nothing to Knative (seconds).
+  # This is only useful if the container runs async workers.
+  # If 0, idle timeout is ignored.
+  idleTimeout: 0
+  # -- Maximum time that a container can send nothing to Knative after initial submission (seconds).
+  # This is only useful if the container runs async workers.
+  # If 0, startup timeout is ignored.
+  responseStartTimeout: 0
 
 # -- Override the base name for resources
 nameOverride: ""

--- a/charts/prompt-proto-service/values.yaml
+++ b/charts/prompt-proto-service/values.yaml
@@ -32,6 +32,8 @@ worker:
   restart: 0
   # -- Maximum time that a worker can process a next_visit request (seconds).
   timeout: 900
+  # -- When Knative shuts down a pod, the time its workers have to abort processing and save intermediate results (seconds).
+  grace_period: 45
 
 instrument:
   # -- The "short" name of the instrument

--- a/charts/prompt-proto-service/values.yaml
+++ b/charts/prompt-proto-service/values.yaml
@@ -30,6 +30,8 @@ worker:
   # -- The number of requests to process before rebooting a worker.
   # If 0, workers process requests indefinitely.
   restart: 0
+  # -- Maximum time that a worker can process a next_visit request (seconds).
+  timeout: 900
 
 instrument:
   # -- The "short" name of the instrument


### PR DESCRIPTION
This PR reworks Prompt Processing's timeout configuration to be worker-centric rather than Knative-centric. It also adds a control for each worker's grace period.