### PR TITLE
DM-47148: Clean up Gafaelfawr Helm chart

### DIFF
--- a/applications/gafaelfawr/README.md
+++ b/applications/gafaelfawr/README.md
@@ -104,7 +104,7 @@ Authentication and identity system
 | podAnnotations | object | `{}` | Annotations for the Gafaelfawr frontend pod |
 | redis.affinity | object | `{}` | Affinity rules for the Redis pod |
 | redis.config.secretKey | string | `"redis-password"` | Key inside secret from which to get the Redis password (do not change) |
-| redis.config.secretName | string | `"gafaelfawr-secret"` | Name of secret containing Redis password (may require changing if fullnameOverride is set) |
+| redis.config.secretName | string | `"gafaelfawr"` | Name of secret containing Redis password (do not change) |
 | redis.nodeSelector | object | `{}` | Node selection rules for the Redis pod |
 | redis.persistence.accessMode | string | `"ReadWriteOnce"` | Access mode of storage to request |
 | redis.persistence.enabled | bool | `true` | Whether to persist Redis storage and thus tokens. Setting this to false will use `emptyDir` and reset all tokens on every restart. Only use this for a test deployment. |

--- a/applications/gafaelfawr/templates/_helpers.tpl
+++ b/applications/gafaelfawr/templates/_helpers.tpl
@@ -43,19 +43,19 @@ Common environment variables
 - name: "GAFAELFAWR_BOOTSTRAP_TOKEN"
   valueFrom:
     secretKeyRef:
-      name: {{ .secretName | quote }}
+      name: "gafaelfawr"
       key: "bootstrap-token"
 {{- if .Values.config.cilogon.clientId }}
 - name: "GAFAELFAWR_CILOGON_CLIENT_SECRET"
   valueFrom:
     secretKeyRef:
-      name: {{ .secretName | quote }}
+      name: "gafaelfawr"
       key: "cilogon-client-secret"
 {{- end }}
 - name: "GAFAELFAWR_DATABASE_PASSWORD"
   valueFrom:
     secretKeyRef:
-      name: {{ .secretName | quote }}
+      name: "gafaelfawr"
       key: "database-password"
 {{- if (or .Values.cloudsql.enabled .Values.config.internalDatabase) }}
 - name: "GAFAELFAWR_DATABASE_URL"
@@ -71,28 +71,28 @@ Common environment variables
 - name: "GAFAELFAWR_GITHUB_CLIENT_SECRET"
   valueFrom:
     secretKeyRef:
-      name: {{ .secretName | quote }}
+      name: "gafaelfawr"
       key: "github-client-secret"
 {{- end }}
 {{- if .Values.config.ldap.userDn }}
 - name: "GAFAELFAWR_LDAP_PASSWORD"
   valueFrom:
     secretKeyRef:
-      name: {{ .secretName | quote }}
+      name: "gafaelfawr"
       key: "ldap-password"
 {{- end }}
 {{- if .Values.config.oidc.clientId }}
 - name: "GAFAELFAWR_OIDC_CLIENT_SECRET"
   valueFrom:
     secretKeyRef:
-      name: {{ .secretName | quote }}
+      name: "gafaelfawr"
       key: "oidc-client-secret"
 {{- end }}
 {{- if .Values.config.oidcServer.enabled }}
 - name: "GAFAELFAWR_OIDC_SERVER_CLIENTS"
   valueFrom:
     secretKeyRef:
-      name: {{ .secretName | quote }}
+      name: "gafaelfawr"
       key: "oidc-server-secrets"
 {{- if (not .Values.config.oidcServer.issuer) }}
 - name: "GAFAELFAWR_OIDC_SERVER_ISSUER"
@@ -101,7 +101,7 @@ Common environment variables
 - name: "GAFAELFAWR_OIDC_SERVER_KEY"
   valueFrom:
     secretKeyRef:
-      name: {{ .secretName | quote }}
+      name: "gafaelfawr"
       key: "signing-key"
 {{- end }}
 {{- if (not .Values.config.realm) }}
@@ -113,20 +113,20 @@ Common environment variables
 - name: "GAFAELFAWR_REDIS_PASSWORD"
   valueFrom:
     secretKeyRef:
