### PR TITLE
DM-47011: Allow configuring Gafaelfawr internal URL

### DIFF
--- a/applications/gafaelfawr/README.md
+++ b/applications/gafaelfawr/README.md
@@ -26,6 +26,7 @@ Authentication and identity system
 | cloudsql.serviceAccount | string | None, must be set if Cloud SQL Auth Proxy is enabled | The Google service account that has an IAM binding to the `gafaelfawr` Kubernetes service account and has the `cloudsql.client` role |
 | cloudsql.tolerations | list | `[]` | Tolerations for the Cloud SQL Proxy pod |
 | config.afterLogoutUrl | string | Top-level page of this Phalanx environment | Where to send the user after they log out |
+| config.baseInternalUrl | string | FQDN under `svc.cluster.local` | URL for direct connections to the Gafaelfawr service, bypassing the Ingress. Must use a service name of `gafaelfawr` and port 8080. |
 | config.cilogon.clientId | string | `nil` | CILogon client ID. One and only one of this, `config.github.clientId`, or `config.oidc.clientId` must be set. |
 | config.cilogon.enrollmentUrl | string | Login fails with an error | Where to send the user if their username cannot be found in LDAP |
 | config.cilogon.loginParams | object | `{"skin":"LSST"}` | Additional parameters to add |

--- a/applications/gafaelfawr/templates/_helpers.tpl
+++ b/applications/gafaelfawr/templates/_helpers.tpl
@@ -36,8 +36,10 @@ Common environment variables
 {{- end }}
 - name: "GAFAELFAWR_BASE_URL"
   value: {{ .Values.global.baseUrl | quote }}
+{{- if not .Values.config.baseInternalUrl }}
 - name: "GAFAELFAWR_BASE_INTERNAL_URL"
   value: "http://gafaelfawr.{{ .Release.Namespace }}.svc.cluster.local:8080"
+{{- end }}
 - name: "GAFAELFAWR_BOOTSTRAP_TOKEN"
   valueFrom:
     secretKeyRef:

--- a/applications/gafaelfawr/values.yaml
+++ b/applications/gafaelfawr/values.yaml
@@ -41,6 +41,11 @@ config:
   # @default -- Top-level page of this Phalanx environment
   afterLogoutUrl: null
 
+  # -- URL for direct connections to the Gafaelfawr service, bypassing the
+  # Ingress. Must use a service name of `gafaelfawr` and port 8080.
+  # @default -- FQDN under `svc.cluster.local`
+  baseInternalUrl: null
+
   # -- URL for the PostgreSQL database
   # @default -- None, must be set if neither `cloudsql.enabled` nor
   # `config.internalDatabase` are true


### PR DESCRIPTION
Just in case someone is using a cluster FQDN other than `svc.cluster.local`, allow configuring the Gafaelfawr internal URL.