### PR TITLE
[DM-46735] Implement the repair connector functionality for the Telegraf based connectors in Sasquatch

### DIFF
--- a/applications/sasquatch/charts/telegraf-kafka-consumer/templates/_helpers.tpl
+++ b/applications/sasquatch/charts/telegraf-kafka-consumer/templates/_helpers.tpl
@@ -66,6 +66,36 @@ data:
       max_undelivered_messages = {{ default 10000 .value.max_undelivered_messages }}
       compression_codec = {{ default 3 .value.compression_codec }}
 
+    {{- if .value.repair }}
+    [[inputs.kafka_consumer]]
+      brokers = [
+        "sasquatch-kafka-brokers.sasquatch:9092"
+      ]
+      consumer_group = "telegraf-kafka-consumer-{{ .key }}-repairer"
+      sasl_mechanism = "SCRAM-SHA-512"
+      sasl_password = "$TELEGRAF_PASSWORD"
+      sasl_username = "telegraf"
+      data_format = "avro"
+      avro_schema_registry = "http://sasquatch-schema-registry.sasquatch:8081"
+      avro_timestamp = {{ default "private_efdStamp" .value.timestamp_field | quote }}
+      avro_timestamp_format = {{ default "unix" .value.timestamp_format | quote }}
+      avro_union_mode = {{ default "nullable" .value.union_mode | quote }}
+      avro_field_separator = {{ default "" .value.union_field_separator | quote }}
+      {{- if .value.fields }}
+      avro_fields = {{ .value.fields }}
+      {{- end }}
+      {{- if .value.tags }}
+      avro_tags = {{ .value.tags }}
+      {{- end }}
+      topic_regexps = {{ .value.topicRegexps }}
+      offset = "oldest"
+      precision = {{ default "1us" .value.precision | quote }}
+      max_processing_time = {{ default "5s" .value.max_processing_time | quote }}
+      consumer_fetch_default = {{ default "20MB" .value.consumer_fetch_default | quote }}
+      max_undelivered_messages = {{ default 10000 .value.max_undelivered_messages }}
+      compression_codec = {{ default 3 .value.compression_codec }}
+    {{- end }}
+
     [[inputs.internal]]
       name_prefix = "telegraf_"
       collect_memstats = true

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -143,7 +143,7 @@ telegraf-kafka-consumer:
     # CSC connectors
     maintel:
       enabled: true
-      repair: true
+      repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
       topicRegexps: |
@@ -151,7 +151,7 @@ telegraf-kafka-consumer:
       debug: true
     mtmount:
       enabled: true
-      repair: true
+      repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
       topicRegexps: |
@@ -159,7 +159,7 @@ telegraf-kafka-consumer:
       debug: true
     comcam:
       enabled: true
-      repair: true
+      repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
       topicRegexps: |
@@ -167,7 +167,7 @@ telegraf-kafka-consumer:
       debug: true
     eas:
       enabled: true
-      repair: true
+      repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
       topicRegexps: |
@@ -175,7 +175,7 @@ telegraf-kafka-consumer:
       debug: true
     m1m3:
       enabled: true
-      repair: true
+      repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
       topicRegexps: |
@@ -183,7 +183,7 @@ telegraf-kafka-consumer:
       debug: true
     m2:
       enabled: true
-      repair: true
+      repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
       topicRegexps: |
@@ -191,7 +191,7 @@ telegraf-kafka-consumer:
       debug: true
     obssys:
       enabled: true
-      repair: true
+      repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
       topicRegexps: |
@@ -199,7 +199,7 @@ telegraf-kafka-consumer:
       debug: true
     ocps:
       enabled: true
-      repair: true
+      repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
       topicRegexps: |
@@ -207,7 +207,7 @@ telegraf-kafka-consumer:
       debug: true
     pmd:
       enabled: true
-      repair: true
+      repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
       topicRegexps: |
@@ -215,7 +215,7 @@ telegraf-kafka-consumer:
       debug: true
     calsys:
       enabled: true
-      repair: true
+      repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
       topicRegexps: |
@@ -223,7 +223,7 @@ telegraf-kafka-consumer:
       debug: true
     mtaircompressor:
       enabled: true
-      repair: true
+      repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
       topicRegexps: |
@@ -231,7 +231,7 @@ telegraf-kafka-consumer:
       debug: true
     genericcamera:
       enabled: true
-      repair: true
+      repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
       topicRegexps: |
@@ -239,7 +239,7 @@ telegraf-kafka-consumer:
       debug: true
     gis:
       enabled: true
-      repair: true
+      repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
       topicRegexps: |
@@ -247,6 +247,7 @@ telegraf-kafka-consumer:
       debug: true
     mtvms:
       enabled: true
+      repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
       topicRegexps: |
@@ -254,7 +255,7 @@ telegraf-kafka-consumer:
       debug: true
     lsstcam:
       enabled: true
-      repair: true
+      repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
       topicRegexps: |
@@ -262,7 +263,7 @@ telegraf-kafka-consumer:
       debug: true
     auxtel:
       enabled: true
-      repair: true
+      repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
       topicRegexps: |
@@ -270,7 +271,7 @@ telegraf-kafka-consumer:
       debug: true
     latiss:
       enabled: true
-      repair: true
+      repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
       topicRegexps: |
