### PR TITLE
DM-45383: Update to Unfurlbot 0.3.0

### DIFF
--- a/applications/squarebot/Chart.yaml
+++ b/applications/squarebot/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: squarebot
 version: 1.0.0
-appVersion: "0.8.0"
+appVersion: "0.9.0"
 description: Squarebot feeds events from services like Slack and GitHub into the SQuaRE Events Kafka message bus running on Roundtable. Backend apps like Templatebot and Unfurlbot can subscribe to these events and take domain-specific action.
 type: application
 home: https://squarebot.lsst.io/

--- a/applications/unfurlbot/Chart.yaml
+++ b/applications/unfurlbot/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "0.2.2"
+appVersion: "0.3.0"
 description: Squarebot backend that unfurls Jira issues.
 name: unfurlbot
 sources:


### PR DESCRIPTION
This version of unfurlbot supports unfurling tokens from bot messaes like Sup standup reports.

See https://github.com/lsst-sqre/unfurlbot/pull/8

Also update squarebot to 0.9.0 to support bot messages and reducing the combined content of slack messages across attachments. https://github.com/lsst-sqre/squarebot/releases/tag/0.9.0