### PR TITLE
[DM-45415] Sasquatch dependency updates

### DIFF
--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -362,7 +362,7 @@ Rubin Observatory's telemetry service
 | strimzi-kafka.kafka.storage.size | string | `"500Gi"` | Size of the backing storage disk for each of the Kafka brokers |
 | strimzi-kafka.kafka.storage.storageClassName | string | `""` | Name of a StorageClass to use when requesting persistent volumes |
 | strimzi-kafka.kafka.tolerations | list | `[]` | Tolerations for Kafka broker pod assignment |
-| strimzi-kafka.kafka.version | string | `"3.7.0"` | Version of Kafka to deploy |
+| strimzi-kafka.kafka.version | string | `"3.7.1"` | Version of Kafka to deploy |
 | strimzi-kafka.kafkaController.enabled | bool | `false` | Enable Kafka Controller |
 | strimzi-kafka.kafkaController.resources | object | See `values.yaml` | Kubernetes requests and limits for the Kafka Controller |
 | strimzi-kafka.kafkaController.storage.size | string | `"20Gi"` | Size of the backing storage disk for each of the Kafka controllers |

--- a/applications/sasquatch/charts/strimzi-kafka/Chart.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: strimzi-kafka
 version: 1.0.0
 description: A subchart to deploy Strimzi Kafka components for Sasquatch.
-appVersion: 0.36.1
+appVersion: 0.42.0

--- a/applications/sasquatch/charts/strimzi-kafka/README.md
+++ b/applications/sasquatch/charts/strimzi-kafka/README.md
@@ -40,7 +40,7 @@ A subchart to deploy Strimzi Kafka components for Sasquatch.
 | kafka.storage.size | string | `"500Gi"` | Size of the backing storage disk for each of the Kafka brokers |
 | kafka.storage.storageClassName | string | `""` | Name of a StorageClass to use when requesting persistent volumes |
 | kafka.tolerations | list | `[]` | Tolerations for Kafka broker pod assignment |
-| kafka.version | string | `"3.7.0"` | Version of Kafka to deploy |
+| kafka.version | string | `"3.7.1"` | Version of Kafka to deploy |
 | kafkaController.enabled | bool | `false` | Enable Kafka Controller |
 | kafkaController.resources | object | See `values.yaml` | Kubernetes requests and limits for the Kafka Controller |
 | kafkaController.storage.size | string | `"20Gi"` | Size of the backing storage disk for each of the Kafka controllers |

--- a/applications/sasquatch/charts/strimzi-kafka/values.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/values.yaml
@@ -11,7 +11,7 @@ cluster:
 
 kafka:
   # -- Version of Kafka to deploy
-  version: "3.7.0"
+  version: "3.7.1"
 
   # -- Number of Kafka broker replicas to run
   replicas: 3

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -69,14 +69,10 @@ telegraf-kafka-consumer:
   kafkaConsumers:
     test:
       enabled: true
+      database: "telegraf-kafka-consumer-v1"
       replicaCount: 1
       topicRegexps: |
         [ "lsst.Test.*" ]
-    atmcs:
-      enabled: false
-      replicaCount: 1
-      topicRegexps: |
-        [ ".*ATMCS" ]
 
 kafdrop:
   cmdArgs: "--message.format=AVRO --topic.deleteEnabled=true --topic.createEnabled=true"


### PR DESCRIPTION
Alongside with renovate PRs, test these Sasquatch dependencies on data-dev before rolling out to other environments.  
- Strimzi 0.42.0
- Kafka 3.7.1
- Kafka REST Proxy v7.6.2
- Kafdrop v4.0.2
- Kapacitor v1.7.5