### PR TITLE
Record MTVMS telemetry at both Summit and USDF

### DIFF
--- a/applications/sasquatch/values-summit.yaml
+++ b/applications/sasquatch/values-summit.yaml
@@ -401,6 +401,13 @@ telegraf-kafka-consumer:
       topicRegexps: |
         [ "lsst.sal.GIS" ]
       debug: true
+    mtvms:
+      enabled: true
+      database: "efd"
+      timestamp_field: "private_efdStamp"
+      topicRegexps: |
+        [ "lsst.sal.MTVMS" ]
+      debug: true
     lsstcam:
       enabled: true
       database: "efd"

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -232,6 +232,13 @@ telegraf-kafka-consumer:
       topicRegexps: |
         [ "lsst.sal.GIS" ]
       debug: true
+    mtvms:
+      enabled: true
+      database: "efd"
+      timestamp_field: "private_efdStamp"
+      topicRegexps: |
+        [ "lsst.sal.MTVMS" ]
+      debug: true
     lsstcam:
       enabled: true
       database: "efd"


### PR DESCRIPTION
Per discussion in[ Slack](https://rubin-obs.slack.com/archives/C07QM71CVQU/p1728406878984569) Brian Stalder and ​Petr Kubanek concluded we should record all MTVS telemetry in the EFD.

The raw telemetry is now downsampled from 1kHz to 200Hz, and we should record it at both Summit and USDF.

On the EFD side we have made improvements that makes this possible now.

- We improved significantly the EFD at USDF with an InfluxDB Enterprise cluster and local (fast) storage. 
- Kafka is also running on local (fast) storage and we are not constrained by disk space as before.
- We have a timeout that would kill queries longer than 5 min to protect the database.