### PR TITLE
[DM-46595] Review metric_batch_size configuration in Sasquatch

### DIFF
--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -419,7 +419,7 @@ Rubin Observatory's telemetry service
 | telegraf-kafka-consumer.kafkaConsumers.test.flush_jitter | string | "0s" | Jitter the flush interval by a random amount. This is primarily to avoid large write spikes for users running a large number of telegraf instances. |
 | telegraf-kafka-consumer.kafkaConsumers.test.max_processing_time | string | "5s" | Maximum processing time for a single message. |
 | telegraf-kafka-consumer.kafkaConsumers.test.max_undelivered_messages | int | 10000 | Maximum number of undelivered messages. Should be a multiple of metric_batch_size, setting it too low may never flush the broker's messages. |
-| telegraf-kafka-consumer.kafkaConsumers.test.metric_batch_size | int | 5000 | Sends metrics to the output in batches of at most metric_batch_size metrics. |
+| telegraf-kafka-consumer.kafkaConsumers.test.metric_batch_size | int | 1000 | Sends metrics to the output in batches of at most metric_batch_size metrics. |
 | telegraf-kafka-consumer.kafkaConsumers.test.metric_buffer_limit | int | 100000 | Caches metric_buffer_limit metrics for each output, and flushes this buffer on a successful write. This should be a multiple of metric_batch_size and could not be less than 2 times metric_batch_size. |
 | telegraf-kafka-consumer.kafkaConsumers.test.offset | string | `"oldest"` | Kafka consumer offset. Possible values are `oldest` and `newest`. |
 | telegraf-kafka-consumer.kafkaConsumers.test.precision | string | "1us" | Data precision. |
@@ -456,7 +456,7 @@ Rubin Observatory's telemetry service
 | telegraf-kafka-consumer-oss.kafkaConsumers.test.flush_jitter | string | "0s" | Jitter the flush interval by a random amount. This is primarily to avoid large write spikes for users running a large number of telegraf instances. |
 | telegraf-kafka-consumer-oss.kafkaConsumers.test.max_processing_time | string | "5s" | Maximum processing time for a single message. |
 | telegraf-kafka-consumer-oss.kafkaConsumers.test.max_undelivered_messages | int | 10000 | Maximum number of undelivered messages. Should be a multiple of metric_batch_size, setting it too low may never flush the broker's messages. |
-| telegraf-kafka-consumer-oss.kafkaConsumers.test.metric_batch_size | int | 5000 | Sends metrics to the output in batches of at most metric_batch_size metrics. |
+| telegraf-kafka-consumer-oss.kafkaConsumers.test.metric_batch_size | int | 1000 | Sends metrics to the output in batches of at most metric_batch_size metrics. |
 | telegraf-kafka-consumer-oss.kafkaConsumers.test.metric_buffer_limit | int | 100000 | Caches metric_buffer_limit metrics for each output, and flushes this buffer on a successful write. This should be a multiple of metric_batch_size and could not be less than 2 times metric_batch_size. |
 | telegraf-kafka-consumer-oss.kafkaConsumers.test.offset | string | `"oldest"` | Kafka consumer offset. Possible values are `oldest` and `newest`. |
 | telegraf-kafka-consumer-oss.kafkaConsumers.test.precision | string | "1us" | Data precision. |

--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -403,9 +403,9 @@ Rubin Observatory's telemetry service
 | telegraf-kafka-consumer.enabled | bool | `false` | Wether the Telegraf Kafka Consumer is enabled |
 | telegraf-kafka-consumer.env | list | See `values.yaml` | Telegraf agent enviroment variables |
 | telegraf-kafka-consumer.envFromSecret | string | `""` | Name of the secret with values to be added to the environment. |
-| telegraf-kafka-consumer.image.pullPolicy | string | `"Always"` | Image pull policy |
-| telegraf-kafka-consumer.image.repo | string | `"docker.io/library/telegraf"` | Telegraf image repository |
-| telegraf-kafka-consumer.image.tag | string | `"1.30.2-alpine"` | Telegraf image tag |
+| telegraf-kafka-consumer.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
+| telegraf-kafka-consumer.image.repo | string | `"docker.io/lsstsqre/telegraf"` | Telegraf image repository |
+| telegraf-kafka-consumer.image.tag | string | `"avro-mutex"` | Telegraf image tag |
 | telegraf-kafka-consumer.imagePullSecrets | list | `[]` | Secret names to use for Docker pulls |
 | telegraf-kafka-consumer.influxdb.database | string | `"telegraf-kafka-consumer-v1"` | Name of the InfluxDB v1 database to write to |
 | telegraf-kafka-consumer.influxdb.url | string | `"http://sasquatch-influxdb.sasquatch:8086"` | URL of the InfluxDB v1 instance to write to |
@@ -440,9 +440,9 @@ Rubin Observatory's telemetry service
 | telegraf-kafka-consumer-oss.enabled | bool | `false` | Wether the Telegraf Kafka Consumer is enabled |
 | telegraf-kafka-consumer-oss.env | list | See `values.yaml` | Telegraf agent enviroment variables |
 | telegraf-kafka-consumer-oss.envFromSecret | string | `""` | Name of the secret with values to be added to the environment. |
