### PR TITLE
DM-46399: Convert manual ingresses to GafaelfawrIngress

### DIFF
--- a/applications/exposurelog/README.md
+++ b/applications/exposurelog/README.md
@@ -40,7 +40,7 @@ Log messages related to an exposure
 | image.pullPolicy | string | `"Always"` | Pull policy for the exposurelog image |
 | image.repository | string | `"lsstsqre/exposurelog"` | exposurelog image to use |
 | image.tag | string | The appVersion of the chart | Tag of exposure image to use |
-| ingress.gafaelfawrAuthQuery | string | `""` | Gafaelfawr auth query string |
+| ingress.auth.enabled | bool | `false` | Whether to require Gafaelfawr authentication for access |
 | nameOverride | string | `""` | Override the base name for resources |
 | nodeSelector | object | `{}` | Node selector rules for the exposurelog pod |
 | podAnnotations | object | `{}` | Annotations for the exposurelog pod |

--- a/applications/exposurelog/templates/ingress.yaml
+++ b/applications/exposurelog/templates/ingress.yaml
@@ -1,30 +1,34 @@
-apiVersion: networking.k8s.io/v1
-kind: Ingress
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
 metadata:
   name: {{ template "exposurelog.fullname" . }}
   labels:
     {{- include "exposurelog.labels" . | nindent 4 }}
-  annotations:
-    {{- if .Values.ingress.gafaelfawrAuthQuery }}
-    nginx.ingress.kubernetes.io/auth-method: "GET"
-    nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-User,X-Auth-Request-Email,X-Auth-Request-Token"
-    nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.global.baseUrl }}/login"
-    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.baseUrl }}/auth?{{ .Values.ingress.gafaelfawrAuthQuery }}"
-    {{- end }}
-    {{- with .Values.ingress.annotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-spec:
-  ingressClassName: "nginx"
-  rules:
-    - host: {{ required "global.host must be set" .Values.global.host | quote }}
-      http:
-        paths:
-          - path: "/exposurelog"
-            pathType: "Prefix"
-            backend:
-              service:
-                name: {{ include "exposurelog.fullname" . }}
-                port:
-                  number: 8080
-
+config:
+  baseUrl: {{ .Values.global.baseUrl | quote }}
+  {{- if .Values.ingress.auth.enabled }}
+  loginRedirect: true
+  scopes:
+    all:
+      - "exec:internal-tools"
+  {{- else }}
+  scopes:
+    anonymous: true
+  {{- end }}
+template:
+  metadata:
+    name: {{ template "exposurelog.fullname" . }}
+    labels:
+      {{- include "exposurelog.labels" . | nindent 4 }}
+  spec:
+    rules:
+      - host: {{ required "global.host must be set" .Values.global.host | quote }}
+        http:
+          paths:
+            - path: "/exposurelog"
+              pathType: "Prefix"
+              backend:
+                service:
+                  name: {{ include "exposurelog.fullname" . }}
+                  port:
+                    number: 8080

--- a/applications/exposurelog/values.yaml
+++ b/applications/exposurelog/values.yaml
@@ -20,6 +20,11 @@ image:
   # @default -- The appVersion of the chart
   tag: ""
 
+ingress:
+  auth:
+    # -- Whether to require Gafaelfawr authentication for access
+    enabled: false
+
 db:
   # -- database host
   host: postgres.postgres
@@ -29,10 +34,6 @@ db:
   user: exposurelog
   # -- database name
   database: exposurelog
-
-ingress:
-  # -- Gafaelfawr auth query string
-  gafaelfawrAuthQuery: ""
 
 # -- Application-specific configuration
 config:

--- a/applications/narrativelog/README.md
+++ b/applications/narrativelog/README.md
@@ -30,7 +30,7 @@ Narrative log service
 | image.pullPolicy | string | `"Always"` | Pull policy for the narrativelog image |
 | image.repository | string | `"lsstsqre/narrativelog"` | narrativelog image to use |
 | image.tag | string | The appVersion of the chart | Tag of exposure image to use |
-| ingress.gafaelfawrAuthQuery | string | `""` | Gafaelfawr auth query string |
+| ingress.auth.enabled | bool | `false` | Whether to require Gafaelfawr authentication for access |
 | nameOverride | string | `""` | Override the base name for resources |
 | nodeSelector | object | `{}` | Node selector rules for the narrativelog pod |
 | podAnnotations | object | `{}` | Annotations for the narrativelog pod |

--- a/applications/narrativelog/templates/ingress.yaml
+++ b/applications/narrativelog/templates/ingress.yaml
@@ -1,29 +1,34 @@
-apiVersion: networking.k8s.io/v1
-kind: Ingress
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
 metadata:
   name: {{ template "narrativelog.fullname" . }}
   labels:
     {{- include "narrativelog.labels" . | nindent 4 }}
-  annotations:
-    {{- if .Values.ingress.gafaelfawrAuthQuery }}
-    nginx.ingress.kubernetes.io/auth-method: "GET"
-    nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-User,X-Auth-Request-Email,X-Auth-Request-Token"
-    nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.global.baseUrl }}/login"
-    nginx.ingress.kubernetes.io/auth-url: "https://{{ .Values.global.baseUrl }}/auth?{{ .Values.ingress.gafaelfawrAuthQuery }}"
-    {{- end }}
-    {{- with .Values.ingress.annotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-spec:
-  ingressClassName: "nginx"
-  rules:
-    - host: {{ required "global.host must be set" .Values.global.host | quote }}
-      http:
-        paths:
-          - path: /narrativelog
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ include "narrativelog.fullname" . }}
-                port:
-                  number: 8080
+config:
+  baseUrl: {{ .Values.global.baseUrl | quote }}
+  {{- if .Values.ingress.auth.enabled }}
+  loginRedirect: true
+  scopes:
+    all:
+      - "exec:internal-tools"
+  {{- else }}
+  scopes:
+    anonymous: true
+  {{- end }}
+template:
+  metadata:
+    name: {{ template "narrativelog.fullname" . }}
+    labels:
+      {{- include "narrativelog.labels" . | nindent 4 }}
+  spec:
+    rules:
+      - host: {{ required "global.host must be set" .Values.global.host | quote }}
+        http:
+          paths:
+            - path: /narrativelog
+              pathType: Prefix
+              backend:
+                service:
+                  name: {{ include "narrativelog.fullname" . }}
+                  port:
+                    number: 8080

