### PR TITLE
DM-46396: Add a COmanage link to environment pages

### DIFF
--- a/docs/environments/_summary.rst.jinja
+++ b/docs/environments/_summary.rst.jinja
@@ -5,7 +5,7 @@
    * - Root domain
      - `{{ env.fqdn }} <https://{{ env.fqdn }}>`__
    * - Identity provider
-     - {{ env.gafaelfawr.provider.value }}{% if env.gafaelfawr.provider_hostname %} ({{ env.gafaelfawr.provider_hostname }}){% endif %}
+     - {{ env.gafaelfawr.provider.value }}{% if env.gafaelfawr.provider_hostname %} ({{ env.gafaelfawr.provider_hostname }}){% endif %}{% if env.gafaelfawr.comanage_hostname %} (COmanage: `{{ env.gafaelfawr.comanage_hostname }} <https://{{ env.gafaelfawr.comanage_hostname }}/>`__){% endif %}
    {%- if env.argocd.url %}
    * - Argo CD
      - {{ env.argocd.url }}

--- a/src/phalanx/models/environments.py
+++ b/src/phalanx/models/environments.py
@@ -23,12 +23,14 @@ from .applications import Application, ApplicationInstance
 from .secrets import Secret
 
 __all__ = [
+    "ArgoCDDetails",
     "ControlSystemConfig",
     "Environment",
     "EnvironmentBaseConfig",
     "EnvironmentConfig",
     "EnvironmentDetails",
     "GCPMetadata",
+    "GafaelfawrDetails",
     "GafaelfawrGitHubGroup",
     "GafaelfawrGitHubTeam",
     "GafaelfawrScope",
@@ -466,6 +468,9 @@ class GafaelfawrDetails(BaseModel):
 
     provider_hostname: str | None = None
     """Hostname of upstream identity provider, if meaningful."""
+
+    comanage_hostname: str | None = None
+    """Hostname of COmanage instance, if COmanage is in use."""
 
     scopes: list[GafaelfawrScope] = []
     """Gafaelfawr scopes and their associated groups."""

--- a/src/phalanx/storage/config.py
+++ b/src/phalanx/storage/config.py
@@ -786,9 +786,14 @@ class ConfigStorage:
 
         # Determine the upstream identity provider.
         provider_hostname = None
+        comanage_hostname = None
         if gafaelfawr:
             if gafaelfawr.values["config"]["cilogon"]["clientId"]:
                 provider = IdentityProvider.CILOGON
+                cilogon_config = gafaelfawr.values["config"]["cilogon"]
+                if cilogon_config["enrollmentUrl"]:
+                    url = cilogon_config["enrollmentUrl"]
+                    comanage_hostname = urlparse(url).hostname
             elif gafaelfawr.values["config"]["github"]["clientId"]:
                 provider = IdentityProvider.GITHUB
             elif gafaelfawr.values["config"]["oidc"]["clientId"]:
@@ -828,6 +833,7 @@ class ConfigStorage:
         return GafaelfawrDetails(
             provider=provider,
             provider_hostname=provider_hostname,
+            comanage_hostname=comanage_hostname,
             scopes=sorted(gafaelfawr_scopes, key=lambda s: s.scope),
         )
 


### PR DESCRIPTION
If Gafaelfawr is configured with CILogon and there's an enrollment URL, assume that it points to COmanage and extract its hostname. Add a COmanage link to the environment page for this environment.