### PR TITLE
DM-46257: Add initial version of ppdb-replication application

### DIFF
--- a/applications/ppdb-replication/.helmignore
+++ b/applications/ppdb-replication/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/applications/ppdb-replication/Chart.yaml
+++ b/applications/ppdb-replication/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+appVersion: 0.1.0
+description: Replicates data from the APDB to the PPDB
+name: ppdb-replication
+sources:
+- https://github.com/lsst/dax_ppdb.git
+type: application
+version: 1.0.0

--- a/applications/ppdb-replication/README.md
+++ b/applications/ppdb-replication/README.md
@@ -1,0 +1,44 @@
+# ppdb-replication
+
+Replicates data from the APDB to the PPDB
+
+## Source Code
+
+* <https://github.com/lsst/dax_ppdb.git>
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Affinity rules for the ppdb-replication deployment pod |
+| config.additionalS3ProfileName | string | `nil` | Additional S3 profile name |
+| config.additionalS3ProfileUrl | string | `nil` | Additional S3 profile URL |
+| config.apdbConfig | string | `nil` | APDB config file resource |
+| config.apdbIndexUri | string | `nil` | APDB index URI |
+| config.checkInterval | string | `nil` | Time to wait before checking for new chunks, if no chunk appears |
+| config.disableBucketValidation | int | `1` | Disable bucket validation in LSST S3 tools |
+| config.logLevel | string | `"INFO"` | Logging level |
+| config.logProfile | string | `"production"` | Logging profile (`production` for JSON, `development` for human-friendly) |
+| config.maxWaitTime | string | `nil` | Maximum time to wait before replicating a chunk after next chunk appears |
+| config.minWaitTime | string | `nil` | Minimum time to wait before replicating a chunk after next chunk appears |
+| config.monLogger | string | `"lsst.dax.ppdb.monitor"` | Name of logger for monitoring |
+| config.monRules | string | `nil` | Comma-separated list of monitoring filter rules |
+| config.pathPrefix | string | `"/ppdb-replication"` | URL path prefix |
+| config.persistentVolumeClaims | list | `[]` | Persistent volume claims |
+| config.ppdbConfig | string | `nil` | PPDB config file resource |
+| config.s3EndpointUrl | string | `nil` | S3 endpoint URL |
+| config.updateExisting | bool | `false` | Allow updates to already replicated data |
+| config.volumeMounts | list | `[]` | Volume mounts |
+| config.volumes | list | `[]` | Volumes specific to the environment |
+| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
+| global.host | string | Set by Argo CD | Host name for ingress |
+| global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
+| image.pullPolicy | string | `"Always"` | Pull policy for the ppdb-replication image |
+| image.repository | string | `"ghcr.io/lsst/ppdb-replication"` | Image to use in the ppdb-replication deployment |
+| image.tag | string | The appVersion of the chart | Tag of image to use |
+| ingress.annotations | object | `{}` | Additional annotations for the ingress rule |
+| nodeSelector | object | `{}` | Node selection rules for the ppdb-replication deployment pod |
+| podAnnotations | object | `{}` | Annotations for the ppdb-replication deployment pod |
+| replicaCount | int | `1` | Number of deployment pods to start |
+| resources | object | see `values.yaml` | Resource limits and requests for the ppdb-replication deployment pod |
+| tolerations | list | `[]` | Tolerations for the ppdb-replication deployment pod |

--- a/applications/ppdb-replication/secrets.yaml
+++ b/applications/ppdb-replication/secrets.yaml
@@ -1,0 +1,9 @@
+"aws-credentials.ini":
+  description: >-
+    AWS credentials required for acessing configuration files in S3.
+"db-auth.yaml":
+  description: >-
+    Cassandra database credentials for the APDB.
+"postgres-credentials.txt":
+  description: >-
+    PostgreSQL credentials in its pgpass format for the PPDB database.

