### PR TITLE
DM-47646: Update Gafaelfawr to 12.1.1

### DIFF
--- a/applications/gafaelfawr/Chart.yaml
+++ b/applications/gafaelfawr/Chart.yaml
@@ -5,7 +5,7 @@ description: "Authentication and identity system"
 home: "https://gafaelfawr.lsst.io/"
 sources:
   - "https://github.com/lsst-sqre/gafaelfawr"
-appVersion: 12.1.0
+appVersion: 12.1.1
 
 dependencies:
   - name: "redis"


### PR DESCRIPTION
Update the Gafaelfawr relesae to 12.1.1, which fixes doubled slashes in the OpenID Connect configuration endpoint.

Note that this version of Gafaelfawr no longer supports direct upgrades from versions prior to 10.0.0. Upgrade to an earlier version first, complete the schema migration, and then upgrade to the latest version.