### PR TITLE
DM-44635: appmetrics Kafka/Sasquatch user

### DIFF
--- a/applications/sasquatch/charts/strimzi-kafka/templates/users.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/users.yaml
@@ -300,3 +300,41 @@ spec:
         host: "*"
         operation: All
 {{- end }}
+{{- if .Values.users.appmetrics.enabled }}
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaUser
+metadata:
+  name: appmetrics
+  labels:
+    strimzi.io/cluster: {{ .Values.cluster.name }}
+spec:
+  authentication:
+    type: scram-sha-512
+    password:
+      valueFrom:
+        secretKeyRef:
+          name: sasquatch
+          key: appmetrics-password
+  authorization:
+    type: simple
+    acls:
+      - resource:
+          type: group
+          name: "*"
+          patternType: literal
+        operation: All
+      - resource:
+          type: topic
+          name: "lsst.square.metrics"
+          patternType: prefix
+        type: allow
+        host: "*"
+        operation: All
+      - resource:
+          type: cluster
+        operations:
+          - Describe
+          - DescribeConfigs
+  # TODO: Any quotas needed?
+{{- end }}

--- a/applications/sasquatch/secrets.yaml
+++ b/applications/sasquatch/secrets.yaml
@@ -69,6 +69,10 @@ ts-salkafka-password:
   description: >-
     ts-salkafka KafkaUser password.
   if: strimzi-kafka.users.tsSalKafka.enabled
+appmetrics-password:
+  description: >-
+    appmetrics KafkaUser password.
+  if: strimzi-kafka.users.appmetrics.enabled
 connect-push-secret:
   description: >-
     Write token for pushing generated Strimzi Kafka Connect image to GitHub Container Registry.

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -32,6 +32,8 @@ strimzi-kafka:
       enabled: true
     kafkaConnectManager:
       enabled: true
+    appmetrics:
+      enabled: true
   kraft:
     enabled: true
   kafkaController:
@@ -73,6 +75,12 @@ telegraf-kafka-consumer:
       replicaCount: 1
       topicRegexps: |
         [ "lsst.Test.*" ]
+    appmetrics:
+      enabled: true
+      database: "metrics"
+      replicaCount: 1
+      topicRegexps: |
+        [ "lsst.square.metrics.*" ]
 
 kafdrop:
   cmdArgs: "--message.format=AVRO --topic.deleteEnabled=true --topic.createEnabled=true"


### PR DESCRIPTION
Password is in 1pass: `RSP data-dev.lsst.cloud/sasquatch/appmetrics-password`
Secret has been sync'd.
Test:
```
❯ export KAFKA_PASSWORD=$(op read "op://RSP data-dev.lsst.cloud/sasquatch/appmetrics-password")

❯ echo "blah" | kcat -b sasquatch-dev-kafka-bootstrap.lsst.cloud:9094 -X
security.protocol=SASL_SSL -X sasl.mechanism=SCRAM-SHA-512 -X
sasl.username=appmetrics -X sasl.password=$KAFKA_PASSWORD -P -t
lsst.square.metrics.dfuchs-test

❯ kcat -b sasquatch-dev-kafka-bootstrap.lsst.cloud:9094 -X
security.protocol=SASL_SSL -X sasl.mechanism=SCRAM-SHA-512 -X
sasl.username=appmetrics -X sasl.password=$KAFKA_PASSWORD -P -t
lsst.square.metrics.dfuchs-test -C -o 0

blah
```