### PR TITLE
DM-46399: Convert manual ingress to GafaelfawrIngress

### DIFF
--- a/applications/alert-stream-broker/README.md
+++ b/applications/alert-stream-broker/README.md
@@ -32,7 +32,6 @@ Alert transmission to community brokers
 | alert-database.ingester.serviceAccountName | string | `"alert-database-ingester"` | The name of the Kubernetes ServiceAccount (*not* the Google Cloud IAM service account!) which is used by the alert database ingester. |
 | alert-database.ingress.annotations | object | `{}` |  |
 | alert-database.ingress.enabled | bool | `true` | Whether to create an ingress |
-| alert-database.ingress.gafaelfawrAuthQuery | string | `"scope=read:alertdb"` | Query string for Gafaelfawr to authorize access |
 | alert-database.ingress.host | string | None, must be set if the ingress is enabled | Hostname for the ingress |
 | alert-database.ingress.path | string | `"/alertdb"` | Subpath to host the alert database application under the ingress |
 | alert-database.ingress.tls | list | `[]` | Configures TLS for the ingress if needed. If multiple ingresses share the same hostname, only one of them needs a TLS configuration. |

--- a/applications/alert-stream-broker/charts/alert-database/README.md
+++ b/applications/alert-stream-broker/charts/alert-database/README.md
@@ -23,7 +23,6 @@ Archival database of alerts sent through the alert stream.
 | ingester.serviceAccountName | string | `"alert-database-ingester"` | The name of the Kubernetes ServiceAccount (*not* the Google Cloud IAM service account!) which is used by the alert database ingester. |
 | ingress.annotations | object | `{}` |  |
 | ingress.enabled | bool | `true` | Whether to create an ingress |
-| ingress.gafaelfawrAuthQuery | string | `"scope=read:alertdb"` | Query string for Gafaelfawr to authorize access |
 | ingress.host | string | None, must be set if the ingress is enabled | Hostname for the ingress |
 | ingress.path | string | `"/alertdb"` | Subpath to host the alert database application under the ingress |
 | ingress.tls | list | `[]` | Configures TLS for the ingress if needed. If multiple ingresses share the same hostname, only one of them needs a TLS configuration. |

--- a/applications/alert-stream-broker/charts/alert-database/templates/ingress.yaml
+++ b/applications/alert-stream-broker/charts/alert-database/templates/ingress.yaml
@@ -1,38 +1,45 @@
 {{- if .Values.ingress.enabled -}}
-apiVersion: networking.k8s.io/v1
-kind: Ingress
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
 metadata:
-  annotations:
-    kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/rewrite-target: /$2
-    nginx.ingress.kubernetes.io/auth-method: "GET"
-    nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr.gafaelfawr.svc.cluster.local:8080/auth?{{ required "ingress.gafaelfawrAuthQuery must be set" .Values.ingress.gafaelfawrAuthQuery }}"
-    {{- with .Values.ingress.annotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
   name: {{ template "alertDatabase.fullname" . }}
   labels:
     {{- include "alertDatabase.labels" . | nindent 4 }}
-spec:
-  rules:
-    - host: {{ required "ingress.host must be set" .Values.ingress.host | quote }}
-      http:
-        paths:
-          - path: "{{ .Values.ingress.path }}(/|$)(.*)"
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ template "alertDatabase.fullname" . }}
-                port:
-                  name: http
-  {{- if .Values.ingress.tls }}
-  tls:
-    {{- range .Values.ingress.tls }}
-    - hosts:
-        {{- range .hosts }}
-        - {{ . | quote }}
-        {{- end }}
-      secretName: {{ .secretName }}
+config:
+  baseUrl: {{ .Values.global.baseUrl | quote }}
+  scopes:
+    all:
+      - "read:alertdb"
+template:
+  metadata:
+    name: {{ template "alertDatabase.fullname" . }}
+    annotations:
+      nginx.ingress.kubernetes.io/rewrite-target: "/$2"
+      {{- with .Values.ingress.annotations }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+    labels:
+      {{- include "alertDatabase.labels" . | nindent 4 }}
+  spec:
+    rules:
+      - host: {{ required "ingress.host must be set" .Values.ingress.host | quote }}
+        http:
+          paths:
+            - path: "{{ .Values.ingress.path }}(/|$)(.*)"
+              pathType: ImplementationSpecific
+              backend:
+                service:
+                  name: {{ template "alertDatabase.fullname" . }}
+                  port:
+                    name: http
+    {{- if .Values.ingress.tls }}
+    tls:
+      {{- range .Values.ingress.tls }}
+      - hosts:
+          {{- range .hosts }}
+          - {{ . | quote }}
+          {{- end }}
+        secretName: {{ .secretName }}
+      {{- end }}
     {{- end }}
-  {{- end }}
 {{- end }}

--- a/applications/alert-stream-broker/charts/alert-database/values.yaml
+++ b/applications/alert-stream-broker/charts/alert-database/values.yaml
@@ -101,6 +101,3 @@ ingress:
 
   # -- Subpath to host the alert database application under the ingress
   path: "/alertdb"
-
-  # -- Query string for Gafaelfawr to authorize access
-  gafaelfawrAuthQuery: "scope=read:alertdb"

--- a/applications/alert-stream-broker/values-usdfdev.yaml
+++ b/applications/alert-stream-broker/values-usdfdev.yaml
@@ -110,7 +110,6 @@ alert-database:
   ingress:
     enabled: true
     host: "usdf-rsp-dev.slac.stanford.edu"
-    gafaelfawrAuthQuery: "scope=read:alertdb"
 
   storage:
     gcp:


### PR DESCRIPTION
The next release of Gafaelfawr will drop support for manually configuring Kubernetes ingresses to use Gafaelfawr and will require the use of `GafaelfawrIngress` resources. Convert the ingress for the alert-database subchart of alert-stream-broker to use `GafaelfawrIngress`.