### PR TITLE
[DM-46000] Upgrade Kafka to version 3.8.0

### DIFF
--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -363,7 +363,7 @@ Rubin Observatory's telemetry service
 | strimzi-kafka.kafka.storage.size | string | `"500Gi"` | Size of the backing storage disk for each of the Kafka brokers |
 | strimzi-kafka.kafka.storage.storageClassName | string | `""` | Name of a StorageClass to use when requesting persistent volumes |
 | strimzi-kafka.kafka.tolerations | list | `[]` | Tolerations for Kafka broker pod assignment |
-| strimzi-kafka.kafka.version | string | `"3.7.1"` | Version of Kafka to deploy |
+| strimzi-kafka.kafka.version | string | `"3.8.0"` | Version of Kafka to deploy |
 | strimzi-kafka.kafkaController.enabled | bool | `false` | Enable Kafka Controller |
 | strimzi-kafka.kafkaController.resources | object | See `values.yaml` | Kubernetes requests and limits for the Kafka Controller |
 | strimzi-kafka.kafkaController.storage.size | string | `"20Gi"` | Size of the backing storage disk for each of the Kafka controllers |

--- a/applications/sasquatch/charts/strimzi-kafka/README.md
+++ b/applications/sasquatch/charts/strimzi-kafka/README.md
@@ -41,7 +41,7 @@ A subchart to deploy Strimzi Kafka components for Sasquatch.
 | kafka.storage.size | string | `"500Gi"` | Size of the backing storage disk for each of the Kafka brokers |
 | kafka.storage.storageClassName | string | `""` | Name of a StorageClass to use when requesting persistent volumes |
 | kafka.tolerations | list | `[]` | Tolerations for Kafka broker pod assignment |
-| kafka.version | string | `"3.7.1"` | Version of Kafka to deploy |
+| kafka.version | string | `"3.8.0"` | Version of Kafka to deploy |
 | kafkaController.enabled | bool | `false` | Enable Kafka Controller |
 | kafkaController.resources | object | See `values.yaml` | Kubernetes requests and limits for the Kafka Controller |
 | kafkaController.storage.size | string | `"20Gi"` | Size of the backing storage disk for each of the Kafka controllers |

--- a/applications/sasquatch/charts/strimzi-kafka/values.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/values.yaml
@@ -11,7 +11,7 @@ cluster:
 
 kafka:
   # -- Version of Kafka to deploy
-  version: "3.7.1"
+  version: "3.8.0"
 
   # -- Number of Kafka broker replicas to run
   replicas: 3


### PR DESCRIPTION
More information on this version in this [blog post](https://kafka.apache.org/blog#apache_kafka_380_release_announcement).