### PR TITLE
DM-47220: Update exposurelog to point to new embargo rack

### DIFF
--- a/applications/exposurelog/values-usdfdev.yaml
+++ b/applications/exposurelog/values-usdfdev.yaml
@@ -10,7 +10,7 @@ env:
   - name: DAF_BUTLER_REPOSITORY_INDEX
     value: "/project/data-repos.yaml"
   - name: S3_ENDPOINT_URL
-    value: "https://s3dfrgw.slac.stanford.edu"
+    value: "https://sdfembs3.sdf.slac.stanford.edu"
   - name: PGPASSFILE
     value: "/var/secrets/butler/postgres-credentials.txt"
   - name: PGUSER


### PR DESCRIPTION
For the `usdfdev` environment, the S3 endpoint was configured incorrectly.  It was pulling in the config from the old embargo Butler repo instead of the new one.