### PR TITLE
DM-45281: Update datalinker, vo-cutouts, and butler

### DIFF
--- a/applications/butler/Chart.yaml
+++ b/applications/butler/Chart.yaml
@@ -4,4 +4,4 @@ version: 1.0.0
 description: Server for Butler data abstraction service
 sources:
   - https://github.com/lsst/daf_butler
-appVersion: w.2024.15
+appVersion: w.2024.27

--- a/applications/datalinker/Chart.yaml
+++ b/applications/datalinker/Chart.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 description: IVOA DataLink-based service and data discovery
 sources:
   - https://github.com/lsst-sqre/datalinker
-appVersion: 1.7.1
+appVersion: 3.0.0
 annotations:
   phalanx.lsst.io/docs: |
     - id: "DMTN-238"

--- a/applications/vo-cutouts/Chart.yaml
+++ b/applications/vo-cutouts/Chart.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 description: "Image cutout service complying with IVOA SODA"
 sources:
   - "https://github.com/lsst-sqre/vo-cutouts"
-appVersion: 2.0.0
+appVersion: 3.1.0
 
 dependencies:
   - name: redis

--- a/applications/vo-cutouts/README.md
+++ b/applications/vo-cutouts/README.md
@@ -17,13 +17,13 @@ Image cutout service complying with IVOA SODA
 | cloudsql.instanceConnectionName | string | None, must be set if Cloud SQL is used | Instance connection name for a Cloud SQL PostgreSQL instance |
 | cloudsql.resources | object | See `values.yaml` | Resource limits and requests for the Cloud SQL Proxy container |
 | config.databaseUrl | string | None, must be set if `cloudsql.enabled` is false | URL for the PostgreSQL database if Cloud SQL is not in use |
-| config.lifetime | string | 2592000s (30 days) | Lifetime of job results in safir parse_timedelta format |
+| config.lifetime | string | `"30d"` | Lifetime of job results in Safir `parse_timedelta` format |
 | config.loglevel | string | `"INFO"` | Choose from the text form of Python logging levels |
 | config.pathPrefix | string | `"/api/cutout"` | URL path prefix for the cutout API |
 | config.serviceAccount | string | None, must be set | Google service account with an IAM binding to the `vo-cutouts` Kubernetes service accounts and has the `cloudsql.client` role, access to write to the GCS bucket, and ability to sign URLs as itself |
 | config.slackAlerts | bool | `true` | Whether to send Slack alerts for unexpected failures |
 | config.storageBucketUrl | string | None, must be set | URL for the GCS bucket for results (must start with `gs`) |
-| config.syncTimeout | string | 60s (1 minute) | Timeout for results from a sync cutout in safir parse_timedelta format |
+| config.syncTimeout | string | `"1m"` | Timeout for results from a sync cutout in Safir `parse_timedelta` format |
 | config.timeout | int | 600 (10 minutes) | Timeout for a single cutout job in seconds |
 | cutoutWorker.affinity | object | `{}` | Affinity rules for the cutout worker pod |
 | cutoutWorker.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for cutout workers |

--- a/applications/vo-cutouts/README.md
+++ b/applications/vo-cutouts/README.md
@@ -17,6 +17,7 @@ Image cutout service complying with IVOA SODA
 | cloudsql.instanceConnectionName | string | None, must be set if Cloud SQL is used | Instance connection name for a Cloud SQL PostgreSQL instance |
 | cloudsql.resources | object | See `values.yaml` | Resource limits and requests for the Cloud SQL Proxy container |
 | config.databaseUrl | string | None, must be set if `cloudsql.enabled` is false | URL for the PostgreSQL database if Cloud SQL is not in use |
+| config.gracePeriod | int | `60` | Grace period in seconds to wait for cutout worker jobs to finish |
 | config.lifetime | string | `"30d"` | Lifetime of job results in Safir `parse_timedelta` format |
 | config.loglevel | string | `"INFO"` | Choose from the text form of Python logging levels |
 | config.pathPrefix | string | `"/api/cutout"` | URL path prefix for the cutout API |

--- a/applications/vo-cutouts/README.md
+++ b/applications/vo-cutouts/README.md
@@ -17,13 +17,13 @@ Image cutout service complying with IVOA SODA
 | cloudsql.instanceConnectionName | string | None, must be set if Cloud SQL is used | Instance connection name for a Cloud SQL PostgreSQL instance |
 | cloudsql.resources | object | See `values.yaml` | Resource limits and requests for the Cloud SQL Proxy container |
 | config.databaseUrl | string | None, must be set if `cloudsql.enabled` is false | URL for the PostgreSQL database if Cloud SQL is not in use |