-      name: {{ .secretName | quote }}
+      name: "gafaelfawr"
       key: "redis-password"
 - name: "GAFAELFAWR_REDIS_URL"
   value: "redis://gafaelfawr-redis.{{ .Release.Namespace }}:6379/0"
 - name: "GAFAELFAWR_SESSION_SECRET"
   valueFrom:
     secretKeyRef:
-      name: {{ .secretName | quote }}
+      name: "gafaelfawr"
       key: "session-secret"
 {{- if .Values.config.slackAlerts }}
 - name: "GAFAELFAWR_SLACK_WEBHOOK"
   valueFrom:
     secretKeyRef:
-      name: {{ .secretName | quote }}
+      name: "gafaelfawr"
       key: "slack-webhook"
 {{- end }}
 {{- if .Values.config.metrics.enabled }}

--- a/applications/gafaelfawr/templates/configmap-kerberos.yaml
+++ b/applications/gafaelfawr/templates/configmap-kerberos.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "gafaelfawr-config-kerberos"
+  name: "gafaelfawr-kerberos"
   labels:
     {{- include "gafaelfawr.labels" . | nindent 4 }}
 data:

--- a/applications/gafaelfawr/templates/configmap.yaml
+++ b/applications/gafaelfawr/templates/configmap.yaml
@@ -1,27 +1,15 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "gafaelfawr-config"
+  name: "gafaelfawr"
   labels:
     {{- include "gafaelfawr.labels" . | nindent 4 }}
-data:
-  gafaelfawr.yaml: |
-    {{- toYaml .Values.config | nindent 4 }}
-{{- if .Values.config.updateSchema }}
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: "gafaelfawr-config-schema-update"
   {{- if .Values.config.updateSchema }}
   annotations:
     helm.sh/hook: "pre-install,pre-upgrade"
-    helm.sh/hook-delete-policy: "hook-succeeded"
+    helm.sh/hook-delete-policy: "before-hook-creation"
     helm.sh/hook-weight: "0"
   {{- end }}
-  labels:
-    {{- include "gafaelfawr.labels" . | nindent 4 }}
 data:
   gafaelfawr.yaml: |
     {{- toYaml .Values.config | nindent 4 }}
-{{- end }}

--- a/applications/gafaelfawr/templates/cronjob-audit.yaml
+++ b/applications/gafaelfawr/templates/cronjob-audit.yaml
@@ -37,7 +37,7 @@ spec:
                 - "gafaelfawr"
                 - "audit"
               env:
-                {{- include "gafaelfawr.envVars" (dict "Release" .Release "Values" .Values "secretName" "gafaelfawr-secret") | nindent 16 }}
+                {{- include "gafaelfawr.envVars" (dict "Release" .Release "Values" .Values) | nindent 16 }}
                 {{- if .Values.config.metrics.enabled }}
                 - name: "KAFKA_CLIENT_CERT_PATH"
                   value: "/etc/gafaelfawr-kafka/user.crt"
@@ -95,7 +95,7 @@ spec:
           volumes:
             - name: "config"
               configMap:
-                name: "gafaelfawr-config"
+                name: "gafaelfawr"
             {{- if .Values.config.metrics.enabled }}
             - name: "kafka"
               secret:
@@ -107,7 +107,7 @@ spec:
                 secretName: "gafaelfawr-keytab"
             - name: "kerberos-config"
               configMap:
-                name: "gafaelfawr-config-kerberos"
+                name: "gafaelfawr-kerberos"
             - name: "tmp"
               emptyDir: {}
             {{- end }}

--- a/applications/gafaelfawr/templates/cronjob-maintenance.yaml
+++ b/applications/gafaelfawr/templates/cronjob-maintenance.yaml
@@ -36,7 +36,7 @@ spec:
                 - "gafaelfawr"
                 - "maintenance"
               env:
-                {{- include "gafaelfawr.envVars" (dict "Release" .Release "Values" .Values "secretName" "gafaelfawr-secret") | nindent 16 }}
+                {{- include "gafaelfawr.envVars" (dict "Release" .Release "Values" .Values) | nindent 16 }}
                 {{- if .Values.config.metrics.enabled }}
                 - name: "KAFKA_CLIENT_CERT_PATH"
                   value: "/etc/gafaelfawr-kafka/user.crt"
