### PR TITLE
DM-45494: Add fastapi-safir-uws starter

### DIFF
--- a/docs/developers/helm-chart/create-new-chart.rst
+++ b/docs/developers/helm-chart/create-new-chart.rst
@@ -20,8 +20,14 @@ Use the ``--starter`` flag to specify a different Helm chart starter.
 There are three options:
 
 fastapi-safir
-    Use this starter for FastAPI web services based on Safir, created from the "FastAPI application (Safir)" template.
+    Use this starter for FastAPI web services based on Safir, created from the "FastAPI application (Safir)" template with the "Default" flavor selected.
     This is the default.
+
+fastapi-safir-uws
+    Use this starter for FastAPI web services based on Safir that use UWS.
+    These services separate the work of the service into a frontend and several backend workers, connected by a queuing system.
+    It is used for services that have a backend that needs to run on a stack container.
+    This starter corresponds to applications created from the "FastAPI application (Safir)" template with the "UWS" flavor selected.
 
 web-service
     Use this starter if the new Helm application is some other web service.

--- a/src/phalanx/models/helm.py
+++ b/src/phalanx/models/helm.py
@@ -27,3 +27,4 @@ class HelmStarter(Enum):
     EMPTY = "empty"
     WEB_SERVICE = "web-service"
     FASTAPI_SAFIR = "fastapi-safir"
+    FASTAPI_SAFIR_UWS = "fastapi-safir-uws"

--- a/src/phalanx/storage/helm.py
+++ b/src/phalanx/storage/helm.py
@@ -76,14 +76,13 @@ class HelmStorage:
         with (path / "Chart.yaml").open("w") as fh:
             yaml.dump(chart, fh)
 
