### PR TITLE
DM-45518: Enable OpenTelemetry input for Telegraf

### DIFF
--- a/applications/gafaelfawr/README.md
+++ b/applications/gafaelfawr/README.md
@@ -55,6 +55,7 @@ Authentication and identity system
 | config.ldap.userDn | string | Use anonymous binds | Bind DN for simple bind authentication. If set, `ldap-secret` must be set in the Gafaelfawr Vault secret. Set this or `kerberosConfig`, not both. |
 | config.ldap.userSearchAttr | string | `"uid"` | Search attribute containing the user's username |
 | config.logLevel | string | `"INFO"` | Choose from the text form of Python logging levels |
+| config.metricsUrl | string | `"http://telegraf.telegraf:4317"` | URL of an OpenTelemetry collector to which to send metrics |
 | config.oidc.audience | string | Same as `clientId` | Audience (`aud` claim) to expect in ID tokens. |
 | config.oidc.clientId | string | `nil` | Client ID for generic OpenID Connect support. One and only one of this, `config.cilogon.clientId`, or `config.github.clientId` must be set. |
 | config.oidc.enrollmentUrl | string | Login fails with an error | Where to send the user if their username cannot be found in LDAP |

--- a/applications/gafaelfawr/values-idfdev.yaml
+++ b/applications/gafaelfawr/values-idfdev.yaml
@@ -1,3 +1,7 @@
+image:
+  tag: "tickets-DM-45518"
+  pullPolicy: "Always"
+
 # Use the CSI storage class so that we can use snapshots.
 redis:
   persistence:

--- a/applications/gafaelfawr/values.yaml
+++ b/applications/gafaelfawr/values.yaml
@@ -62,6 +62,9 @@ config:
   # -- Choose from the text form of Python logging levels
   logLevel: "INFO"
 
+  # -- URL of an OpenTelemetry collector to which to send metrics
+  metricsUrl: "http://telegraf.telegraf:4317"
+
   # -- List of netblocks used for internal Kubernetes IP addresses, used to
   # determine the true client IP for logging
   # @default -- [`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`]

--- a/applications/telegraf/README.md
+++ b/applications/telegraf/README.md
@@ -18,16 +18,14 @@ Application telemetry collection service
 | global.host | string | Set by Argo CD | Host name for instance identification |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | prometheus_config | object | `{"argocd":{"application_controller":"http://argocd-application-controller-metrics.argocd.svc:8082/metrics","notifications_controller":"http://argocd-notifications-controller-metrics.argocd.svc:9001/metrics","repo_server":"http://argocd-repo-server-metrics.argocd.svc:8084/metrics","server":"http://argocd-server-metrics.argocd.svc:8083/metrics"},"ingress-nginx":{"controller":"http://ingress-nginx-controller-metrics.ingress-nginx:10254/metrics"},"nublado":{"hub":"http://hub.nublado:8081/metrics"}}` | Use prometheus_config to specify all the services in the RSP that expose prometheus endpoints.  A better option, eventually, will be to use telegraf-operator and capture these as pod annotations. |
-| telegraf.args[0] | string | `"--config"` |  |
-| telegraf.args[1] | string | `"/etc/telegraf-generated/telegraf-generated.conf"` |  |
-| telegraf.config.inputs | list | `[]` |  |
-| telegraf.config.outputs | list | `[]` |  |
-| telegraf.config.processors | list | `[]` |  |
+| telegraf.config.inputs[0].opentelemetry.service_address | string | `":4317"` |  |
+| telegraf.config.outputs[0].influxdb_v2.bucket | string | `"opentelemetry"` |  |
+| telegraf.config.outputs[0].influxdb_v2.organization | string | `"square"` |  |
+| telegraf.config.outputs[0].influxdb_v2.token | string | `"$INFLUX_TOKEN"` |  |
+| telegraf.config.outputs[0].influxdb_v2.urls[0] | string | `"https://monitoring.lsst.cloud"` |  |
 | telegraf.env[0].name | string | `"INFLUX_TOKEN"` |  |
 | telegraf.env[0].valueFrom.secretKeyRef.key | string | `"influx-token"` |  |
 | telegraf.env[0].valueFrom.secretKeyRef.name | string | `"telegraf"` |  |
-| telegraf.mountPoints[0].mountPath | string | `"/etc/telegraf-generated"` |  |
-| telegraf.mountPoints[0].name | string | `"telegraf-generated-config"` |  |
 | telegraf.podLabels."hub.jupyter.org/network-access-hub" | string | `"true"` |  |
 | telegraf.rbac.clusterWide | bool | `true` |  |
 | telegraf.resources.limits.cpu | string | `"1"` |  |
@@ -35,5 +33,3 @@ Application telemetry collection service
 | telegraf.resources.requests.cpu | string | `"50m"` |  |
 | telegraf.resources.requests.memory | string | `"350Mi"` |  |
 | telegraf.tplVersion | int | `2` |  |
-| telegraf.volumes[0].configMap.name | string | `"telegraf-generated-config"` |  |
-| telegraf.volumes[0].name | string | `"telegraf-generated-config"` |  |

