### PR TITLE
DM-45307: Move UWS databases for all idfs to CloudSQL & upgrade TAP images

### DIFF
--- a/applications/ssotap/values-idfdev.yaml
+++ b/applications/ssotap/values-idfdev.yaml
@@ -2,3 +2,9 @@ cadc-tap:
   tapSchema:
     image:
       repository: "lsstsqre/tap-schema-idfdev-sso"
+
+  cloudsql:
+    enabled: true
+    instanceConnectionName: "science-platform-dev-7696:us-central1:science-platform-dev-e9e11de2"
+    serviceAccount: "ssotap@science-platform-dev-7696.iam.gserviceaccount.com"
+    database: "ssotap"

--- a/applications/ssotap/values-idfint.yaml
+++ b/applications/ssotap/values-idfint.yaml
@@ -2,3 +2,9 @@ cadc-tap:
   tapSchema:
     image:
       repository: "lsstsqre/tap-schema-idfint-sso"
+
+  cloudsql:
+    enabled: true
+    instanceConnectionName: "science-platform-int-dc5d:us-central1:science-platform-int-8f439af2"
+    serviceAccount: "ssotap@science-platform-int-dc5d.iam.gserviceaccount.com"
+    database: "ssotap"

--- a/applications/ssotap/values-idfprod.yaml
+++ b/applications/ssotap/values-idfprod.yaml
@@ -2,3 +2,9 @@ cadc-tap:
   tapSchema:
     image:
       repository: "lsstsqre/tap-schema-idfprod-sso"
+
+  cloudsql:
+    enabled: true
+    instanceConnectionName: "science-platform-stable-6994:us-central1:science-platform-stable-0c29612b"
+    serviceAccount: "ssotap@science-platform-stable-6994.iam.gserviceaccount.com"
+    database: "ssotap"

--- a/applications/tap/secrets-idfdev.yaml
+++ b/applications/tap/secrets-idfdev.yaml
@@ -1,3 +1,7 @@
 uws-db-password:
   description: >-
     Password for external UWS PostgreSQL server
+qserv-password:
+  description: >-
+    Password for the QServ database server
+  if: cadc-tap.config.qserv.passwordEnabled

--- a/applications/tap/values-idfdev.yaml
+++ b/applications/tap/values-idfdev.yaml
@@ -5,5 +5,12 @@ cadc-tap:
 
   config:
     qserv:
-      host: "10.140.1.211:4040"
-      # Change to 134.79.23.209:4040 to point to USDF qserv
+      host: "qserv-int.slac.stanford.edu:4090"
+      jdbcParams: "?enabledTLSProtocols=TLSv1.3"
+      passwordEnabled: true
+
+  cloudsql:
+    enabled: true
+    instanceConnectionName: "science-platform-dev-7696:us-central1:science-platform-dev-e9e11de2"
+    serviceAccount: "tap-service@science-platform-dev-7696.iam.gserviceaccount.com"
+    database: "tap"

--- a/applications/tap/values-idfint.yaml
+++ b/applications/tap/values-idfint.yaml
@@ -6,5 +6,11 @@ cadc-tap:
   config:
     qserv:
       host: "qserv-int.slac.stanford.edu:4090"
-      jdbcParams: "?enabledTLSProtocols=TLSv1.2"
+      jdbcParams: "?enabledTLSProtocols=TLSv1.3"
       passwordEnabled: true
+
+  cloudsql:
+    enabled: true
+    instanceConnectionName: "science-platform-int-dc5d:us-central1:science-platform-int-8f439af2"
+    serviceAccount: "tap-service@science-platform-int-dc5d.iam.gserviceaccount.com"
+    database: "tap"

--- a/applications/tap/values-idfprod.yaml
+++ b/applications/tap/values-idfprod.yaml
@@ -6,3 +6,9 @@ cadc-tap:
   config:
     qserv:
       host: "10.140.1.211:4040"
+
+  cloudsql:
+    enabled: true
+    instanceConnectionName: "science-platform-stable-6994:us-central1:science-platform-stable-0c29612b"
+    serviceAccount: "tap-service@science-platform-stable-6994.iam.gserviceaccount.com"
+    database: "tap"

