### PR TITLE
Update ConsDb Tag to fix current migration issues

### DIFF
--- a/applications/consdb/values-summit.yaml
+++ b/applications/consdb/values-summit.yaml
@@ -8,15 +8,15 @@ lfa:
 hinfo:
   latiss:
     enable: true
-    tag: "24.10.1"
+    tag: "24.10.3"
     logConfig: "consdb.hinfo=DEBUG"
   lsstcomcam:
     enable: true
-    tag: "24.10.1"
+    tag: "24.10.3"
     logConfig: "consdb.hinfo=DEBUG"
   lsstcam:
     enable: false
-    tag: "24.10.1"
+    tag: "24.10.3"
 pq:
   image:
-    tag: "24.10.1"
+    tag: "24.10.3"

--- a/applications/consdb/values-tucson-teststand.yaml
+++ b/applications/consdb/values-tucson-teststand.yaml
@@ -8,19 +8,19 @@ lfa:
 hinfo:
   latiss:
     enable: true
-    tag: "24.10.1"
+    tag: "24.10.3"
     logConfig: "consdb.hinfo=DEBUG"
   lsstcomcam:
     enable: true
-    tag: "24.10.1"
+    tag: "24.10.3"
     logConfig: "consdb.hinfo=DEBUG"
   lsstcam:
     enable: false
-    tag: "24.10.1"
+    tag: "24.10.3"
 
 pq:
   image:
-    tag: "24.10.1"
+    tag: "24.10.3"
 
 resources:
   requests:

--- a/applications/consdb/values-usdfdev.yaml
+++ b/applications/consdb/values-usdfdev.yaml
@@ -6,13 +6,13 @@ db:
 hinfo:
   latiss:
     enable: false
-    tag: "24.10.1"
+    tag: "24.10.3"
   lsstcomcam:
     enable: false
-    tag: "24.10.1"
+    tag: "24.10.3"
   lsstcam:
     enable: false
-    tag: "24.10.1"
+    tag: "24.10.3"
 pq:
   image:
-    tag: "24.10.1"
+    tag: "24.10.3"

--- a/applications/consdb/values-usdfprod.yaml
+++ b/applications/consdb/values-usdfprod.yaml
@@ -6,13 +6,13 @@ db:
 hinfo:
   latiss:
     enable: false
-    tag: "24.10.1"
+    tag: "24.10.3"
   lsstcomcam:
     enable: false
-    tag: "24.10.1"
+    tag: "24.10.3"
   lsstcam:
     enable: false
-    tag: "24.10.1"
+    tag: "24.10.3"
 pq:
   image:
-    tag: "24.10.1"
+    tag: "24.10.3"


### PR DESCRIPTION
Upon updating ConsDb on the summit, we ran into some issues and those have been fixed and tested in TTS in version 24.10.3 consdb. 