### PR TITLE
Increase memory for Times Square redis

### DIFF
--- a/applications/times-square/values.yaml
+++ b/applications/times-square/values.yaml
@@ -200,10 +200,10 @@ redis:
   resources:
     limits:
       cpu: "1"
-      memory: "2Gi"
+      memory: "4Gi"
     requests:
       cpu: "6m"
-      memory: "50Mi"
+      memory: "1Gi"
 
   # -- Pod annotations for the Redis pod
   podAnnotations: {}


### PR DESCRIPTION
We're experiencing OOMKilled with 2Gi memory limits for the Times Square redis on usdf-rsp-dev