### PR TITLE
DM-46494: Migrate Prompt Processing to pure db-auth authentication

### DIFF
--- a/charts/prompt-proto-service/templates/prompt-proto-service.yaml
+++ b/charts/prompt-proto-service/templates/prompt-proto-service.yaml
@@ -13,17 +13,6 @@ spec:
     spec:
       containerConcurrency: {{ .Values.containerConcurrency }}
       initContainers:
-      - name: init-pgpass
-        # Make a copy of the read-only secret that's owned by lsst
-        # lsst account is created by main image with id 1000
-        image: busybox
-        command: ["sh", "-c", "cp -L /app/pg-mount/.pgpass /app/pgsql/ && chown 1000:1000 /app/pgsql/.pgpass && chmod u=r,go-rwx /app/pgsql/.pgpass"]
-        volumeMounts:
-        - mountPath: /app/pg-mount
-          name: pgpass-mount
-          readOnly: true
-        - mountPath: /app/pgsql
-          name: pgpass-credentials-file
       - name: init-db-auth
         # Make a copy of the read-only secret that's owned by lsst
         # lsst account is created by main image with id 1000
@@ -103,8 +92,6 @@ spec:
         - name: AWS_SHARED_CREDENTIALS_FILE
           value: /app/s3/credentials
         {{- end }}
-        - name: PGPASSFILE
-          value: /app/pgsql/.pgpass
         - name: LSST_DB_AUTH
           value: /app/lsst-credentials/db-auth.yaml
         - name: AP_KAFKA_PRODUCER_PASSWORD
@@ -133,9 +120,6 @@ spec:
         volumeMounts:
         - mountPath: /tmp-butler
           name: ephemeral
-        - mountPath: /app/pgsql
-          name: pgpass-credentials-file
-          readOnly: true
         - mountPath: /app/lsst-credentials
           name: db-auth-credentials-file
           readOnly: true
@@ -166,17 +150,6 @@ spec:
       - name: ephemeral
         emptyDir:
           sizeLimit: {{ .Values.knative.ephemeralStorageLimit }}
-      - name: pgpass-mount
-        # Temporary mount for .pgpass; cannot be read directly because it's owned by root
-        secret:
-          secretName: {{ template "prompt-proto-service.fullname" . }}-secret
-          items:
-          - key: pgpass_file
-            path: .pgpass
-          defaultMode: 0400  # Minimal permissions, as extra protection
-      - name: pgpass-credentials-file
-        emptyDir:
-          sizeLimit: 10Ki  # Just a text file!
       - name: db-auth-mount
         # Temporary mount for db-auth.yaml; cannot be read directly because it's owned by root
         secret:


### PR DESCRIPTION
This PR removes all references to `.pgpass` from Prompt Processing configurations.