--- a/applications/narrativelog/values.yaml
+++ b/applications/narrativelog/values.yaml
@@ -20,6 +20,11 @@ image:
   # @default -- The appVersion of the chart
   tag: ""
 
+ingress:
+  auth:
+    # -- Whether to require Gafaelfawr authentication for access
+    enabled: false
+
 db:
   # -- database host
   host: postgres.postgres
@@ -29,10 +34,6 @@ db:
   user: narrativelog
   # -- database name
   database: narrativelog
-
-ingress:
-  # -- Gafaelfawr auth query string
-  gafaelfawrAuthQuery: ""
 
 # -- Application-specific configuration
 config:

--- a/applications/nightreport/README.md
+++ b/applications/nightreport/README.md
@@ -31,7 +31,7 @@ Night report log service
 | image.pullPolicy | string | `"Always"` | Pull policy for the nightreport image |
 | image.repository | string | `"lsstts/nightreport"` | nightreport image to use |
 | image.tag | string | The appVersion of the chart | Tag of exposure image to use |
-| ingress.gafaelfawrAuthQuery | string | `""` | Gafaelfawr auth query string |
+| ingress.auth.enabled | bool | `false` | Whether to require Gafaelfawr authentication for access |
 | nameOverride | string | `""` | Override the base name for resources |
 | nodeSelector | object | `{}` | Node selector rules for the nightreport pod |
 | podAnnotations | object | `{}` | Annotations for the nightreport pod |

--- a/applications/nightreport/templates/ingress.yaml
+++ b/applications/nightreport/templates/ingress.yaml
@@ -1,29 +1,34 @@
-apiVersion: networking.k8s.io/v1
-kind: Ingress
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
 metadata:
   name: {{ template "nightreport.fullname" . }}
   labels:
     {{- include "nightreport.labels" . | nindent 4 }}
-  annotations:
-    {{- if .Values.ingress.gafaelfawrAuthQuery }}
-    nginx.ingress.kubernetes.io/auth-method: "GET"
-    nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-User,X-Auth-Request-Email,X-Auth-Request-Token"
-    nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.global.baseUrl }}/login"
-    nginx.ingress.kubernetes.io/auth-url: "https://{{ .Values.global.baseUrl }}/auth?{{ .Values.ingress.gafaelfawrAuthQuery }}"
-    {{- end }}
-    {{- with .Values.ingress.annotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-spec:
-  ingressClassName: "nginx"
-  rules:
-    - host: {{ required "global.host must be set" .Values.global.host | quote }}
-      http:
-        paths:
-          - path: /nightreport
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ include "nightreport.fullname" . }}
-                port:
-                  number: 8080
+config:
+  baseUrl: {{ .Values.global.baseUrl | quote }}
+  {{- if .Values.ingress.auth.enabled }}
+  loginRedirect: true
+  scopes:
+    all:
+      - "exec:internal-tools"
+  {{- else }}
+  scopes:
+    anonymous: true
+  {{- end }}
+template:
+  metadata:
+    name: {{ template "nightreport.fullname" . }}
+    labels:
+      {{- include "nightreport.labels" . | nindent 4 }}
+  spec:
+    rules:
+      - host: {{ required "global.host must be set" .Values.global.host | quote }}
+        http:
+          paths:
+            - path: /nightreport
+              pathType: Prefix
+              backend:
+                service:
+                  name: {{ include "nightreport.fullname" . }}
+                  port:
+                    number: 8080

--- a/applications/nightreport/values.yaml
+++ b/applications/nightreport/values.yaml
@@ -20,6 +20,11 @@ image:
   # @default -- The appVersion of the chart
   tag: ""
 
+ingress:
+  auth:
+    # -- Whether to require Gafaelfawr authentication for access
+    enabled: false
+
 db:
   # -- database host
   host: postgres.postgres
@@ -29,10 +34,6 @@ db:
   user: nightreport
   # -- database name
   database: nightreport
-
-ingress:
-  # -- Gafaelfawr auth query string
-  gafaelfawrAuthQuery: ""
 
 # -- Application-specific configuration
 config:


### PR DESCRIPTION
The next release of Gafaelfawr will drop support for manually configuring Kubernetes ingresses to use Gafaelfawr and will require the use of `GafaelfawrIngress` resources. Convert the three remaining relevant usages in Phalanx.

These ingresses previously didn't require any specific scopes for access. I added `exec:internal-tools` for this purpose about a year ago so everyone's tokens should now have that scope. Add that scope restriction as part of this conversion if authentication is enabled.

Currently, the authentication portion was disabled. Preserve that by configuring the ingreses to be anonymous by default, but add a configuration option that can be used to enable authentication when that is ready.