### PR TITLE
Increase liveness probe failureThreshold for InfluxDB Enterprise

### DIFF
--- a/applications/sasquatch/charts/influxdb-enterprise/templates/data-statefulset.yaml
+++ b/applications/sasquatch/charts/influxdb-enterprise/templates/data-statefulset.yaml
@@ -86,6 +86,7 @@ spec:
               containerPort: 25826
               protocol: UDP
           livenessProbe:
+            failureThreshold: 6
             httpGet:
               path: /ping
               port: http


### PR DESCRIPTION
- Increase the failureThreshold to ensure that the pod can remain not ready for longer before it is killed by the liveness probe, and thus has enough time to start.