### PR TITLE
DM-43699: Add Phalanx application for Templatebot

### DIFF
--- a/applications/sasquatch/charts/square-events/templates/templatebot-user.yaml
+++ b/applications/sasquatch/charts/square-events/templates/templatebot-user.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaUser
+metadata:
+  name: templatebot
+  labels:
+    strimzi.io/cluster: {{ .Values.cluster.name }}
+spec:
+  template:
+      secret:
+        metadata:
+          annotations:
+            replicator.v1.mittwald.de/replication-allowed: "true"
+            replicator.v1.mittwald.de/replication-allowed-namespaces: "templatebot"
+  authentication:
+    type: tls
+  authorization:
+    type: simple
+    acls:
+      - resource:
+          type: group
+          name: "templatebot"
+          patternType: prefix
+        operations:
+          - "Read"
+        host: "*"
+      - resource:
+          type: topic
+          name: "lsst.square-events.squarebot.slack.app.mention"
+          patternType: literal
+        type: allow
+        host: "*"
+        operations:
+          - "Read"
+          - "Describe"
+      - resource:
+          type: topic
+          name: "lsst.square-events.squarebot.slack.message.im"
+          patternType: literal
+        type: allow
+        host: "*"
+        operations:
+          - "Read"
+          - "Describe"

--- a/applications/templatebot/.helmignore
+++ b/applications/templatebot/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/applications/templatebot/Chart.yaml
+++ b/applications/templatebot/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+appVersion: "tickets-DM-43699"
+description: Create new projects
+name: templatebot
+sources:
+  - https://github.com/lsst-sqre/templatebot
+type: application
+version: 1.0.0

--- a/applications/templatebot/README.md
+++ b/applications/templatebot/README.md
@@ -1,0 +1,30 @@
+# templatebot
+
+Create new projects
+
+## Source Code
+
+* <https://github.com/lsst-sqre/templatebot>
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Affinity rules for the templatebot deployment pod |
+| config.logLevel | string | `"INFO"` | Logging level |
+| config.logProfile | string | `"production"` | Logging profile (`production` for JSON, `development` for human-friendly) |
+| config.pathPrefix | string | `"/templatebot"` | URL path prefix |
+| config.topics.slackAppMention | string | `"lsst.square-events.squarebot.slack.app.mention"` | Kafka topic name for the Slack `app_mention` events |
+| config.topics.slackMessageIm | string | `"lsst.square-events.squarebot.slack.message.im"` | Kafka topic name for the Slack `message.im` events (direct message channels) |
+| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
+| global.host | string | Set by Argo CD | Host name for ingress |
+| global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
+| image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the templatebot image |
+| image.repository | string | `"ghcr.io/lsst-sqre/templatebot"` | Image to use in the templatebot deployment |
+| image.tag | string | The appVersion of the chart | Tag of image to use |
+| ingress.annotations | object | `{}` | Additional annotations for the ingress rule |
+| nodeSelector | object | `{}` | Node selection rules for the templatebot deployment pod |
+| podAnnotations | object | `{}` | Annotations for the templatebot deployment pod |
+| replicaCount | int | `1` | Number of web deployment pods to start |
+| resources | object | See `values.yaml` | Resource limits and requests for the templatebot deployment pod |
+| tolerations | list | `[]` | Tolerations for the templatebot deployment pod |

--- a/applications/templatebot/secrets.yaml
+++ b/applications/templatebot/secrets.yaml
@@ -1,0 +1,26 @@
+TEMPLATEBOT_GITHUB_APP_ID:
+  description: >-
+    The ID of the GitHub App shared by all Squarebot services.
+  copy:
+    application: squarebot
+    key: SQUAREBOT_GITHUB_APP_ID
+TEMPLATEBOT_GITHUB_APP_PRIVATE_KEY:
+  description: >-
+    The private key for the GitHub App shared by all Squarebot services.
+  onepassword:
+    encoded: true
+  copy:
+    application: squarebot
+    key: SQUAREBOT_GITHUB_APP_PRIVATE_KEY
+TEMPLATEBOT_SLACK_APP_ID:
+  description: >-
+    The ID of the Slack App shared by all Squarebot services.
+  copy:
+    application: squarebot
+    key: SQUAREBOT_SLACK_APP_ID
+TEMPLATEBOT_SLACK_TOKEN:
+  description: >-
+    The Slack bot user oauth token for the Slack App shared by all Squarebot services.
+  copy:
+    application: squarebot
+    key: SQUAREBOT_SLACK_TOKEN

