### PR TITLE
DM-45522 mobu: App metrics events config

### DIFF
--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -90,7 +90,7 @@ Rubin Observatory's telemetry service
 | app-metrics.debug | bool | false | Run Telegraf in debug mode. |
 | app-metrics.env | list | See `values.yaml` | Telegraf agent enviroment variables |
 | app-metrics.envFromSecret | string | `""` | Name of the secret with values to be added to the environment. |
-| app-metrics.globalAppConfig | object | `{}` | app-metrics configuration in any environment in which the subchart is enabled. This should stay globally specified here, and it shouldn't be overridden. See [here](https://sasquatch.lsst.io/user-guide/app-metrics.html#configuration) for the structure of this value. |
+| app-metrics.globalAppConfig | object | See `values.yaml` | app-metrics configuration in any environment in which the subchart is enabled. This should stay globally specified here, and it shouldn't be overridden. See [here](https://sasquatch.lsst.io/user-guide/app-metrics.html#configuration) for the structure of this value.  |
 | app-metrics.globalInfluxTags | list | `["service"]` | Keys in an every event sent by any app that should be recorded in InfluxDB as "tags" (vs. "fields"). These will be concatenated with the `influxTags` from `globalAppConfig` |
 | app-metrics.image.pullPolicy | string | `"Always"` | Image pull policy |
 | app-metrics.image.repo | string | `"docker.io/library/telegraf"` | Telegraf image repository |

--- a/applications/sasquatch/charts/app-metrics/README.md
+++ b/applications/sasquatch/charts/app-metrics/README.md
@@ -13,7 +13,7 @@ Kafka topics, users, and a telegraf connector for metrics events.
 | debug | bool | false | Run Telegraf in debug mode. |
 | env | list | See `values.yaml` | Telegraf agent enviroment variables |
 | envFromSecret | string | `""` | Name of the secret with values to be added to the environment. |
-| globalAppConfig | object | `{}` | app-metrics configuration in any environment in which the subchart is enabled. This should stay globally specified here, and it shouldn't be overridden. See [here](https://sasquatch.lsst.io/user-guide/app-metrics.html#configuration) for the structure of this value. |
+| globalAppConfig | object | See `values.yaml` | app-metrics configuration in any environment in which the subchart is enabled. This should stay globally specified here, and it shouldn't be overridden. See [here](https://sasquatch.lsst.io/user-guide/app-metrics.html#configuration) for the structure of this value.  |
 | globalInfluxTags | list | `["service"]` | Keys in an every event sent by any app that should be recorded in InfluxDB as "tags" (vs. "fields"). These will be concatenated with the `influxTags` from `globalAppConfig` |
 | image.pullPolicy | string | `"Always"` | Image pull policy |
 | image.repo | string | `"docker.io/library/telegraf"` | Telegraf image repository |

--- a/applications/sasquatch/charts/app-metrics/values.yaml
+++ b/applications/sasquatch/charts/app-metrics/values.yaml
@@ -5,7 +5,12 @@
 # overridden.
 # See [here](https://sasquatch.lsst.io/user-guide/app-metrics.html#configuration)
 # for the structure of this value.
-globalAppConfig: {}
+#
+# @default -- See `values.yaml`
+globalAppConfig:
+  mobu:
+    influxTags:
+      - "type"
 
 # -- A list of applications that will publish metrics events, and the keys that should be ingested into InfluxDB as tags.
 # The names should be the same as the app names in Phalanx.

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -108,3 +108,8 @@ chronograf:
     GENERIC_API_KEY: sub
     PUBLIC_URL: https://data-dev.lsst.cloud/
     STATUS_FEED_URL: https://raw.githubusercontent.com/lsst-sqre/rsp_broadcast/main/jsonfeeds/idfdev.json
+
+app-metrics:
+  enabled: true
+  apps:
+    - mobu


### PR DESCRIPTION
Provision initial app metrics Sasquatch config for mobu, following these instructions:
https://sasquatch.lsst.io/user-guide/app-metrics.html#configuration