-| config.lifetime | string | 2592000 (30 days) | Lifetime of job results in seconds (quote so that Helm doesn't turn it into a floating point number) |
+| config.lifetime | string | 2592000s (30 days) | Lifetime of job results in safir parse_timedelta format |
 | config.loglevel | string | `"INFO"` | Choose from the text form of Python logging levels |
 | config.pathPrefix | string | `"/api/cutout"` | URL path prefix for the cutout API |
 | config.serviceAccount | string | None, must be set | Google service account with an IAM binding to the `vo-cutouts` Kubernetes service accounts and has the `cloudsql.client` role, access to write to the GCS bucket, and ability to sign URLs as itself |
 | config.slackAlerts | bool | `true` | Whether to send Slack alerts for unexpected failures |
 | config.storageBucketUrl | string | None, must be set | URL for the GCS bucket for results (must start with `gs`) |
-| config.syncTimeout | int | 60 (1 minute) | Timeout for results from a sync cutout in seconds |
+| config.syncTimeout | string | 60s (1 minute) | Timeout for results from a sync cutout in safir parse_timedelta format |
 | config.timeout | int | 600 (10 minutes) | Timeout for a single cutout job in seconds |
 | cutoutWorker.affinity | object | `{}` | Affinity rules for the cutout worker pod |
 | cutoutWorker.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for cutout workers |

--- a/applications/vo-cutouts/templates/configmap.yaml
+++ b/applications/vo-cutouts/templates/configmap.yaml
@@ -9,6 +9,7 @@ data:
   {{- if .Values.cloudsql.enabled }}
   CUTOUT_DATABASE_URL: "postgresql://vo-cutouts@localhost/vo-cutouts"
   {{- end }}
+  CUTOUT_GRACE_PERIOD: {{ .Values.config.gracePeriod | quote }}
   CUTOUT_LIFETIME: {{ .Values.config.lifetime | quote }}
   CUTOUT_SERVICE_ACCOUNT: {{ required "config.serviceAccount must be set" .Values.config.serviceAccount | quote }}
   CUTOUT_STORAGE_URL: {{ required "config.storageBucketUrl must be set" .Values.config.storageBucketUrl | quote }}

--- a/applications/vo-cutouts/templates/worker-deployment.yaml
+++ b/applications/vo-cutouts/templates/worker-deployment.yaml
@@ -75,6 +75,7 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
         runAsGroup: 1000
+      terminationGracePeriodSeconds: {{ .Values.config.gracePeriod }}
       volumes:
         - name: "tmp"
           emptyDir: {}

--- a/applications/vo-cutouts/values.yaml
+++ b/applications/vo-cutouts/values.yaml
@@ -13,10 +13,9 @@ config:
   # @default -- None, must be set if `cloudsql.enabled` is false
   databaseUrl: null
 
-  # -- Lifetime of job results in seconds (quote so that Helm doesn't turn it
-  # into a floating point number)
-  # @default -- 2592000 (30 days)
-  lifetime: "2592000"
+  # -- Lifetime of job results in safir parse_timedelta format
+  # @default -- 2592000s (30 days)
+  lifetime: "2592000s"
 
   # -- Google service account with an IAM binding to the `vo-cutouts`
   # Kubernetes service accounts and has the `cloudsql.client` role, access
@@ -31,9 +30,9 @@ config:
   # @default -- None, must be set
   storageBucketUrl: null
 
-  # -- Timeout for results from a sync cutout in seconds
-  # @default -- 60 (1 minute)
-  syncTimeout: 60
+  # -- Timeout for results from a sync cutout in safir parse_timedelta format
+  # @default -- 60s (1 minute)
+  syncTimeout: "60s"
 
   # -- Timeout for a single cutout job in seconds
   # @default -- 600 (10 minutes)

--- a/applications/vo-cutouts/values.yaml
+++ b/applications/vo-cutouts/values.yaml
@@ -13,6 +13,9 @@ config:
   # @default -- None, must be set if `cloudsql.enabled` is false
   databaseUrl: null
 
+  # -- Grace period in seconds to wait for cutout worker jobs to finish
+  gracePeriod: 60
+
   # -- Lifetime of job results in Safir `parse_timedelta` format
   lifetime: "30d"
 

--- a/applications/vo-cutouts/values.yaml
+++ b/applications/vo-cutouts/values.yaml
@@ -13,9 +13,8 @@ config:
   # @default -- None, must be set if `cloudsql.enabled` is false
   databaseUrl: null
 
-  # -- Lifetime of job results in safir parse_timedelta format
-  # @default -- 2592000s (30 days)
-  lifetime: "2592000s"
+  # -- Lifetime of job results in Safir `parse_timedelta` format
+  lifetime: "30d"
 
   # -- Google service account with an IAM binding to the `vo-cutouts`
   # Kubernetes service accounts and has the `cloudsql.client` role, access
@@ -30,9 +29,9 @@ config:
   # @default -- None, must be set
   storageBucketUrl: null
 
-  # -- Timeout for results from a sync cutout in safir parse_timedelta format
-  # @default -- 60s (1 minute)
-  syncTimeout: "60s"
+  # -- Timeout for results from a sync cutout in Safir `parse_timedelta`
+  # format
+  syncTimeout: "1m"
 
   # -- Timeout for a single cutout job in seconds
   # @default -- 600 (10 minutes)


### PR DESCRIPTION
Update datalinker, vo-cutouts, and butler to their latest releases. These releases have to be updated together due to backwards-incompatible changes to the Butler server API. This release of datalinker drops support for direct Butler and requires client/server Butler.

Update the Phalanx Helm chart for vo-cutouts for the latest release, which changes the format of some time intervals and adds a new grace period configuration option.