### PR TITLE
DM-46701: Update Butler configuration in preparation for moving DP02 files to SLAC

### DIFF
--- a/applications/butler/templates/configmap.yaml
+++ b/applications/butler/templates/configmap.yaml
@@ -17,6 +17,12 @@ data:
             reject:
               - all
         - constraints:
+            reject:
+              - all
+        - constraints:
+            reject:
+              - all
+        - constraints:
             accept:
               - all
       datastores:
@@ -24,6 +30,22 @@ data:
             name: FileDatastore@s3://butler-us-central1-panda-dev/dc2
             cls: lsst.daf.butler.datastores.fileDatastore.FileDatastore
             root: s3://butler-us-central1-panda-dev/dc2
+        - datastore:
+            # Datasets of type 'raw' are stored in a separate bucket for
+            # historical reasons.
+            name: FileDatastore@s3://curation-us-central1-desc-dc2-run22i
+            cls: lsst.daf.butler.datastores.fileDatastore.FileDatastore
+            root: s3://curation-us-central1-desc-dc2-run22i/
+            records:
+              table: raw_datastore_records
+        - datastore:
+            # Also for historical reasons, some files that originated in DP01
+            # are kept in a separate bucket.
+            name: FileDatastore@s3://butler-us-central1-dp01-desc-dr6
+            cls: lsst.daf.butler.datastores.fileDatastore.FileDatastore
+            root: s3://butler-us-central1-dp01-desc-dr6/
+            records:
+              table: dp01_datastore_records
         - datastore:
             name: FileDatastore@s3://butler-us-central1-dp02-user
             cls: lsst.daf.butler.datastores.fileDatastore.FileDatastore


### PR DESCRIPTION
In the Butler configuration used for Butler server and DirectButler, add new relative roots that can be used to reference the DP02 raw image files and files from DP01.

Raw images for DP02 and datasets imported from DP01 were stored in a different S3 buckets than the rest of the files, when this repository was first created.  These were previously referenced from the Registry DB as absolute URLs, which are going to break when the data moves to its new home at SLAC.

Initially no datasets will be present in the new datastores -- it will require a separate migration for this change to take effect.