### PR TITLE
[DM-46250] Review configuration for the Telegraf connectors at BTS

### DIFF
--- a/applications/sasquatch/values-base.yaml
+++ b/applications/sasquatch/values-base.yaml
@@ -133,6 +133,9 @@ influxdb:
 
 telegraf-kafka-consumer:
   enabled: true
+  image:
+    repo: "docker.io/lsstsqre/telegraf"
+    tag: "avro-mutex"
   kafkaConsumers:
     auxtel:
       enabled: true

--- a/applications/sasquatch/values-base.yaml
+++ b/applications/sasquatch/values-base.yaml
@@ -142,71 +142,85 @@ telegraf-kafka-consumer:
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.ATAOS", "lsst.sal.ATDome", "lsst.sal.ATDomeTrajectory", "lsst.sal.ATHexapod", "lsst.sal.ATPneumatics", "lsst.sal.ATPtg", "lsst.sal.ATMCS" ]
+      debug: true
     maintel:
       enabled: true
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.MTAOS", "lsst.sal.MTDome", "lsst.sal.MTDomeTrajectory", "lsst.sal.MTPtg" ]
+      debug: true
     mtmount:
       enabled: true
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.MTMount" ]
+      debug: true
     eas:
       enabled: true
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.DIMM", "lsst.sal.DSM", "lsst.sal.EPM", "lsst.sal.ESS", "lsst.sal.HVAC", "lsst.sal.WeatherForecast" ]
+      debug: true
     latiss:
       enabled: true
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.ATCamera", "lsst.sal.ATHeaderService", "lsst.sal.ATOODS", "lsst.sal.ATSpectrograph" ]
+      debug: true
     m1m3:
       enabled: true
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.MTM1M3" ]
+      debug: true
     m2:
       enabled: true
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.MTHexapod", "lsst.sal.MTM2", "lsst.sal.MTRotator" ]
+      debug: true
     obssys:
       enabled: true
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.Scheduler", "lsst.sal.Script", "lsst.sal.ScriptQueue", "lsst.sal.Watcher" ]
+      debug: true
     ocps:
       enabled: true
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.OCPS" ]
+      debug: true
     test:
       enabled: true
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.Test" ]
+      debug: true
     mtaircompressor:
       enabled: true
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.MTAirCompressor" ]
+      debug: true
     lasertracker:
       enabled: true
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.LaserTracker" ]
+      debug: true
     genericcamera:
       enabled: true
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.GCHeaderService", "lsst.sal.GenericCamera" ]
+      debug: true
     lsstcam:
       enabled: true
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.MTCamera", "lsst.sal.MTHeaderService", "lsst.sal.MTOODS" ]
+      debug: true
 
 kafdrop:
   cmdArgs: "--message.format=AVRO --message.keyFormat=DEFAULT --topic.deleteEnabled=false --topic.createEnabled=false"

--- a/applications/sasquatch/values-base.yaml
+++ b/applications/sasquatch/values-base.yaml
@@ -147,7 +147,6 @@ telegraf-kafka-consumer:
     mtmount:
       enabled: true
       database: "efd"
-      replicaCount: 8
       topicRegexps: |
         [ "lsst.sal.MTMount" ]
     eas:
@@ -163,7 +162,6 @@ telegraf-kafka-consumer:
     m1m3:
       enabled: true
       database: "efd"
-      replicaCount: 8
       topicRegexps: |
         [ "lsst.sal.MTM1M3" ]
     m2:


### PR DESCRIPTION
We optimized the connector configuration for throughput, we can run m1m3 and mtmount connectors with one replica now. Also use a Telegraf version that fixes a race condition bug found in the Telegraf Avro parser.
