### PR TITLE
[DM-45466] Optional QServ pw secret & idfint to point to new pw-protected Qserv 

### DIFF
--- a/applications/tap/secrets-idfint.yaml
+++ b/applications/tap/secrets-idfint.yaml
@@ -1,3 +1,6 @@
 uws-db-password:
   description: >-
     Password for external UWS PostgreSQL server
+qserv-password:
+  description: >-
+    Password for the QServ database server

--- a/applications/tap/values-idfdev.yaml
+++ b/applications/tap/values-idfdev.yaml
@@ -5,5 +5,7 @@ cadc-tap:
 
   config:
     qserv:
-      host: "10.140.1.211:4040"
       # Change to 134.79.23.209:4040 to point to USDF qserv
+      host: "qserv-int.slac.stanford.edu:4040"
+      jdbcParams: "?enabledTLSProtocols=TLSv1.2"
+      passwordEnabled: true

--- a/applications/tap/values-idfint.yaml
+++ b/applications/tap/values-idfint.yaml
@@ -5,5 +5,6 @@ cadc-tap:
 
   config:
     qserv:
-      host: "134.79.23.227:4040"
+      host: "qserv-int.slac.stanford.edu:4040"
       jdbcParams: "?enabledTLSProtocols=TLSv1.2"
+      passwordEnabled: true

--- a/applications/times-square/secrets.yaml
+++ b/applications/times-square/secrets.yaml
@@ -13,3 +13,6 @@ TS_SLACK_WEBHOOK_URL:
   description: >-
     Slack webhook URL for Times Square.
     This is used to send messages to the Times Square Slack status channel.
+  copy:
+    application: mobu
+    key: app-alert-webhook

--- a/charts/cadc-tap/README.md
+++ b/charts/cadc-tap/README.md
@@ -38,6 +38,7 @@ IVOA TAP service
 | config.qserv.image.repository | string | `"ghcr.io/lsst-sqre/lsst-tap-service"` | TAP image to use |
 | config.qserv.image.tag | string | `"2.2.0"` | Tag of TAP image to use |
 | config.qserv.jdbcParams | string | `""` | Extra JDBC connection parameters |
+| config.qserv.passwordEnabled | bool | false | Whether the Qserv database is password protected |
 | config.tapSchemaAddress | string | `"cadc-tap-schema-db:3306"` | Address to a MySQL database containing TAP schema data |
 | config.vaultSecretName | string | `""` | Vault secret name, this is appended to the global path to find the vault secrets associated with this deployment. |
 | fullnameOverride | string | `"cadc-tap"` | Override the full name for resources (includes the release name) |

--- a/charts/cadc-tap/templates/tap-deployment.yaml
+++ b/charts/cadc-tap/templates/tap-deployment.yaml
@@ -86,7 +86,7 @@ spec:
                 {{- end }}
                 {{- if eq .Values.config.backend "qserv" }}
                 -Dqservuser.username=qsmaster
-                -Dqservuser.password=
+                -Dqservuser.password=$QSERV_DB_PASSWORD
                 -Dqservuser.driverClassName=com.mysql.cj.jdbc.Driver
                 -Dqservuser.url=jdbc:mysql://{{ .Values.config.qserv.host }}/{{ .Values.config.qserv.jdbcParams }}
                 -Dqservuser.maxActive=100
@@ -100,6 +100,13 @@ spec:
                 -Dbase_url={{ .Values.global.baseUrl }}
                 -Dca.nrc.cadc.util.PropertiesReader.dir=/etc/creds/
                 -Xmx{{ .Values.config.jvmMaxHeapSize }}
+            {{- if and (eq .Values.config.backend "qserv") (eq .Values.config.qserv.passwordEnabled true) }}
+            - name: "QSERV_DB_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  name: "cadc-tap"
+                  key: "qserv-password"
+            {{- end }}
             {{- if eq .Values.config.backend "pg" }}
             - name: "TAP_DB_PASSWORD"
               valueFrom:

--- a/charts/cadc-tap/values.yaml
+++ b/charts/cadc-tap/values.yaml
@@ -91,6 +91,10 @@ config:
       # -- Tag of TAP image to use
       tag: "2.2.0"
 
+    # -- Whether the Qserv database is password protected
+    # @default -- false
+    passwordEnabled: false
+
   # -- Address to a MySQL database containing TAP schema data
   tapSchemaAddress: "cadc-tap-schema-db:3306"
 


### PR DESCRIPTION
This PR modifies the cadc-tap chart to accept and pass in an optional QServ password. The password is expected and passed in when `config.qserv.passwordEnabled` is set to true otherwise the qserv password env value is empty, which is what it was previously to this change.

The other change is to move idfint to use the new QServ host: "qserv-int.slac.stanford.edu:4040" with passwordEnabled: true.
 Additional changes include adding a qserv-password for idfint (secrets-idfint.yaml).

**JIRA issue:**
https://rubinobs.atlassian.net/browse/DM-45466

**Tests:**
The change was tested on dev, by applying the equivalent changes here, and testing with the new Qserv and passwordEnabled, as well as with the previous and without passwordEnabled