### PR TITLE
Upgrade butler server to fix conflict with weekly 44

### DIFF
--- a/applications/butler/Chart.yaml
+++ b/applications/butler/Chart.yaml
@@ -4,4 +4,4 @@ version: 1.0.0
 description: Server for Butler data abstraction service
 sources:
   - https://github.com/lsst/daf_butler
-appVersion: w.2024.43
+appVersion: server-2.2.1


### PR DESCRIPTION
Upgrade Butler server to fix an issue where dataset queries were failing with a weekly 44 client, due to extra properties added in the new version that were being rejected by the old server.