### PR TITLE
DM-45503: Add Argo CD auth provider details to docs

### DIFF
--- a/docs/applications/_summary.rst.jinja
+++ b/docs/applications/_summary.rst.jinja
@@ -41,8 +41,8 @@
           {% for env_name in app.active_environments %}
           * - :px-env:`{{ env_name }}`
             - `values <https://github.com/lsst-sqre/phalanx/blob/main/applications/{{ app.name }}/values-{{ env_name }}.yaml>`__
-            {%- if envs[env_name].argocd_url %}
-            - `Argo CD <{{ envs[env_name].argocd_url }}/applications/{{ app.name }}>`__
+            {%- if envs[env_name].argocd.url %}
+            - `Argo CD <{{ envs[env_name].argocd.url }}/applications/{{ app.name }}>`__
             {%- else %}
             -
             {%- endif %}

--- a/docs/environments/_summary.rst.jinja
+++ b/docs/environments/_summary.rst.jinja
@@ -5,9 +5,13 @@
    * - Root domain
      - `{{ env.fqdn }} <https://{{ env.fqdn }}>`__
    * - Identity provider
-     - {{ env.identity_provider.value }}{% if env.identity_provider_hostname %} ({{ env.identity_provider_hostname }}){% endif %}
+     - {{ env.gafaelfawr.provider.value }}{% if env.gafaelfawr.provider_hostname %} ({{ env.gafaelfawr.provider_hostname }}){% endif %}
+   {%- if env.argocd.url %}
    * - Argo CD
-     - {% if env.argocd_url %}{{ env.argocd_url }}{% else %}N/A{% endif %}
+     - {{ env.argocd.url }}
+   {%- endif %}
+   * - Argo CD identity provider
+     - {{ env.argocd.provider.value }}{% if env.argocd.provider_hostname %} ({{ env.argocd.provider_hostname }}){% endif %}
    {%- if env.gcp %}
    * - Google console
      - - `Log Explorer <https://console.cloud.google.com/logs/query?project={{ env.gcp.project_id }}>`__
@@ -41,13 +45,13 @@
             -
             {%- endif %}
           {% endfor %}
-   {%- if env.gafaelfawr_scopes %}
+   {%- if env.gafaelfawr.scopes %}
    * - Gafaelfawr groups
      - .. list-table::
 
           * - Scope
             - Groups
-          {% for scope_groups in env.gafaelfawr_scopes %}
+          {% for scope_groups in env.gafaelfawr.scopes %}
           * - ``{{ scope_groups.scope }}``
             - - {{ scope_groups.groups_as_rst()[0] }}
             {%- if scope_groups.groups|length > 1 %}
@@ -57,13 +61,13 @@
             {%- endif %}
           {%- endfor %}
    {%- endif %}
-   {%- if env.argocd_rbac %}
+   {%- if env.argocd.rbac %}
    * - Argo CD RBAC
      - .. list-table::
 
           * - Role
             - Groups or users
-          {% for role, members in env.argocd_rbac.roles.items() %}
+          {% for role, members in env.argocd.rbac.roles.items() %}
           * - ``{{ role }}``
             - - {{ members[0] }}
             {%- if members|length > 1 %}

--- a/src/phalanx/models/environments.py
+++ b/src/phalanx/models/environments.py
@@ -400,6 +400,7 @@ class IdentityProvider(Enum):
 
     CILOGON = "CILogon"
     GITHUB = "GitHub"
+    GOOGLE = "Google"
     OIDC = "OpenID Connect"
     NONE = "None"
 
@@ -447,6 +448,35 @@ class GafaelfawrScope(BaseModel):
         return result
 
 
