### PR TITLE
DM-44605: Enable LATISS Prompt Processing to process BLOCK-T17

### DIFF
--- a/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
@@ -23,7 +23,7 @@ prompt-proto-service:
         (survey="BLOCK-306")=[${PROMPT_PROCESSING_DIR}/pipelines/LATISS/ApPipe.yaml,
         ${PROMPT_PROCESSING_DIR}/pipelines/LATISS/SingleFrame.yaml,
         ${PROMPT_PROCESSING_DIR}/pipelines/LATISS/Isr.yaml]
-        (survey="BLOCK-T17")=[]
+        (survey="BLOCK-T17")=[${PROMPT_PROCESSING_DIR}/pipelines/LATISS/Isr-cal.yaml]
         (survey="cwfs")=[]
         (survey="cwfs-focus-sweep")=[]
         (survey="spec-survey")=[]


### PR DESCRIPTION
This PR should wait for a future prompt-service release that includes https://github.com/lsst-dm/prompt_processing/pull/181 changes 