### PR TITLE
DM-45572: Move Butler server configuration files into Phalanx

### DIFF
--- a/applications/butler/README.md
+++ b/applications/butler/README.md
@@ -15,6 +15,7 @@ Server for Butler data abstraction service
 | autoscaling.maxReplicas | int | `100` | Maximum number of butler deployment pods |
 | autoscaling.minReplicas | int | `1` | Minimum number of butler deployment pods |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU utilization of butler deployment pods |
+| config.dp02PostgresUri | string | No configuration file for DP02 will be generated. | Postgres connection string pointing to the registry database hosting Data Preview 0.2 data. |
 | config.pathPrefix | string | `"/api/butler"` | The prefix of the path portion of the URL where the Butler service will be exposed.  For example, if the service should be exposed at `https://data.lsst.cloud/api/butler`, this should be set to `/api/butler` |
 | config.pguser | string | Use values specified in per-repository Butler config files. | Postgres username used to connect to the Butler DB |
 | config.repositories | object | `{}` | Mapping from Butler repository label to Butler configuration URI for repositories which will be hosted by this server. |

--- a/applications/butler/templates/configmap.yaml
+++ b/applications/butler/templates/configmap.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: butler
+data:
+{{- if .Values.config.dp02PostgresUri }}
+  dp02.yaml: |
+    datastore:
+      cls: lsst.daf.butler.datastores.chainedDatastore.ChainedDatastore
+      datastore_constraints:
+        # One entry per datastore in datastores section
+        # Use empty `-` if no constraint override required
+        - constraints:
+            reject:
+              - all
+        - constraints:
+            accept:
+              - all
+      datastores:
+        - datastore:
+            name: FileDatastore@s3://butler-us-central1-panda-dev/dc2
+            cls: lsst.daf.butler.datastores.fileDatastore.FileDatastore
+            root: s3://butler-us-central1-panda-dev/dc2
+        - datastore:
+            name: FileDatastore@s3://butler-us-central1-dp02-user
+            cls: lsst.daf.butler.datastores.fileDatastore.FileDatastore
+            root: s3://butler-us-central1-dp02-user/
+            records:
+              table: user_datastore_records
+    registry:
+      db: {{ .Values.config.dp02PostgresUri }}
+      managers:
+        collections: lsst.daf.butler.registry.collections.synthIntKey.SynthIntKeyCollectionManager
+        datasets: lsst.daf.butler.registry.datasets.byDimensions.ByDimensionsDatasetRecordStorageManagerUUID
+        attributes: lsst.daf.butler.registry.attributes.DefaultButlerAttributeManager
+        datastores: lsst.daf.butler.registry.bridge.monolithic.MonolithicDatastoreRegistryBridgeManager
+        dimensions: lsst.daf.butler.registry.dimensions.static.StaticDimensionRecordStorageManager
+        opaque: lsst.daf.butler.registry.opaque.ByNameOpaqueTableStorageManager
+      namespace: dc2_20210215
+{{- end }}

--- a/applications/butler/templates/deployment.yaml
+++ b/applications/butler/templates/deployment.yaml
@@ -13,10 +13,12 @@ spec:
       {{- include "butler.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        # Force the pod to restart when the config maps are updated.
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "butler.selectorLabels" . | nindent 8 }}
     spec:
@@ -60,6 +62,10 @@ spec:
             - name: "butler-secrets"
               mountPath: "/opt/lsst/butler/secrets"
               readOnly: true
+            # Mount configuration files generated in configmap.yaml.
+            - name: config
+              mountPath: "/opt/lsst/butler/config"
+              readOnly: true
       volumes:
         # butler-secrets-raw pulls in the secrets from the vault as files.
         # These files are owned by root and group/world readable.
@@ -76,6 +82,9 @@ spec:
         # Butler application.
         - name: "butler-secrets"
           emptyDir: {}
+        - name: config
+          configMap:
+            name: butler
       initContainers:
         # To deal with the Postgres file permission issued mentioned above,
         # copy the secrets from butler-secrets-raw to butler-secrets.

--- a/applications/butler/values-idfdev.yaml
+++ b/applications/butler/values-idfdev.yaml
@@ -2,6 +2,7 @@ image:
   pullPolicy: Always
 
 config:
+  dp02PostgresUri: postgresql://postgres@sqlproxy-butler-int.sqlproxy-cross-project:5432/dp02
   s3EndpointUrl: "https://storage.googleapis.com"
   repositories:
-    dp02: "s3://butler-us-central1-panda-dev/dc2/butler-external-idfdev.yaml"
+    dp02: "file:///opt/lsst/butler/config/dp02.yaml"

--- a/applications/butler/values-idfint.yaml
+++ b/applications/butler/values-idfint.yaml
@@ -1,4 +1,5 @@
 config:
+  dp02PostgresUri: postgresql://postgres@sqlproxy-butler-int.sqlproxy-cross-project:5432/dp02
   s3EndpointUrl: "https://storage.googleapis.com"
   repositories:
-    dp02: "s3://butler-us-central1-panda-dev/dc2/butler-external.yaml"
+    dp02: "file:///opt/lsst/butler/config/dp02.yaml"

--- a/applications/butler/values-idfprod.yaml
+++ b/applications/butler/values-idfprod.yaml
@@ -1,5 +1,5 @@
 config:
+  dp02PostgresUri: postgresql://postgres@10.163.0.3/idfdp02
   s3EndpointUrl: "https://storage.googleapis.com"
   repositories:
-    dp01: "s3://butler-us-central1-dp01/"
-    dp02: "s3://butler-us-central1-dp02-user/"
+    dp02: "file:///opt/lsst/butler/config/dp02.yaml"

--- a/applications/butler/values.yaml
+++ b/applications/butler/values.yaml
@@ -75,6 +75,11 @@ config:
   # repositories which will be hosted by this server.
   repositories: {}
 
+  # -- Postgres connection string pointing to the registry database hosting
+  # Data Preview 0.2 data.
+  # @default -- No configuration file for DP02 will be generated.
+  dp02PostgresUri: ""
+
   # -- Postgres username used to connect to the Butler DB
   # @default -- Use values specified in per-repository Butler config files.
   pguser: ""


### PR DESCRIPTION
Butler configuration files on IDF were previously hosted in an S3 bucket, which is difficult to manage and not version controlled.  They are now injected from Phalanx as a ConfigMap instead.