### PR TITLE
DM-46396: Stop using fullname macro in docs

### DIFF
--- a/docs/developers/helm-chart/define-secrets.rst
+++ b/docs/developers/helm-chart/define-secrets.rst
@@ -136,7 +136,7 @@ A typical ``VaultSecret`` Helm template for an application looks like this (repl
    apiVersion: ricoberger.de/v1alpha1
    kind: VaultSecret
    metadata:
-     name: {{ include "myapp.fullname" . }}
+     name: "myapp"
      labels:
        {{- include "myapp.labels" . | nindent 4 }}
    spec:


### PR DESCRIPTION
The new starters no longer define a fullname macro since it's not needed for Phalanx Helm charts. Remove the last reference to it in the documentation.