### PR TITLE
Increase M1M3 connector metric batch size

### DIFF
--- a/applications/sasquatch/values-summit.yaml
+++ b/applications/sasquatch/values-summit.yaml
@@ -343,6 +343,7 @@ telegraf-kafka-consumer:
       debug: true
     m1m3:
       enabled: true
+      metric_batch_size: 2500
       database: "efd"
       timestamp_field: "private_efdStamp"
       topicRegexps: |

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -170,6 +170,7 @@ telegraf-kafka-consumer:
     m1m3:
       enabled: true
       repair: false
+      metric_batch_size: 2500
       database: "efd"
       timestamp_field: "private_efdStamp"
       topicRegexps: |


### PR DESCRIPTION
- We notice the M1M3 cannot keep up with the default metric_batch_size of 1000 messages and increased its value to 2500