### PR TITLE
DM-44635: mobu: ditch `exclude_dirs` from autostart config

### DIFF
--- a/applications/mobu/Chart.yaml
+++ b/applications/mobu/Chart.yaml
@@ -5,4 +5,4 @@ description: "Continuous integration testing"
 home: https://mobu.lsst.io/
 sources:
   - "https://github.com/lsst-sqre/mobu"
-appVersion: 10.1.0
+appVersion: 11.0.0

--- a/applications/mobu/values-idfdev.yaml
+++ b/applications/mobu/values-idfdev.yaml
@@ -28,7 +28,6 @@ config:
         options:
           repo_url: "https://github.com/lsst-sqre/dfuchs-test-mobu.git"
           repo_ref: "main"
-          exclude_dirs: ["exceptions"]
         restart: true
     - name: "recommended"
       count: 1
@@ -44,7 +43,6 @@ config:
         options:
           repo_url: "https://github.com/lsst-sqre/system-test.git"
           repo_ref: "prod"
-          exclude_dirs: ["experiments"]
         restart: true
     - name: "tutorial"
       count: 1
@@ -60,7 +58,6 @@ config:
         options:
           repo_url: "https://github.com/rubin-dp0/tutorial-notebooks.git"
           repo_ref: "prod"
-          exclude_dirs: ["DP02_09_Custom_Coadds", "DP02_11_User_Packages"]
           max_executions: 1
           working_directory: "notebooks/tutorial-notebooks"
         restart: true

--- a/applications/mobu/values-idfint.yaml
+++ b/applications/mobu/values-idfint.yaml
@@ -30,7 +30,6 @@ config:
         options:
           repo_url: "https://github.com/lsst-sqre/system-test.git"
           repo_ref: "prod"
-          exclude_dirs: ["experiments"]
         restart: true
     - name: "weekly"
       count: 1
@@ -48,7 +47,6 @@ config:
             image_class: "latest-weekly"
           repo_url: "https://github.com/lsst-sqre/system-test.git"
           repo_ref: "prod"
-          exclude_dirs: ["experiments"]
         restart: true
     - name: "tutorial"
       count: 1
@@ -64,7 +62,6 @@ config:
         options:
           repo_url: "https://github.com/rubin-dp0/tutorial-notebooks.git"
           repo_ref: "prod"
-          exclude_dirs: ["DP02_09_Custom_Coadds", "DP02_11_User_Packages"]
           max_executions: 1
           working_directory: "notebooks/tutorial-notebooks"
         restart: true
@@ -84,7 +81,6 @@ config:
             image_class: "latest-weekly"
           repo_url: "https://github.com/rubin-dp0/tutorial-notebooks.git"
           repo_ref: "prod"
-          exclude_dirs: ["DP02_09_Custom_Coadds", "DP02_11_User_Packages", "DP02_03c_Big_deepCoadd_Cutout"]
           max_executions: 1
           working_directory: "notebooks/tutorial-notebooks"
         restart: true

--- a/applications/mobu/values-idfprod.yaml
+++ b/applications/mobu/values-idfprod.yaml
@@ -17,7 +17,6 @@ config:
         options:
           repo_url: "https://github.com/lsst-sqre/system-test.git"
           repo_ref: "prod"
-          exclude_dirs: ["experiments"]
           max_executions: 1
         restart: true
     - name: "quickbeam"
@@ -34,7 +33,6 @@ config:
         options:
           repo_url: "https://github.com/lsst-sqre/system-test.git"
           repo_ref: "prod"
-          exclude_dirs: ["experiments"]
           idle_time: 900
           delete_lab: false
         restart: true
@@ -52,7 +50,6 @@ config:
         options:
           repo_url: "https://github.com/rubin-dp0/tutorial-notebooks.git"
           repo_ref: "prod"
-          exclude_dirs: ["DP02_09_Custom_Coadds", "DP02_11_User_Packages"]
           max_executions: 1
           working_directory: "notebooks/tutorial-notebooks"
         restart: true

--- a/applications/mobu/values-usdfdev.yaml
+++ b/applications/mobu/values-usdfdev.yaml
@@ -22,7 +22,6 @@ config:
             image_class: "latest-weekly"
           repo_url: "https://github.com/lsst-sqre/system-test.git"
           repo_ref: "prod"
-          exclude_dirs: ["experiments"]
         restart: true
     - name: "tap"
       count: 1

--- a/applications/mobu/values-usdfint.yaml
+++ b/applications/mobu/values-usdfint.yaml
@@ -22,5 +22,4 @@ config:
             image_class: "latest-weekly"
           repo_url: "https://github.com/lsst-sqre/system-test.git"
           repo_ref: "prod"
-          exclude_dirs: ["experiments"]
         restart: true

--- a/applications/mobu/values-usdfprod.yaml
+++ b/applications/mobu/values-usdfprod.yaml
@@ -17,7 +17,6 @@ config:
         options:
           repo_url: "https://github.com/lsst-sqre/system-test.git"
           repo_ref: "prod"
-          exclude_dirs: ["experiments"]
         restart: true
     - name: "tap"
       count: 1


### PR DESCRIPTION
It's in the [in-repo config](https://mobu.lsst.io/user_guide/in_repo_config.html) in each notebook repo now.