### PR TITLE
DM-47070: Use client-server butler for default dp02 in prod

### DIFF
--- a/applications/butler/values-idfprod.yaml
+++ b/applications/butler/values-idfprod.yaml
@@ -1,4 +1,5 @@
 config:
+  dp02ClientServerIsDefault: true
   dp02PostgresUri: postgresql://postgres@10.163.0.3/idfdp02
   s3EndpointUrl: "https://storage.googleapis.com"
   repositories:


### PR DESCRIPTION
We are ready to switch over to client-server Butler as the default in production, so switch the `dp02` alias at IDF prod to point to client-server Butler.