### PR TITLE
Do not allocate nodePort for meta and data services

### DIFF
--- a/applications/sasquatch/charts/influxdb-enterprise/values.yaml
+++ b/applications/sasquatch/charts/influxdb-enterprise/values.yaml
@@ -157,7 +157,7 @@ meta:
 
     # -- Node port for the meta service
     # @default -- Do not allocate a node port
-    nodePort: 30086
+    nodePort: 0
 
     # -- Extra annotations for the meta service
     annotations: {}
@@ -294,7 +294,7 @@ data:
 
     # -- Node port for the data service
     # @default -- Do not allocate a node port
-    nodePort: 30091
+    nodePort: 0
 
     # -- Extra annotations for the data service
     annotations: {}


### PR DESCRIPTION
nodePorts are currently specified in the InfluxDB Enterprise meta and data services in Sasquatch.
Kubernetes is automatically assigning their values and the Service gets out of sync in ArgoCD from time to time. 
It turns out nodePorts are not required for these services, so just not allocate them.