### PR TITLE
Deploy Prompt Processing 4.7.2.

### DIFF
--- a/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
@@ -14,7 +14,7 @@ prompt-proto-service:
   image:
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: 4.7.0
+    tag: 4.7.2
 
   instrument:
     pipelines:

--- a/applications/prompt-proto-service-lsstcomcam/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/values-usdfprod-prompt-processing.yaml
@@ -15,7 +15,7 @@ prompt-proto-service:
   image:
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: 4.7.1
+    tag: 4.7.2
 
   instrument:
     pipelines:


### PR DESCRIPTION
This PR updates Prompt Processing ComCam-prod from 4.7.1 to 4.7.2. It also synchronizes the unused LATISS-prod configuration to avoid bit-rot.