### PR TITLE
Update sync-secrets.rst

### DIFF
--- a/docs/admin/sync-secrets.rst
+++ b/docs/admin/sync-secrets.rst
@@ -23,7 +23,7 @@ It can then be run again whenever the secrets for that environment change.
 Deleting secrets
 ================
 
-By default old secrets that are no longer required are deleted out of Vault.
+By default old secrets that are no longer required are not deleted out of Vault.
 To delete obsolete secrets, pass the ``--delete`` flag to :command:`phalanx secrets sync`.
 
 This will keep your Vault tidy, but you should use this flag with caution if you have applications temporarily disabled or if you store static secrets directly in Vault and nowhere else.


### PR DESCRIPTION
This *appears* to be a typo.  Assuming that by default, obsolete secrets are *not* deleted, and to delete them the user must explicitly add the `--delete` flag to the `phalanx sync secrets`, then the word "not" should be added here.

The code indeed appears to require the `--delete` flag in order to trigger the `self._clean_vault_secrets()` method call:

https://github.com/lsst-sqre/phalanx/blob/main/src/phalanx/services/secrets.py#L243-L297