### PR TITLE
Deploy Next Visit Fan Out 2.4.0.

### DIFF
--- a/applications/next-visit-fan-out/values-usdfdev-prompt-processing.yaml
+++ b/applications/next-visit-fan-out/values-usdfdev-prompt-processing.yaml
@@ -13,6 +13,6 @@ image:
   repository: ghcr.io/lsst-dm/next_visit_fan_out
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 2.3.0
+  tag: 2.4.0
 
 instruments: "LATISS LSSTComCamSim HSC"

--- a/applications/next-visit-fan-out/values-usdfprod-prompt-processing.yaml
+++ b/applications/next-visit-fan-out/values-usdfprod-prompt-processing.yaml
@@ -11,6 +11,6 @@ image:
   repository: ghcr.io/lsst-dm/next_visit_fan_out
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 2.3.0
+  tag: 2.4.0
 
 instruments: "LATISS"


### PR DESCRIPTION
This PR updates the fan-out version in both -dev and -prod.