### PR TITLE
DM-45620: Removed unused butlerRepositoryIndex config

### DIFF
--- a/applications/datalinker/README.md
+++ b/applications/datalinker/README.md
@@ -24,10 +24,8 @@ IVOA DataLink-based service and data discovery
 | config.slackAlerts | bool | `false` | Whether to send certain serious alerts to Slack. If `true`, the `slack-webhook` secret must also be set. |
 | config.storageBackend | string | `"GCS"` | Storage backend to use (either `GCS` or `S3`) |
 | config.tapMetadataUrl | string | `"https://github.com/lsst/sdm_schemas/releases/download/1.2.0/datalink-columns.zip"` | URL containing TAP schema metadata used to construct queries |
-| config.useButlerServer | bool | `true` | If true, use Butler in client/server mode instead of connecting directly to the Butler database |
 | fullnameOverride | string | `""` | Override the full name for resources (includes the release name) |
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |
-| global.butlerRepositoryIndex | string | Set by Argo CD | URI to the Butler configuration of available repositories |
 | global.butlerServerRepositories | string | Set by Argo CD | Butler repositories accessible via Butler server |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |

--- a/applications/datalinker/templates/deployment.yaml
+++ b/applications/datalinker/templates/deployment.yaml
@@ -72,13 +72,8 @@ spec:
             # and authenticate to its database.
             - name: "AWS_SHARED_CREDENTIALS_FILE"
               value: "/tmp/secrets/aws-credentials.ini"
-            {{- if .Values.config.useButlerServer }}
             - name: "DAF_BUTLER_REPOSITORIES"
               value: {{ .Values.global.butlerServerRepositories | b64dec | quote }}
-            {{- else }}
-            - name: "DAF_BUTLER_REPOSITORY_INDEX"
-              value: {{ .Values.global.butlerRepositoryIndex | quote }}
-            {{- end }}
             - name: "PGUSER"
               value: {{ .Values.config.pgUser }}
             - name: "PGPASSFILE"

--- a/applications/datalinker/values.yaml
+++ b/applications/datalinker/values.yaml
@@ -61,10 +61,6 @@ config:
   # -- Whether to use the new secrets management scheme
   separateSecrets: false
 
-  # -- If true, use Butler in client/server mode instead of connecting
-  # directly to the Butler database
-  useButlerServer: true
-
   # -- User to use from the PGPASSFILE if datalinker is using a direct Butler
   # connection (`useButlerServer` is false)
   pgUser: "rubin"
@@ -101,10 +97,6 @@ global:
   # -- Base URL for the environment
   # @default -- Set by Argo CD
   baseUrl: ""
-
-  # -- URI to the Butler configuration of available repositories
-  # @default -- Set by Argo CD
-  butlerRepositoryIndex: ""
 
   # -- Butler repositories accessible via Butler server
   # @default -- Set by Argo CD

--- a/docs/developers/injected-values.rst
+++ b/docs/developers/injected-values.rst
@@ -41,9 +41,6 @@ Optional injected values
 
 The following additional values are not normally injected by the default ``Application`` template but can be added if needed by adding a new entry to the ``spec.source.helm.parameters`` key of the ``Application`` resource template.
 
-``global.butlerRepositoryIndex``
-    The URI for the Butler index for this environment, used by services that connect directly to the Butler database without using the Butler server.
-
 ``global.butlerServerRepositories``
     A mapping from Butler repository labels to URIs that is used by applications that talk to the Butler server.
     Since this is a complex data structure, it has to be injected as a base64-encoded value to prevent Helm from misinterpreting it:

--- a/docs/extras/schemas/environment.json
+++ b/docs/extras/schemas/environment.json
@@ -189,19 +189,6 @@
       "description": "Name of the parent Argo CD app-of-apps that manages all of the enabled applications. This is required in the merged values file that includes environment overrides, but the environment override file doesn't need to set it, so it's marked as optional for schema checking purposes to allow the override file to be schema-checked independently.",
       "title": "Argo CD app-of-apps name"
     },