@@ -94,7 +94,7 @@ spec:
           volumes:
             - name: "config"
               configMap:
-                name: "gafaelfawr-config"
+                name: "gafaelfawr"
             {{- if .Values.config.metrics.enabled }}
             - name: "kafka"
               secret:
@@ -106,7 +106,7 @@ spec:
                 secretName: "gafaelfawr-keytab"
             - name: "kerberos-config"
               configMap:
-                name: "gafaelfawr-config-kerberos"
+                name: "gafaelfawr-kerberos"
             - name: "tmp"
               emptyDir: {}
             {{- end }}

--- a/applications/gafaelfawr/templates/deployment-operator.yaml
+++ b/applications/gafaelfawr/templates/deployment-operator.yaml
@@ -42,7 +42,7 @@ spec:
             - "-m"
             - "gafaelfawr.operator"
           env:
-            {{- include "gafaelfawr.envVars" (dict "Release" .Release "Values" .Values "secretName" "gafaelfawr-secret") | nindent 12 }}
+            {{- include "gafaelfawr.envVars" (dict "Release" .Release "Values" .Values) | nindent 12 }}
             {{- if .Values.config.metrics.enabled }}
             - name: "KAFKA_CLIENT_CERT_PATH"
               value: "/etc/gafaelfawr-kafka/user.crt"
@@ -112,7 +112,7 @@ spec:
       volumes:
         - name: "config"
           configMap:
-            name: "gafaelfawr-config"
+            name: "gafaelfawr"
         {{- if .Values.config.metrics.enabled }}
         - name: "kafka"
           secret:
@@ -124,7 +124,7 @@ spec:
             secretName: "gafaelfawr-keytab"
         - name: "kerberos-config"
           configMap:
-            name: "gafaelfawr-config-kerberos"
+            name: "gafaelfawr-kerberos"
         - name: "tmp"
           emptyDir: {}
         {{- end }}

--- a/applications/gafaelfawr/templates/deployment.yaml
+++ b/applications/gafaelfawr/templates/deployment.yaml
@@ -54,7 +54,7 @@ spec:
         {{- end }}
         - name: "gafaelfawr"
           env:
-            {{- include "gafaelfawr.envVars" (dict "Release" .Release "Values" .Values "secretName" "gafaelfawr-secret" "sidecar" true) | nindent 12 }}
+            {{- include "gafaelfawr.envVars" (dict "Release" .Release "Values" .Values "sidecar" true) | nindent 12 }}
             {{- if .Values.config.metrics.enabled }}
             - name: "KAFKA_CLIENT_CERT_PATH"
               value: "/etc/gafaelfawr-kafka/user.crt"
@@ -135,7 +135,7 @@ spec:
       volumes:
         - name: "config"
           configMap:
-            name: "gafaelfawr-config"
+            name: "gafaelfawr"
         {{- if .Values.config.metrics.enabled }}
         - name: "kafka"
           secret:
@@ -147,7 +147,7 @@ spec:
             secretName: "gafaelfawr-keytab"
         - name: "kerberos-config"
           configMap:
-            name: "gafaelfawr-config-kerberos"
+            name: "gafaelfawr-kerberos"
         - name: "tmp"
           emptyDir: {}
         {{- end }}

--- a/applications/gafaelfawr/templates/job-schema-update.yaml
+++ b/applications/gafaelfawr/templates/job-schema-update.yaml
@@ -23,7 +23,7 @@ spec:
         gafaelfawr-redis-client: "true"
     spec:
       {{- if .Values.cloudsql.enabled }}
-      serviceAccountName: "gafaelfawr-schema-update"
+      serviceAccountName: "gafaelfawr"
       {{- else }}
       automountServiceAccountToken: false
       {{- end }}
@@ -79,7 +79,7 @@ spec:
               gafaelfawr update-schema
               touch /lifecycle/main-terminated
           env:
