### PR TITLE
Set baseline config for Prompt Processing ComCam

### DIFF
--- a/applications/prompt-proto-service-lsstcomcam/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/values-usdfprod-prompt-processing.yaml
@@ -22,13 +22,13 @@ prompt-proto-service:
         (survey="comcam-ap")=[${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCam/ApPipe.yaml,
         ${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCam/SingleFrame.yaml,
         ${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCam/Isr.yaml]
-        (survey="BLOCK-T208")=[${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCam/Isr-cal.yaml]
         (survey="BLOCK-T60")=[${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCam/Isr-cal.yaml]
+        (survey="BLOCK-T208")=[${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCam/Isr-cal.yaml]
         (survey="")=[]
       preprocessing: >-
         (survey="comcam-ap")=[${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCam/Preprocessing.yaml]
-        (survey="BLOCK-T208")=[]
         (survey="BLOCK-T60")=[]
+        (survey="BLOCK-T208")=[]
         (survey="")=[]
     calibRepo: s3://rubin-summit-users
 

--- a/applications/prompt-proto-service-lsstcomcam/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/values-usdfprod-prompt-processing.yaml
@@ -18,17 +18,28 @@ prompt-proto-service:
 
   instrument:
     pipelines:
+      # BLOCK-T60 is optics alignment
+      # BLOCK-T75 is giant donuts
+      # BLOCK-T88 is optics alignment
+      # BLOCK-T246 is instrument checkout
+      # BLOCK-T249 is AOS alignment
       main: >-
-        (survey="comcam-ap")=[${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCam/ApPipe.yaml,
+        (survey="PP-SURVEY")=[${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCam/ApPipe.yaml,
         ${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCam/SingleFrame.yaml,
         ${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCam/Isr.yaml]
         (survey="BLOCK-T60")=[${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCam/Isr-cal.yaml]
-        (survey="BLOCK-T208")=[${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCam/Isr-cal.yaml]
+        (survey="BLOCK-T75")=[]
+        (survey="BLOCK-T88")=[${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCam/Isr-cal.yaml]
+        (survey="BLOCK-T246")=[${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCam/Isr-cal.yaml]
+        (survey="BLOCK-T249")=[${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCam/Isr-cal.yaml]
         (survey="")=[]
       preprocessing: >-
-        (survey="comcam-ap")=[${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCam/Preprocessing.yaml]
+        (survey="PP-SURVEY")=[${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCam/Preprocessing.yaml]
         (survey="BLOCK-T60")=[]
-        (survey="BLOCK-T208")=[]
+        (survey="BLOCK-T75")=[]
+        (survey="BLOCK-T88")=[]
+        (survey="BLOCK-T246")=[]
+        (survey="BLOCK-T249")=[]
         (survey="")=[]
     calibRepo: s3://rubin-summit-users
 

--- a/applications/prompt-proto-service-lsstcomcam/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/values-usdfprod-prompt-processing.yaml
@@ -2,8 +2,9 @@ prompt-proto-service:
 
   podAnnotations:
     # HACK: disable autoscaling as workaround for DM-41829
-    autoscaling.knative.dev/min-scale: "20"
-    autoscaling.knative.dev/max-scale: "20"
+    autoscaling.knative.dev/min-scale: "200"
+    # see values.yaml for calculation of max-scale
+    autoscaling.knative.dev/max-scale: "200"
     # Update this field if using latest or static image tag in dev
     revision: "1"
 


### PR DESCRIPTION
This PR updates the surveys and scalings for ComCam-prod to reflect our current understanding of how ComCam will operate. It does not include short-term surveys or config overrides associated with commissioning the Prompt Processing system itself.