+class ArgoCDDetails(BaseModel):
+    """Details about the Argo CD configuration for an environment."""
+
+    provider: IdentityProvider
+    """Type of identity provider used for Argo CD."""
+
+    provider_hostname: str | None = None
+    """Hostname of Argo CD identity provider, if meaningful."""
+
+    rbac: ArgoCDRBAC | None = None
+    """Argo CD RBAC configuration."""
+
+    url: str | None = None
+    """URL for the Argo CD UI."""
+
+
+class GafaelfawrDetails(BaseModel):
+    """Details about the Gafaelfawr configuration for an environment."""
+
+    provider: IdentityProvider
+    """Type of identity provider used by Gafaelfawr in this environment."""
+
+    provider_hostname: str | None = None
+    """Hostname of upstream identity provider, if meaningful."""
+
+    scopes: list[GafaelfawrScope] = []
+    """Gafaelfawr scopes and their associated groups."""
+
+
 class EnvironmentDetails(EnvironmentBaseConfig):
     """Full details about an environment, including auth and Argo CD.
 
@@ -459,20 +489,11 @@ class EnvironmentDetails(EnvironmentBaseConfig):
     applications: list[Application]
     """List of enabled applications."""
 
-    argocd_url: str | None
-    """URL for the Argo CD UI."""
+    argocd: ArgoCDDetails
+    """Details about the Argo CD configuration."""
 
-    argocd_rbac: ArgoCDRBAC | None
-    """Argo CD RBAC configuration."""
-
-    identity_provider: IdentityProvider
-    """Type of identity provider used by Gafaelfawr in this environment."""
-
-    identity_provider_hostname: str | None
-    """Hostname of upstream identity provider, if meaningful."""
-
-    gafaelfawr_scopes: list[GafaelfawrScope]
-    """Gafaelfawr scopes and their associated groups."""
+    gafaelfawr: GafaelfawrDetails
+    """Details about the Gafaelfawr configuration."""
 
 
 class PhalanxConfig(BaseModel):

--- a/src/phalanx/storage/config.py
+++ b/src/phalanx/storage/config.py
@@ -31,10 +31,12 @@ from ..models.applications import (
     Project,
 )
 from ..models.environments import (
+    ArgoCDDetails,
     ArgoCDRBAC,
     Environment,
     EnvironmentConfig,
     EnvironmentDetails,
+    GafaelfawrDetails,
     GafaelfawrScope,
     IdentityProvider,
     PhalanxConfig,
@@ -687,10 +689,58 @@ class ConfigStorage:
         InvalidApplicationConfigError
             Raised if the Gafaelfawr or Argo CD configuration is invalid.
         """
-        # Public URL of Argo CD (or none for environments like minikube).
-        argocd_url = None
-        with suppress(KeyError):
-            argocd_url = argocd.values["argo-cd"]["configs"]["cm"]["url"]
+        return EnvironmentDetails(
+            **config.model_dump(exclude={"applications"}),
+            applications=applications,
+            gafaelfawr=self._build_gafaelfawr_details(config, gafaelfawr),
+            argocd=self._build_argocd_details(argocd),
+        )
+
+    def _build_argocd_details(
+        self, argocd: ApplicationInstance
+    ) -> ArgoCDDetails:
+        """Construct the details of an Argo CD configuration.
+
+        Parameters
+        ----------
+        argocd
+            Argo CD application configuration.
+
+        Returns
+        -------
+        ArgoCDDetails
+            Fleshed-out details for that environment.
+
+        Raises
+        ------
+        InvalidApplicationConfigError
+            Raised if the Gafaelfawr or Argo CD configuration is invalid.
+        """
+        try:
+            config = argocd.values["argo-cd"]["configs"]["cm"]
+        except KeyError:
+            return ArgoCDDetails(provider=IdentityProvider.NONE)
+
+        # Public URL of Argo CD.
+        url = config.get("url")
+
+        # Argo CD identity provider.
+        provider = IdentityProvider.NONE
+        provider_hostname = None
+        if "oidc.config" in config:
+            provider = IdentityProvider.OIDC
+            oidc_config = yaml.safe_load(config["oidc.config"])
+            with suppress(KeyError):
+                provider_hostname = urlparse(oidc_config["issuer"]).hostname
+        elif "dex.config" in config:
+            dex_config = yaml.safe_load(config["dex.config"])
+            with suppress(KeyError):
+                connector = dex_config["connectors"][0]
+                if connector["name"] == "GitHub":
+                    provider = IdentityProvider.GITHUB
+                elif connector["name"] == "Google":
+                    provider = IdentityProvider.GOOGLE
+                    provider_hostname = connector["config"]["hostedDomains"][0]
 
         # Argo CD role-based access control configuration.
         argocd_rbac = None
