### PR TITLE
Add BLOCK-306 for LATISS prompt processing

### DIFF
--- a/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
@@ -26,6 +26,9 @@ prompt-proto-service:
         (survey="AUXTEL_DRP_IMAGING")=[${PROMPT_PROCESSING_DIR}/pipelines/LATISS/ApPipe.yaml,
         ${PROMPT_PROCESSING_DIR}/pipelines/LATISS/SingleFrame.yaml,
         ${PROMPT_PROCESSING_DIR}/pipelines/LATISS/Isr.yaml]
+        (survey="BLOCK-306")=[${PROMPT_PROCESSING_DIR}/pipelines/LATISS/ApPipe.yaml,
+        ${PROMPT_PROCESSING_DIR}/pipelines/LATISS/SingleFrame.yaml,
+        ${PROMPT_PROCESSING_DIR}/pipelines/LATISS/Isr.yaml]
         (survey="BLOCK-T17")=[]
         (survey="cwfs")=[]
         (survey="cwfs-focus-sweep")=[]
@@ -36,6 +39,7 @@ prompt-proto-service:
       preprocessing: >-
         (survey="AUXTEL_PHOTO_IMAGING")=[${PROMPT_PROCESSING_DIR}/pipelines/LATISS/Preprocessing.yaml]
         (survey="AUXTEL_DRP_IMAGING")=[${PROMPT_PROCESSING_DIR}/pipelines/LATISS/Preprocessing.yaml]
+        (survey="BLOCK-306")=[${PROMPT_PROCESSING_DIR}/pipelines/LATISS/Preprocessing.yaml]
         (survey="BLOCK-T17")=[]
         (survey="cwfs")=[]
         (survey="cwfs-focus-sweep")=[]


### PR DESCRIPTION
Not removing  "AUXTEL_PHOTO_IMAGING" yet so if the summit changes their mind, it's still covered.