--- a/charts/cadc-tap/README.md
+++ b/charts/cadc-tap/README.md
@@ -31,12 +31,12 @@ IVOA TAP service
 | config.pg.host | string | None, must be set if backend is `pg` | Host to connect to |
 | config.pg.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the TAP image |
 | config.pg.image.repository | string | `"ghcr.io/lsst-sqre/tap-postgres-service"` | TAP image to use |
-| config.pg.image.tag | string | `"1.16.0"` | Tag of TAP image to use |
+| config.pg.image.tag | string | `"1.18.5"` | Tag of TAP image to use |
 | config.pg.username | string | None, must be set if backend is `pg` | Username to connect with |
 | config.qserv.host | string | `"mock-db:3306"` (the mock QServ) | QServ hostname:port to connect to |
 | config.qserv.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the TAP image |
 | config.qserv.image.repository | string | `"ghcr.io/lsst-sqre/lsst-tap-service"` | TAP image to use |
-| config.qserv.image.tag | string | `"2.2.0"` | Tag of TAP image to use |
+| config.qserv.image.tag | string | `"2.4.7"` | Tag of TAP image to use |
 | config.qserv.jdbcParams | string | `""` | Extra JDBC connection parameters |
 | config.qserv.passwordEnabled | bool | false | Whether the Qserv database is password protected |
 | config.tapSchemaAddress | string | `"cadc-tap-schema-db:3306"` | Address to a MySQL database containing TAP schema data |
@@ -78,7 +78,7 @@ IVOA TAP service
 | uws.affinity | object | `{}` | Affinity rules for the UWS database pod |
 | uws.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the UWS database image |
 | uws.image.repository | string | `"ghcr.io/lsst-sqre/lsst-tap-uws-db"` | UWS database image to use |
-| uws.image.tag | string | `"2.2.0"` | Tag of UWS database image to use |
+| uws.image.tag | string | `"2.4.7"` | Tag of UWS database image to use |
 | uws.nodeSelector | object | `{}` | Node selection rules for the UWS database pod |
 | uws.podAnnotations | object | `{}` | Annotations for the UWS databse pod |
 | uws.resources | object | See `values.yaml` | Resource limits and requests for the UWS database pod |

--- a/charts/cadc-tap/templates/configmap.yaml
+++ b/charts/cadc-tap/templates/configmap.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cadc-tap-config
+  labels:
+    {{- include "cadc-tap.labels" . | nindent 4 }}
+data:
+  cadc-registry.properties: |
+    ivo://ivoa.net/sso#OpenID = {{ .Values.global.baseUrl }}/auth/cadc
+  catalina.properties: |
+    # tomcat properties
+    tomcat.connector.connectionTimeout=20000
+    tomcat.connector.keepAliveTimeout=120000
+    tomcat.connector.secure=false
+    tomcat.connector.scheme=http
+    tomcat.connector.proxyName={{ .Values.global.host }}
+    tomcat.connector.proxyPort=80
+
+    # authentication provider
+    ca.nrc.cadc.auth.IdentityManager=org.opencadc.auth.StandardIdentityManager

--- a/charts/cadc-tap/templates/tap-deployment.yaml
+++ b/charts/cadc-tap/templates/tap-deployment.yaml
@@ -82,7 +82,6 @@ spec:
                 -Dtap.password=$TAP_DB_PASSWORD
                 -Dtap.url=jdbc:postgresql://{{ .Values.config.pg.host }}/{{ .Values.config.pg.database }}
                 -Dtap.maxActive=100
-                -Dca.nrc.cadc.auth.Authenticator=ca.nrc.cadc.sample.AuthenticatorImpl
                 {{- end }}
                 {{- if eq .Values.config.backend "qserv" }}
                 -Dqservuser.username=qsmaster
