### PR TITLE
DM-46137: Deploy Times Square 0.13.0

### DIFF
--- a/applications/noteburst/Chart.yaml
+++ b/applications/noteburst/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: noteburst
 version: 1.0.0
-appVersion: "0.12.1"
+appVersion: "0.13.0"
 description: Noteburst is a notebook execution service for the Rubin Science Platform.
 type: application
 home: https://noteburst.lsst.io/

--- a/applications/noteburst/README.md
+++ b/applications/noteburst/README.md
@@ -25,7 +25,7 @@ Noteburst is a notebook execution service for the Rubin Science Platform.
 | config.worker.imageSelector | string | `"recommended"` | Nublado image stream to select: "recommended", "weekly" or "reference" |
 | config.worker.jobTimeout | int | `300` | The default notebook execution timeout, in seconds. |
 | config.worker.keepAlive | string | `"normal"` | Worker keep alive mode: "normal", "fast", "disabled" |
-| config.worker.maxConcurrentJobs | int | `3` | Max number of concurrent notebook executions per worker |
+| config.worker.maxConcurrentJobs | int | `1` | Max number of concurrent notebook executions per worker |
 | config.worker.tokenLifetime | string | `"2419200"` | Worker token lifetime, in seconds. |
 | config.worker.tokenScopes | string | `"exec:notebook,read:image,read:tap,read:alertdb"` | Nublado2 worker account's token scopes as a comma-separated list. |
 | config.worker.workerCount | int | `1` | Number of workers to run |

--- a/applications/noteburst/values.yaml
+++ b/applications/noteburst/values.yaml
@@ -123,7 +123,7 @@ config:
     jobTimeout: 300
 
     # -- Max number of concurrent notebook executions per worker
-    maxConcurrentJobs: 3
+    maxConcurrentJobs: 1
 
     # -- Worker token lifetime, in seconds.
     tokenLifetime: "2419200"

--- a/applications/times-square/Chart.yaml
+++ b/applications/times-square/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 type: application
 
 # The default version tag of the times-square docker image
-appVersion: "0.12.0"
+appVersion: "0.13.0"
 
 dependencies:
   - name: redis

--- a/applications/times-square/README.md
+++ b/applications/times-square/README.md
@@ -23,10 +23,10 @@ An API service for managing and rendering parameterized Jupyter notebooks.
 | cloudsql.instanceConnectionName | string | `""` | Instance connection name for a Cloud SQL PostgreSQL instance |
 | cloudsql.serviceAccount | string | `""` | The Google service account that has an IAM binding to the `times-square` Kubernetes service accounts and has the `cloudsql.client` role |
 | config.databaseUrl | string | None, must be set | URL for the PostgreSQL database |
-| config.defaultExecutionTimeout | string | `"60"` | Default execution timeout for notebooks in seconds |
+| config.defaultExecutionTimeout | string | `"300"` | Default execution timeout for notebooks in seconds |
 | config.enableGitHubApp | string | `"False"` | Toggle to enable the GitHub App functionality |
 | config.githubAppId | string | `""` | GitHub application ID |
-| config.githubCheckRunTimeout | string | `"600"` | Timeout for GitHub check runs in seconds |
+| config.githubCheckRunTimeout | string | `"900"` | Timeout for GitHub check runs in seconds |
 | config.githubOrgs | string | `"lsst,lsst-sqre,lsst-dm,lsst-ts,lsst-sitcom,lsst-pst"` | GitHub organizations that can sync repos to Times Square (comma-separated). |
 | config.logLevel | string | `"INFO"` | Logging level: "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL" |
 | config.name | string | `"times-square"` | Name of the service. |

--- a/applications/times-square/README.md
+++ b/applications/times-square/README.md
@@ -23,8 +23,10 @@ An API service for managing and rendering parameterized Jupyter notebooks.
 | cloudsql.instanceConnectionName | string | `""` | Instance connection name for a Cloud SQL PostgreSQL instance |
 | cloudsql.serviceAccount | string | `""` | The Google service account that has an IAM binding to the `times-square` Kubernetes service accounts and has the `cloudsql.client` role |
 | config.databaseUrl | string | None, must be set | URL for the PostgreSQL database |
