### PR TITLE
Deploy Prompt Processing 4.5.1 for LATISS

### DIFF
--- a/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
@@ -14,7 +14,7 @@ prompt-proto-service:
   image:
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: 4.5.0
+    tag: 4.5.1
 
   instrument:
     pipelines:

--- a/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
@@ -18,6 +18,9 @@ prompt-proto-service:
 
   instrument:
     pipelines:
+      # BLOCK-306 is photographic imaging
+      # BLOCK-T17 is daytime checkout
+      # BLOCK-271 is photon transfer curve calibrations
       # BLOCK-295 is the daily calibration sequence as of May 27, 2024
       main: >-
         (survey="BLOCK-306")=[${PROMPT_PROCESSING_DIR}/pipelines/LATISS/ApPipe.yaml,


### PR DESCRIPTION
This PR updates the LATISS production version for Prompt Processing and adds some clarifying comments to the config.