### PR TITLE
Update consdb secrets in TTS

### DIFF
--- a/applications/consdb/Chart.yaml
+++ b/applications/consdb/Chart.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 description: Consolidated Database of Image Metadata
 type: application
 appVersion: 1.1.0
-home: consdb.lsst.io
+home: https://consdb.lsst.io/
 sources:
   - https://github.com/lsst-dm/consdb
 annotations:

--- a/applications/consdb/README.md
+++ b/applications/consdb/README.md
@@ -2,7 +2,7 @@
 
 Consolidated Database of Image Metadata
 
-**Homepage:** <consdb.lsst.io>
+**Homepage:** <https://consdb.lsst.io/>
 
 ## Source Code
 

--- a/applications/consdb/secrets.yaml
+++ b/applications/consdb/secrets.yaml
@@ -4,14 +4,24 @@ consdb-password:
   copy:
     application: sasquatch
     key: consdb-password
+exposurelog-password:
+  description: >-
+    PostgreSQL password for the exposurelog user exposurelog database.
+  copy:
+    application: exposurelog
+    key: exposurelog_password
 oods-password:
   description: >-
     PostgreSQL password for the OODS user Butler database.
 lfa-password:
   description: >-
     LFA password
-exposurelog-password:
-  description: "Password for the TTS where we use exposurelog database."
   copy:
-    application: exposure-log
-    key: exposurelog_password
+    application: auxtel
+    key: aws-secret-access-key
+lfa-key:
+  description: >-
+    LFA key
+  copy:
+    application: auxtel
+    key: aws-access-key-id

--- a/applications/consdb/templates/hinfo-deployment.yaml
+++ b/applications/consdb/templates/hinfo-deployment.yaml
@@ -47,7 +47,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: consdb
-                  key: "oods-password"
+                  key: "{{ .Values.db.passwordkey }}"
             - name: "DB_USER"
               value: "{{ .Values.db.user }}"
             - name: "DB_NAME"
@@ -73,7 +73,7 @@ spec:
             - name: "KAFKA_PASSWORD"
               valueFrom:
                 secretKeyRef:
-                  name: sasquatch
+                  name: consdb
                   key: "consdb-password"
             - name: "KAFKA_GROUP_ID"
               value: "{{ .Values.kafka.group_id }}"
@@ -145,7 +145,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: consdb
-                  key: "oods-password"
+                  key: "{{ .Values.db.passwordkey }}"
             - name: "DB_USER"
               value: "{{ .Values.db.user }}"
             - name: "DB_NAME"
@@ -171,7 +171,7 @@ spec:
             - name: "KAFKA_PASSWORD"
               valueFrom:
                 secretKeyRef:
-                  name: sasquatch
+                  name: consdb
                   key: "consdb-password"
             - name: "KAFKA_GROUP_ID"
               value: "{{ .Values.kafka.group_id }}"
@@ -243,7 +243,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: consdb
-                  key: "oods-password"
+                  key: "{{ .Values.db.passwordkey }}"
             - name: "DB_USER"
               value: "{{ .Values.db.user }}"
             - name: "DB_NAME"
@@ -269,7 +269,7 @@ spec:
             - name: "KAFKA_PASSWORD"
               valueFrom:
                 secretKeyRef:
-                  name: sasquatch
+                  name: consdb
                   key: "consdb-password"
             - name: "KAFKA_GROUP_ID"
               value: "{{ .Values.kafka.group_id }}"

--- a/applications/consdb/templates/pq-deployment.yaml
+++ b/applications/consdb/templates/pq-deployment.yaml
@@ -49,7 +49,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: consdb
-                  key: "oods-password"
+                  key: "{{ .Values.db.passwordkey }}"
             - name: "DB_USER"
               value: "{{ .Values.db.user }}"
             - name: "DB_NAME"

--- a/applications/consdb/templates/vault-secrets.yaml
+++ b/applications/consdb/templates/vault-secrets.yaml
@@ -4,16 +4,7 @@ metadata:
   name: consdb
   namespace: consdb
 spec:
-  path:  {{ .Values.global.vaultSecretsPath }}/consdb
-  type: Opaque
----
-apiVersion: ricoberger.de/v1alpha1
-kind: VaultSecret
-metadata:
-  name: sasquatch
-  namespace: consdb
-spec:
-  path:  {{ .Values.global.vaultSecretsPath }}/sasquatch
+  path:  "{{ .Values.global.vaultSecretsPath }}/consdb"
   type: Opaque
 ---
 apiVersion: ricoberger.de/v1alpha1

--- a/applications/consdb/values-base.yaml
+++ b/applications/consdb/values-base.yaml
@@ -1,5 +1,6 @@
 db:
   user: "oods"
+  passwordkey: "oods-password"
   host: "postgresdb01.ls.lsst.org"
   database: "butler"
 lfa:

--- a/applications/consdb/values-summit.yaml
+++ b/applications/consdb/values-summit.yaml
@@ -1,5 +1,6 @@
 db:
   user: "oods"
+  passwordkey: "oods-password"
   host: "postgresdb01.cp.lsst.org"
   database: "exposurelog"
 lfa:

--- a/applications/consdb/values-tucson-teststand.yaml
+++ b/applications/consdb/values-tucson-teststand.yaml
@@ -1,5 +1,6 @@
 db:
-  user: "oods"
+  user: "exposurelog"
+  passwordkey: "exposurelog-password"
   host: "postgresdb01.tu.lsst.org"
   database: "exposurelog"
 lfa:

--- a/applications/consdb/values-usdfdev.yaml
+++ b/applications/consdb/values-usdfdev.yaml
@@ -1,5 +1,6 @@
 db:
   user: "usdf"
+  passwordkey: "oods-password"
   host: "usdf-summitdb.slac.stanford.edu"
   database: "exposurelog"
 hinfo:

--- a/applications/consdb/values-usdfprod.yaml
+++ b/applications/consdb/values-usdfprod.yaml
@@ -1,5 +1,6 @@
 db:
   user: "usdf"
+  passwordkey: "oods-password"
   host: "usdf-summitdb.slac.stanford.edu"
   database: "exposurelog"
 hinfo:

--- a/applications/sasquatch/values-tucson-teststand.yaml
+++ b/applications/sasquatch/values-tucson-teststand.yaml
@@ -49,6 +49,8 @@ strimzi-kafka:
       enabled: true
     kafkaConnectManager:
       enabled: true
+    consdb:
+      enabled: true
   registry:
     ingress:
       enabled: true

--- a/docs/developers/helm-chart/values-yaml.rst
+++ b/docs/developers/helm-chart/values-yaml.rst
@@ -3,7 +3,7 @@ Write the values.yaml file
 ##########################
 
 The :file:`values.yaml` file contains the customizable settings for your application.
-Those settings can be overriden for each environment in :file:`values-{environmet}.yaml`.
+Those settings can be overriden for each environment in :file:`values-{environment}.yaml`.
 
 As a general rule, only use :file:`values.yaml` settings for things that may vary between Phalanx environments.
 If something is the same in every Phalanx environment, it can be hard-coded into the Kubernetes resource templates.


### PR DESCRIPTION
Add consdb to Sasquatch's kafka users. Reorganize secrets for consdb. This first step was meant to create consdb on TTS, with the same configuration as on Summit as far as we can. The next steps will be to upgrade consdb, hinfo, pqserver to the most recent commits and test that they work as expected with the correct alembic migration already applied. (At TTS then at Summit)