### PR TITLE
Add dirving to idfprod Argo CD as a developer

### DIFF
--- a/applications/argocd/values-idfprod.yaml
+++ b/applications/argocd/values-idfprod.yaml
@@ -35,6 +35,7 @@ argo-cd:
         g, rra@lsst.cloud, role:admin
         g, svoutsin@lsst.cloud, role:admin
 
+        g, dirving@lsst.cloud, role:developer
         g, gpdf@lsst.cloud, role:developer
         g, loi@lsst.cloud, role:developer
         g, roby@lsst.cloud, role:developer


### PR DESCRIPTION
He needs to see Argo CD status for the Butler server in production.