### PR TITLE
Add TAXICAB to unfurlbot Jira topics

### DIFF
--- a/applications/unfurlbot/README.md
+++ b/applications/unfurlbot/README.md
@@ -15,7 +15,7 @@ Squarebot backend that unfurls Jira issues.
 | autoscaling.maxReplicas | int | `100` | Maximum number of unfurlbot deployment pods |
 | autoscaling.minReplicas | int | `1` | Minimum number of unfurlbot deployment pods |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU utilization of unfurlbot deployment pods |
-| config.jiraProjects | string | `"ADMIN, CCB, CAP, COMCAM, COMT, DM, EPO, FRACAS, IAM, IHS, IT, ITRFC, LOVE, LASD, LIT, LOPS, LVV, M1M3V, OPSIM, PHOSIM, PST, PSV, PUB, RFC, RM, SAFE, SIM, SPP, SBTT, SE, SUMMIT, TSAIV, TCT, SECMVERIF, TMDC, TPC, TSEIA, TAS, TELV, TSSAL, TSS, TSSPP, WMP, PREOPS, OBS, SITCOM, BLOCK\n"` | Names of Jira projects to unfurl (comma-separated) |
+| config.jiraProjects | string | See `values.yaml` | Names of Jira projects to unfurl (comma-separated) |
 | config.jiraUrl | string | `"https://rubinobs.atlassian.net/"` | Jira base URL |
 | config.logLevel | string | `"INFO"` | Logging level: "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL" |
 | config.redisUrl | string | `"redis://unfurlbot-redis:6379/0"` | URL to the local redis instance |

--- a/applications/unfurlbot/values.yaml
+++ b/applications/unfurlbot/values.yaml
@@ -26,22 +26,27 @@ config:
     # -- Kafka topic name for the Slack `app_mention` events
     slackAppMention: "lsst.square-events.squarebot.slack.app.mention"
 
-    # -- Kafka topic name for the Slack `message.channels` events (public channels)
+    # -- Kafka topic name for the Slack `message.channels` events (public
+    # channels)
     slackMessageChannels: "lsst.square-events.squarebot.slack.message.channels"
 
-    # -- Kafka topic name for the Slack `message.groups` events (private channels)
+    # -- Kafka topic name for the Slack `message.groups` events (private
+    # channels)
     slackMessageGroups: "lsst.square-events.squarebot.slack.message.groups"
 
-    # -- Kafka topic name for the Slack `message.im` events (direct message channels)
+    # -- Kafka topic name for the Slack `message.im` events (direct message
+    # channels)
     slackMessageIm: "lsst.square-events.squarebot.slack.message.im"
 
-    # -- Kafka topic name for the Slack `message.mpim` events (multi-person direct messages)
+    # -- Kafka topic name for the Slack `message.mpim` events (multi-person
+    # direct messages)
     slackMessageMpim: "lsst.square-events.squarebot.slack.message.mpim"
 
   # -- Jira base URL
   jiraUrl: "https://rubinobs.atlassian.net/"
 
   # -- Names of Jira projects to unfurl (comma-separated)
+  # @default -- See `values.yaml`
   jiraProjects: >
     ADMIN,
     CCB,
@@ -81,6 +86,7 @@ config:
     TPC,
     TSEIA,
     TAS,
+    TAXICAB,
     TELV,
     TSSAL,
     TSS,


### PR DESCRIPTION
Also clean up the unfurlbot `values.yaml` documentation a bit. The addition was requested by Eli Rykoff.