@@ -698,17 +748,53 @@ class ConfigStorage:
             rbac_config = argocd.values["argo-cd"]["configs"]["rbac"]
             argocd_rbac = ArgoCDRBAC.from_csv(rbac_config["policy.csv"])
 
-        # Type of identity provider used for Gafaelfawr.
-        identity_provider_hostname = None
+        # Return the results.
+        return ArgoCDDetails(
+            provider=provider,
+            provider_hostname=provider_hostname,
+            rbac=argocd_rbac,
+            url=url,
+        )
+
+    def _build_gafaelfawr_details(
+        self,
+        config: EnvironmentConfig,
+        gafaelfawr: ApplicationInstance | None,
+    ) -> GafaelfawrDetails:
+        """Construct the details of a Gafaelfawr configuration.
+
+        Parameters
+        ----------
+        config
+            Configuration for the environment.
+        gafaelfawr
+            Gafaelfawr application configuration, if Gafaelfawr is enabled for
+            this environment.
+
+        Returns
+        -------
+        GafaelfawrDetails
+            Fleshed-out details for that environment.
+
+        Raises
+        ------
+        InvalidApplicationConfigError
+            Raised if the Gafaelfawr or Argo CD configuration is invalid.
+        """
+        if not gafaelfawr:
+            return GafaelfawrDetails(provider=IdentityProvider.NONE)
+
+        # Determine the upstream identity provider.
+        provider_hostname = None
         if gafaelfawr:
             if gafaelfawr.values["config"]["cilogon"]["clientId"]:
-                identity_provider = IdentityProvider.CILOGON
+                provider = IdentityProvider.CILOGON
             elif gafaelfawr.values["config"]["github"]["clientId"]:
-                identity_provider = IdentityProvider.GITHUB
+                provider = IdentityProvider.GITHUB
             elif gafaelfawr.values["config"]["oidc"]["clientId"]:
-                identity_provider = IdentityProvider.OIDC
+                provider = IdentityProvider.OIDC
                 url = gafaelfawr.values["config"]["oidc"]["loginUrl"]
-                identity_provider_hostname = urlparse(url).hostname
+                provider_hostname = urlparse(url).hostname
             else:
                 raise InvalidApplicationConfigError(
                     "gafaelfawr",
@@ -716,40 +802,33 @@ class ConfigStorage:
                     environment=config.name,
                 )
         else:
-            identity_provider = IdentityProvider.NONE
+            provider = IdentityProvider.NONE
 
         # Gafaelfawr scopes. Restructure the data to let Pydantic do most of
         # the parsing.
         gafaelfawr_scopes = []
-        if gafaelfawr:
-            try:
-                group_mapping = gafaelfawr.values["config"]["groupMapping"]
-                for scope, groups in group_mapping.items():
-                    raw = {"scope": scope, "groups": groups}
-                    gafaelfawr_scope = GafaelfawrScope.model_validate(raw)
-                    gafaelfawr_scopes.append(gafaelfawr_scope)
-            except KeyError as e:
-                raise InvalidApplicationConfigError(
-                    "gafaelfawr",
-                    "No config.groupMapping",
-                    environment=config.name,
-                ) from e
-            except ValidationError as e:
-                raise InvalidApplicationConfigError(
-                    "gafaelfawr",
-                    "Invalid config.groupMapping",
-                    environment=config.name,
-                ) from e
+        try:
+            group_mapping = gafaelfawr.values["config"]["groupMapping"]
+            for scope, groups in group_mapping.items():
+                raw = {"scope": scope, "groups": groups}
+                gafaelfawr_scope = GafaelfawrScope.model_validate(raw)
+                gafaelfawr_scopes.append(gafaelfawr_scope)
+        except KeyError as e:
+            raise InvalidApplicationConfigError(
+                "gafaelfawr", "No config.groupMapping", environment=config.name
+            ) from e
+        except ValidationError as e:
+            raise InvalidApplicationConfigError(
+                "gafaelfawr",
+                "Invalid config.groupMapping",
+                environment=config.name,
+            ) from e
 
