### PR TITLE
Update schema registry version to 7.7.1

### DIFF
--- a/applications/sasquatch/charts/strimzi-kafka/templates/schema-registry.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/schema-registry.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   listener: tls
   compatibilityLevel: none
+  registryImageTag: "7.7.1"
   cpuLimit: {{ .Values.registry.resources.limits.cpu | quote }}
   cpuRequest: {{ .Values.registry.resources.requests.cpu | quote }}
   memoryLimit: {{ .Values.registry.resources.limits.memory | quote }}


### PR DESCRIPTION
We are using the default version of the Schema Registry  deployed by the schema-registry-operator, which is now quite old. 
This was an oversight of my part and we should set the Schema Registry version as part of the Sasquatch configuration.