### PR TITLE
Exclude telegraf internal metrics from default output

### DIFF
--- a/applications/sasquatch/charts/app-metrics/templates/telegraf-configmap.yaml
+++ b/applications/sasquatch/charts/app-metrics/templates/telegraf-configmap.yaml
@@ -19,6 +19,7 @@ data:
       omit_hostname = true
 
     [[outputs.influxdb]]
+      namedrop = ["telegraf_*"]
       urls = [
         {{ .Values.influxdb.url | quote }}
       ]

--- a/applications/sasquatch/charts/telegraf-kafka-consumer/templates/_helpers.tpl
+++ b/applications/sasquatch/charts/telegraf-kafka-consumer/templates/_helpers.tpl
@@ -21,6 +21,7 @@ data:
       omit_hostname = true
 
     [[outputs.influxdb]]
+      namedrop = ["telegraf_*"]
       urls = [
         {{ .influxdbUrl | quote }}
       ]


### PR DESCRIPTION
We used the `namepass` filter in the Telegraf configuration to route Telegraf internal metrics to its own database. We also need to exclude them from the default output using the `namedrop` filter.
