### PR TITLE
DM-47214: Remove default_instrument from sia values

### DIFF
--- a/applications/sia/Chart.yaml
+++ b/applications/sia/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.1.2
+appVersion: 0.1.3
 description: Simple Image Access (SIA) IVOA Service using Butler
 name: sia
 sources:

--- a/applications/sia/README.md
+++ b/applications/sia/README.md
@@ -11,7 +11,7 @@ Simple Image Access (SIA) IVOA Service using Butler
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules for the sia deployment pod |
-| config.butlerDataCollections | list | `[]` | List of data (Butler) Collections Expected attributes: `config`, `label`, `name`, `butler_type`, `repository`, `datalink_url` & `default_instrument` |
+| config.butlerDataCollections | list | `[]` | List of data (Butler) Collections Expected attributes: `config`, `label`, `name`, `butler_type`, `repository` & `datalink_url` |
 | config.directButlerEnabled | bool | `false` | Whether direct butler access is enabled |
 | config.logLevel | string | `"INFO"` | Logging level |
 | config.logProfile | string | `"production"` | Logging profile (`production` for JSON, `development` for human-friendly) |

--- a/applications/sia/values-idfdev.yaml
+++ b/applications/sia/values-idfdev.yaml
@@ -8,4 +8,3 @@ config:
       butler_type: "REMOTE"
       repository: "https://data-dev.lsst.cloud/api/butler/repo/dp02/butler.yaml"
       datalink_url: "https://data-dev.lsst.cloud/api/datalink/links?ID=butler%3A//dp02/{id}"
-      default_instrument: "LSSTCam-imSim"

--- a/applications/sia/values-idfint.yaml
+++ b/applications/sia/values-idfint.yaml
@@ -8,4 +8,3 @@ config:
       butler_type: "REMOTE"
       repository: "https://data-int.lsst.cloud/api/butler/repo/dp02/butler.yaml"
       datalink_url: "https://data-int.lsst.cloud/api/datalink/links?ID=butler%3A//dp02/{id}"
-      default_instrument: "LSSTCam-imSim"

--- a/applications/sia/values.yaml
+++ b/applications/sia/values.yaml
@@ -40,7 +40,7 @@ config:
   directButlerEnabled: false
 
   # -- List of data (Butler) Collections
-  # Expected attributes: `config`, `label`, `name`, `butler_type`, `repository`, `datalink_url` & `default_instrument`
+  # Expected attributes: `config`, `label`, `name`, `butler_type`, `repository` & `datalink_url`
   butlerDataCollections: []
 
   # -- User to use from the PGPASSFILE if sia is using a direct Butler


### PR DESCRIPTION
**Summary**
Removes the default_instrument configuration attribute for Butler Data collections which was a temporary workaround. No longer needed as fix to daf_butler has been released.
Also upgrades requirements & sia chart version with the required fixes to no longer use this field.