### PR TITLE
[DM-46176] Add an extra tag for the Telegraf internal metrics 

### DIFF
--- a/applications/sasquatch/charts/telegraf-kafka-consumer/templates/configmap.yaml
+++ b/applications/sasquatch/charts/telegraf-kafka-consumer/templates/configmap.yaml
@@ -58,5 +58,6 @@ data:
 
     [[inputs.internal]]
       collect_memstats = false
+      collect_memstats = true
 {{- end }}
 {{- end }}

--- a/applications/sasquatch/charts/telegraf-kafka-consumer/templates/configmap.yaml
+++ b/applications/sasquatch/charts/telegraf-kafka-consumer/templates/configmap.yaml
@@ -30,6 +30,15 @@ data:
       username = "${INFLUXDB_USER}"
       password = "${INFLUXDB_PASSWORD}"
 
+    [[outputs.influxdb]]
+      namepass = ["telegraf_*"]
+      urls = [
+        {{ $.Values.influxdb.url | quote }}
+      ]
+      database = "telegraf"
+      username = "${INFLUXDB_USER}"
+      password = "${INFLUXDB_PASSWORD}"
+
     [[inputs.kafka_consumer]]
       brokers = [
         "sasquatch-kafka-brokers.sasquatch:9092"
@@ -57,6 +66,7 @@ data:
       consumer_fetch_default = {{ default "20MB" $value.consumer_fetch_default | quote }}
 
     [[inputs.internal]]
+      name_prefix = "telegraf_"
       collect_memstats = true
       tags = { instance = "{{ $key }}" }
 

--- a/applications/sasquatch/charts/telegraf-kafka-consumer/templates/configmap.yaml
+++ b/applications/sasquatch/charts/telegraf-kafka-consumer/templates/configmap.yaml
@@ -57,7 +57,8 @@ data:
       consumer_fetch_default = {{ default "20MB" $value.consumer_fetch_default | quote }}
 
     [[inputs.internal]]
-      collect_memstats = false
       collect_memstats = true
+      tags = { instance = "{{ $key }}" }
+
 {{- end }}
 {{- end }}


### PR DESCRIPTION
We need an extra tag to identify the Telegraf instance from which the internal metrics are collected when running multiple instances of Telegraf (e.g. one Telegraf instance per connector).
As a result route the Telegraf internal metrics to its own database to separate them and configure a different retention period for Telegraf database.



Example:

<img width="1457" alt="image" src="https://github.com/user-attachments/assets/1ccc383d-295e-4c03-8bdb-adc5e8d2261d">