-| telegraf-kafka-consumer-oss.image.pullPolicy | string | `"Always"` | Image pull policy |
-| telegraf-kafka-consumer-oss.image.repo | string | `"docker.io/library/telegraf"` | Telegraf image repository |
-| telegraf-kafka-consumer-oss.image.tag | string | `"1.30.2-alpine"` | Telegraf image tag |
+| telegraf-kafka-consumer-oss.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
+| telegraf-kafka-consumer-oss.image.repo | string | `"docker.io/lsstsqre/telegraf"` | Telegraf image repository |
+| telegraf-kafka-consumer-oss.image.tag | string | `"avro-mutex"` | Telegraf image tag |
 | telegraf-kafka-consumer-oss.imagePullSecrets | list | `[]` | Secret names to use for Docker pulls |
 | telegraf-kafka-consumer-oss.influxdb.database | string | `"telegraf-kafka-consumer-v1"` | Name of the InfluxDB v1 database to write to |
 | telegraf-kafka-consumer-oss.influxdb.url | string | `"http://sasquatch-influxdb.sasquatch:8086"` | URL of the InfluxDB v1 instance to write to |

--- a/applications/sasquatch/charts/telegraf-kafka-consumer/README.md
+++ b/applications/sasquatch/charts/telegraf-kafka-consumer/README.md
@@ -11,9 +11,9 @@ Telegraf is an agent written in Go for collecting, processing, aggregating, and 
 | enabled | bool | `false` | Wether the Telegraf Kafka Consumer is enabled |
 | env | list | See `values.yaml` | Telegraf agent enviroment variables |
 | envFromSecret | string | `""` | Name of the secret with values to be added to the environment. |
-| image.pullPolicy | string | `"Always"` | Image pull policy |
-| image.repo | string | `"docker.io/library/telegraf"` | Telegraf image repository |
-| image.tag | string | `"1.30.2-alpine"` | Telegraf image tag |
+| image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
+| image.repo | string | `"docker.io/lsstsqre/telegraf"` | Telegraf image repository |
+| image.tag | string | `"avro-mutex"` | Telegraf image tag |
 | imagePullSecrets | list | `[]` | Secret names to use for Docker pulls |
 | influxdb.database | string | `"telegraf-kafka-consumer-v1"` | Name of the InfluxDB v1 database to write to |
 | influxdb.url | string | `"http://sasquatch-influxdb.sasquatch:8086"` | URL of the InfluxDB v1 instance to write to |

--- a/applications/sasquatch/charts/telegraf-kafka-consumer/README.md
+++ b/applications/sasquatch/charts/telegraf-kafka-consumer/README.md
@@ -27,7 +27,7 @@ Telegraf is an agent written in Go for collecting, processing, aggregating, and 
 | kafkaConsumers.test.flush_jitter | string | "0s" | Jitter the flush interval by a random amount. This is primarily to avoid large write spikes for users running a large number of telegraf instances. |
 | kafkaConsumers.test.max_processing_time | string | "5s" | Maximum processing time for a single message. |
 | kafkaConsumers.test.max_undelivered_messages | int | 10000 | Maximum number of undelivered messages. Should be a multiple of metric_batch_size, setting it too low may never flush the broker's messages. |
-| kafkaConsumers.test.metric_batch_size | int | 5000 | Sends metrics to the output in batches of at most metric_batch_size metrics. |
+| kafkaConsumers.test.metric_batch_size | int | 1000 | Sends metrics to the output in batches of at most metric_batch_size metrics. |
 | kafkaConsumers.test.metric_buffer_limit | int | 100000 | Caches metric_buffer_limit metrics for each output, and flushes this buffer on a successful write. This should be a multiple of metric_batch_size and could not be less than 2 times metric_batch_size. |
 | kafkaConsumers.test.offset | string | `"oldest"` | Kafka consumer offset. Possible values are `oldest` and `newest`. |
 | kafkaConsumers.test.precision | string | "1us" | Data precision. |

--- a/applications/sasquatch/charts/telegraf-kafka-consumer/templates/_helpers.tpl
+++ b/applications/sasquatch/charts/telegraf-kafka-consumer/templates/_helpers.tpl
@@ -12,7 +12,7 @@ metadata:
 data:
   telegraf.conf: |+
     [agent]
-      metric_batch_size = {{ default 5000 .value.metric_batch_size }}
+      metric_batch_size = {{ default 1000 .value.metric_batch_size }}
       metric_buffer_limit = {{ default 100000 .value.metric_buffer_limit }}
       collection_jitter = {{ default "0s" .value.collection_jitter | quote }}
       flush_interval = {{ default "10s" .value.flush_interval | quote }}