-            {{- include "gafaelfawr.envVars" (dict "Release" .Release "Values" .Values "secretName" "gafaelfawr-secret-schema-update" "sidecar" true) | nindent 12 }}
+            {{- include "gafaelfawr.envVars" (dict "Release" .Release "Values" .Values "sidecar" true) | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
           {{- with .Values.resources }}
@@ -106,7 +106,7 @@ spec:
       volumes:
         - name: "config"
           configMap:
-            name: "gafaelfawr-config-schema-update"
+            name: "gafaelfawr"
         - name: "lifecycle"
           emptyDir: {}
       {{- with .Values.nodeSelector }}

--- a/applications/gafaelfawr/templates/serviceaccount.yaml
+++ b/applications/gafaelfawr/templates/serviceaccount.yaml
@@ -6,19 +6,10 @@ metadata:
   labels:
     {{- include "gafaelfawr.labels" . | nindent 4 }}
   annotations:
-    iam.gke.io/gcp-service-account: {{ required "cloudsql.serviceAccount must be set to a valid Google service account" .Values.cloudsql.serviceAccount | quote }}
-{{- if .Values.config.updateSchema }}
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: "gafaelfawr-schema-update"
-  labels:
-    {{- include "gafaelfawr.labels" . | nindent 4 }}
-  annotations:
+    {{- if .Values.config.updateSchema }}
     helm.sh/hook: "pre-install,pre-upgrade"
-    helm.sh/hook-delete-policy: "hook-succeeded"
+    helm.sh/hook-delete-policy: "before-hook-creation"
     helm.sh/hook-weight: "0"
+    {{- end }}
     iam.gke.io/gcp-service-account: {{ required "cloudsql.serviceAccount must be set to a valid Google service account" .Values.cloudsql.serviceAccount | quote }}
-{{- end }}
 {{- end }}

--- a/applications/gafaelfawr/templates/vault-secrets.yaml
+++ b/applications/gafaelfawr/templates/vault-secrets.yaml
@@ -1,29 +1,20 @@
 apiVersion: ricoberger.de/v1alpha1
 kind: VaultSecret
 metadata:
-  name: "gafaelfawr-secret"
+  name: "gafaelfawr"
   labels:
     {{- include "gafaelfawr.labels" . | nindent 4 }}
-spec:
-  path: "{{ .Values.global.vaultSecretsPath }}/gafaelfawr"
-  type: Opaque
-{{- if .Values.config.updateSchema }}
----
-apiVersion: ricoberger.de/v1alpha1
-kind: VaultSecret
-metadata:
-  name: "gafaelfawr-secret-schema-update"
+  {{- if .Values.config.updateSchema }}
   annotations:
     helm.sh/hook: "pre-install,pre-upgrade"
+    helm.sh/hook-delete-policy: "before-hook-creation"
     helm.sh/hook-weight: "0"
-  labels:
-    {{- include "gafaelfawr.labels" . | nindent 4 }}
+  {{- end }}
 spec:
   path: "{{ .Values.global.vaultSecretsPath }}/gafaelfawr"
   type: Opaque
-{{- end }}
----
 {{- if .Values.config.ldap.kerberosConfig }}
+---
 apiVersion: ricoberger.de/v1alpha1
 kind: VaultSecret
 metadata:

--- a/applications/gafaelfawr/values-ccin2p3.yaml
+++ b/applications/gafaelfawr/values-ccin2p3.yaml
@@ -6,7 +6,6 @@ redis:
 config:
   logLevel: "DEBUG"
   internalDatabase: true
-  updateSchema: False
 
   # Session length and token expiration (in minutes).
   #issuer:

--- a/applications/gafaelfawr/values.yaml
+++ b/applications/gafaelfawr/values.yaml
@@ -415,9 +415,8 @@ operator:
 
 redis:
   config:
-    # -- Name of secret containing Redis password (may require changing if
-    # fullnameOverride is set)
-    secretName: "gafaelfawr-secret"
+    # -- Name of secret containing Redis password (do not change)
+    secretName: "gafaelfawr"
 
     # -- Key inside secret from which to get the Redis password (do not
     # change)


### PR DESCRIPTION
Use a different method for handling Gafaelfawr schema updates: add the hook metadata to the required supporting resources rather than creating new ones. We tested this approach with vo-cutouts and it worked well, so adopt it here as well. This results in replacing instead of updating the resources on the next sync, but it avoids having duplicate resources that have to be manually deleted.

Remove the -config and -secret endings on the names of the Gafaelfawr VaultSecret and ConfigMap resources, adopting our current conventions. The endings duplicate information already available in Kubernetes in other ways.