### PR TITLE
Force a docs build if dependencies change

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -40,6 +40,7 @@ jobs:
               - "applications/argocd/values-*.yaml"
               - "applications/gafaelfawr/values-*.yaml"
               - "environments/values-*.yaml"
+              - "requirements/*.txt"
               - "src/phalanx/**"
             docsSpecific:
               - "docs/**"


### PR DESCRIPTION
We need to test the documentation build if any dependencies have changed, since they may be Sphinx dependencies. We missed a breaking Sphinx change because we didn't have that test.