### PR TITLE
Allow an unlimited number of series per database in Sasquatch (InfluxDB OSS)

### DIFF
--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -40,6 +40,7 @@ Rubin Observatory's telemetry service
 | influxdb.config.coordinator.query-timeout | string | `"30s"` | Maximum duration a query is allowed to run before it is killed |
 | influxdb.config.coordinator.write-timeout | string | `"1h"` | Duration a write request waits before timeout is returned to the caller |
 | influxdb.config.data.cache-max-memory-size | int | `0` | Maximum size a shared cache can reach before it starts rejecting writes |
+| influxdb.config.data.max-series-per-database | int | `0` | Maximum number of series allowed per database before writes are dropped. Change the setting to 0 to allow an unlimited number of series per database. |
 | influxdb.config.data.trace-logging-enabled | bool | `true` | Whether to enable verbose logging of additional debug information within the TSM engine and WAL |
 | influxdb.config.data.wal-fsync-delay | string | `"100ms"` | Duration a write will wait before fsyncing. This is useful for slower disks or when WAL write contention is present. |
 | influxdb.config.http.auth-enabled | bool | `true` | Whether authentication is required |

--- a/applications/sasquatch/values-usdfdev.yaml
+++ b/applications/sasquatch/values-usdfdev.yaml
@@ -98,6 +98,7 @@ kafka-connect-manager:
         topicsRegex: ".*GIS"
       lsstdm:
         enabled: true
+        repairerConnector: true
         timestamp: "timestamp"
         connectInfluxDb: "lsst.dm"
         topicsRegex: "lsst.dm.*"

--- a/applications/sasquatch/values-usdfdev.yaml
+++ b/applications/sasquatch/values-usdfdev.yaml
@@ -98,7 +98,6 @@ kafka-connect-manager:
         topicsRegex: ".*GIS"
       lsstdm:
         enabled: true
-        repairerConnector: true
         timestamp: "timestamp"
         connectInfluxDb: "lsst.dm"
         topicsRegex: "lsst.dm.*"

--- a/applications/sasquatch/values.yaml
+++ b/applications/sasquatch/values.yaml
@@ -93,6 +93,11 @@ influxdb:
       # within the TSM engine and WAL
       trace-logging-enabled: true
 
+      # -- Maximum number of series allowed per database before writes are
+      # dropped. Change the setting to 0 to allow an unlimited number of series per
+      # database.
+      max-series-per-database: 0
+
     http:
       # -- Whether to enable the HTTP endpoints
       enabled: true


### PR DESCRIPTION
We reached [this limit](https://docs.influxdata.com/influxdb/v1/administration/config/#:~:text=max%2Dseries%2Dper%2Ddatabase,is%201000000%20(one%20million).) in the database which caused the following error:

```
2024-10-23 04:29:08,071 ERROR [influxdb-sink-lsstdm-repairer|task-0] Encountered error [partial write: max-series-per-database limit exceeded: (1000000) dropped=484] (com.datamountaineer.streamreactor.connect.influx.writers.InfluxDbWriter) [task-thread-influxdb-sink-lsstdm-repairer-0]
```
and then some data points were dropped. 

For the moment I disabled the max-series-per-database limit to allow an unlimited number of series per database, and I enabled the repair connector in Sasquatch to reingest the data from Kafka.

That error indicates a cardinality issue in how we are designing our tags. Looking at the schema it seems that the run tag is the problem, if we multiple the number of values for each tag by the number of metrics we have in [lsst.dm](http://lsst.dm/) we reach the default limit of 1000000 series per database.
