### PR TITLE
[DM-46463] Fix context deadline exceeded error

### DIFF
--- a/applications/sasquatch/values-base.yaml
+++ b/applications/sasquatch/values-base.yaml
@@ -172,6 +172,7 @@ telegraf-kafka-consumer:
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.MTM1M3" ]
+      metric_batch_size: 2500
       debug: true
     m2:
       enabled: true


### PR DESCRIPTION
- Reducing the batch size configuration in Telegraf from 5000 to 2500 messages fixed the problem. It seems that 5000 messages * avg size of M1M3 messages was too large for a request to the InfluxDB API.