### PR TITLE
[DM-45801] Enable CCS data replication to USDF and configure connectors

### DIFF
--- a/applications/sasquatch/charts/telegraf-kafka-consumer/values.yaml
+++ b/applications/sasquatch/charts/telegraf-kafka-consumer/values.yaml
@@ -185,11 +185,11 @@ influxdb:
 # @default -- See `values.yaml`
 resources:
   limits:
-    cpu: "1"
-    memory: "1Gi"
+    cpu: "4"
+    memory: "8Gi"
   requests:
-    cpu: "1"
-    memory: "1Gi"
+    cpu: "4"
+    memory: "8Gi"
 
 # -- Node labels for pod assignment
 nodeSelector: {}

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -255,6 +255,36 @@ telegraf-kafka-consumer:
       timestamp_field: "private_efdStamp"
       topicRegexps: |
         [ "lsst.sal.LaserTracker" ]
+    atcamera:
+      enabled: true
+      replicaCount: 1
+      database: "lsst.ATCamera"
+      timestamp_format: "unix_ms"
+      timestamp_field: "timestamp"
+      tags: |
+        [ "Agent", "Aspic", "Location", "Raft", "Reb", "Sensor", "Source" ]
+      topicRegexps: |
+        [ "lsst.ATCamera" ]
+    cccamera:
+      enabled: true
+      replicaCount: 1
+      database: "lsst.CCCamera"
+      timestamp_format: "unix_ms"
+      timestamp_field: "timestamp"
+      tags: |
+        [ "Agent", "Aspic", "Cold", "Cryo", "Hardware", "Location", "Ps", "RTD", "Raft", "Reb", "Segment", "Sensor", "Source" ]
+      topicRegexps: |
+        [ "lsst.CCCamera" ]
+    mtcamera:
+      enabled: true
+      replicaCount: 1
+      database: "lsst.MTCamera"
+      timestamp_format: "unix_ms"
+      timestamp_field: "timestamp"
+      tags: |
+        [ "Agent", "Aspic", "Axis", "Canbus", "Cip", "Clamp", "Cold", "Controller", "Cryo", "Gateway", "Hardware", "Hip", "Hook", "Latch", "Location", "Ps", "RTD", "Raft", "Reb", "Segment", "Sensor", "Socket", "Source", "Truck" ]
+      topicRegexps: |
+        [ "lsst.MTCamera" ]
 
 kafdrop:
   ingress:

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -138,65 +138,65 @@ kafka-connect-manager-enterprise:
       enterprise-maintel:
         enabled: true
         repairerConnector: false
-        topicsRegex: ".*MTAOS|.*MTDome|.*MTDomeTrajectory|.*MTPtg"
+        topicsRegex: "lsst.sal.MTAOS|lsst.sal.MTDome|lsst.sal.MTDomeTrajectory|lsst.sal.MTPtg"
       enterprise-mtmount:
         enabled: true
         repairerConnector: false
-        topicsRegex: ".*MTMount"
+        topicsRegex: "lsst.sal.MTMount"
         tasksMax: "8"
       enterprise-comcam:
         enabled: true
         repairerConnector: false
-        topicsRegex: ".*CCCamera|.*CCHeaderService|.*CCOODS"
+        topicsRegex: "lsst.sal.CCCamera|lsst.sal.CCHeaderService|lsst.sal.CCOODS"
       enterprise-eas:
         enabled: true
         repairerConnector: false
-        topicsRegex: ".*DIMM|.*DSM|.*EPM|.*ESS|.*HVAC|.*WeatherForecast"
+        topicsRegex: "lsst.sal.DIMM|lsst.sal.DSM|lsst.sal.EPM|lsst.sal.ESS|lsst.sal.HVAC|lsst.sal.WeatherForecast"
       enterprise-m1m3:
         enabled: true
         repairerConnector: false
-        topicsRegex: ".*MTM1M3"
+        topicsRegex: "lsst.sal.MTM1M3"
         tasksMax: "8"
       enterprise-m2:
         enabled: true
         repairerConnector: false
-        topicsRegex: ".*MTHexapod|.*MTM2|.*MTRotator"
+        topicsRegex: "lsst.sal.MTHexapod|lsst.sal.MTM2|lsst.sal.MTRotator"
       enterprise-obssys:
         enabled: true
         repairerConnector: false
-        topicsRegex: ".*Scheduler|.*Script|.*ScriptQueue|.*Watcher"
+        topicsRegex: "lsst.sal.Scheduler|lsst.sal.Script|lsst.sal.ScriptQueue|lsst.sal.Watcher"
       enterprise-ocps:
         enabled: true
         repairerConnector: false
-        topicsRegex: ".*OCPS"
+        topicsRegex: "lsst.sal.OCPS"
       enterprise-pmd:
         enabled: true
         repairerConnector: false
-        topicsRegex: ".*PMD"
+        topicsRegex: "lsst.sal.PMD"
       enterprise-calsys:
         enabled: true
         repairerConnector: false
-        topicsRegex: ".*ATMonochromator|.*ATWhiteLight|.*CBP|.*Electrometer|.*FiberSpectrograph|.*LinearStage|.*TunableLaser"
+        topicsRegex: "lsst.sal.ATMonochromator|lsst.sal.ATWhiteLight|lsst.sal.CBP|lsst.sal.Electrometer|lsst.sal.FiberSpectrograph|lsst.sal.LinearStage|lsst.sal.TunableLaser"
       enterprise-mtaircompressor:
         enabled: true
         repairerConnector: false
-        topicsRegex: ".*MTAirCompressor"
+        topicsRegex: "lsst.sal.MTAirCompressor"
       enterprise-genericcamera:
         enabled: true
         repairerConnector: false
-        topicsRegex: ".*GCHeaderService|.*GenericCamera"
+        topicsRegex: "lsst.sal.GCHeaderService|lsst.sal.GenericCamera"
       enterprise-gis:
         enabled: true
         repairerConnector: false
-        topicsRegex: ".*GIS"
+        topicsRegex: "lsst.sal.GIS"
       enterprise-mtvms:
         enabled: true
         repairerConnector: false
-        topicsRegex: ".*MTVMS"
+        topicsRegex: "lsst.sal.MTVMS"
       enterprise-lsstcam:
         enabled: true
         repairerConnector: false
-        topicsRegex: ".*MTCamera|.*MTHeaderService|.*MTOODS"
+        topicsRegex: "lsst.sal.MTCamera|lsst.sal.MTHeaderService|lsst.sal.MTOODS"
 
 telegraf-kafka-consumer:
   enabled: true

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -22,7 +22,7 @@ strimzi-kafka:
     enabled: true
     source:
       bootstrapServer: sasquatch-summit-kafka-bootstrap.lsst.codes:9094
-      topicsPattern: "registry-schemas, lsst.sal.*, lsst.dm.*, lsst.backpack.*"
+      topicsPattern: "registry-schemas, lsst.sal.*, lsst.dm.*, lsst.backpack.*, lsst.ATCamera.*, lsst.CCCamera.*, lsst.MTCamera.*"
     resources:
       requests:
         cpu: 2


### PR DESCRIPTION
CCS kafka producers are running routinely now and publishing data to Sasquatch at the Summit.
Thought this is still experimental, we are enabling replication to USDF and configuring connectors at USDF to ingest CCS data in the InfluxDB Enterprise. 