### PR TITLE
DM-47594: Add Sentry tracing to Butler server

### DIFF
--- a/applications/butler/Chart.yaml
+++ b/applications/butler/Chart.yaml
@@ -4,4 +4,4 @@ version: 1.0.0
 description: Server for Butler data abstraction service
 sources:
   - https://github.com/lsst/daf_butler
-appVersion: server-2.4.1
+appVersion: server-2.5.0

--- a/applications/butler/README.md
+++ b/applications/butler/README.md
@@ -20,6 +20,7 @@ Server for Butler data abstraction service
 | config.dp02PostgresUri | string | No configuration file for DP02 will be generated. | Postgres connection string pointing to the registry database hosting Data Preview 0.2 data. |
 | config.dp02UseSlacDatastore | bool | `false` | True if the 'dp02' datastore files should be served from SLAC, false if they should be served from Google. |
 | config.dp1PostgresUri | string | No configuration file for DP1 will be generated. | Postgres connection string pointing to the registry database hosting Data Preview 1 data. |
+| config.enableSentry | bool | `false` | True to enable capture of trace and other diagnostics to Sentry.io. |
 | config.pathPrefix | string | `"/api/butler"` | The prefix of the path portion of the URL where the Butler service will be exposed.  For example, if the service should be exposed at `https://data.lsst.cloud/api/butler`, this should be set to `/api/butler` |
 | config.pguser | string | Use values specified in per-repository Butler config files. | Postgres username used to connect to the Butler DB |
 | config.repositories | object | `{}` | Mapping from Butler repository label to Butler configuration URI for repositories which will be hosted by this server. |

--- a/applications/butler/secrets.yaml
+++ b/applications/butler/secrets.yaml
@@ -17,3 +17,7 @@
     if: config.shareNubladoSecrets
   onepassword:
     encoded: true
+"sentry-dsn":
+  description: >-
+    DSN URL where Sentry trace and error logging will be sent.
+  if: config.enableSentry

--- a/applications/butler/templates/deployment.yaml
+++ b/applications/butler/templates/deployment.yaml
@@ -68,6 +68,18 @@ spec:
             - name: PGUSER
               value: {{ .Values.config.pguser | quote }}
             {{ end }}
+            {{ if .Values.config.enableSentry }}
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: "butler"
+                  key: "sentry-dsn"
+            - name: SENTRY_RELEASE
+              value: {{ .Chart.Name }}@{{ .Chart.AppVersion }}
+            - name: SENTRY_ENVIRONMENT
+              value: {{ .Values.global.host }}
+
+            {{ end }}
           volumeMounts:
             - name: "butler-secrets"
               mountPath: "/opt/lsst/butler/secrets"

--- a/applications/butler/values-idfdev.yaml
+++ b/applications/butler/values-idfdev.yaml
@@ -14,3 +14,4 @@ config:
   shareNubladoSecrets: false
   additionalS3EndpointUrls:
     slac: "https://sdfdatas3.slac.stanford.edu"
+  enableSentry: true

--- a/applications/butler/values-idfint.yaml
+++ b/applications/butler/values-idfint.yaml
@@ -12,3 +12,4 @@ config:
   shareNubladoSecrets: false
   additionalS3EndpointUrls:
     slac: "https://sdfdatas3.slac.stanford.edu"
+  enableSentry: true

--- a/applications/butler/values-idfprod.yaml
+++ b/applications/butler/values-idfprod.yaml
@@ -10,3 +10,4 @@ config:
   shareNubladoSecrets: false
   additionalS3EndpointUrls:
     slac: "https://sdfdatas3.slac.stanford.edu"
+  enableSentry: true

--- a/applications/butler/values.yaml
+++ b/applications/butler/values.yaml
@@ -130,3 +130,6 @@ config:
   # end-users.  Otherwise, use secrets specifically set up for the Butler
   # server.
   shareNubladoSecrets: true
+
+  # -- True to enable capture of trace and other diagnostics to Sentry.io.
+  enableSentry: false


### PR DESCRIPTION
To help debug performance issues with the deployed Butler server, set up Sentry trace.