### PR TITLE
DM-47298: Enable SIA on idfprod

### DIFF
--- a/applications/sia/values-idfprod.yaml
+++ b/applications/sia/values-idfprod.yaml
@@ -1,0 +1,10 @@
+config:
+
+  # Data (Butler) Collections
+  butlerDataCollections:
+    - config: "https://raw.githubusercontent.com/lsst-dm/dax_obscore/refs/heads/main/configs/dp02.yaml"
+      label: "LSST.DP02"
+      name: "dp02"
+      butler_type: "REMOTE"
+      repository: "https://data.lsst.cloud/api/butler/repo/dp02/butler.yaml"
+      datalink_url: "https://data.lsst.cloud/api/datalink/links?ID=butler%3A//dp02/{id}"

--- a/environments/values-idfprod.yaml
+++ b/environments/values-idfprod.yaml
@@ -24,7 +24,7 @@ applications:
   portal: true
   sasquatch: true
   semaphore: true
-  sia: false
+  sia: true
   siav2: false
   squareone: true
   strimzi: true


### PR DESCRIPTION
Enables new SIA application on **idfprod**.
- Added sia/values-idfprod.yaml
- Set `sia: true` in environments/values-idfprod.yaml