### PR TITLE
Improve the secrets sync documentation

### DIFF
--- a/docs/admin/audit-secrets.rst
+++ b/docs/admin/audit-secrets.rst
@@ -2,7 +2,7 @@
 Audit secrets for an environment
 ################################
 
-To check that all of the necessary secrets for an environment named ``<environment>`` are in Vault and appear to have the proper form, run:
+To check that all of the necessary secrets for an environment named ``<environment>`` are in Vault and appear to have the proper form, and to see exactly what a :doc:`syncing secrets for that environment <sync-secrets>` would do, run:
 
 .. prompt:: bash
 

--- a/docs/admin/sync-secrets.rst
+++ b/docs/admin/sync-secrets.rst
@@ -2,8 +2,21 @@
 Sync secrets for an environment
 ###############################
 
-Before syncing secrets for an environment, you should normally audit the secrets so that you know what will change.
-See :doc:`audit-secrets`.
+Phalanx uses :px-app:`vault-secrets-operator` to create Kubernetes ``Secret`` resources from ``VaultSecret`` resources and entries in Vault.
+It requires every Phalanx application with secrets have its own entry in Vault whose keys and values collect all secrets used by that application.
+Some secrets therefore have to be duplicated between applications, and others can be automatically generated if missing.
+This process of copying and generating secrets as needed is called syncing secrets.
+
+Syncing secrets must be done before installing a Phalanx environment for the first time, and then every time the secrets for that environment change.
+Even if the environment stores static secrets in Vault directly, secrets will still need to be synced periodically to handle the copied and generated secrets also stored in Vault.
+
+Syncing secrets
+===============
+
+.. warning::
+
+   Before syncing secrets for an environment, you should normally audit the secrets so that you know what will change.
+   See :doc:`audit-secrets`.
 
 To populate Vault with all of the necessary secrets for an environment named ``<environment>``, run:
 
@@ -17,13 +30,13 @@ For SQuaRE-managed deployments, the 1Password token for ``OP_CONNECT_TOKEN`` com
 If you did not store the Vault write token for your environment with the static secrets, the ``VAULT_TOKEN`` environment variable must be set to the Vault write token for this environment.
 For SQuaRE-managed environments, you can get the write token from the ``Phalanx Vault write tokens`` item in the SQuaRE 1Password vault.
 
-This must be done before installing a Phalanx environment for the first time.
-It can then be run again whenever the secrets for that environment change.
+Only secrets for the named environment will be affected.
+No changes will be made outside of the configured secrets path for that environment.
 
 Deleting secrets
 ================
 
-By default old secrets that are no longer required are not deleted out of Vault.
+By default, old secrets that are no longer required are not deleted out of Vault.
 To delete obsolete secrets, pass the ``--delete`` flag to :command:`phalanx secrets sync`.
 
 This will keep your Vault tidy, but you should use this flag with caution if you have applications temporarily disabled or if you store static secrets directly in Vault and nowhere else.
@@ -34,11 +47,12 @@ Regenerating secrets
 
 By default, :command:`phalanx secrets sync` will leave any existing generated secrets set to their current values.
 This is almost always what you want.
-In the rare case where you are completely reinstalling an environment and want to invalidate all existing secrets (such as after a security breach), you can add the ``--regenerate`` flag to regenerate all static secrets.
+
+In the rare case where you are completely reinstalling an environment and want to invalidate all existing secrets (such as after a security breach), you can add the ``--regenerate`` flag to regenerate all non-static secrets.
 
 .. warning::
 
    Using ``--regenerate`` will invalidate all user sessions, all user tokens, and other, possibly unanticipated, interactions with the existing cluster.
-   It will also break most running Phalanx applications until their secrets have been recreated and they have been restarted.
+   It will also break most running Phalanx applications until their Kubernetes ``Secret`` resources have been recreated and they have been restarted.
 
    This should only be used when you also plan to empty the Gafaelfawr database and otherwise reset the environment to start fresh.


### PR DESCRIPTION
Add an introduction to secrets syncing, fix a couple of errors, and emphasize that secrets audit should be run before secrets sync.