### PR TITLE
Make broker migration generic

### DIFF
--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -328,6 +328,7 @@ Rubin Observatory's telemetry service
 | rest-proxy.service.port | int | `8082` | Kafka REST proxy service port |
 | rest-proxy.tolerations | list | `[]` | Tolerations configuration |
 | square-events.cluster.name | string | `"sasquatch"` |  |
+| strimzi-kafka.brokerStorage | object | `{"enabled":false,"migration":{"brokers":[0,1,2],"enabled":false,"rebalance":false},"size":"1.5Ti","storageClassName":"localdrive"}` | Configuration for deploying Kafka brokers with local storage |
 | strimzi-kafka.cluster.monitorLabel | object | `{}` | Site wide label required for gathering Prometheus metrics if they are enabled |
 | strimzi-kafka.cluster.name | string | `"sasquatch"` | Name used for the Kafka cluster, and used by Strimzi for many annotations |
 | strimzi-kafka.connect.config."key.converter" | string | `"io.confluent.connect.avro.AvroConverter"` | Set the converter for the message ke |
@@ -374,7 +375,6 @@ Rubin Observatory's telemetry service
 | strimzi-kafka.kafkaExporter.resources | object | See `values.yaml` | Kubernetes requests and limits for the Kafka exporter |
 | strimzi-kafka.kafkaExporter.topicRegex | string | `".*"` | Kafka topics to monitor |
 | strimzi-kafka.kraft.enabled | bool | `false` | Enable KRaft mode for Kafka |
-| strimzi-kafka.localStorage | object | `{"enabled":false,"migration":{"brokers":[0,1,2],"enabled":false,"rebalance":false},"size":"1.5Ti","storageClassName":"localdrive"}` | Configuration for deploying Kafka brokers with local storage |
 | strimzi-kafka.mirrormaker2.enabled | bool | `false` | Enable replication in the target (passive) cluster |
 | strimzi-kafka.mirrormaker2.replicas | int | `3` | Number of Mirror Maker replicas to run |
 | strimzi-kafka.mirrormaker2.replication.policy.class | string | `"org.apache.kafka.connect.mirror.IdentityReplicationPolicy"` | Replication policy. |

--- a/applications/sasquatch/charts/strimzi-kafka/README.md
+++ b/applications/sasquatch/charts/strimzi-kafka/README.md
@@ -6,6 +6,7 @@ A subchart to deploy Strimzi Kafka components for Sasquatch.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| brokerStorage | object | `{"enabled":false,"migration":{"brokers":[0,1,2],"enabled":false,"rebalance":false},"size":"1.5Ti","storageClassName":"localdrive"}` | Configuration for deploying Kafka brokers with local storage |
 | cluster.monitorLabel | object | `{}` | Site wide label required for gathering Prometheus metrics if they are enabled |
 | cluster.name | string | `"sasquatch"` | Name used for the Kafka cluster, and used by Strimzi for many annotations |
 | connect.config."key.converter" | string | `"io.confluent.connect.avro.AvroConverter"` | Set the converter for the message ke |
@@ -52,7 +53,6 @@ A subchart to deploy Strimzi Kafka components for Sasquatch.
 | kafkaExporter.resources | object | See `values.yaml` | Kubernetes requests and limits for the Kafka exporter |
 | kafkaExporter.topicRegex | string | `".*"` | Kafka topics to monitor |
 | kraft.enabled | bool | `false` | Enable KRaft mode for Kafka |
-| localStorage | object | `{"enabled":false,"migration":{"brokers":[0,1,2],"enabled":false,"rebalance":false},"size":"1.5Ti","storageClassName":"localdrive"}` | Configuration for deploying Kafka brokers with local storage |
 | mirrormaker2.enabled | bool | `false` | Enable replication in the target (passive) cluster |
 | mirrormaker2.replicas | int | `3` | Number of Mirror Maker replicas to run |
 | mirrormaker2.replication.policy.class | string | `"org.apache.kafka.connect.mirror.IdentityReplicationPolicy"` | Replication policy. |

--- a/applications/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
@@ -24,7 +24,7 @@ spec:
     {{- toYaml . | nindent 6 }}
   {{- end }}
 {{- end }}
-{{- if not .Values.localStorage.enabled }}
+{{- if not .Values.brokerStorage.enabled }}
 ---
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaNodePool
@@ -53,7 +53,7 @@ spec:
     {{- toYaml . | nindent 6 }}
   {{- end }}
 {{- end }}
-{{- if or .Values.localStorage.enabled .Values.localStorage.migration.enabled }}
+{{- if or .Values.brokerStorage.enabled .Values.brokerStorage.migration.enabled }}
 ---
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaNodePool
@@ -72,14 +72,14 @@ spec:
     volumes:
     - id: 0
       type: persistent-claim
-      size: {{ .Values.localStorage.size }}
-      {{- if .Values.localStorage.storageClassName }}
-      class: {{ .Values.localStorage.storageClassName }}
+      size: {{ .Values.brokerStorage.size }}
+      {{- if .Values.brokerStorage.storageClassName }}
+      class: {{ .Values.brokerStorage.storageClassName }}
       {{- end}}
       deleteClaim: false
   template:
     pod:
-      {{- with .Values.localStorage.affinity }}
+      {{- with .Values.brokerStorage.affinity }}
       affinity:
         {{- toYaml . | nindent 10 }}
       {{- end }}
@@ -88,7 +88,7 @@ spec:
     {{- toYaml . | nindent 6 }}
   {{- end }}
 {{- end }}
-{{- if and .Values.localStorage.migration.enabled .Values.localStorage.migration.rebalance }}
+{{- if and .Values.brokerStorage.migration.enabled .Values.brokerStorage.migration.rebalance }}
 ---
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaRebalance
@@ -100,7 +100,7 @@ metadata:
     strimzi.io/rebalance-auto-approval: "true"
 spec:
   mode: remove-brokers
-  {{- with .Values.localStorage.migration.brokers }}
+  {{- with .Values.brokerStorage.migration.brokers }}
   brokers:
     {{- toYaml . | nindent 6 }}
   {{- end }}

--- a/applications/sasquatch/charts/strimzi-kafka/values.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/values.yaml
@@ -316,7 +316,7 @@ cruiseControl:
   enabled: false
 
 # -- Configuration for deploying Kafka brokers with local storage
-localStorage:
+brokerStorage:
   enabled: false
   migration:
     enabled: false

--- a/applications/sasquatch/values-base.yaml
+++ b/applications/sasquatch/values-base.yaml
@@ -102,7 +102,7 @@ strimzi-kafka:
       key.converter.schemas.enable: false
   cruiseControl:
     enabled: true
-  localStorage:
+  brokerStorage:
     enabled: true
     migration:
       enabled: false

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -49,7 +49,7 @@ strimzi-kafka:
     enabled: true
   cruiseControl:
     enabled: true
-  localStorage:
+  brokerStorage:
     enabled: true
     migration:
       enabled: false


### PR DESCRIPTION
- Since we specify the storage class, rename localStorage to brokerStorage to make the broker migration generic.