### PR TITLE
DM-43418: Divide AP pipeline into preload and prompt subsets

### DIFF
--- a/applications/prompt-proto-service-hsc-gpu/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-hsc-gpu/values-usdfdev-prompt-processing.yaml
@@ -13,7 +13,7 @@ prompt-proto-service:
   instrument:
     pipelines:
       main: (survey="SURVEY")=[${PROMPT_PROCESSING_DIR}/pipelines/HSC/ApPipe.yaml]
-      preprocessing: (survey="SURVEY")=[]
+      preprocessing: (survey="SURVEY")=[${PROMPT_PROCESSING_DIR}/pipelines/HSC/Preprocessing.yaml]
     calibRepo: s3://rubin-pp-dev-users/central_repo/
 
   s3:

--- a/applications/prompt-proto-service-hsc/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-hsc/values-usdfdev-prompt-processing.yaml
@@ -14,7 +14,7 @@ prompt-proto-service:
   instrument:
     pipelines:
       main: (survey="SURVEY")=[${PROMPT_PROCESSING_DIR}/pipelines/HSC/ApPipe.yaml]
-      preprocessing: (survey="SURVEY")=[]
+      preprocessing: (survey="SURVEY")=[${PROMPT_PROCESSING_DIR}/pipelines/HSC/Preprocessing.yaml]
     calibRepo: s3://rubin-pp-dev-users/central_repo/
 
   s3:

--- a/applications/prompt-proto-service-latiss/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfdev-prompt-processing.yaml
@@ -14,7 +14,7 @@ prompt-proto-service:
       main: >-
         (survey="SURVEY")=[${PROMPT_PROCESSING_DIR}/pipelines/LATISS/ApPipe.yaml,
         ${PROMPT_PROCESSING_DIR}/pipelines/LATISS/Isr.yaml]
-      preprocessing: (survey="SURVEY")=[]
+      preprocessing: (survey="SURVEY")=[${PROMPT_PROCESSING_DIR}/pipelines/LATISS/Preprocessing.yaml]
     calibRepo: s3://rubin-pp-dev-users/central_repo/
 
   s3:

--- a/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
@@ -34,8 +34,8 @@ prompt-proto-service:
         (survey="BLOCK-295")=[]
         (survey="")=[]
       preprocessing: >-
-        (survey="AUXTEL_PHOTO_IMAGING")=[]
-        (survey="AUXTEL_DRP_IMAGING")=[]
+        (survey="AUXTEL_PHOTO_IMAGING")=[${PROMPT_PROCESSING_DIR}/pipelines/LATISS/Preprocessing.yaml]
+        (survey="AUXTEL_DRP_IMAGING")=[${PROMPT_PROCESSING_DIR}/pipelines/LATISS/Preprocessing.yaml]
         (survey="BLOCK-T17")=[]
         (survey="cwfs")=[]
         (survey="cwfs-focus-sweep")=[]

--- a/applications/prompt-proto-service-lsstcomcamsim/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcomcamsim/values-usdfdev-prompt-processing.yaml
@@ -15,7 +15,7 @@ prompt-proto-service:
         (survey="SURVEY")=[${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCamSim/ApPipe.yaml,
         ${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCamSim/SingleFrame.yaml,
         ${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCamSim/Isr.yaml]
-      preprocessing: (survey="SURVEY")=[]
+      preprocessing: (survey="SURVEY")=[${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCamSim/Preprocessing.yaml]
     calibRepo: s3://rubin-pp-dev-users/central_repo/
 
   s3:

--- a/applications/prompt-proto-service-lsstcomcamsim/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcomcamsim/values-usdfprod-prompt-processing.yaml
@@ -25,7 +25,7 @@ prompt-proto-service:
         ${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCamSim/Isr.yaml]
         (survey="")=[]
       preprocessing: >-
-        (survey="BLOCK-297")=[]
+        (survey="BLOCK-297")=[${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCamSim/Preprocessing.yaml]
         (survey="")=[]
     calibRepo: s3://rubin-summit-users
 


### PR DESCRIPTION
This PR configures Prompt Processing to run a preprocessing pipeline before raw arrival. It must be merged together with lsst-dm/prompt_processing#191.