--- a/applications/templatebot/templates/_helpers.tpl
+++ b/applications/templatebot/templates/_helpers.tpl
@@ -1,0 +1,26 @@
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "templatebot.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "templatebot.labels" -}}
+helm.sh/chart: {{ include "templatebot.chart" . }}
+{{ include "templatebot.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "templatebot.selectorLabels" -}}
+app.kubernetes.io/name: "templatebot"
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/applications/templatebot/templates/configmap.yaml
+++ b/applications/templatebot/templates/configmap.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "templatebot"
+  labels:
+    {{- include "templatebot.labels" . | nindent 4 }}
+data:
+  TEMPLATEBOT_LOG_LEVEL: {{ .Values.config.logLevel | quote }}
+  TEMPLATEBOT_ENVIRONMENT_URL: {{ .Values.global.baseUrl | quote }}
+  TEMPLATEBOT_PATH_PREFIX: {{ .Values.config.pathPrefix | quote }}
+  TEMPLATEBOT_PROFILE: {{ .Values.config.logProfile | quote }}
+  TEMPLATEBOT_APP_MENTION_TOPIC: {{ .Values.config.topics.slackAppMention | quote }}
+  TEMPLATEBOT_MESSAGE_IM_TOPIC: {{ .Values.config.topics.slackMessageIm | quote }}

--- a/applications/templatebot/templates/deployment.yaml
+++ b/applications/templatebot/templates/deployment.yaml
@@ -1,0 +1,111 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "templatebot"
+  labels:
+    {{- include "templatebot.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "templatebot.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "templatebot.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      automountServiceAccountToken: false
+      containers:
+        - name: {{ .Chart.Name }}
+          envFrom:
+            - configMapRef:
+                name: "templatebot"
+          env:
+            # Writeable directory for concatenating certs. See "tmp" volume.
+            - name: "KAFKA_CERT_TEMP_DIR"
+              value: "/tmp/kafka_certs"
+            - name: "KAFKA_SECURITY_PROTOCOL"
+              value: "SSL"
+            # From KafkaAccess
+            - name: "KAFKA_BOOTSTRAP_SERVERS"
+              valueFrom:
+                secretKeyRef:
+                  name: templatebot-kafka
+                  key: "bootstrapServers"
+            - name: "KAFKA_CLUSTER_CA_PATH"
+              value: "/etc/kafkacluster/ca.crt"
+            - name: "KAFKA_CLIENT_CERT_PATH"
+              value: "/etc/kafkauser/user.crt"
+            - name: "KAFKA_CLIENT_KEY_PATH"
+              value: "/etc/kafkauser/user.key"
+            # From Vault secrets
+            - name: "TEMPLATEBOT_SLACK_APP_ID"
+              valueFrom:
+                secretKeyRef:
+                  name: "templatebot"
+                  key: "TEMPLATEBOT_SLACK_APP_ID"
+            - name: "TEMPLATEBOT_SLACK_TOKEN"
+              valueFrom:
+                secretKeyRef:
+                  name: "templatebot"
+                  key: "TEMPLATEBOT_SLACK_TOKEN"
+          volumeMounts:
+            - name: "kafka"
+              mountPath: "/etc/kafkacluster/ca.crt"
+              subPath: "ssl.truststore.crt" # CA cert from the Kafka cluster
+            - name: "kafka"
+              mountPath: "/etc/kafkauser/user.crt"
+              subPath: "ssl.keystore.crt" # User cert from the Kafka cluster signed by the clients' CA
+            - name: "kafka"
+              mountPath: "/etc/kafkauser/user.key"
+              subPath: "ssl.keystore.key" # private key for the consuming client
+            - name: "tmp"
+              mountPath: "/tmp/kafka_certs"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: "http"
+              containerPort: 8080
+              protocol: "TCP"
+          readinessProbe:
+            httpGet:
+              path: "/"
+              port: "http"
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+            readOnlyRootFilesystem: true
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+      volumes:
+        - name: "kafka"
+          secret:
+            secretName: templatebot-kafka
+        - name: "templatebot"
+          secret:
+            secretName: "templatebot"
+        - name: "tmp"
+          emptyDir: {}

--- a/applications/templatebot/templates/kafkaaccess.yaml
+++ b/applications/templatebot/templates/kafkaaccess.yaml
@@ -1,0 +1,14 @@
+apiVersion: access.strimzi.io/v1alpha1
+kind: KafkaAccess
+metadata:
+  name: templatebot-kafka
+spec:
+  kafka:
+    name: sasquatch
+    namespace: sasquatch
+    listener: tls
+  user:
+    kind: KafkaUser
+    apiGroup: kafka.strimzi.io
+    name: templatebot
+    namespace: sasquatch

--- a/applications/templatebot/templates/networkpolicy.yaml
+++ b/applications/templatebot/templates/networkpolicy.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: "templatebot"
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "templatebot.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - "Ingress"
+  ingress:
+    # Allow inbound access from pods (in any namespace) labeled
+    # gafaelfawr.lsst.io/ingress: true.
+    - from:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              gafaelfawr.lsst.io/ingress: "true"
+      ports:
+        - protocol: "TCP"
+          port: 8080

--- a/applications/templatebot/templates/service.yaml
+++ b/applications/templatebot/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "templatebot"
+  labels:
+    {{- include "templatebot.labels" . | nindent 4 }}
+spec:
+  type: "ClusterIP"
+  ports:
+    - port: 8080
+      targetPort: "http"
+      protocol: "TCP"
+      name: "http"
+  selector:
+    {{- include "templatebot.selectorLabels" . | nindent 4 }}

--- a/applications/templatebot/templates/vaultsecret.yaml
+++ b/applications/templatebot/templates/vaultsecret.yaml
@@ -1,0 +1,9 @@
+apiVersion: ricoberger.de/v1alpha1
+kind: VaultSecret
+metadata:
+  name: templatebot
+  labels:
+    {{- include "templatebot.labels" . | nindent 4 }}
+spec:
+  path: "{{ .Values.global.vaultSecretsPath }}/templatebot"
+  type: Opaque

--- a/applications/templatebot/values-roundtable-dev.yaml
+++ b/applications/templatebot/values-roundtable-dev.yaml
@@ -1,0 +1,5 @@
+image:
+  pullPolicy: Always
+
+config:
+  logLevel: "DEBUG"

--- a/applications/templatebot/values.yaml
+++ b/applications/templatebot/values.yaml
@@ -1,0 +1,70 @@
+# Default values for templatebot.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# -- Number of web deployment pods to start
+replicaCount: 1
+
+image:
+  # -- Image to use in the templatebot deployment
+  repository: "ghcr.io/lsst-sqre/templatebot"
+
+  # -- Pull policy for the templatebot image
+  pullPolicy: "IfNotPresent"
+
+  # -- Tag of image to use
+  # @default -- The appVersion of the chart
+  tag: null
+
+config:
+  # -- Logging level
+  logLevel: "INFO"
+
+  # -- Logging profile (`production` for JSON, `development` for
+  # human-friendly)
+  logProfile: "production"
+
+  # -- URL path prefix
+  pathPrefix: "/templatebot"
+
+  topics:
+    # -- Kafka topic name for the Slack `app_mention` events
+    slackAppMention: "lsst.square-events.squarebot.slack.app.mention"
+
+    # -- Kafka topic name for the Slack `message.im` events (direct message channels)
+    slackMessageIm: "lsst.square-events.squarebot.slack.message.im"
+
+ingress:
+  # -- Additional annotations for the ingress rule
+  annotations: {}
+
+# -- Affinity rules for the templatebot deployment pod
+affinity: {}
+
+# -- Node selection rules for the templatebot deployment pod
+nodeSelector: {}
+
+# -- Annotations for the templatebot deployment pod
+podAnnotations: {}
+
+# -- Resource limits and requests for the templatebot deployment pod
+# @default -- See `values.yaml`
+resources: {}
+
+# -- Tolerations for the templatebot deployment pod
+tolerations: []
+
+# The following will be set by parameters injected by Argo CD and should not
+# be set in the individual environment values files.
+global:
+  # -- Base URL for the environment
+  # @default -- Set by Argo CD
+  baseUrl: null
+
+  # -- Host name for ingress
+  # @default -- Set by Argo CD
+  host: null
+
+  # -- Base path for Vault secrets
+  # @default -- Set by Argo CD
+  vaultSecretsPath: null

--- a/docs/applications/roundtable.rst
+++ b/docs/applications/roundtable.rst
@@ -19,6 +19,7 @@ Argo CD project: ``roundtable``
    ook/index
    sqrbot-sr/index
    squarebot/index
+   templatebot/index
    unfurlbot/index
    vault/index
 

--- a/docs/applications/templatebot/index.rst
+++ b/docs/applications/templatebot/index.rst
@@ -1,0 +1,16 @@
+.. px-app:: templatebot
+
+#################################
+templatebot — Create new projects
+#################################
+
+.. jinja:: templatebot
+   :file: applications/_summary.rst.jinja
+
+Guides
+======
+
+.. toctree::
+   :maxdepth: 1
+
+   values

--- a/docs/applications/templatebot/values.md
+++ b/docs/applications/templatebot/values.md
@@ -1,0 +1,12 @@
+```{px-app-values} templatebot
+```
+
+# templatebot Helm values reference
+
+Helm values reference table for the {px-app}`templatebot` application.
+
+```{include} ../../../applications/templatebot/README.md
+---
+start-after: "## Values"
+---
+```

--- a/environments/README.md
+++ b/environments/README.md
@@ -67,6 +67,7 @@
 | applications.tap | bool | `false` | Enable the tap application |
 | applications.telegraf | bool | `false` | Enable the telegraf application |
 | applications.telegraf-ds | bool | `false` | Enable the telegraf-ds application |
+| applications.templatebot | bool | `false` | Enable the templatebot application |
 | applications.times-square | bool | `false` | Enable the times-square application |
 | applications.unfurlbot | bool | `false` | Enable the unfurlbot application |
 | applications.uws | bool | `false` | Enable the uws application. This includes the dmocps control system application. |

--- a/environments/templates/applications/roundtable/templatebot.yaml
+++ b/environments/templates/applications/roundtable/templatebot.yaml
@@ -1,0 +1,34 @@
+{{- if (index .Values "applications" "templatebot") -}}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "templatebot"
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: "templatebot"
+  namespace: "argocd"
+  finalizers:
+    - "resources-finalizer.argocd.argoproj.io"
+spec:
+  destination:
+    namespace: "templatebot"
+    server: "https://kubernetes.default.svc"
+  project: "roundtable"
+  source:
+    path: "applications/templatebot"
+    repoURL: {{ .Values.repoUrl | quote }}
+    targetRevision: {{ .Values.targetRevision | quote }}
+    helm:
+      parameters:
+        - name: "global.host"
+          value: {{ .Values.fqdn | quote }}
+        - name: "global.baseUrl"
+          value: "https://{{ .Values.fqdn }}"
+        - name: "global.vaultSecretsPath"
+          value: {{ .Values.vaultPathPrefix | quote }}
+      valueFiles:
+        - "values.yaml"
+        - "values-{{ .Values.name }}.yaml"
+{{- end -}}

--- a/environments/values-roundtable-dev.yaml
+++ b/environments/values-roundtable-dev.yaml
@@ -27,5 +27,6 @@ applications:
   strimzi-access-operator: true
   telegraf: true
   telegraf-ds: true
+  templatebot: true
   unfurlbot: true
   vault: true

--- a/environments/values.yaml
+++ b/environments/values.yaml
@@ -225,6 +225,9 @@ applications:
   # -- Enable the telegraf-ds application
   telegraf-ds: false
 
+  # -- Enable the templatebot application
+  templatebot: false
+
   # -- Enable the times-square application
   times-square: false
 


### PR DESCRIPTION
This adds [templatebot](https://github.com/lsst-sqre/templatebot) into Phalanx for deployment with the modern Roundtable clusters.

Templatebot works with the Squarebot message bus, so it works similarly to apps like Unfurlbot.

See https://github.com/lsst-sqre/templatebot/pull/67