--- a/applications/sasquatch/charts/telegraf-kafka-consumer/values.yaml
+++ b/applications/sasquatch/charts/telegraf-kafka-consumer/values.yaml
@@ -62,8 +62,8 @@ kafkaConsumers:
 
     # -- Sends metrics to the output in batches of at most metric_batch_size
     # metrics.
-    # @default -- 5000
-    metric_batch_size: 5000
+    # @default -- 1000
+    metric_batch_size: 1000
 
     # -- Caches metric_buffer_limit metrics for each output, and flushes this
     # buffer on a successful write. This should be a multiple of metric_batch_size

--- a/applications/sasquatch/charts/telegraf-kafka-consumer/values.yaml
+++ b/applications/sasquatch/charts/telegraf-kafka-consumer/values.yaml
@@ -5,13 +5,13 @@ enabled: false
 
 image:
   # -- Telegraf image repository
-  repo: "docker.io/library/telegraf"
+  repo: "docker.io/lsstsqre/telegraf"
 
   # -- Telegraf image tag
-  tag: "1.30.2-alpine"
+  tag: "avro-mutex"
 
   # -- Image pull policy
-  pullPolicy: "Always"
+  pullPolicy: "IfNotPresent"
 
 # -- Annotations for telegraf-kafka-consumers pods
 podAnnotations: {}

--- a/applications/sasquatch/values-base.yaml
+++ b/applications/sasquatch/values-base.yaml
@@ -133,9 +133,6 @@ influxdb:
 
 telegraf-kafka-consumer:
   enabled: true
-  image:
-    repo: "docker.io/lsstsqre/telegraf"
-    tag: "avro-mutex"
   kafkaConsumers:
     auxtel:
       enabled: true

--- a/applications/sasquatch/values-base.yaml
+++ b/applications/sasquatch/values-base.yaml
@@ -172,7 +172,6 @@ telegraf-kafka-consumer:
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.MTM1M3" ]
-      metric_batch_size: 2500
       debug: true
     m2:
       enabled: true

--- a/applications/sasquatch/values-tucson-teststand.yaml
+++ b/applications/sasquatch/values-tucson-teststand.yaml
@@ -116,7 +116,6 @@ telegraf-kafka-consumer:
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.MTM1M3" ]
-      metric_batch_size: 2500
       debug: true
     m2:
       enabled: true

--- a/applications/sasquatch/values-tucson-teststand.yaml
+++ b/applications/sasquatch/values-tucson-teststand.yaml
@@ -77,9 +77,6 @@ influxdb:
 
 telegraf-kafka-consumer:
   enabled: true
-  image:
-    repo: "docker.io/lsstsqre/telegraf"
-    tag: "avro-mutex"
   kafkaConsumers:
     auxtel:
       enabled: true

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -167,14 +167,7 @@ telegraf-kafka-consumer:
       database: "efd"
       timestamp_field: "private_efdStamp"
       topicRegexps: |
-         [ "lsst.sal.ESS" ]
-      debug: true
-    eas2:
-      enabled: true
-      database: "efd"
-      timestamp_field: "private_efdStamp"
-      topicRegexps: |
-         [ "lsst.sal.DIMM", "lsst.sal.DSM", "lsst.sal.EPM", "lsst.sal.HVAC", "lsst.sal.WeatherForecast" ]
+         [ "lsst.sal.DIMM", "lsst.sal.ESS", "lsst.sal.DSM", "lsst.sal.EPM", "lsst.sal.HVAC", "lsst.sal.WeatherForecast" ]
       debug: true
     m1m3:
       enabled: true
@@ -251,14 +244,7 @@ telegraf-kafka-consumer:
       database: "efd"
       timestamp_field: "private_efdStamp"
       topicRegexps: |
-        [ "lsst.sal.ATAOS", "lsst.sal.ATDome", "lsst.sal.ATDomeTrajectory" ]
-      debug: true
-    auxtel2:
-      enabled: true
-      database: "efd"
-      timestamp_field: "private_efdStamp"
-      topicRegexps: |
-        [ "lsst.sal.ATHexapod", "lsst.sal.ATPneumatics", "lsst.sal.ATPtg", "lsst.sal.ATMCS" ]
+        [ "lsst.sal.ATAOS", "lsst.sal.ATDome", "lsst.sal.ATDomeTrajectory", "lsst.sal.ATHexapod", "lsst.sal.ATPneumatics", "lsst.sal.ATPtg", "lsst.sal.ATMCS" ]
       debug: true
     latiss:
       enabled: true

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -182,7 +182,6 @@ telegraf-kafka-consumer:
       timestamp_field: "private_efdStamp"
       topicRegexps: |
         [ "lsst.sal.MTM1M3" ]
-      metric_batch_size: 2500
       debug: true
     m2:
       enabled: true


### PR DESCRIPTION
In DM-46463 we reduced the `metric_batch_size` configuration to 2500 to fix the error at BTS. This was seen later at USDF and Summit with the M1M3 connector where we reduced metric_batch_size even further to 1000 messages.

This ticket makes metric_batch_size = 1000 the default configuration in all environments.