@@ -90,15 +89,14 @@ spec:
                 -Dqservuser.driverClassName=com.mysql.cj.jdbc.Driver
                 -Dqservuser.url=jdbc:mysql://{{ .Values.config.qserv.host }}/{{ .Values.config.qserv.jdbcParams }}
                 -Dqservuser.maxActive=100
-                -Dca.nrc.cadc.auth.Authenticator=org.opencadc.tap.impl.AuthenticatorImpl
                 {{- end }}
-                -Dca.nrc.cadc.reg.client.RegistryClient.local=true
                 -Dgafaelfawr_url={{ .Values.global.baseUrl }}/auth/api/v1/user-info
                 -Dgcs_bucket={{ .Values.config.gcsBucket }}
                 -Dgcs_bucket_url={{ .Values.config.gcsBucketUrl }}
                 -Dgcs_bucket_type={{ .Values.config.gcsBucketType }}
                 -Dbase_url={{ .Values.global.baseUrl }}
-                -Dca.nrc.cadc.util.PropertiesReader.dir=/etc/creds/
+                -Dpath_prefix=/api/{{ .Values.ingress.path }}
+                -Dca.nrc.cadc.util.PropertiesReader.dir=/config/
                 -Xmx{{ .Values.config.jvmMaxHeapSize }}
             {{- if (and (eq .Values.config.backend "qserv") .Values.config.qserv.passwordEnabled) }}
             - name: "QSERV_DB_PASSWORD"
@@ -149,6 +147,8 @@ spec:
               readOnly: true
             - name: "tmp"
               mountPath: "/tmp"
+            - name: "config-volume"
+              mountPath: "/config"
           livenessProbe:
             failureThreshold: 3
             httpGet:
@@ -165,6 +165,9 @@ spec:
             secretName: "cadc-tap"
         - name: "tmp"
           emptyDir: {}
+        - name: "config-volume"
+          configMap:
+            name: "cadc-tap-config"
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/cadc-tap/values.yaml
+++ b/charts/cadc-tap/values.yaml
@@ -71,7 +71,7 @@ config:
       pullPolicy: "IfNotPresent"
 
       # -- Tag of TAP image to use
-      tag: "1.16.0"
+      tag: "1.18.5"
 
   qserv:
     # -- QServ hostname:port to connect to
@@ -89,7 +89,7 @@ config:
       pullPolicy: "IfNotPresent"
 
       # -- Tag of TAP image to use
-      tag: "2.2.0"
+      tag: "2.4.7"
 
     # -- Whether the Qserv database is password protected
     # @default -- false
@@ -195,7 +195,7 @@ uws:
     pullPolicy: "IfNotPresent"
 
     # -- Tag of UWS database image to use
-    tag: "2.2.0"
+    tag: "2.4.7"
 
   # -- Resource limits and requests for the UWS database pod
   # @default -- See `values.yaml`


### PR DESCRIPTION
**Summary:**

Move UWS databases for all idfs to CloudSQL & upgrade TAP images

**Detailed Description:**

This PR includes the following changes to phalanx:

- Enable cloudsql on all the idfs to move the UWS database to CloudSQL for the ssotap & tap applications
- Upgrade TAP to version 2.4.7
- Upgrade tap-postgres to version 1.18.5
- Add -Dpath_prefix param, needed by the upgraded version of TAP (Lets it know what the path is for generating the redirect URLs)
- Move tap config to /config on the tomcat container, needed by the upgraded TAP version (upstream cadc changes)
- Move idfdev to use the new int QServ that is password protected
- Change idfdev & idfint TAP services to use TLSv1.3 for the QServ connection (This is enabled via upgrade to mysql connector in the newer TAP releases)

The TAP version for tap-postgres (ssotap) & lsst-tap-service (tap) jumps up quite a few versions from what is currently released on prod & available on phalanx/main.
- lsst-tap-service (2.2.0 -> 2.4.7)
- tap-postgres (1.16.0 -> 1.18.5)