+| config.defaultExecutionTimeout | string | `"60"` | Default execution timeout for notebooks in seconds |
 | config.enableGitHubApp | string | `"False"` | Toggle to enable the GitHub App functionality |
 | config.githubAppId | string | `""` | GitHub application ID |
+| config.githubCheckRunTimeout | string | `"600"` | Timeout for GitHub check runs in seconds |
 | config.githubOrgs | string | `"lsst,lsst-sqre,lsst-dm,lsst-ts,lsst-sitcom,lsst-pst"` | GitHub organizations that can sync repos to Times Square (comma-separated). |
 | config.logLevel | string | `"INFO"` | Logging level: "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL" |
 | config.name | string | `"times-square"` | Name of the service. |

--- a/applications/times-square/templates/configmap.yaml
+++ b/applications/times-square/templates/configmap.yaml
@@ -16,3 +16,5 @@ data:
   TS_ENABLE_GITHUB_APP: {{ .Values.config.enableGitHubApp | quote }}
   TS_GITHUB_APP_ID: {{ .Values.config.githubAppId | quote }}
   TS_GITHUB_ORGS: {{ .Values.config.githubOrgs | quote }}
+  TS_CHECK_RUN_TIMEOUT: {{ .Values.config.githubCheckRunTimeout | quote }}
+  TS_DEFAULT_EXECUTION_TIMEOUT: {{ .Values.config.defaultExecutionTimeout | quote }}

--- a/applications/times-square/values-idfdev.yaml
+++ b/applications/times-square/values-idfdev.yaml
@@ -7,6 +7,8 @@ config:
   databaseUrl: "postgresql://times-square@localhost/times-square"
   githubAppId: "196798"
   enableGitHubApp: "True"
+  githubCheckRunTimeout: "600" # 10 minutes
+  defaultExecutionTimeout: "60" # 1 minute
 cloudsql:
   enabled: true
   instanceConnectionName: "science-platform-dev-7696:us-central1:science-platform-dev-e9e11de2"

--- a/applications/times-square/values.yaml
+++ b/applications/times-square/values.yaml
@@ -137,10 +137,10 @@ config:
   githubOrgs: "lsst,lsst-sqre,lsst-dm,lsst-ts,lsst-sitcom,lsst-pst"
 
   # -- Timeout for GitHub check runs in seconds
-  githubCheckRunTimeout: "600" # 10 minutes
+  githubCheckRunTimeout: "900" # 15 minutes
 
   # -- Default execution timeout for notebooks in seconds
-  defaultExecutionTimeout: "60" # 1 minute
+  defaultExecutionTimeout: "300" # 5 minutes
 
   worker:
     # -- Enable liveness checks for the arq queue

--- a/applications/times-square/values.yaml
+++ b/applications/times-square/values.yaml
@@ -136,6 +136,12 @@ config:
   # -- GitHub organizations that can sync repos to Times Square (comma-separated).
   githubOrgs: "lsst,lsst-sqre,lsst-dm,lsst-ts,lsst-sitcom,lsst-pst"
 
+  # -- Timeout for GitHub check runs in seconds
+  githubCheckRunTimeout: "600" # 10 minutes
+
+  # -- Default execution timeout for notebooks in seconds
+  defaultExecutionTimeout: "60" # 1 minute
+
   worker:
     # -- Enable liveness checks for the arq queue
     enableLivenessCheck: true


### PR DESCRIPTION
This version of Times Square adds timeouts for GitHub Check runs to protect against hanging Noteburst executions.

See https://github.com/lsst-sqre/times-square/pull/81 and https://github.com/lsst-sqre/times-square/releases/tag/0.13.0

Also deploys noteburst 0.13.0 with support for timeouts in its jobs. https://github.com/lsst-sqre/noteburst/releases/tag/0.13.0