### PR TITLE
DM-45338: Update unfurlbot to 0.2.2

### DIFF
--- a/applications/unfurlbot/Chart.yaml
+++ b/applications/unfurlbot/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "0.2.1"
+appVersion: "0.2.2"
 description: Squarebot backend that unfurls Jira issues.
 name: unfurlbot
 sources:


### PR DESCRIPTION
Unfurlbot 0.2.2 fixes support for epics. See https://github.com/lsst-sqre/unfurlbot/pull/7