### PR TITLE
[DM-46884] Deploy InfluxDB Enterprise on IDF dev

### DIFF
--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -90,10 +90,10 @@ influxdb-enterprise:
         memory: 4Gi
         cpu: 2
   data:
-    replicas: 1
+    replicas: 2
     config:
       antiEntropy:
-        enabled: false
+        enabled: true
     ingress:
       enabled: true
       hostname: data-dev.lsst.cloud

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -64,6 +64,48 @@ influxdb:
       memory: 16Gi
       cpu: 2
 
+influxdb-enterprise:
+  enabled: true
+  license:
+    secret:
+      name: sasquatch
+      key: influxdb-enterprise-license
+  meta:
+    ingress:
+      enabled: true
+      hostname: data-dev.lsst.cloud
+    persistence:
+      enabled: true
+      accessMode: ReadWriteOnce
+      size: 16Gi
+    sharedSecret:
+      secret:
+        name: sasquatch
+        key: influxdb-enterprise-shared-secret
+    resources:
+      requests:
+        memory: 2Gi
+        cpu: 1
+      limits:
+        memory: 4Gi
+        cpu: 2
+  data:
+    replicas: 2
+    ingress:
+      enabled: true
+      hostname: data-dev.lsst.cloud
+    persistence:
+      enabled: true
+      accessMode: ReadWriteOnce
+      size: 1Ti
+    resources:
+      requests:
+        memory: 8Gi
+        cpu: 2
+      limits:
+        memory: 16Gi
+        cpu: 4
+
 telegraf-kafka-consumer:
   enabled: true
   kafkaConsumers:

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -91,6 +91,9 @@ influxdb-enterprise:
         cpu: 2
   data:
     replicas: 2
+    config:
+      antiEntropy:
+        enabled: false
     ingress:
       enabled: true
       hostname: data-dev.lsst.cloud

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -90,7 +90,7 @@ influxdb-enterprise:
         memory: 4Gi
         cpu: 2
   data:
-    replicas: 2
+    replicas: 1
     config:
       antiEntropy:
         enabled: false

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -90,7 +90,7 @@ influxdb-enterprise:
         memory: 4Gi
         cpu: 2
   data:
-    replicas: 1
+    replicas: 2
     config:
       antiEntropy:
         enabled: false


### PR DESCRIPTION
We deployed InfluxDB Enterprise on IDF dev to investigate the slow query issue in a new environment.
I'll merge this PR and let it running there. 
I uses the InfluxDB Enterprise cluster license for development.