-    "butlerRepositoryIndex": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "description": "URL to Butler repository index",
-      "title": "Butler repository index URL"
-    },
     "butlerServerRepositories": {
       "anyOf": [
         {

--- a/environments/README.md
+++ b/environments/README.md
@@ -73,7 +73,6 @@
 | applications.vault | bool | `false` | Enable the vault application. This is the actual vault storage and there should only be one production and one development instance globally. |
 | applications.vault-secrets-operator | bool | `true` | Enable the vault-secrets-operator application. This is required for all environments. |
 | applications.vo-cutouts | bool | `false` | Enable the vo-cutouts application |
-| butlerRepositoryIndex | string | None, must be set | Butler repository index URI to use for this environment, for services that connect directly to the Butler database. |
 | butlerServerRepositories | object | None, must be set | Butler repositories that can be accessed via Butler server, as a dictionary from repository label to URI. |
 | controlSystem.appNamespace | string | None, must be set | Application namespacce for the control system deployment |
 | controlSystem.imageTag | string | None, must be set | Image tag for the control system deployment |

--- a/environments/templates/applications/rsp/datalinker.yaml
+++ b/environments/templates/applications/rsp/datalinker.yaml
@@ -24,8 +24,6 @@ spec:
       parameters:
         - name: "global.baseUrl"
           value: "https://{{ .Values.fqdn }}"
-        - name: "global.butlerRepositoryIndex"
-          value: {{ .Values.butlerRepositoryIndex | quote }}
         - name: "global.butlerServerRepositories"
           value: {{ .Values.butlerServerRepositories | toJson | b64enc }}
         - name: "global.host"

--- a/environments/templates/applications/rsp/vo-cutouts.yaml
+++ b/environments/templates/applications/rsp/vo-cutouts.yaml
@@ -24,8 +24,6 @@ spec:
       parameters:
         - name: "global.baseUrl"
           value: "https://{{ .Values.fqdn }}"
-        - name: "global.butlerRepositoryIndex"
-          value: {{ .Values.butlerRepositoryIndex | quote }}
         - name: "global.butlerServerRepositories"
           value: {{ .Values.butlerServerRepositories | toJson | b64enc }}
         - name: "global.host"

--- a/environments/values-idfdemo.yaml
+++ b/environments/values-idfdemo.yaml
@@ -1,7 +1,6 @@
 name: "idfdemo"
 fqdn: "demo.lsst.cloud"
 appOfAppsName: "science-platform"
-butlerRepositoryIndex: "s3://butler-us-central1-repo-locations/data-dev-repos.yaml"
 butlerServerRepositories:
   dp02: "https://demo.lsst.cloud/api/butler/repo/dp02/butler.yaml"
 gcp:

--- a/environments/values-idfdev.yaml
+++ b/environments/values-idfdev.yaml
@@ -1,7 +1,6 @@
 name: "idfdev"
 fqdn: "data-dev.lsst.cloud"
 appOfAppsName: "science-platform"
-butlerRepositoryIndex: "s3://butler-us-central1-repo-locations/data-dev-repos.yaml"
 butlerServerRepositories:
   dp02: "https://data-dev.lsst.cloud/api/butler/repo/dp02/butler.yaml"
 gcp:

--- a/environments/values-idfint.yaml
+++ b/environments/values-idfint.yaml
@@ -1,7 +1,6 @@
 name: "idfint"
 fqdn: "data-int.lsst.cloud"
 appOfAppsName: "science-platform"
-butlerRepositoryIndex: "s3://butler-us-central1-repo-locations/data-int-repos.yaml"
 butlerServerRepositories:
   dp02: "https://data-int.lsst.cloud/api/butler/repo/dp02/butler.yaml"
 gcp:

--- a/environments/values-idfprod.yaml
+++ b/environments/values-idfprod.yaml
@@ -1,7 +1,6 @@
 name: "idfprod"
 fqdn: "data.lsst.cloud"
 appOfAppsName: "science-platform"
-butlerRepositoryIndex: "s3://butler-us-central1-repo-locations/data-repos.yaml"
 butlerServerRepositories:
   dp01: "https://data.lsst.cloud/api/butler/repo/dp01/butler.yaml"
   dp02: "https://data.lsst.cloud/api/butler/repo/dp02/butler.yaml"

--- a/environments/values-usdfdev.yaml
+++ b/environments/values-usdfdev.yaml
@@ -1,7 +1,6 @@
 fqdn: "usdf-rsp-dev.slac.stanford.edu"
 name: "usdfdev"
 appOfAppsName: "science-platform"
-butlerRepositoryIndex: "s3://rubin-summit-users/data-repos.yaml"
 butlerServerRepositories:
   embargo: "https://usdf-rsp-dev.slac.stanford.edu/api/butler/repo/embargo/butler.yaml"
 vaultUrl: "https://vault.slac.stanford.edu"

--- a/environments/values-usdfint.yaml
+++ b/environments/values-usdfint.yaml
@@ -1,7 +1,6 @@
 fqdn: "usdf-rsp-int.slac.stanford.edu"
 name: "usdfint"
 appOfAppsName: "science-platform"
-butlerRepositoryIndex: "s3://rubin-summit-users/data-repos.yaml"
 butlerServerRepositories:
   embargo: "https://usdf-rsp-int.slac.stanford.edu/api/butler/repo/embargo/butler.yaml"
 vaultUrl: "https://vault.slac.stanford.edu"

--- a/environments/values-usdfprod.yaml
+++ b/environments/values-usdfprod.yaml
@@ -1,7 +1,6 @@
 fqdn: "usdf-rsp.slac.stanford.edu"
 name: "usdfprod"
 appOfAppsName: "science-platform"
-butlerRepositoryIndex: "s3://rubin-summit-users/data-repos.yaml"
 butlerServerRepositories:
   embargo: "https://usdf-rsp.slac.stanford.edu/api/butler/repo/embargo/butler.yaml"
 vaultUrl: "https://vault.slac.stanford.edu"

--- a/environments/values.yaml
+++ b/environments/values.yaml
@@ -12,11 +12,6 @@ fqdn: ""
 # enabled for this environment
 appOfAppsName: "app-of-apps"
 
-# -- Butler repository index URI to use for this environment, for services that
-# connect directly to the Butler database.
-# @default -- None, must be set
-butlerRepositoryIndex: ""
-
 # -- Butler repositories that can be accessed via Butler server, as a
 # dictionary from repository label to URI.
 # @default -- None, must be set

--- a/src/phalanx/models/environments.py
+++ b/src/phalanx/models/environments.py
@@ -180,12 +180,6 @@ class EnvironmentBaseConfig(CamelCaseModel):
         ),
     )
 
-    butler_repository_index: str | None = Field(
-        None,
-        title="Butler repository index URL",
-        description="URL to Butler repository index",
-    )
-
     butler_server_repositories: dict[str, AnyUrl] | None = Field(
         None,
         title="Butler repositories accessible via Butler server",

--- a/src/phalanx/services/application.py
+++ b/src/phalanx/services/application.py
@@ -283,9 +283,6 @@ class ApplicationService:
         if environment.gcp:
             values["global.gcpProjectId"] = environment.gcp.project_id
             values["global.gcpRegion"] = environment.gcp.region
-        if environment.butler_repository_index:
-            butler_index = environment.butler_repository_index
-            values["global.butlerRepositoryIndex"] = butler_index
         if environment.butler_server_repositories:
             butler_repos = {
                 k: str(v)


### PR DESCRIPTION
The environment-global configuration item`butlerRepositoryIndex` appears to be unused now that datalinker and vo-cutouts have dropped support for DirectButler, so it can be removed.  (nublado always separately hardcoded this path in its own configuration, and nothing else is using it.)