### PR TITLE
Upgrade version of ssotap to 1.18.6

### DIFF
--- a/charts/cadc-tap/README.md
+++ b/charts/cadc-tap/README.md
@@ -31,7 +31,7 @@ IVOA TAP service
 | config.pg.host | string | None, must be set if backend is `pg` | Host to connect to |
 | config.pg.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the TAP image |
 | config.pg.image.repository | string | `"ghcr.io/lsst-sqre/tap-postgres-service"` | TAP image to use |
-| config.pg.image.tag | string | `"1.18.5"` | Tag of TAP image to use |
+| config.pg.image.tag | string | `"1.18.6"` | Tag of TAP image to use |
 | config.pg.username | string | None, must be set if backend is `pg` | Username to connect with |
 | config.qserv.host | string | `"mock-db:3306"` (the mock QServ) | QServ hostname:port to connect to |
 | config.qserv.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the TAP image |

--- a/charts/cadc-tap/values.yaml
+++ b/charts/cadc-tap/values.yaml
@@ -71,7 +71,7 @@ config:
       pullPolicy: "IfNotPresent"
 
       # -- Tag of TAP image to use
-      tag: "1.18.5"
+      tag: "1.18.6"
 
   qserv:
     # -- QServ hostname:port to connect to


### PR DESCRIPTION
**Summary**
Upgrades the tap-postgres release to 1.18.6

**What has changed?**

- Remove deprecated AuthenticatorImpl class by @stvoutsin in https://github.com/lsst-sqre/tap-postgres/pull/41
- Remove jcenter repo as it is obsolete and no longer used by cadc by @stvoutsin in https://github.com/lsst-sqre/tap-postgres/pull/42
- Switch RubinUploadManagerImpl to use UploadLimits by @stvoutsin in https://github.com/lsst-sqre/tap-postgres/pull/43
- Enable storage of results in non-GCS S3 buckets by @stvoutsin in https://github.com/lsst-sqre/tap-postgres/pull/44
- Prepare release 1.18.6 by @stvoutsin in https://github.com/lsst-sqre/tap-postgres/pull/45

**How was this tested?**
https://github.com/stvoutsin/rspvalidator