### PR TITLE
Update the survey to BLOCK-320 for ComCam Prompt Processing

### DIFF
--- a/applications/prompt-proto-service-lsstcomcam/README.md
+++ b/applications/prompt-proto-service-lsstcomcam/README.md
@@ -34,7 +34,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.instrument.pipelines.main | string | None, must be set | Machine-readable string describing which pipeline(s) should be run for which visits. Notation is complex and still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |
 | prompt-proto-service.instrument.pipelines.preprocessing | string | None, must be set | Machine-readable string describing which pipeline(s) should be run before which visits' raw arrival. |
 | prompt-proto-service.instrument.preloadPadding | int | `30` | Number of arcseconds to pad the spatial region in preloading. |
-| prompt-proto-service.instrument.skymap | string | `"ops_rehersal_prep_2k_v1"` | Skymap to use with the instrument |
+| prompt-proto-service.instrument.skymap | string | `"lsst_cells_v1"` | Skymap to use with the instrument |
 | prompt-proto-service.knative.cpuLimit | int | `1` | The maximum cpu cores for the full pod (see `containerConcurrency`). |
 | prompt-proto-service.knative.cpuRequest | int | `1` | The cpu cores requested for the full pod (see `containerConcurrency`). |
 | prompt-proto-service.knative.ephemeralStorageLimit | string | `"5Gi"` | The maximum storage space allowed for each container (mostly local Butler). This allocation is for the full pod (see `containerConcurrency`) |

--- a/applications/prompt-proto-service-lsstcomcam/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/values-usdfprod-prompt-processing.yaml
@@ -22,25 +22,37 @@ prompt-proto-service:
       # BLOCK-T60 is optics alignment
       # BLOCK-T75 is giant donuts
       # BLOCK-T88 is optics alignment
+      # BLOCK-T215 is evening twilight flats
+      # BLOCK-T216 is morning twilight flats
+      # BLOCK-T219 is pretty picture
       # BLOCK-T246 is instrument checkout
       # BLOCK-T249 is AOS alignment
+      # BLOCK-T250 is TMA daytime checkout
       main: >-
-        (survey="PP-SURVEY")=[${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCam/ApPipe.yaml,
+        (survey="BLOCK-320")=[${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCam/ApPipe.yaml,
         ${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCam/SingleFrame.yaml,
         ${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCam/Isr.yaml]
-        (survey="BLOCK-T60")=[${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCam/Isr-cal.yaml]
-        (survey="BLOCK-T75")=[]
-        (survey="BLOCK-T88")=[${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCam/Isr-cal.yaml]
-        (survey="BLOCK-T246")=[${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCam/Isr-cal.yaml]
-        (survey="BLOCK-T249")=[${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCam/Isr-cal.yaml]
-        (survey="")=[]
-      preprocessing: >-
-        (survey="PP-SURVEY")=[${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCam/Preprocessing.yaml]
         (survey="BLOCK-T60")=[]
         (survey="BLOCK-T75")=[]
         (survey="BLOCK-T88")=[]
+        (survey="BLOCK-T215")=[]
+        (survey="BLOCK-T216")=[]
+        (survey="BLOCK-T219")=[]
+        (survey="BLOCK-T246")=[${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCam/Isr-cal.yaml]
+        (survey="BLOCK-T249")=[]
+        (survey="BLOCK-T250")=[]
+        (survey="")=[]
+      preprocessing: >-
+        (survey="BLOCK-320")=[${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCam/Preprocessing.yaml]
+        (survey="BLOCK-T60")=[]
+        (survey="BLOCK-T75")=[]
+        (survey="BLOCK-T88")=[]
+        (survey="BLOCK-T215")=[]
+        (survey="BLOCK-T216")=[]
+        (survey="BLOCK-T219")=[]
         (survey="BLOCK-T246")=[]
         (survey="BLOCK-T249")=[]
+        (survey="BLOCK-T250")=[]
         (survey="")=[]
     calibRepo: s3://rubin-summit-users
 

--- a/applications/prompt-proto-service-lsstcomcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/values.yaml
@@ -49,7 +49,7 @@ prompt-proto-service:
       # @default -- None, must be set
       preprocessing: ""
     # -- Skymap to use with the instrument
-    skymap: "ops_rehersal_prep_2k_v1"
+    skymap: "lsst_cells_v1"
     # -- Number of arcseconds to pad the spatial region in preloading.
     preloadPadding: 30
     # -- URI to the shared repo used for calibrations, templates, and pipeline outputs.


### PR DESCRIPTION
`BLOCK-T248` and `PP-SURVEY` is no longer expected.   `BLOCK-320` 

< performs the observations for the individual visits that are queued up by the Feature Based Scheduler. BLOCK-320 is expected to be the standard json block for taking science images with ComCam going forward 


