### PR TITLE
DM-46701: Add additional datastore for dp02 raws

### DIFF
--- a/applications/butler/templates/configmap.yaml
+++ b/applications/butler/templates/configmap.yaml
@@ -33,6 +33,14 @@ data:
             records:
               table: raw_datastore_records
         - datastore:
+            # Also for historical reasons, some files that originated in DP01
+            # are kept in a separate bucket.
+            name: FileDatastore@s3://butler-us-central1-dp01-desc-dr6
+            cls: lsst.daf.butler.datastores.fileDatastore.FileDatastore
+            root: s3://butler-us-central1-dp01-desc-dr6/
+            records:
+              table: dp01_datastore_records
+        - datastore:
             name: FileDatastore@s3://butler-us-central1-dp02-user
             cls: lsst.daf.butler.datastores.fileDatastore.FileDatastore
             root: s3://butler-us-central1-dp02-user/

--- a/applications/butler/templates/configmap.yaml
+++ b/applications/butler/templates/configmap.yaml
@@ -25,6 +25,14 @@ data:
             cls: lsst.daf.butler.datastores.fileDatastore.FileDatastore
             root: s3://butler-us-central1-panda-dev/dc2
         - datastore:
+            # Datasets of type 'raw' are stored in a separate bucket for
+            # historical reasons.
+            name: FileDatastore@s3://curation-us-central1-desc-dc2-run22i
+            cls: lsst.daf.butler.datastores.fileDatastore.FileDatastore
+            root: s3://curation-us-central1-desc-dc2-run22i/
+            records:
+              table: raw_datastore_records
+        - datastore:
             name: FileDatastore@s3://butler-us-central1-dp02-user
             cls: lsst.daf.butler.datastores.fileDatastore.FileDatastore
             root: s3://butler-us-central1-dp02-user/


### PR DESCRIPTION
Add a new relative root that can be used to reference the DP02 raw image files.

Raw images for DP02 were stored in a different S3 bucket than the rest of the files, when this repository was first created.  These were previously referenced from the Registry DB as absolute URLs, which are going to break when the data moves to its new home at SLAC.