### PR TITLE
Enable cadcBaseUuid in gafaelfawr for roe environment

### DIFF
--- a/applications/gafaelfawr/values-roe.yaml
+++ b/applications/gafaelfawr/values-roe.yaml
@@ -8,6 +8,9 @@ config:
   github:
     clientId: "10172b4db1b67ee31620"
 
+  # Support generating user metadata for CADC authentication code.
+  cadcBaseUuid: "4cb5f948-aad9-466c-837b-5eae565b0a77"
+
   # Allow access by GitHub team.
   groupMapping:
     "exec:admin":


### PR DESCRIPTION
**Summary:**
New version of TAP services expect to find the auth/cadc endpoint which requires setting up a cadcBaseUuid in gafaelfawr. This PR addresses this for the roe environment.
