### PR TITLE
Disable vo-cutouts schema updates

### DIFF
--- a/applications/vo-cutouts/values-idfint.yaml
+++ b/applications/vo-cutouts/values-idfint.yaml
@@ -1,7 +1,6 @@
 config:
   serviceAccount: "vo-cutouts@science-platform-int-dc5d.iam.gserviceaccount.com"
   storageBucketUrl: "gs://rubin-cutouts-int-us-central1-output/"
-  updateSchema: true
 
 cloudsql:
   enabled: true

--- a/applications/vo-cutouts/values-idfprod.yaml
+++ b/applications/vo-cutouts/values-idfprod.yaml
@@ -1,7 +1,6 @@
 config:
   serviceAccount: "vo-cutouts@science-platform-stable-6994.iam.gserviceaccount.com"
   storageBucketUrl: "gs://rubin-cutouts-stable-us-central1-output/"
-  updateSchema: true
 
 cloudsql:
   enabled: true


### PR DESCRIPTION
These schema updates have been complete, so disable schema updates to return to the default.