### PR TITLE
DM-46254: Switch LATISS Prompt Processing to the new Embargo Rack buckets

### DIFF
--- a/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
@@ -52,13 +52,13 @@ prompt-proto-service:
 
   s3:
     imageBucket: rubin-summit
-    endpointUrl: https://s3dfrgw.slac.stanford.edu
+    endpointUrl: https://sdfembs3.sdf.slac.stanford.edu
 
-  raw_microservice: http://172.24.5.144:8080/presence
+  raw_microservice: http://172.24.5.158:8080/presence
 
   imageNotifications:
     kafkaClusterAddress: prompt-processing-2-kafka-bootstrap.kafka:9092
-    topic: rubin-prompt-processing-prod
+    topic: rubin-summit-notification
     # Scheduler adds an extra 60-80-second delay for first visit in a sequence,
     # and files can take up to 20 seconds to arrive. Scheduler delay associated
     # with CWFS engineering data, should not apply to other cameras.


### PR DESCRIPTION
Merging of this PR should wait until LATISS is re-configured to send data to Embargo Rack.