### PR TITLE
[DM-46075] Fix for ["outputs.influxdb"] did not complete within its flush interval

### DIFF
--- a/applications/sasquatch/charts/telegraf-kafka-consumer/templates/configmap.yaml
+++ b/applications/sasquatch/charts/telegraf-kafka-consumer/templates/configmap.yaml
@@ -15,7 +15,7 @@ data:
       metric_batch_size = {{ default 1000 $value.metric_batch_size }}
       metric_buffer_limit = {{ default 10000 $value.metric_buffer_limit }}
       collection_jitter = {{ default "0s" $value.collection_jitter | quote }}
-      flush_interval = {{ default "1s" $value.flush_interval | quote }}
+      flush_interval = {{ default "10s" $value.flush_interval | quote }}
       flush_jitter = {{ default "0s" $value.flush_jitter | quote }}
       debug = {{ default false $value.debug }}
       omit_hostname = true

--- a/applications/sasquatch/charts/telegraf-kafka-consumer/templates/configmap.yaml
+++ b/applications/sasquatch/charts/telegraf-kafka-consumer/templates/configmap.yaml
@@ -6,7 +6,9 @@ kind: ConfigMap
 metadata:
   name: sasquatch-telegraf-{{ $key }}
   labels:
-    app: sasquatch-telegraf-kakfa-consumer
+    app.kubernetes.io/name: sasquatch-telegraf
+    app.kubernetes.io/instance: sasquatch-telegraf-{{ $key }}
+    app.kubernetes.io/part-of: sasquatch
 data:
   telegraf.conf: |+
     [agent]

--- a/applications/sasquatch/charts/telegraf-kafka-consumer/templates/deployment.yaml
+++ b/applications/sasquatch/charts/telegraf-kafka-consumer/templates/deployment.yaml
@@ -6,16 +6,18 @@ kind: Deployment
 metadata:
   name: sasquatch-telegraf-{{ $key }}
   labels:
-    app: sasquatch-telegraf-kafka-consumer
+    app.kubernetes.io/name: sasquatch-telegraf
+    app.kubernetes.io/instance: sasquatch-telegraf-{{ $key }}
+    app.kubernetes.io/part-of: sasquatch
 spec:
   replicas: {{ default 1 $value.replicaCount }}
   selector:
     matchLabels:
-      app: sasquatch-telegraf-kafka-consumer
+      app.kubernetes.io/instance: sasquatch-telegraf-{{ $key }}
   template:
     metadata:
       labels:
-        app: sasquatch-telegraf-kafka-consumer
+        app.kubernetes.io/instance: sasquatch-telegraf-{{ $key }}
       {{- if $.Values.podAnnotations }}
       annotations:
         {{- toYaml $.Values.podAnnotations | nindent 8 }}


### PR DESCRIPTION
Increase default ``flush_interval`` to fix warning and improve labels to select connector instances.