### PR TITLE
[DM-46408] Increase readiness probe initial delay

### DIFF
--- a/applications/sasquatch/charts/influxdb-enterprise/templates/data-statefulset.yaml
+++ b/applications/sasquatch/charts/influxdb-enterprise/templates/data-statefulset.yaml
@@ -90,7 +90,7 @@ spec:
               path: /ping
               port: http
           readinessProbe:
-            initialDelaySeconds: 30
+            initialDelaySeconds: 60
             httpGet:
               path: /ping
               port: http


### PR DESCRIPTION
- InfluxDB Enterprise needs more time to read the shards from disk when restarting. The readiness probe was killing the data pods too early preventing it to restart.