### PR TITLE
DM-45979: Enable a cadcBaseUuid for CCIN2P3 environment

### DIFF
--- a/applications/gafaelfawr/values-ccin2p3.yaml
+++ b/applications/gafaelfawr/values-ccin2p3.yaml
@@ -68,6 +68,9 @@ config:
   oidcServer:
     enabled: false
 
+  # Support generating user metadata for CADC authentication code.
+  cadcBaseUuid: "df534647-a1df-4608-b08e-3af8dc291e41"
+
   # initialAdmins:
   #   - "mainetti"
 


### PR DESCRIPTION
**Summary:**
Hopefully addresses recent authentication issues at CCIN2P3 which were due to upgrades to TAP & the authentication mechanism, which in the current version require a `cadcBaseUuid`.

**Error info**

    WWW-Authenticate    : Bearer error="invalid_token", error_description="{"detail":[{"msg":"CADC-compatible authentication not configured","type":"not_supported"}]}" 

**Jira issue**
https://rubinobs.atlassian.net/browse/DM-45979

**Relevant links**
https://github.com/lsst-sqre/phalanx/blob/main/charts/cadc-tap/templates/configmap.yaml#L9
https://github.com/lsst-sqre/gafaelfawr/blob/ba47b71f9e80474bc032fc72cb4c78fcef46cdca/src/gafaelfawr/handlers/cadc.py#L65
https://github.com/lsst-sqre/phalanx/blob/main/applications/gafaelfawr/values-ccin2p3.yaml