### PR TITLE
[DM-45647] Set Kafka retention period back to its default configuration at the Summit

### DIFF
--- a/applications/sasquatch/values-summit.yaml
+++ b/applications/sasquatch/values-summit.yaml
@@ -18,10 +18,6 @@ strimzi-kafka:
         - broker: 2
           loadBalancerIP: "139.229.180.5"
           host: sasquatch-summit-kafka-2.lsst.codes
-    config:
-      offsets.retention.minutes: 10080
-      log.retention.hours: 168
-
   kraft:
     enabled: true
   kafkaController:


### PR DESCRIPTION
- In the last Summit window we increased the Kafka retention period to 7 days due to the USDF outage, we are setting this configuration back to its default which is 24h.