### PR TITLE
[DM-46785] Increase Kafka retention to 7 days at Summit and USDF Sasquatch environments

### DIFF
--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -366,9 +366,9 @@ Rubin Observatory's telemetry service
 | strimzi-kafka.connect.replicas | int | `3` | Number of Kafka Connect replicas to run |
 | strimzi-kafka.cruiseControl | object | `{"enabled":false}` | Configuration for the Kafka Cruise Control |
 | strimzi-kafka.kafka.affinity | object | See `values.yaml` | Affinity for Kafka pod assignment |
-| strimzi-kafka.kafka.config."log.retention.minutes" | int | `2880` | Number of days for a topic's data to be retained |
+| strimzi-kafka.kafka.config."log.retention.minutes" | int | 4320 minutes (3 days) | Number of days for a topic's data to be retained |
 | strimzi-kafka.kafka.config."message.max.bytes" | int | `10485760` | The largest record batch size allowed by Kafka |
-| strimzi-kafka.kafka.config."offsets.retention.minutes" | int | `2880` | Number of minutes for a consumer group's offsets to be retained |
+| strimzi-kafka.kafka.config."offsets.retention.minutes" | int | 4320 minutes (3 days) | Number of minutes for a consumer group's offsets to be retained |
 | strimzi-kafka.kafka.config."replica.fetch.max.bytes" | int | `10485760` | The number of bytes of messages to attempt to fetch for each partition |
 | strimzi-kafka.kafka.externalListener.bootstrap.annotations | object | `{}` | Annotations that will be added to the Ingress, Route, or Service resource |
 | strimzi-kafka.kafka.externalListener.bootstrap.host | string | Do not configure TLS | Name used for TLS hostname verification |

--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -366,7 +366,6 @@ Rubin Observatory's telemetry service
 | strimzi-kafka.connect.replicas | int | `3` | Number of Kafka Connect replicas to run |
 | strimzi-kafka.cruiseControl | object | `{"enabled":false}` | Configuration for the Kafka Cruise Control |
 | strimzi-kafka.kafka.affinity | object | See `values.yaml` | Affinity for Kafka pod assignment |
-| strimzi-kafka.kafka.config."log.retention.bytes" | string | `"350000000000"` | How much disk space Kafka will ensure is available, set to 70% of the data partition size |
 | strimzi-kafka.kafka.config."log.retention.hours" | int | `48` | Number of days for a topic's data to be retained |
 | strimzi-kafka.kafka.config."message.max.bytes" | int | `10485760` | The largest record batch size allowed by Kafka |
 | strimzi-kafka.kafka.config."offsets.retention.minutes" | int | `2880` | Number of minutes for a consumer group's offsets to be retained |

--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -366,7 +366,7 @@ Rubin Observatory's telemetry service
 | strimzi-kafka.connect.replicas | int | `3` | Number of Kafka Connect replicas to run |
 | strimzi-kafka.cruiseControl | object | `{"enabled":false}` | Configuration for the Kafka Cruise Control |
 | strimzi-kafka.kafka.affinity | object | See `values.yaml` | Affinity for Kafka pod assignment |
-| strimzi-kafka.kafka.config."log.retention.hours" | int | `48` | Number of days for a topic's data to be retained |
+| strimzi-kafka.kafka.config."log.retention.minutes" | int | `2880` | Number of days for a topic's data to be retained |
 | strimzi-kafka.kafka.config."message.max.bytes" | int | `10485760` | The largest record batch size allowed by Kafka |
 | strimzi-kafka.kafka.config."offsets.retention.minutes" | int | `2880` | Number of minutes for a consumer group's offsets to be retained |
 | strimzi-kafka.kafka.config."replica.fetch.max.bytes" | int | `10485760` | The number of bytes of messages to attempt to fetch for each partition |

--- a/applications/sasquatch/charts/strimzi-kafka/README.md
+++ b/applications/sasquatch/charts/strimzi-kafka/README.md
@@ -20,7 +20,7 @@ A subchart to deploy Strimzi Kafka components for Sasquatch.
 | connect.replicas | int | `3` | Number of Kafka Connect replicas to run |
 | cruiseControl | object | `{"enabled":false}` | Configuration for the Kafka Cruise Control |
 | kafka.affinity | object | See `values.yaml` | Affinity for Kafka pod assignment |
-| kafka.config."log.retention.hours" | int | `48` | Number of days for a topic's data to be retained |
+| kafka.config."log.retention.minutes" | int | `2880` | Number of days for a topic's data to be retained |
 | kafka.config."message.max.bytes" | int | `10485760` | The largest record batch size allowed by Kafka |
 | kafka.config."offsets.retention.minutes" | int | `2880` | Number of minutes for a consumer group's offsets to be retained |
 | kafka.config."replica.fetch.max.bytes" | int | `10485760` | The number of bytes of messages to attempt to fetch for each partition |