-        # Support an additional substitution variable, <CHARTENVPREFIX>,
-        # that's only used in templates/configmap.yaml.
-        configmap_path = path / "templates" / "configmap.yaml"
-        if configmap_path.exists():
-            configmap = configmap_path.read_text().replace(
-                "<CHARTENVPREFIX>", application.upper().replace("-", "_")
-            )
-            configmap_path.write_text(configmap)
+        # Support an additional substitution variable, <CHARTENVPREFIX>.
+        for env_path in (path / "templates").iterdir():
+            if env_path.is_file() and env_path.suffix == ".yaml":
+                text = env_path.read_text().replace(
+                    "<CHARTENVPREFIX>", application.upper().replace("-", "_")
+                )
+                env_path.write_text(text)
 
     def dependency_update(
         self, application: str, *, quiet: bool = False

--- a/starters/README.md
+++ b/starters/README.md
@@ -1,11 +1,10 @@
 # Helm starters for Phalanx
 
 Each subdirectory of this directory is a Helm starter for a class of Phalanx service.
-Use the starters with the `-p` option to `helm create`.
-For example, from the `applications` directory:
+These are used by the `phalanx application create` command.
+
+For example, from the top of a Phalanx checkout:
 
 ```sh
-helm create new-service -p $(pwd)/../starters/rsp-web-service
+phalanx application create --starter fastapi-safir <application>
 ```
-
-The path to the starter directory must be absolute, not relative, or Helm will try to use it has a path relative to `$HOME/.local/share/helm`.

--- a/starters/fastapi-safir-uws/Chart.yaml
+++ b/starters/fastapi-safir-uws/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: <CHARTNAME>
+version: 1.0.0
+description: "Helm starter chart for a new FastAPI Safir app using UWS"
+sources:
+  - "https://github.com/lsst-sqre/<CHARTNAME>"
+appVersion: 0.1.0
+
+dependencies:
+  - name: redis
+    version: 1.0.12
+    repository: https://lsst-sqre.github.io/charts/

--- a/starters/fastapi-safir-uws/secrets.yaml
+++ b/starters/fastapi-safir-uws/secrets.yaml
@@ -1,0 +1,13 @@
+database-password:
+  description: >-
+    Password used to authenticate to the PostgreSQL database used to store job
+    information. This password may be changed at any time.
+redis-password:
+  description: >-
+    Password used to authenticate to the internal Redis server, deployed as
+    part of the same Argo CD application and used to manage the work
+    queue. This secret can be changed at any time, but both the Redis server
+    and all deployments will then have to be restarted to pick up the new
+    value.
+  generate:
+    type: password

--- a/starters/fastapi-safir-uws/templates/_helpers.tpl
+++ b/starters/fastapi-safir-uws/templates/_helpers.tpl
@@ -1,0 +1,27 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "<CHARTNAME>.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "<CHARTNAME>.labels" -}}
+helm.sh/chart: {{ include "<CHARTNAME>.chart" . }}
+{{ include "<CHARTNAME>.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "<CHARTNAME>.selectorLabels" -}}
+app.kubernetes.io/name: "<CHARTNAME>"
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/starters/fastapi-safir-uws/templates/configmap.yaml
+++ b/starters/fastapi-safir-uws/templates/configmap.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: <CHARTNAME>
+  labels:
+    {{- include "<CHARTNAME>.labels" . | nindent 4 }}
+data:
+  <CHARTENVPREFIX>_ARQ_QUEUE_URL: "redis://<CHARTNAME>-redis.{{ .Release.Namespace }}"
+  {{- if .Values.cloudsql.enabled }}
+  <CHARTENVPREFIX>_DATABASE_URL: "postgresql://<CHARTNAME>@localhost/<CHARTNAME>"
+  {{- end }}
+  <CHARTENVPREFIX>_GRACE_PERIOD: {{ .Values.config.gracePeriod | quote }}
+  <CHARTENVPREFIX>_LIFETIME: {{ .Values.config.lifetime | quote }}
+  <CHARTENVPREFIX>_SERVICE_ACCOUNT: {{ required "config.serviceAccount must be set" .Values.config.serviceAccount | quote }}
+  <CHARTENVPREFIX>_STORAGE_URL: {{ required "config.storageBucketUrl must be set" .Values.config.storageBucketUrl | quote }}
+  <CHARTENVPREFIX>_SYNC_TIMEOUT: {{ .Values.config.syncTimeout | quote }}
+  <CHARTENVPREFIX>_TIMEOUT: {{ .Values.config.timeout | quote }}
+  <CHARTENVPREFIX>_LOG_LEVEL: {{ .Values.config.loglevel | quote }}
+  <CHARTENVPREFIX>_PATH_PREFIX: {{ .Values.config.pathPrefix | quote }}
+  <CHARTENVPREFIX>_PROFILE: {{ .Values.config.logProfile | quote }}

--- a/starters/fastapi-safir-uws/templates/db-worker-deployment.yaml
+++ b/starters/fastapi-safir-uws/templates/db-worker-deployment.yaml
@@ -1,0 +1,96 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: <CHARTNAME>-db-worker
+  labels:
+    {{- include "<CHARTNAME>.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.databaseWorker.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "<CHARTNAME>.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: "db-worker"
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.databaseWorker.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "<CHARTNAME>.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: "db-worker"
+        <CHARTNAME>-redis-client: "true"
+    spec:
+      {{- with .Values.databaseWorker.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.cloudsql.enabled }}
+      serviceAccountName: "<CHARTNAME>"
+      {{- else }}
+      automountServiceAccountToken: false
+      {{- end }}
+      containers:
+        {{- if .Values.cloudsql.enabled }}
+        - name: "cloud-sql-proxy"
+          command:
+            - "/cloud_sql_proxy"
+            - "-ip_address_types=PRIVATE"
+            - "-log_debug_stdout=true"
+            - "-structured_logs=true"
+            - "-instances={{ required "cloudsql.instanceConnectionName must be specified" .Values.cloudsql.instanceConnectionName }}=tcp:5432"
+          image: "{{ .Values.cloudsql.image.repository }}:{{ .Values.cloudsql.image.tag }}"
+          imagePullPolicy: {{ .Values.cloudsql.image.pullPolicy | quote }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+        {{- end }}
+        - name: "db-worker"
+          command:
+            - "arq"
+            - "<CHARTNAME>.workers.uws.WorkerSettings"
+          env:
+            - name: "<CHARTENVPREFIX>_ARQ_QUEUE_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  name: "<CHARTNAME>"
+                  key: "redis-password"
+            - name: "<CHARTENVPREFIX>_DATABASE_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  name: "<CHARTNAME>"
+                  key: "database-password"
+          envFrom:
+            - configMapRef:
+                name: "<CHARTNAME>"
+          {{- with .Values.databaseWorker.resources }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+            readOnlyRootFilesystem: true
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+      {{- with .Values.databaseWorker.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.databaseWorker.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/starters/fastapi-safir-uws/templates/db-worker-networkpolicy.yaml
+++ b/starters/fastapi-safir-uws/templates/db-worker-networkpolicy.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: <CHARTNAME>-db-worker
+  labels:
+    {{- include "<CHARTNAME>.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    # This policy controls inbound access to the database workers.
+    matchLabels:
+      {{- include "<CHARTNAME>.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: "db-worker"
+  policyTypes:
+    # Block all inbound access.
+    - Ingress

--- a/starters/fastapi-safir-uws/templates/deployment.yaml
+++ b/starters/fastapi-safir-uws/templates/deployment.yaml
@@ -1,0 +1,105 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "<CHARTNAME>"
+  labels:
+    {{- include "<CHARTNAME>.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.frontend.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "<CHARTNAME>.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: "frontend"
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.frontend.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "<CHARTNAME>.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: "frontend"
+        <CHARTNAME>-redis-client: "true"
+    spec:
+      {{- with .Values.frontend.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.cloudsql.enabled }}
+      serviceAccountName: "<CHARTNAME>"
+      {{- else }}
+      automountServiceAccountToken: false
+      {{- end }}
+      containers:
+        {{- if .Values.cloudsql.enabled }}
+        - name: "cloud-sql-proxy"
+          command:
+            - "/cloud_sql_proxy"
+            - "-ip_address_types=PRIVATE"
+            - "-log_debug_stdout=true"
+            - "-structured_logs=true"
+            - "-instances={{ required "cloudsql.instanceConnectionName must be specified" .Values.cloudsql.instanceConnectionName }}=tcp:5432"
+          image: "{{ .Values.cloudsql.image.repository }}:{{ .Values.cloudsql.image.tag }}"
+          imagePullPolicy: {{ .Values.cloudsql.image.pullPolicy | quote }}
+          {{- with .Values.cloudsql.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+        {{- end }}
+        - name: "<CHARTNAME>"
+          env:
+            - name: "<CHARTENVPREFIX>_ARQ_QUEUE_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  name: "<CHARTNAME>"
+                  key: "redis-password"
+            - name: "<CHARTENVPREFIX>_DATABASE_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  name: "<CHARTNAME>"
+                  key: "database-password"
+          envFrom:
+            - configMapRef:
+                name: "<CHARTNAME>"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          ports:
+            - containerPort: 8080
+              name: "http"
+              protocol: "TCP"
+          readinessProbe:
+            httpGet:
+              path: "/api/<CHARTNAME>/availability"
+              port: "http"
+          {{- with .Values.frontend.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+            readOnlyRootFilesystem: true
+      {{- with .Values.frontend.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+      {{- with .Values.frontend.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/starters/fastapi-safir-uws/templates/ingress.yaml
+++ b/starters/fastapi-safir-uws/templates/ingress.yaml
@@ -1,0 +1,37 @@
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
+metadata:
+  name: "<CHARTNAME>"
+  labels:
+    {{- include "<CHARTNAME>.labels" . | nindent 4 }}
+config:
+  baseUrl: {{ .Values.global.baseUrl | quote }}
+  scopes:
+    all:
+      - "read:image"
+  # Request a delegated token to use for making calls to Butler server with the
+  # end-user's credentials.
+  delegate:
+    internal:
+      service: "<CHARTNAME>"
+      scopes:
+        - "read:image"
+template:
+  metadata:
+    name: "<CHARTNAME>"
+    {{- with .Values.ingress.annotations }}
+    annotations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  spec:
+    rules:
+      - host: {{ required "global.host must be set" .Values.global.host | quote }}
+        http:
+          paths:
+            - path: {{ .Values.config.pathPrefix | quote }}
+              pathType: "Prefix"
+              backend:
+                service:
+                  name: "<CHARTNAME>"
+                  port:
+                    number: 8080

--- a/starters/fastapi-safir-uws/templates/networkpolicy.yaml
+++ b/starters/fastapi-safir-uws/templates/networkpolicy.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: "<CHARTNAME>"
+  labels:
+    {{- include "<CHARTNAME>.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    # This policy controls inbound access to the frontend component.
+    matchLabels:
+      {{- include "<CHARTNAME>.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: "frontend"
+  policyTypes:
+    - Ingress
+  ingress:
+    # Allow inbound access from pods (in any namespace) labeled
+    # gafaelfawr.lsst.io/ingress: true.
+    - from:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              gafaelfawr.lsst.io/ingress: "true"
+      ports:
+        - protocol: "TCP"
+          port: 8080

--- a/starters/fastapi-safir-uws/templates/service.yaml
+++ b/starters/fastapi-safir-uws/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "<CHARTNAME>"
+  labels:
+    {{- include "<CHARTNAME>.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - protocol: "TCP"
+      port: 8080
+      targetPort: "http"
+  selector:
+    {{- include "<CHARTNAME>.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: "frontend"
+  sessionAffinity: None

--- a/starters/fastapi-safir-uws/templates/serviceaccount.yaml
+++ b/starters/fastapi-safir-uws/templates/serviceaccount.yaml
@@ -1,0 +1,10 @@
+{{- if (or .Values.config.serviceAccount .Values.cloudsql.enabled) }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "<CHARTNAME>"
+  labels:
+    {{- include "<CHARTNAME>.labels" . | nindent 4 }}
+  annotations:
+    iam.gke.io/gcp-service-account: {{ required "config.serviceAccount must be set to a valid Google service account" .Values.config.serviceAccount | quote }}
+{{- end }}

--- a/starters/fastapi-safir-uws/templates/vault-secrets.yaml
+++ b/starters/fastapi-safir-uws/templates/vault-secrets.yaml
@@ -1,0 +1,9 @@
+apiVersion: ricoberger.de/v1alpha1
+kind: VaultSecret
+metadata:
+  name: "<CHARTNAME>"
+  labels:
+    {{- include "<CHARTNAME>.labels" . | nindent 4 }}
+spec:
+  path: "{{ .Values.global.vaultSecretsPath }}/<CHARTNAME>"
+  type: Opaque

--- a/starters/fastapi-safir-uws/templates/worker-deployment.yaml
+++ b/starters/fastapi-safir-uws/templates/worker-deployment.yaml
@@ -1,0 +1,89 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "<CHARTNAME>-worker"
+  labels:
+    {{- include "<CHARTNAME>.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.databaseWorker.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "<CHARTNAME>.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: "worker"
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.databaseWorker.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "<CHARTNAME>.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: "worker"
+        <CHARTNAME>-redis-client: "true"
+    spec:
+      {{- with .Values.worker.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.config.serviceAccount }}
+      serviceAccountName: "<CHARTNAME>"
+      {{- else }}
+      automountServiceAccountToken: false
+      {{- end }}
+      containers:
+        - name: "worker"
+          env:
+            # Password for Redis for the job queue.
+            - name: "<CHARTENVPREFIX>_ARQ_QUEUE_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  name: "<CHARTNAME>"
+                  key: "redis-password"
+
+            # Temporary directory into which to stage work.
+            - name: "<CHARTENVPREFIX>_TMPDIR"
+              value: "/tmp/<CHARTNAME>"
+
+            # Used by Butler to retrieve its configuration.
+            - name: "DAF_BUTLER_REPOSITORIES"
+              value: {{ .Values.global.butlerServerRepositories | b64dec | quote }}
+
+            # lsst-resources writes temp files into the current working
+            # directory unless you explicitly specify one.
+            - name: "TMPDIR"
+              value: "/tmp"
+          envFrom:
+            - configMapRef:
+                name: "<CHARTNAME>"
+          image: "{{ .Values.worker.image.repository }}:{{ .Values.worker.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.worker.image.pullPolicy | quote }}
+          {{- with .Values.worker.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: "tmp"
+              mountPath: "/tmp"
+      {{- with .Values.worker.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+      terminationGracePeriodSeconds: {{ .Values.config.gracePeriod }}
+      {{- with .Values.worker.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: "tmp"
+          emptyDir: {}

--- a/starters/fastapi-safir-uws/templates/worker-networkpolicy.yaml
+++ b/starters/fastapi-safir-uws/templates/worker-networkpolicy.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: "<CHARTNAME>-worker"
+  labels:
+    {{- include "<CHARTNAME>.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    # This policy controls inbound access to the workers.
+    matchLabels:
+      {{- include "<CHARTNAME>.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: "worker"
+  policyTypes:
+    # Block all inbound access.
+    - Ingress

--- a/starters/fastapi-safir-uws/values.yaml
+++ b/starters/fastapi-safir-uws/values.yaml
@@ -1,0 +1,232 @@
+# Default values for <CHARTNAME>.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+config:
+  # -- Choose from the text form of Python logging levels
+  loglevel: "INFO"
+
+  # -- Logging profile (`production` for JSON, `development` for
+  # human-friendly)
+  logProfile: "production"
+
+  # -- URL path prefix for the API
+  pathPrefix: "/api/<CHARTNAME>"
+
+  # -- URL for the PostgreSQL database if Cloud SQL is not in use
+  # @default -- None, must be set if `cloudsql.enabled` is false
+  databaseUrl: null
+
+  # -- Grace period in seconds to wait for worker jobs to finish
+  gracePeriod: 60
+
+  # -- Lifetime of job results in Safir `parse_timedelta` format
+  lifetime: "30d"
+
+  # -- Google service account with an IAM binding to the Kubernetes service
+  # account for the application. Must have the `cloudsql.client` role, access
+  # to write to the GCS bucket, and ability to sign URLs as itself
+  # @default -- None, must be set
+  serviceAccount: null
+
+  # -- URL for the GCS bucket for results (must start with `s3` or `gs`)
+  # @default -- None, must be set
+  storageBucketUrl: null
+
+  # -- Timeout for results from a sync request in Safir `parse_timedelta`
+  # format
+  syncTimeout: "1m"
+
+  # -- Timeout for a single job in seconds
+  # @default -- 600 (10 minutes)
+  timeout: 600
+
+image:
+  # -- Image to use for the frontend and database workers
+  repository: "ghcr.io/lsst-sqre/<CHARTNAME>"
+
+  # -- Pull policy for the image
+  pullPolicy: "IfNotPresent"
+
+  # -- Tag of image to use
+  # @default -- The appVersion of the chart
+  tag: null
+
+ingress:
+  # -- Additional annotations to add to the ingress
+  annotations: {}
+
+frontend:
+  # -- Number of web frontend pods to start
+  replicaCount: 1
+
+  # -- Resource limits and requests for the <CHARTNAME> frontend pod
+  # @default -- See `values.yaml`
+  resources: {}
+
+  # -- Affinity rules for the <CHARTNAME> frontend pod
+  affinity: {}
+
+  # -- Node selector rules for the <CHARTNAME> frontend pod
+  nodeSelector: {}
+
+  # -- Annotations for the <CHARTNAME> frontend pod
+  podAnnotations: {}
+
+  # -- Tolerations for the <CHARTNAME> frontend pod
+  tolerations: []
+
+cloudsql:
+  # -- Enable the Cloud SQL Auth Proxy sidecar, used with Cloud SQL databases
+  # on Google Cloud
+  enabled: false
+
+  image:
+    # -- Cloud SQL Auth Proxy image to use
+    repository: "gcr.io/cloudsql-docker/gce-proxy"
+
+    # -- Cloud SQL Auth Proxy tag to use
+    tag: "1.35.4"
+
+    # -- Pull policy for Cloud SQL Auth Proxy images
+    pullPolicy: "IfNotPresent"
+
+  # -- Instance connection name for a Cloud SQL PostgreSQL instance
+  # @default -- None, must be set if Cloud SQL is used
+  instanceConnectionName: null
+
+  # -- Resource limits and requests for the Cloud SQL Proxy container
+  # @default -- See `values.yaml`
+  resources:
+    limits:
+      cpu: "100m"
+      memory: "20Mi"
+    requests:
+      cpu: "5m"
+      memory: "7Mi"
+
+worker:
+  # -- Number of <CHARTNAME> worker pods to start
+  replicaCount: 2
+
+  image:
+    # -- Stack image to use for the backend worker
+    repository: "ghcr.io/lsst-sqre/<CHARTNAME>-worker"
+
+    # -- Tag of worker image to use
+    # @default -- The appVersion of the chart
+    tag: null
+
+    # -- Pull policy for workers
+    pullPolicy: "IfNotPresent"
+
+  # -- Resource limits and requests for the <CHARTNAME> worker pod
+  # @default -- See `values.yaml`
+  resources: {}
+
+  # -- Affinity rules for the <CHARTNAME> worker pod
+  affinity: {}
+
+  # -- Node selection rules for the <CHARTNAME> worker pod
+  nodeSelector: {}
+
+  # -- Annotations for the <CHARTNAME> worker pod
+  podAnnotations: {}
+
+  # -- Tolerations for the <CHARTNAME> worker pod
+  tolerations: []
+
+databaseWorker:
+  # -- Number of database worker pods to start
+  replicaCount: 1
+
+  # -- Resource limits and requests for the database worker pod
+  # @default -- See `values.yaml`
+  resources:
+    limits:
+      cpu: "0.1"
+      memory: "200Mi"
+    requests:
+      cpu: "0.02"
+      memory: "85Mi"
+
+  # -- Affinity rules for the database worker pod
+  affinity: {}
+
+  # -- Node selection rules for the database worker pod
+  nodeSelector: {}
+
+  # -- Annotations for the database worker pod
+  podAnnotations: {}
+
+  # -- Tolerations for the database worker pod
+  tolerations: []
+
+redis:
+  config:
+    # -- Name of secret containing Redis password
+    secretName: "<CHARTNAME>"
+
+    # -- Key inside secret from which to get the Redis password (do not
+    # change)
+    secretKey: "redis-password"
+
+  persistence:
+    # -- Whether to persist Redis storage and thus tokens. Setting this to
+    # false will use `emptyDir` and reset all tokens on every restart. Only
+    # use this for a test deployment.
+    enabled: true
+
+    # -- Amount of persistent storage to request
+    size: "100Mi"
+
+    # -- Class of storage to request
+    storageClass: null
+
+    # -- Access mode of storage to request
+    accessMode: "ReadWriteOnce"
+
+    # -- Use an existing PVC, not dynamic provisioning. If this is set, the
+    # size, storageClass, and accessMode settings are ignored.
+    volumeClaimName: null
+
+  # -- Resource limits and requests for the Redis pod
+  # @default -- See `values.yaml`
+  resources:
+    limits:
+      cpu: "0.5"
+      memory: "10Mi"
+    requests:
+      cpu: "0.1"
+      memory: "5Mi"
+
+  # -- Affinity rules for the Redis pod
+  affinity: {}
+
+  # -- Node selection rules for the Redis pod
+  nodeSelector: {}
+
+  # -- Pod annotations for the Redis pod
+  podAnnotations: {}
+
+  # -- Tolerations for the Redis pod
+  tolerations: []
+
+# The following will be set by parameters injected by Argo CD and should not
+# be set in the individual environment values files.
+global:
+  # -- Base URL for the environment
+  # @default -- Set by Argo CD
+  baseUrl: null
+
+  # -- Butler repositories accessible via Butler server
+  # @default -- Set by Argo CD
+  butlerServerRepositories: null
+
+  # -- Host name for ingress
+  # @default -- Set by Argo CD
+  host: null
+
+  # -- Base path for Vault secrets
+  # @default -- Set by Argo CD
+  vaultSecretsPath: null


### PR DESCRIPTION
Add a starter for vo-cutouts-style FastAPI Safir apps that use UWS. Update the code underlying phalanx application create so that it will substitute `<CHARTENVPREFIX>` in every template, not just `configmap.yaml`.