This generally shouldn't be the case and is an exception hopefully for this one and the reason was that we deployed an newer release which ran fine for a couple weeks, but eventually we got a series of operations failures where TAP service queries were getting stuck in "QUEUED" phase https://rubinobs.atlassian.net/browse/DM-45307. 
We then rolled back to 2.2.0 while trying to reproduce bug, and simultaneously working on other upgrades. 
While I haven't been able to reproduce the issue, I think the cause was a change to the uws pool settings which has been reverted in the release proposed here. 


**Detailed Description of lsst-tap-service release**

- Remove cadc-tap log package from logLevelPackages & Add header to log4j.xml
- Change authentication provider in QueryJobManager
- Upgrade version of uws-server to 1.2.21
- Upgrade log4j
- Fixed Capabilities handling. Use new CapGetAction & CapInitAction, modified by getting pathPrefix from ENV property
- Change result handling, to use a redirect servlet. Addresses issue with async failing due to auth header propagation with clients like pyvo, topcat
- Upgrade mysql connector to 8.4.0
- Added UWSInitAction class to initialise a UWS database
- Changed Dockerfile for lsst-tap-service to use cadc-tomcat base image
- Deprecated AuthenticatorImpl class
- Fixed capabilities output to be IVOA valid


**Detailed Description of tap-postgres release**

- Fix issue with ownerID missing
- Changed QueryJobManager to use the IdentityManager available via the AuthenticationUtil class (OpenID in our case)
- Upgrade version of uws-server to 1.2.21
- Upgrade log4j
- Fix stilts conflict issue
- Move to using cadc docker base image for TAP
- Fixed broken build due to centos base image EOL
- Change result handling, to use a redirect servlet. Addresses issue with async failing due to auth header propagation with clients like pyvo, topcat
- Fixed Capabilities handling. Use new CapGetAction & CapInitAction, modified by getting pathPrefix from ENV property
- Upgrade mysql-connector to 8.4.0
- Fixed Capabilities based on standard, mainly Table Access and authentication related
- Added PgsphereDeParser to AdqlQueryImpl / Fixes issue with queries having quotes around column names ("size")
- Updated cadc libraries to more recent version. Moved to using the cadc-tomcat Docker image


## Related Issue(s)

https://rubinobs.atlassian.net/browse/DM-45307
https://rubinobs.atlassian.net/browse/DM-45354
https://rubinobs.atlassian.net/browse/DM-45528
https://rubinobs.atlassian.net/browse/DM-45320
https://rubinobs.atlassian.net/browse/DM-45320
https://rubinobs.atlassian.net/browse/DM-44877

## Steps used to Test
- Point ArgoCD to branch and sync
- Run validation suite which does the following:
   - Run some basic queries via Portal
   - Run 4 of the tutorials via Nublado
   - Run a query to ssotap & tap with single user & 10 concurrent users scenarios
   - Validate capabilities endpoint

- Run taplint on prod & PR version and compare

        Prod - Totals: Errors: 70; Warnings: 694; Infos: 143; Summaries: 18; Failures: 3
        PR - Totals: Errors: 92; Warnings: 2; Infos: 155; Summaries: 21; Failures: 3

I think the reason for the additional errors are that the version on prod has an invalid capabilities endpoint, which leads to several tests like the obscore model not being tested:

        Section OBS: Test implementation of ObsCore Data Model
        I-OBS-NODM-1 Table capabilities lists no ObsCore DataModel - no ObsCore tests


The Errors that appear can be stripped down to the following:

        E-OBS-CUTP-1 Wrong Utype in ObsCore column .. 
        E-OBS-OCOL-2 Required ObsCore column .. is missing
        
        E-MDQ-QERR-6 Failed TAP query SELECT TOP 1 * FROM uws.Job (Known issue, uws is not queryable, will be removed soon)
        
        E-MDQ-QERR-5 Failed TAP query SELECT TOP 1 * FROM dp01_dc2_catalogs.truth_match (Known issue, uws is not queryable, will be removed soon from tap schema)
        
        E-TMS-TSSZ-5 Size does not match arraysize for vector: dp02_dc2_catalogs.DiaSource.filterName: arraysize=1; size=null (Fixed in sdm_schemas, new version should fix error when added to phalanx)