### PR TITLE
DM-46286: Make Butler client/server default on IDF int/dev dp02

### DIFF
--- a/applications/butler/README.md
+++ b/applications/butler/README.md
@@ -16,6 +16,7 @@ Server for Butler data abstraction service
 | autoscaling.minReplicas | int | `1` | Minimum number of butler deployment pods |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU utilization of butler deployment pods |
 | config.additionalS3ProfileName | string | No second S3 profile is available. | Profile name identifying a second S3 endpoint and set of credentials to use for accessing files in the datastore. |
+| config.dp02ClientServerIsDefault | bool | `false` | True if the 'dp02' Butler repository alias should use client/server Butler.  False if it should use DirectButler. |
 | config.dp02PostgresUri | string | No configuration file for DP02 will be generated. | Postgres connection string pointing to the registry database hosting Data Preview 0.2 data. |
 | config.pathPrefix | string | `"/api/butler"` | The prefix of the path portion of the URL where the Butler service will be exposed.  For example, if the service should be exposed at `https://data.lsst.cloud/api/butler`, this should be set to `/api/butler` |
 | config.pguser | string | Use values specified in per-repository Butler config files. | Postgres username used to connect to the Butler DB |

--- a/applications/butler/templates/configmap.yaml
+++ b/applications/butler/templates/configmap.yaml
@@ -46,11 +46,17 @@ data:
   # connecting to the Butler server.
   #
   # We provide both DirectButler and RemoteButler versions of dp02 because some
-  # users rely on functionality not yet available via RemoteButler.  The default is currently
-  # DirectButler because the Community Science team has not had the opportunity to test RemoteButler,
-  # and RemoteButler is not available in the current "recommended" RSP image.
+  # users rely on functionality not yet available via RemoteButler.  The default in production is
+  # DirectButler because RemoteButler is not available in the current recommended RSP image.
+  # On dev and int it is RemoteButler -- the Community Science team is testing the new system.
   idf-repositories.yaml: |
-    dp02: {{ .Values.global.baseUrl }}{{ .Values.config.pathPrefix }}/configs/dp02.yaml
-    dp02-direct: {{ .Values.global.baseUrl }}{{ .Values.config.pathPrefix }}/configs/dp02.yaml
-    dp02-remote: {{ .Values.global.baseUrl }}{{ .Values.config.pathPrefix }}/repo/dp02/butler.yaml
+    {{- $dp02Direct := print .Values.global.baseUrl .Values.config.pathPrefix "/configs/dp02.yaml" -}}
+    {{- $dp02Remote := print .Values.global.baseUrl .Values.config.pathPrefix "/repo/dp02/butler.yaml" -}}
+    {{- if .Values.config.dp02ClientServerIsDefault }}
+    dp02: {{ $dp02Remote }}
+    {{- else }}
+    dp02: {{ $dp02Direct }}
+    {{- end }}
+    dp02-direct: {{ $dp02Direct }}
+    dp02-remote: {{ $dp02Remote }}
 {{- end }}

--- a/applications/butler/values-idfdev.yaml
+++ b/applications/butler/values-idfdev.yaml
@@ -2,6 +2,7 @@ image:
   pullPolicy: Always
 
 config:
+  dp02ClientServerIsDefault: true
   dp02PostgresUri: postgresql://postgres@sqlproxy-butler-int.sqlproxy-cross-project:5432/dp02
   s3EndpointUrl: "https://storage.googleapis.com"
   additionalS3ProfileName: "ir2"

--- a/applications/butler/values-idfint.yaml
+++ b/applications/butler/values-idfint.yaml
@@ -1,4 +1,5 @@
 config:
+  dp02ClientServerIsDefault: true
   dp02PostgresUri: postgresql://postgres@sqlproxy-butler-int.sqlproxy-cross-project:5432/dp02
   s3EndpointUrl: "https://storage.googleapis.com"
   repositories:

--- a/applications/butler/values.yaml
+++ b/applications/butler/values.yaml
@@ -85,6 +85,10 @@ config:
   # @default -- No configuration file for DP02 will be generated.
   dp02PostgresUri: ""
 
+  # -- True if the 'dp02' Butler repository alias should use client/server
+  # Butler.  False if it should use DirectButler.
+  dp02ClientServerIsDefault: false
+
   # -- Postgres username used to connect to the Butler DB
   # @default -- Use values specified in per-repository Butler config files.
   pguser: ""


### PR DESCRIPTION
To facilitate testing by the Community Science Team and start getting stability testing from Mobu, switch the default dp02 alias on `idfdev` and `idfint` to point to client/server Butler instead of DirectButler.

`idfprod` will remain on DirectButler until testing has been completed and information about the transition has been communicated to users.