-        # Return the resulting model.
-        return EnvironmentDetails(
-            **config.model_dump(exclude={"applications"}),
-            applications=applications,
-            argocd_url=argocd_url,
-            argocd_rbac=argocd_rbac,
-            identity_provider=identity_provider,
-            identity_provider_hostname=identity_provider_hostname,
-            gafaelfawr_scopes=sorted(gafaelfawr_scopes, key=lambda s: s.scope),
+        # Return the results.
+        return GafaelfawrDetails(
+            provider=provider,
+            provider_hostname=provider_hostname,
+            scopes=sorted(gafaelfawr_scopes, key=lambda s: s.scope),
         )
 
     def _find_application_namespace(self, application: str) -> str:

--- a/tests/docs/jinja_test.py
+++ b/tests/docs/jinja_test.py
@@ -38,8 +38,10 @@ def test_build_jinja_contexts(factory: Factory) -> None:
         # Check the additional environment information we gather.
         assert idfdev.name == "idfdev"
         assert idfdev.fqdn == "data-dev.lsst.cloud"
-        assert idfdev.argocd_url == "https://data-dev.lsst.cloud/argo-cd"
-        assert idfdev.argocd_rbac.roles == {
+        assert idfdev.argocd.provider == IdentityProvider.GOOGLE
+        assert idfdev.argocd.provider_hostname == "lsst.cloud"
+        assert idfdev.argocd.url == "https://data-dev.lsst.cloud/argo-cd"
+        assert idfdev.argocd.rbac.roles == {
             "role:admin": [
                 "adam@lsst.cloud",
                 "afausti@lsst.cloud",
@@ -58,21 +60,22 @@ def test_build_jinja_contexts(factory: Factory) -> None:
                 "roby@lsst.cloud",
             ],
         }
-        assert idfdev.identity_provider == IdentityProvider.CILOGON
+        assert idfdev.gafaelfawr.provider == IdentityProvider.CILOGON
         assert idfdev.gcp.project_id == "science-platform-dev-7696"
         assert idfdev.gcp.region == "us-central1"
         assert idfdev.gcp.cluster_name == "science-platform"
         assert minikube.name == "minikube"
         assert minikube.fqdn == "minikube.lsst.cloud"
-        assert minikube.argocd_url is None
-        assert minikube.identity_provider == IdentityProvider.GITHUB
+        assert minikube.argocd.provider == IdentityProvider.NONE
+        assert minikube.argocd.url is None
+        assert minikube.gafaelfawr.provider == IdentityProvider.GITHUB
         assert minikube.gcp is None
 
         # Check some of the more complex data.
-        scopes = {s.scope: s.groups_as_rst() for s in idfdev.gafaelfawr_scopes}
+        scopes = {s.scope: s.groups_as_rst() for s in idfdev.gafaelfawr.scopes}
         assert scopes == read_output_json("idfdev", "gafaelfawr-scopes")
         scopes = {
-            s.scope: s.groups_as_rst() for s in minikube.gafaelfawr_scopes
+            s.scope: s.groups_as_rst() for s in minikube.gafaelfawr.scopes
         }
         assert scopes == read_output_json("minikube", "gafaelfawr-scopes")
 


### PR DESCRIPTION
Refactor the `EnvironmentDetails` model to separate the Gafaelfawr and Argo CD information into submodels to make it easier to organize the code. Extract information about the authentication provider used for Argo CD and add it to the environment documentation pages.