### PR TITLE
Remove labels from GafaelfawrIngress tmeplate

### DIFF
--- a/applications/exposurelog/templates/ingress.yaml
+++ b/applications/exposurelog/templates/ingress.yaml
@@ -18,8 +18,6 @@ config:
 template:
   metadata:
     name: {{ template "exposurelog.fullname" . }}
-    labels:
-      {{- include "exposurelog.labels" . | nindent 4 }}
   spec:
     rules:
       - host: {{ required "global.host must be set" .Values.global.host | quote }}

--- a/applications/narrativelog/templates/ingress.yaml
+++ b/applications/narrativelog/templates/ingress.yaml
@@ -18,8 +18,6 @@ config:
 template:
   metadata:
     name: {{ template "narrativelog.fullname" . }}
-    labels:
-      {{- include "narrativelog.labels" . | nindent 4 }}
   spec:
     rules:
       - host: {{ required "global.host must be set" .Values.global.host | quote }}

--- a/applications/nightreport/templates/ingress.yaml
+++ b/applications/nightreport/templates/ingress.yaml
@@ -18,8 +18,6 @@ config:
 template:
   metadata:
     name: {{ template "nightreport.fullname" . }}
-    labels:
-      {{- include "nightreport.labels" . | nindent 4 }}
   spec:
     rules:
       - host: {{ required "global.host must be set" .Values.global.host | quote }}


### PR DESCRIPTION
exposurelog, narrativelog, and nightreport incorrectly added the Helm labels to the template for the Ingress, but that's not allowed by the GafaelfawrIngress schema. Remove them.