@@ -278,7 +279,7 @@ telegraf-kafka-consumer:
       debug: true
     test:
       enabled: true
-      repair: true
+      repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
       topicRegexps: |
@@ -286,7 +287,7 @@ telegraf-kafka-consumer:
       debug: true
     lasertracker:
       enabled: true
-      repair: true
+      repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
       topicRegexps: |

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -143,6 +143,7 @@ telegraf-kafka-consumer:
     # CSC connectors
     maintel:
       enabled: true
+      repair: true
       database: "efd"
       timestamp_field: "private_efdStamp"
       topicRegexps: |
@@ -150,6 +151,7 @@ telegraf-kafka-consumer:
       debug: true
     mtmount:
       enabled: true
+      repair: true
       database: "efd"
       timestamp_field: "private_efdStamp"
       topicRegexps: |
@@ -157,6 +159,7 @@ telegraf-kafka-consumer:
       debug: true
     comcam:
       enabled: true
+      repair: true
       database: "efd"
       timestamp_field: "private_efdStamp"
       topicRegexps: |
@@ -164,6 +167,7 @@ telegraf-kafka-consumer:
       debug: true
     eas:
       enabled: true
+      repair: true
       database: "efd"
       timestamp_field: "private_efdStamp"
       topicRegexps: |
@@ -171,6 +175,7 @@ telegraf-kafka-consumer:
       debug: true
     m1m3:
       enabled: true
+      repair: true
       database: "efd"
       timestamp_field: "private_efdStamp"
       topicRegexps: |
@@ -178,6 +183,7 @@ telegraf-kafka-consumer:
       debug: true
     m2:
       enabled: true
+      repair: true
       database: "efd"
       timestamp_field: "private_efdStamp"
       topicRegexps: |
@@ -185,6 +191,7 @@ telegraf-kafka-consumer:
       debug: true
     obssys:
       enabled: true
+      repair: true
       database: "efd"
       timestamp_field: "private_efdStamp"
       topicRegexps: |
@@ -192,6 +199,7 @@ telegraf-kafka-consumer:
       debug: true
     ocps:
       enabled: true
+      repair: true
       database: "efd"
       timestamp_field: "private_efdStamp"
       topicRegexps: |
@@ -199,6 +207,7 @@ telegraf-kafka-consumer:
       debug: true
     pmd:
       enabled: true
+      repair: true
       database: "efd"
       timestamp_field: "private_efdStamp"
       topicRegexps: |
@@ -206,6 +215,7 @@ telegraf-kafka-consumer:
       debug: true
     calsys:
       enabled: true
+      repair: true
       database: "efd"
       timestamp_field: "private_efdStamp"
       topicRegexps: |
@@ -213,6 +223,7 @@ telegraf-kafka-consumer:
       debug: true
     mtaircompressor:
       enabled: true
+      repair: true
       database: "efd"
       timestamp_field: "private_efdStamp"
       topicRegexps: |
@@ -220,6 +231,7 @@ telegraf-kafka-consumer:
       debug: true
     genericcamera:
       enabled: true
+      repair: true
       database: "efd"
       timestamp_field: "private_efdStamp"
       topicRegexps: |
@@ -227,6 +239,7 @@ telegraf-kafka-consumer:
       debug: true
     gis:
       enabled: true
+      repair: true
       database: "efd"
       timestamp_field: "private_efdStamp"
       topicRegexps: |
@@ -241,6 +254,7 @@ telegraf-kafka-consumer:
       debug: true
     lsstcam:
       enabled: true
+      repair: true
       database: "efd"
       timestamp_field: "private_efdStamp"
       topicRegexps: |
@@ -248,6 +262,7 @@ telegraf-kafka-consumer:
       debug: true
     auxtel:
       enabled: true
+      repair: true
       database: "efd"
       timestamp_field: "private_efdStamp"
       topicRegexps: |
@@ -255,6 +270,7 @@ telegraf-kafka-consumer:
       debug: true
     latiss:
       enabled: true
+      repair: true
       database: "efd"
       timestamp_field: "private_efdStamp"
       topicRegexps: |
@@ -262,6 +278,7 @@ telegraf-kafka-consumer:
       debug: true
     test:
       enabled: true
+      repair: true
       database: "efd"
       timestamp_field: "private_efdStamp"
       topicRegexps: |
@@ -269,6 +286,7 @@ telegraf-kafka-consumer:
       debug: true
     lasertracker:
       enabled: true
+      repair: true
       database: "efd"
       timestamp_field: "private_efdStamp"
       topicRegexps: |


### PR DESCRIPTION
The repair connector functionality is missing in the Telegraf based connectors. 
The idea is to enable a repair connector in the Telegraf connector configuration, for example:
```
maintel:
  enabled: true
  repair: true
  database: "efd"
  timestamp_field: "private_efdStamp"
  topicRegexps: |
    [ "lsst.sal.MTAOS", "lsst.sal.MTDome", "lsst.sal.MTDomeTrajectory", "lsst.sal.MTPtg" ]
  debug: true
```  
This will deploy another Kafka consumer with similar configuration but with a  consumer group named `telegraf-kafka-consumer-maintel-repairer` and with offsets set to oldest.
This is the minimal functionality we need to reingest the data in Kafka to InfluxDB.
To have more fine grained control one still can set the offsets for the consumer group manually.

This was used to recover data at USDF between Oct 6 and Oct 7.