--- a/applications/sasquatch/charts/strimzi-kafka/README.md
+++ b/applications/sasquatch/charts/strimzi-kafka/README.md
@@ -20,9 +20,9 @@ A subchart to deploy Strimzi Kafka components for Sasquatch.
 | connect.replicas | int | `3` | Number of Kafka Connect replicas to run |
 | cruiseControl | object | `{"enabled":false}` | Configuration for the Kafka Cruise Control |
 | kafka.affinity | object | See `values.yaml` | Affinity for Kafka pod assignment |
-| kafka.config."log.retention.minutes" | int | `2880` | Number of days for a topic's data to be retained |
+| kafka.config."log.retention.minutes" | int | 4320 minutes (3 days) | Number of days for a topic's data to be retained |
 | kafka.config."message.max.bytes" | int | `10485760` | The largest record batch size allowed by Kafka |
-| kafka.config."offsets.retention.minutes" | int | `2880` | Number of minutes for a consumer group's offsets to be retained |
+| kafka.config."offsets.retention.minutes" | int | 4320 minutes (3 days) | Number of minutes for a consumer group's offsets to be retained |
 | kafka.config."replica.fetch.max.bytes" | int | `10485760` | The number of bytes of messages to attempt to fetch for each partition |
 | kafka.externalListener.bootstrap.annotations | object | `{}` | Annotations that will be added to the Ingress, Route, or Service resource |
 | kafka.externalListener.bootstrap.host | string | Do not configure TLS | Name used for TLS hostname verification |

--- a/applications/sasquatch/charts/strimzi-kafka/README.md
+++ b/applications/sasquatch/charts/strimzi-kafka/README.md
@@ -20,7 +20,6 @@ A subchart to deploy Strimzi Kafka components for Sasquatch.
 | connect.replicas | int | `3` | Number of Kafka Connect replicas to run |
 | cruiseControl | object | `{"enabled":false}` | Configuration for the Kafka Cruise Control |
 | kafka.affinity | object | See `values.yaml` | Affinity for Kafka pod assignment |
-| kafka.config."log.retention.bytes" | string | `"350000000000"` | How much disk space Kafka will ensure is available, set to 70% of the data partition size |
 | kafka.config."log.retention.hours" | int | `48` | Number of days for a topic's data to be retained |
 | kafka.config."message.max.bytes" | int | `10485760` | The largest record batch size allowed by Kafka |
 | kafka.config."offsets.retention.minutes" | int | `2880` | Number of minutes for a consumer group's offsets to be retained |

--- a/applications/sasquatch/charts/strimzi-kafka/values.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/values.yaml
@@ -32,7 +32,7 @@ kafka:
     offsets.retention.minutes: 2880
 
     # -- Number of days for a topic's data to be retained
-    log.retention.hours: 48
+    log.retention.minutes: 2880
 
     # -- The largest record batch size allowed by Kafka
     message.max.bytes: 10485760

--- a/applications/sasquatch/charts/strimzi-kafka/values.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/values.yaml
@@ -29,10 +29,12 @@ kafka:
 
   config:
     # -- Number of minutes for a consumer group's offsets to be retained
-    offsets.retention.minutes: 2880
+    # @default -- 4320 minutes (3 days)
+    offsets.retention.minutes: 4320
 
     # -- Number of days for a topic's data to be retained
-    log.retention.minutes: 2880
+    # @default -- 4320 minutes (3 days)
+    log.retention.minutes: 4320
 
     # -- The largest record batch size allowed by Kafka
     message.max.bytes: 10485760

--- a/applications/sasquatch/charts/strimzi-kafka/values.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/values.yaml
@@ -34,10 +34,6 @@ kafka:
     # -- Number of days for a topic's data to be retained
     log.retention.hours: 48
 
-    # -- How much disk space Kafka will ensure is available, set to 70% of the
-    # data partition size
-    log.retention.bytes: "350000000000"
-
     # -- The largest record batch size allowed by Kafka
     message.max.bytes: 10485760
 

--- a/applications/sasquatch/values-summit.yaml
+++ b/applications/sasquatch/values-summit.yaml
@@ -1,5 +1,8 @@
 strimzi-kafka:
   kafka:
+    config:
+      log.retention.minutes: 10080
+      offsets.retention.minutes: 10080
     storage:
       storageClassName: rook-ceph-block
     externalListener:

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -1,13 +1,5 @@
 strimzi-kafka:
   kafka:
-    minInsyncReplicas: 1
-    listeners:
-      tls:
-        enabled: true
-      plain:
-        enabled: true
-      external:
-        enabled: true
     config:
       # -- Replica lag time can't be smaller than request.timeout.ms configuration in kafka connect.
       replica.lag.time.max.ms: 120000

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -3,6 +3,8 @@ strimzi-kafka:
     config:
       # -- Replica lag time can't be smaller than request.timeout.ms configuration in kafka connect.
       replica.lag.time.max.ms: 120000
+      log.retention.minutes: 10080
+      offsets.retention.minutes: 10080
 
   connect:
     enabled: true


### PR DESCRIPTION
We recently moved Kafka to local storage at both Summit and USDF clusters and have more storage available. Increasing the retention period from 3 to 7 days helps to recover data from outages and we can do it now that we have more storage.