--- a/applications/telegraf/README.md
+++ b/applications/telegraf/README.md
@@ -19,7 +19,7 @@ Application telemetry collection service
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | prometheus_config | object | `{"argocd":{"application_controller":"http://argocd-application-controller-metrics.argocd.svc:8082/metrics","notifications_controller":"http://argocd-notifications-controller-metrics.argocd.svc:9001/metrics","repo_server":"http://argocd-repo-server-metrics.argocd.svc:8084/metrics","server":"http://argocd-server-metrics.argocd.svc:8083/metrics"},"ingress-nginx":{"controller":"http://ingress-nginx-controller-metrics.ingress-nginx:10254/metrics"},"nublado":{"hub":"http://hub.nublado:8081/metrics"}}` | Use prometheus_config to specify all the services in the RSP that expose prometheus endpoints.  A better option, eventually, will be to use telegraf-operator and capture these as pod annotations. |
 | telegraf.config.inputs[0].opentelemetry.service_address | string | `":4317"` |  |
-| telegraf.config.outputs[0].influxdb_v2.bucket | string | `"opentelemetry"` |  |
+| telegraf.config.outputs[0].influxdb_v2.bucket | string | `"gafaelfawr"` |  |
 | telegraf.config.outputs[0].influxdb_v2.organization | string | `"square"` |  |
 | telegraf.config.outputs[0].influxdb_v2.token | string | `"$INFLUX_TOKEN"` |  |
 | telegraf.config.outputs[0].influxdb_v2.urls[0] | string | `"https://monitoring.lsst.cloud"` |  |

--- a/applications/telegraf/README.md
+++ b/applications/telegraf/README.md
@@ -34,7 +34,6 @@ Application telemetry collection service
 | telegraf.resources.limits.memory | string | `"1Gi"` |  |
 | telegraf.resources.requests.cpu | string | `"50m"` |  |
 | telegraf.resources.requests.memory | string | `"350Mi"` |  |
-| telegraf.service.enabled | bool | `false` |  |
 | telegraf.tplVersion | int | `2` |  |
 | telegraf.volumes[0].configMap.name | string | `"telegraf-generated-config"` |  |
 | telegraf.volumes[0].name | string | `"telegraf-generated-config"` |  |

--- a/applications/telegraf/templates/configmap.yaml
+++ b/applications/telegraf/templates/configmap.yaml
@@ -30,6 +30,7 @@ data:
     [[inputs.internal]]
       collect_memstats = false
 
+    [[inputs.opentelemetry]]
 
     {{- range $raw_app_name, $defn := .Values.prometheus_config }}
       {{- $app_name := replace "-" "_" $raw_app_name }}

--- a/applications/telegraf/values.yaml
+++ b/applications/telegraf/values.yaml
@@ -7,7 +7,7 @@ telegraf:
           service_address: ":4317"
     outputs:
       - influxdb_v2:
-          bucket: opentelemetry
+          bucket: "gafaelfawr"
           organization: "square"
           token: "$INFLUX_TOKEN"
           urls:

--- a/applications/telegraf/values.yaml
+++ b/applications/telegraf/values.yaml
@@ -1,11 +1,17 @@
 config:
   influxdb2Url: "https://monitoring.lsst.cloud"
 telegraf:
-  # Remove processors, inputs and outputs: use generated config instead.
   config:
-    processors: []
-    inputs: []
-    outputs: []
+    inputs:
+      - opentelemetry:
+          service_address: ":4317"
+    outputs:
+      - influxdb_v2:
+          bucket: opentelemetry
+          organization: "square"
+          token: "$INFLUX_TOKEN"
+          urls:
+            - "https://monitoring.lsst.cloud"
   resources:
     limits:
       memory: "1Gi"
@@ -13,28 +19,17 @@ telegraf:
     requests:
       memory: "350Mi"
       cpu: "50m"
-  args:
-  - "--config"
-  - "/etc/telegraf-generated/telegraf-generated.conf"
-  # We need the additional rules for prometheus scraping.
   rbac:
     clusterWide: true
   env:
-  - name: INFLUX_TOKEN
-    valueFrom:
-      secretKeyRef:
-        key: influx-token
-        name: telegraf
+    - name: INFLUX_TOKEN
+      valueFrom:
+        secretKeyRef:
+          key: influx-token
+          name: telegraf
   podLabels:
     hub.jupyter.org/network-access-hub: 'true'
   tplVersion: 2
-  volumes:
-  - name: telegraf-generated-config
-    configMap:
-      name: telegraf-generated-config
-  mountPoints:
-  - name: telegraf-generated-config
-    mountPath: /etc/telegraf-generated
 
 # -- Use prometheus_config to specify all the services in the RSP that
 # expose prometheus endpoints.  A better option, eventually, will be to

--- a/applications/telegraf/values.yaml
+++ b/applications/telegraf/values.yaml
@@ -27,8 +27,6 @@ telegraf:
         name: telegraf
   podLabels:
     hub.jupyter.org/network-access-hub: 'true'
-  service:
-    enabled: false
   tplVersion: 2
   volumes:
   - name: telegraf-generated-config


### PR DESCRIPTION
Testing support for OpenTelemetry as a metrics source, since that seems to be the more interesting Python library.