--- a/applications/ppdb-replication/templates/_helpers.tpl
+++ b/applications/ppdb-replication/templates/_helpers.tpl
@@ -1,0 +1,44 @@
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "ppdb-replication.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "ppdb-replication.labels" -}}
+helm.sh/chart: {{ include "ppdb-replication.chart" . }}
+{{ include "ppdb-replication.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "ppdb-replication.selectorLabels" -}}
+app.kubernetes.io/name: "ppdb-replication"
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "ppdb-replication.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/applications/ppdb-replication/templates/configmap.yaml
+++ b/applications/ppdb-replication/templates/configmap.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "ppdb-replication"
+  labels:
+    {{- include "ppdb-replication.labels" . | nindent 4 }}
+data:
+  DAX_APDB_INDEX_URI: {{ .Values.config.apdbIndexUri | quote }}
+  PPDB_REPLICATION_LOG_LEVEL: {{ .Values.config.logLevel | quote }}
+  PPDB_REPLICATION_PATH_PREFIX: {{ .Values.config.pathPrefix | quote }}
+  PPDB_REPLICATION_PROFILE: {{ .Values.config.logProfile | quote }}
+  PPDB_REPLICATION_APDB_CONFIG: {{ .Values.config.apdbConfig | quote }}
+  PPDB_REPLICATION_PPDB_CONFIG: {{ .Values.config.ppdbConfig | quote }}
+  PPDB_REPLICATION_MON_LOGGER: {{ .Values.config.monLogger | quote }}
+  PPDB_REPLICATION_MON_RULES: {{ .Values.config.monRules | quote }}
+  PPDB_REPLICATION_UPDATE_EXISTING: {{ .Values.config.updateExisting | quote}}
+  PPDB_REPLICATION_MIN_WAIT_TIME: {{ .Values.config.minWaitTime | quote }}
+  PPDB_REPLICATION_MAX_WAIT_TIME: {{ .Values.config.maxWaitTime | quote }}
+  PPDB_REPLICATION_CHECK_INTERVAL: {{ .Values.config.checkInterval | quote}}

--- a/applications/ppdb-replication/templates/deployment.yaml
+++ b/applications/ppdb-replication/templates/deployment.yaml
@@ -1,0 +1,89 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ppdb-replication.fullname" . }}
+  labels:
+    {{- include "ppdb-replication.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "ppdb-replication.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "ppdb-replication.selectorLabels" . | nindent 8 }}
+      annotations:
+        # Force the pod to restart when the config maps are updated.
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      volumes:
+        - name: "ppdb-replication-secrets-raw"
+          secret:
+            secretName: {{ include "ppdb-replication.fullname" . }}
+        - name: "ppdb-replication-secrets"
+          emptyDir:
+            sizeLimit: "100Mi"
+        {{- with .Values.config.volumes }}
+        {{- . | toYaml | nindent 8 }}
+        {{- end }}
+      initContainers:
+        - name: fix-secret-permissions
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          command:
+            - "/bin/sh"
+            - "-c"
+            - |
+              cp -RL /tmp/ppdb-replication-secrets-raw/* /app/secrets/
+              chmod 0400 /app/secrets/*
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+            runAsGroup: 0
+          volumeMounts:
+            - name: "ppdb-replication-secrets"
+              mountPath: "/app/secrets"
+            - name: "ppdb-replication-secrets-raw"
+              mountPath: "/tmp/ppdb-replication-secrets-raw"
+              readOnly: true
+      containers:
+        - name: {{ .Chart.Name }}
+          envFrom:
+            - configMapRef:
+                name: "ppdb-replication"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: AWS_SHARED_CREDENTIALS_FILE
+              value: "/app/secrets/aws-credentials.ini"
+            - name: PGPASSFILE
+              value: "/app/secrets/postgres-credentials.txt"
+            - name: LSST_DB_AUTH
+              value: "/app/secrets/db-auth.yaml"
+            - name: S3_ENDPOINT_URL
+              value: {{ .Values.config.s3EndpointUrl | quote }}
+            - name: LSST_RESOURCES_S3_PROFILE_{{ .Values.config.additionalS3ProfileName }}
+              value: {{ .Values.config.additionalS3ProfileUrl | quote }}
+            - name: LSST_DISABLE_BUCKET_VALIDATION
+              value: {{ .Values.config.disableBucketValidation | quote }}
+          volumeMounts:
+            - name: "ppdb-replication-secrets"
+              mountPath: "/app/secrets"
+              readOnly: true
+            {{- with .Values.config.volumeMounts }}
+            {{- . | toYaml | nindent 12 }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/applications/ppdb-replication/templates/ingress.yaml
+++ b/applications/ppdb-replication/templates/ingress.yaml
@@ -1,0 +1,30 @@
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
+metadata:
+  name: "ppdb-replication"
+  labels:
+    {{- include "ppdb-replication.labels" . | nindent 4 }}
+config:
+  baseUrl: {{ .Values.global.baseUrl | quote }}
+  scopes:
+    all:
+      - "read:image"
+template:
+  metadata:
+    name: "ppdb-replication"
+    {{- with .Values.ingress.annotations }}
+    annotations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  spec:
+    rules:
+      - host: {{ required "global.host must be set" .Values.global.host | quote }}
+        http:
+          paths:
+            - path: {{ .Values.config.pathPrefix | quote }}
+              pathType: "Prefix"
+              backend:
+                service:
+                  name: "ppdb-replication"
+                  port:
+                    number: 8080

--- a/applications/ppdb-replication/templates/networkpolicy.yaml
+++ b/applications/ppdb-replication/templates/networkpolicy.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: "ppdb-replication"
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "ppdb-replication.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - "Ingress"
+  ingress:
+    # Allow inbound access from pods (in any namespace) labeled
+    # gafaelfawr.lsst.io/ingress: true.
+    - from:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              gafaelfawr.lsst.io/ingress: "true"
+      ports:
+        - protocol: "TCP"
+          port: 8080

--- a/applications/ppdb-replication/templates/pvc.yaml
+++ b/applications/ppdb-replication/templates/pvc.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.config.persistentVolumeClaims }}
+{{- $top := . -}}
+{{- range $index, $pvc := .Values.config.persistentVolumeClaims }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "{{ $pvc.name }}"
+spec:
+  storageClassName: "{{ $pvc.storageClassName }}"
+  accessModes:
+    - ReadOnlyMany
+  resources:
+    requests:
+      storage: 100Mi
+{{- end }}
+{{- end }}
+

--- a/applications/ppdb-replication/templates/service.yaml
+++ b/applications/ppdb-replication/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "ppdb-replication"
+  labels:
+    {{- include "ppdb-replication.labels" . | nindent 4 }}
+spec:
+  type: "ClusterIP"
+  ports:
+    - port: 8080
+      targetPort: "http"
+      protocol: "TCP"
+      name: "http"
+  selector:
+    {{- include "ppdb-replication.selectorLabels" . | nindent 4 }}

--- a/applications/ppdb-replication/templates/vault-secrets.yaml
+++ b/applications/ppdb-replication/templates/vault-secrets.yaml
@@ -1,0 +1,9 @@
+apiVersion: ricoberger.de/v1alpha1
+kind: VaultSecret
+metadata:
+  name: {{ include "ppdb-replication.fullname" . }}
+  labels:
+    {{- include "ppdb-replication.labels" . | nindent 4 }}
+spec:
+  path: "{{ .Values.global.vaultSecretsPath }}/ppdb-replication"
+  type: Opaque

--- a/applications/ppdb-replication/values-usdfdev.yaml
+++ b/applications/ppdb-replication/values-usdfdev.yaml
@@ -1,0 +1,44 @@
+config:
+
+  # -- Logging level
+  logLevel: "INFO"
+
+  # -- Logging profile (`production` for JSON, `development` for
+  # human-friendly)
+  logProfile: "development"
+
+  # -- APDB config file resource
+  apdbConfig: "label:pp-prod:lsstcomcamsim-or4"
+
+  # -- PPDB config file resource
+  ppdbConfig: "/sdf/group/rubin/user/jeremym/ppdb-replication/config/ppdb-replication-test-1.yaml"
+
+  # -- APDB index URI
+  apdbIndexUri: "/sdf/group/rubin/shared/apdb_config/apdb-index.yaml"
+
+  # -- S3 endpoint URL
+  s3EndpointUrl: https://s3dfrgw.slac.stanford.edu
+
+  # -- S3 profile name for additional S3 profile
+  additionalS3ProfileName: "embargo"
+
+  # -- S3 profile URL for additional S3 profile
+  additionalS3ProfileUrl: "https://sdfembs3.sdf.slac.stanford.edu"
+
+  volumes:
+    - name: sdf-group-rubin
+      persistentVolumeClaim:
+        claimName: sdf-group-rubin
+    - name: sdf-data-rubin
+      persistentVolumeClaim:
+        claimName: sdf-data-rubin
+  volumeMounts:
+    - name: sdf-group-rubin
+      mountPath: /sdf/group/rubin
+    - name: sdf-data-rubin
+      mountPath: /sdf/data/rubin
+  persistentVolumeClaims:
+    - name: sdf-group-rubin
+      storageClassName: sdf-group-rubin
+    - name: sdf-data-rubin
+      storageClassName: sdf-data-rubin

--- a/applications/ppdb-replication/values.yaml
+++ b/applications/ppdb-replication/values.yaml
@@ -1,0 +1,118 @@
+# Default values for ppdb-replication.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# -- Number of deployment pods to start
+replicaCount: 1
+
+image:
+  # -- Image to use in the ppdb-replication deployment
+  repository: "ghcr.io/lsst/ppdb-replication"
+
+  # -- Pull policy for the ppdb-replication image
+  pullPolicy: "Always"
+
+  # -- Tag of image to use
+  # @default -- The appVersion of the chart
+  tag: "main"
+
+ingress:
+  # -- Additional annotations for the ingress rule
+  annotations: {}
+
+# -- Affinity rules for the ppdb-replication deployment pod
+affinity: {}
+
+# -- Node selection rules for the ppdb-replication deployment pod
+nodeSelector: {}
+
+# -- Annotations for the ppdb-replication deployment pod
+podAnnotations: {}
+
+# -- Resource limits and requests for the ppdb-replication deployment pod
+# @default -- see `values.yaml`
+resources:
+  limits:
+    cpu: "1"
+    memory: "16.0Gi"
+  requests:
+    cpu: "200m"  # 20% of a single core
+    memory: "4.0Gi"
+
+# -- Tolerations for the ppdb-replication deployment pod
+tolerations: []
+
+# The following will be set by parameters injected by Argo CD and should not
+# be set in the individual environment values files.
+global:
+  # -- Base URL for the environment
+  # @default -- Set by Argo CD
+  baseUrl: null
+
+  # -- Host name for ingress
+  # @default -- Set by Argo CD
+  host: null
+
+  # -- Base path for Vault secrets
+  # @default -- Set by Argo CD
+  vaultSecretsPath: null
+
+# Application-specific configuration
+config:
+  # -- Logging level
+  logLevel: "INFO"
+
+  # -- Name of logger for monitoring
+  monLogger: "lsst.dax.ppdb.monitor"
+
+  # -- Logging profile (`production` for JSON, `development` for
+  # human-friendly)
+  logProfile: "production"
+
+  # -- URL path prefix
+  pathPrefix: "/ppdb-replication"
+
+  # -- APDB config file resource
+  apdbConfig: null
+
+  # -- PPDB config file resource
+  ppdbConfig: null
+
+  # -- APDB index URI
+  apdbIndexUri: null
+
+  # -- Comma-separated list of monitoring filter rules
+  monRules: null
+
+  # -- Allow updates to already replicated data
+  updateExisting: false
+
+  # -- Minimum time to wait before replicating a chunk after next chunk appears
+  minWaitTime: null
+
+  # -- Maximum time to wait before replicating a chunk after next chunk appears
+  maxWaitTime: null
+
+  # -- Time to wait before checking for new chunks, if no chunk appears
+  checkInterval: null
+
+  # -- S3 endpoint URL
+  s3EndpointUrl: null
+
+  # -- Additional S3 profile name
+  additionalS3ProfileName: null
+
+  # -- Additional S3 profile URL
+  additionalS3ProfileUrl: null
+
+  # -- Disable bucket validation in LSST S3 tools
+  disableBucketValidation: 1
+
+  # -- Volumes specific to the environment
+  volumes: []
+
+  # -- Volume mounts
+  volumeMounts: []
+
+  # -- Persistent volume claims
+  persistentVolumeClaims: []

--- a/docs/applications/ppdb-replication/index.rst
+++ b/docs/applications/ppdb-replication/index.rst
@@ -1,0 +1,19 @@
+.. px-app:: ppdb-replication
+
+############################################################
+ppdb-replication — Replicates data from the APDB to the PPDB
+############################################################
+
+The ``ppdb-replication`` application periodically replicates data from the
+Alert Production DataBase (APDB) to the Prompt Products DataBase (PPDB).
+
+.. jinja:: ppdb-replication
+   :file: applications/_summary.rst.jinja
+
+Guides
+======
+
+.. toctree::
+   :maxdepth: 1
+
+   values

--- a/docs/applications/ppdb-replication/values.md
+++ b/docs/applications/ppdb-replication/values.md
@@ -1,0 +1,12 @@
+```{px-app-values} ppdb-replication
+```
+
+# ppdb-replication Helm values reference
+
+Helm values reference table for the {px-app}`ppdb-replication` application.
+
+```{include} ../../../applications/ppdb-replication/README.md
+---
+start-after: "## Values"
+---
+```

--- a/docs/applications/rsp.rst
+++ b/docs/applications/rsp.rst
@@ -18,6 +18,7 @@ Argo CD project: ``rsp``
    noteburst/index
    nublado/index
    portal/index
+   ppdb-replication/index
    semaphore/index
    siav2/index
    sqlproxy-cross-project/index

--- a/docs/applications/rubin.rst
+++ b/docs/applications/rubin.rst
@@ -18,6 +18,7 @@ Argo CD project: ``rubin``
    nightreport/index
    obsloctap/index
    plot-navigator/index
+   ppdb-replication/index
    production-tools/index
    rapid-analysis/index
    rubintv/index

--- a/environments/README.md
+++ b/environments/README.md
@@ -43,6 +43,7 @@
 | applications.plot-navigator | bool | `false` | Enable the plot-navigator application |
 | applications.portal | bool | `false` | Enable the portal application |
 | applications.postgres | bool | `false` | Enable the in-cluster PostgreSQL server. Use of this server is discouraged in favor of using infrastructure SQL, but will remain supported for use cases such as minikube test deployments. |
+| applications.ppdb-replication | bool | `false` | Enable the ppdb-replication application |
 | applications.production-tools | bool | `false` | Enable the production-tools application |
 | applications.prompt-proto-service-hsc | bool | `false` | Enable the prompt-proto-service-hsc application |
 | applications.prompt-proto-service-hsc-gpu | bool | `false` | Enable the prompt-proto-service-hsc-gpu application |

--- a/environments/templates/applications/rubin/ppdb-replication.yaml
+++ b/environments/templates/applications/rubin/ppdb-replication.yaml
@@ -1,0 +1,34 @@
+{{- if (index .Values "applications" "ppdb-replication") -}}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "ppdb-replication"
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: "ppdb-replication"
+  namespace: "argocd"
+  finalizers:
+    - "resources-finalizer.argocd.argoproj.io"
+spec:
+  destination:
+    namespace: "ppdb-replication"
+    server: "https://kubernetes.default.svc"
+  project: "rubin"
+  source:
+    path: "applications/ppdb-replication"
+    repoURL: {{ .Values.repoUrl | quote }}
+    targetRevision: {{ .Values.targetRevision | quote }}
+    helm:
+      parameters:
+        - name: "global.host"
+          value: {{ .Values.fqdn | quote }}
+        - name: "global.baseUrl"
+          value: "https://{{ .Values.fqdn }}"
+        - name: "global.vaultSecretsPath"
+          value: {{ .Values.vaultPathPrefix | quote }}
+      valueFiles:
+        - "values.yaml"
+        - "values-{{ .Values.name }}.yaml"
+{{- end -}}

--- a/environments/values-usdfdev.yaml
+++ b/environments/values-usdfdev.yaml
@@ -27,6 +27,7 @@ applications:
   plot-navigator: true
   portal: true
   postgres: true
+  ppdb-replication: true
   rubintv: true
   sasquatch: true
   schedview-snapshot: true

--- a/environments/values.yaml
+++ b/environments/values.yaml
@@ -153,6 +153,9 @@ applications:
   # supported for use cases such as minikube test deployments.
   postgres: false
 
+  # -- Enable the ppdb-replication application
+  ppdb-replication: false
+
   # -- Enable the rubintv application
   rubintv: false
 


### PR DESCRIPTION
Add initial version of an application which replicates data between the APDB and PPDB using utilities from [dax_ppdb](https://github.com/lsst/dax_ppdb).

This application is only enabled on `usdf-rsp-dev` for now.