### PR TITLE
DM-46129: Upgrade Butler server for collections API

### DIFF
--- a/applications/butler/Chart.yaml
+++ b/applications/butler/Chart.yaml
@@ -4,4 +4,4 @@ version: 1.0.0
 description: Server for Butler data abstraction service
 sources:
   - https://github.com/lsst/daf_butler
-appVersion: server-2.0.0
+appVersion: server-2.1.0


### PR DESCRIPTION
Upgrade to a new version of Butler server with support for a `query_collection_info` endpoint that is needed by the new Butler Collections API that will be part of the 2024_37 pipelines stack.