### PR TITLE
DM-42606 Update schema registry sync to load all schemas

### DIFF
--- a/applications/alert-stream-broker/README.md
+++ b/applications/alert-stream-broker/README.md
@@ -102,9 +102,9 @@ Alert transmission to community brokers
 | alert-stream-schema-registry.hostname | string | `"usdf-alert-schemas-dev.slac.stanford.edu"` | Hostname for an ingress which sends traffic to the Schema Registry. |
 | alert-stream-schema-registry.name | string | `"alert-schema-registry"` | Name used by the registry, and by its users. |
 | alert-stream-schema-registry.port | int | `8081` | Port where the registry is listening. NOTE: Not actually configurable in strimzi-registry-operator, so this basically cannot be changed. |
-| alert-stream-schema-registry.schemaSync | object | `{"image":{"repository":"lsstdm/lsst_alert_packet","tag":"tickets-DM-44470"},"subject":"alert-packet"}` | Configuration for the Job which injects the most recent alert_packet schema into the Schema Registry |
-| alert-stream-schema-registry.schemaSync.image.repository | string | `"lsstdm/lsst_alert_packet"` | Repository of a container which has the alert_packet syncLatestSchemaToRegistry.py program |
-| alert-stream-schema-registry.schemaSync.image.tag | string | `"tickets-DM-44470"` | Version of the container to use |
+| alert-stream-schema-registry.schemaSync | object | `{"image":{"digest":"sha256:510f9b3417f4c21a5f95f51172ce778cff18263b7448166c888f10499831cd8f","pullPolicy":"Always","repository":"lsstdm/lsst_alert_packet"},"subject":"alert-packet"}` | Configuration for the Job which injects the most recent alert_packet schema into the Schema Registry |
+| alert-stream-schema-registry.schemaSync.image.digest | string | `"sha256:510f9b3417f4c21a5f95f51172ce778cff18263b7448166c888f10499831cd8f"` | Version of the container to use. If container isn't updating in Argo, switch to digest. tag: tickets-DM-42606 |
+| alert-stream-schema-registry.schemaSync.image.repository | string | `"lsstdm/lsst_alert_packet"` | Repository of a container which has the alert_packet syncLatestSchemaToRegistry.py program. |
 | alert-stream-schema-registry.schemaSync.subject | string | `"alert-packet"` | Subject name to use when inserting data into the Schema Registry |
 | alert-stream-schema-registry.schemaTopic | string | `"registry-schemas"` | Name of the topic used by the Schema Registry to store data. |
 | alert-stream-schema-registry.strimziAPIVersion | string | `"v1beta2"` | Version of the Strimzi Custom Resource API. The correct value depends on the deployed version of Strimzi. See [this blog post](https://strimzi.io/blog/2021/04/29/api-conversion/) for more. |

--- a/applications/alert-stream-broker/charts/alert-stream-schema-registry/README.md
+++ b/applications/alert-stream-broker/charts/alert-stream-schema-registry/README.md
@@ -10,9 +10,9 @@ Confluent Schema Registry for managing schema versions for the Alert Stream
 | hostname | string | `"usdf-alert-schemas-dev.slac.stanford.edu"` | Hostname for an ingress which sends traffic to the Schema Registry. |
 | name | string | `"alert-schema-registry"` | Name used by the registry, and by its users. |
 | port | int | `8081` | Port where the registry is listening. NOTE: Not actually configurable in strimzi-registry-operator, so this basically cannot be changed. |
-| schemaSync | object | `{"image":{"repository":"lsstdm/lsst_alert_packet","tag":"tickets-DM-44470"},"subject":"alert-packet"}` | Configuration for the Job which injects the most recent alert_packet schema into the Schema Registry |
-| schemaSync.image.repository | string | `"lsstdm/lsst_alert_packet"` | Repository of a container which has the alert_packet syncLatestSchemaToRegistry.py program |
-| schemaSync.image.tag | string | `"tickets-DM-44470"` | Version of the container to use |
+| schemaSync | object | `{"image":{"digest":"sha256:510f9b3417f4c21a5f95f51172ce778cff18263b7448166c888f10499831cd8f","pullPolicy":"Always","repository":"lsstdm/lsst_alert_packet"},"subject":"alert-packet"}` | Configuration for the Job which injects the most recent alert_packet schema into the Schema Registry |
+| schemaSync.image.digest | string | `"sha256:510f9b3417f4c21a5f95f51172ce778cff18263b7448166c888f10499831cd8f"` | Version of the container to use. If container isn't updating in Argo, switch to digest. tag: tickets-DM-42606 |
+| schemaSync.image.repository | string | `"lsstdm/lsst_alert_packet"` | Repository of a container which has the alert_packet syncLatestSchemaToRegistry.py program. |
 | schemaSync.subject | string | `"alert-packet"` | Subject name to use when inserting data into the Schema Registry |
 | schemaTopic | string | `"registry-schemas"` | Name of the topic used by the Schema Registry to store data. |
 | strimziAPIVersion | string | `"v1beta2"` | Version of the Strimzi Custom Resource API. The correct value depends on the deployed version of Strimzi. See [this blog post](https://strimzi.io/blog/2021/04/29/api-conversion/) for more. |

--- a/applications/alert-stream-broker/charts/alert-stream-schema-registry/templates/schema-registry-server.yaml
+++ b/applications/alert-stream-broker/charts/alert-stream-schema-registry/templates/schema-registry-server.yaml
@@ -2,6 +2,11 @@ apiVersion: roundtable.lsst.codes/v1beta1
 kind: StrimziSchemaRegistry
 metadata:
   name: {{ .Values.name }}
+  annotations:
+    # Update this field if `make apply` by itself doesn't make a new revision.
+    description: "Schema registry for handling Avro schemas"
+    maintained-by: "drbsmart@uw.edu"
+    revision: "1"
 spec:
   strimzi-version: {{ .Values.strimziAPIVersion }}
   listener: internal

--- a/applications/alert-stream-broker/charts/alert-stream-schema-registry/templates/sync-schema-job.yaml
+++ b/applications/alert-stream-broker/charts/alert-stream-schema-registry/templates/sync-schema-job.yaml
@@ -18,12 +18,15 @@ spec:
         app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
         app.kubernetes.io/instance: {{ .Release.Name | quote }}
         helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+      annotations:
+        description: "Load schemas into registry."
     spec:
       restartPolicy: Never
       containers:
       - name: sync-schema-job
-        image: "{{ .Values.schemaSync.image.repository }}:{{ .Values.schemaSync.image.tag | default .Chart.AppVersion }}"
+        image: {{ .Values.schemaSync.image.repository }}@{{ .Values.schemaSync.image.digest }}
+        imagePullPolicy: "{{ .Values.schemaSync.image.pullPolicy}}"
         command:
-          - "syncLatestSchemaToRegistry.py"
+          - "syncAllSchemasToRegistry.py"
           - "--schema-registry-url=http://{{ .Values.name }}:{{ .Values.port }}"
           - "--subject={{ .Values.schemaSync.subject }}"

--- a/applications/alert-stream-broker/charts/alert-stream-schema-registry/values.yaml
+++ b/applications/alert-stream-broker/charts/alert-stream-schema-registry/values.yaml
@@ -26,10 +26,12 @@ tls: true
 schemaSync:
   image:
     # -- Repository of a container which has the alert_packet
-    # syncLatestSchemaToRegistry.py program
+    # syncLatestSchemaToRegistry.py program.
     repository: lsstdm/lsst_alert_packet
-    # -- Version of the container to use
-    tag: tickets-DM-44470
+    # -- Version of the container to use. If container isn't updating in Argo, switch to digest.
+    # tag: tickets-DM-42606
+    digest: sha256:510f9b3417f4c21a5f95f51172ce778cff18263b7448166c888f10499831cd8f
+    pullPolicy: Always
 
   # -- Subject name to use when inserting data into the Schema Registry
   subject: alert-packet


### PR DESCRIPTION
Remakes schema registry every time the broker is fully synced. Keeps versioning consistent in the registry.