### PR TITLE
DM-45522: sasquatch metrics events tweaks

### DIFF
--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -91,7 +91,7 @@ Rubin Observatory's telemetry service
 | app-metrics.env | list | See `values.yaml` | Telegraf agent enviroment variables |
 | app-metrics.envFromSecret | string | `""` | Name of the secret with values to be added to the environment. |
 | app-metrics.globalAppConfig | object | See `values.yaml` | app-metrics configuration in any environment in which the subchart is enabled. This should stay globally specified here, and it shouldn't be overridden. See [here](https://sasquatch.lsst.io/user-guide/app-metrics.html#configuration) for the structure of this value.  |
-| app-metrics.globalInfluxTags | list | `["service"]` | Keys in an every event sent by any app that should be recorded in InfluxDB as "tags" (vs. "fields"). These will be concatenated with the `influxTags` from `globalAppConfig` |
+| app-metrics.globalInfluxTags | list | `["app_name"]` | Keys in an every event sent by any app that should be recorded in InfluxDB as "tags" (vs. "fields"). These will be concatenated with the `influxTags` from `globalAppConfig` |
 | app-metrics.image.pullPolicy | string | `"Always"` | Image pull policy |
 | app-metrics.image.repo | string | `"docker.io/library/telegraf"` | Telegraf image repository |
 | app-metrics.image.tag | string | `"1.30.2-alpine"` | Telegraf image tag |

--- a/applications/sasquatch/charts/app-metrics/README.md
+++ b/applications/sasquatch/charts/app-metrics/README.md
@@ -14,7 +14,7 @@ Kafka topics, users, and a telegraf connector for metrics events.
 | env | list | See `values.yaml` | Telegraf agent enviroment variables |
 | envFromSecret | string | `""` | Name of the secret with values to be added to the environment. |
 | globalAppConfig | object | See `values.yaml` | app-metrics configuration in any environment in which the subchart is enabled. This should stay globally specified here, and it shouldn't be overridden. See [here](https://sasquatch.lsst.io/user-guide/app-metrics.html#configuration) for the structure of this value.  |
-| globalInfluxTags | list | `["service"]` | Keys in an every event sent by any app that should be recorded in InfluxDB as "tags" (vs. "fields"). These will be concatenated with the `influxTags` from `globalAppConfig` |
+| globalInfluxTags | list | `["app_name"]` | Keys in an every event sent by any app that should be recorded in InfluxDB as "tags" (vs. "fields"). These will be concatenated with the `influxTags` from `globalAppConfig` |
 | image.pullPolicy | string | `"Always"` | Image pull policy |
 | image.repo | string | `"docker.io/library/telegraf"` | Telegraf image repository |
 | image.tag | string | `"1.30.2-alpine"` | Telegraf image tag |

--- a/applications/sasquatch/charts/app-metrics/templates/telegraf-configmap.yaml
+++ b/applications/sasquatch/charts/app-metrics/templates/telegraf-configmap.yaml
@@ -23,7 +23,7 @@ data:
       urls = [
         {{ .Values.influxdb.url | quote }}
       ]
-      database = "telegraf-kafka-app-metrics-consumer"
+      database = "lsst.square.metrics"
       username = "${INFLUXDB_USER}"
       password = "${INFLUXDB_PASSWORD}"
 

--- a/applications/sasquatch/charts/app-metrics/values.yaml
+++ b/applications/sasquatch/charts/app-metrics/values.yaml
@@ -19,7 +19,7 @@ apps: []
 # -- Keys in an every event sent by any app that should be recorded in InfluxDB
 # as "tags" (vs. "fields"). These will be concatenated with the `influxTags` from
 # `globalAppConfig`
-globalInfluxTags: ["service"]
+globalInfluxTags: ["app_name"]
 
 cluster:
   # The name of the Strimzi cluster. Synchronize this with the cluster name in


### PR DESCRIPTION
* `service` -> `app_name` for metrics event app metadata InfluxDB tag
* Change the metrics InfluxDB database name to be consistent with how other Sasquatch DBs are named