### PR TITLE
DM-45786: Add Plausible.io tracking support to Squareone

### DIFF
--- a/applications/squareone/Chart.yaml
+++ b/applications/squareone/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
     url: https://github.com/jonathansick
 
 # The default version tag of the squareone docker image
-appVersion: "0.13.1"
+appVersion: "0.14.0"

--- a/applications/squareone/README.md
+++ b/applications/squareone/README.md
@@ -23,6 +23,7 @@ Squareone is the homepage UI for the Rubin Science Platform.
 | config.emailVerifiedPageMdx | string | See `values.yaml` | MDX content for the `/enrollment/thanks-for-verifying` page |
 | config.pendingApprovalPageMdx | string | See `values.yaml` | MDX content for the `/enrollment/pending-approval` page |
 | config.pendingVerificationPageMdx | string | See `values.yaml` | MDX content for the `/enrollment/pending-confirmation` |
+| config.plausibleDomain | string | `nil` | Plausible tracking domain. For example, `data.lsst.cloud`. @default null disables Plausible tracking |
 | config.semaphoreUrl | string | `nil` | URL to the Semaphore (user notifications) API service. @default null disables the Semaphore integration |
 | config.siteDescription | string | `"Access Rubin Observatory Legacy Survey of Space and Time data.\n"` | Site description, used in meta tags |
 | config.siteName | string | `"Rubin Science Platform"` | Name of the site, used in the title and meta tags. |

--- a/applications/squareone/templates/configmap.yaml
+++ b/applications/squareone/templates/configmap.yaml
@@ -18,6 +18,9 @@ data:
     {{- if .Values.config.coManageRegistryUrl }}
     coManageRegistryUrl: {{ .Values.config.coManageRegistryUrl | quote }}
     {{- end}}
+    {{- if .Values.config.plausibleDomain }}
+    plausibleDomain: {{ .Values.config.plausibleDomain | quote }}
+    {{- end}}
     apiAspectPageMdx: {{ .Values.config.apiAspectPageMdx | quote }}
     docsPageMdx: {{ .Values.config.docsPageMdx | quote }}
     supportPageMdx: {{ .Values.config.supportPageMdx | quote }}

--- a/applications/squareone/values-idfdev.yaml
+++ b/applications/squareone/values-idfdev.yaml
@@ -10,6 +10,7 @@ config:
   semaphoreUrl: "https://data-dev.lsst.cloud/semaphore"
   timesSquareUrl: "https://data-dev.lsst.cloud/times-square/api"
   coManageRegistryUrl: "https://id-dev.lsst.cloud"
+  plausibleDomain: "data-dev.lsst.cloud"
 
   supportPageMdx: |
     # Get help with the Rubin Science Platform on idf-dev.lsst.cloud

--- a/applications/squareone/values-idfprod.yaml
+++ b/applications/squareone/values-idfprod.yaml
@@ -7,3 +7,4 @@ config:
   siteName: "Rubin Science Platform"
   semaphoreUrl: "https://data.lsst.cloud/semaphore"
   coManageRegistryUrl: "https://id.lsst.cloud"
+  plausibleDomain: "data.lsst.cloud"

--- a/applications/squareone/values.yaml
+++ b/applications/squareone/values.yaml
@@ -77,6 +77,10 @@ config:
   # @default null disables the COmanage integration
   coManageRegistryUrl: null
 
+  # -- Plausible tracking domain. For example, `data.lsst.cloud`.
+  # @default null disables Plausible tracking
+  plausibleDomain: null
+
   # -- MDX content for the `/api-aspect` page
   # @default -- See `values.yaml`
   apiAspectPageMdx: |


### PR DESCRIPTION
See https://github.com/lsst-sqre/squareone/pull/171

Enables Plausible tracking for data-dev and data.lsst.cloud.