### PR TITLE
DM-47716: Update to Gafaelfawr 12.2.0

### DIFF
--- a/applications/gafaelfawr/Chart.yaml
+++ b/applications/gafaelfawr/Chart.yaml
@@ -5,7 +5,7 @@ description: "Authentication and identity system"
 home: "https://gafaelfawr.lsst.io/"
 sources:
   - "https://github.com/lsst-sqre/gafaelfawr"
-appVersion: 12.1.1
+appVersion: 12.2.0
 
 dependencies:
   - name: "redis"

--- a/applications/gafaelfawr/README.md
+++ b/applications/gafaelfawr/README.md
@@ -33,6 +33,7 @@ Authentication and identity system
 | config.cilogon.test | bool | `false` | Whether to use the test instance of CILogon |
 | config.cilogon.usernameClaim | string | `"username"` | Claim from which to get the username |
 | config.databaseUrl | string | None, must be set if neither `cloudsql.enabled` nor | URL for the PostgreSQL database `config.internalDatabase` are true |
+| config.enableSentry | bool | `false` | Whether to send trace and telemetry information to Sentry. This traces every call and therefore should only be enabled in non-production environments. |
 | config.errorFooter | string | `nil` | HTML footer to add to any login error page (will be enclosed in a <p> tag). |
 | config.firestore.project | string | Firestore support is disabled | If set, assign UIDs and GIDs using Google Firestore in the given project. Cloud SQL must be enabled and the Cloud SQL service account must have read/write access to that Firestore instance. |
 | config.github.clientId | string | `nil` | GitHub client ID. One and only one of this, `config.cilogon.clientId`, or `config.oidc.clientId` must be set. |

--- a/applications/gafaelfawr/secrets.yaml
+++ b/applications/gafaelfawr/secrets.yaml
@@ -58,6 +58,10 @@ redis-password:
     deployments will then have to be restarted to pick up the new value.
   generate:
     type: password
+sentry-dsn:
+  description: >-
+    DSN URL to which Sentry trace and error logging will be sent.
+  if: config.enableSentry
 session-secret:
   description: >-
     Encryption key used to encrypt the contents of Redis and the cookie data

--- a/applications/gafaelfawr/templates/_helpers.tpl
+++ b/applications/gafaelfawr/templates/_helpers.tpl
@@ -141,4 +141,15 @@ Common environment variables
       name: "gafaelfawr-kafka"
       key: "securityProtocol"
 {{- end }}
+{{- if .Values.config.enableSentry }}
+- name: SENTRY_DSN
+  valueFrom:
+    secretKeyRef:
+      name: "gafaelfawr"
+      key: "sentry-dsn"
+- name: SENTRY_RELEASE
+  value: {{ .Chart.Name }}@{{ .Chart.AppVersion }}
+- name: SENTRY_ENVIRONMENT
+  value: {{ .Values.global.host }}
+{{- end }}
 {{- end }}

--- a/applications/gafaelfawr/templates/cronjob-audit.yaml
+++ b/applications/gafaelfawr/templates/cronjob-audit.yaml
@@ -37,7 +37,7 @@ spec:
                 - "gafaelfawr"
                 - "audit"
               env:
-                {{- include "gafaelfawr.envVars" (dict "Release" .Release "Values" .Values) | nindent 16 }}
+                {{- include "gafaelfawr.envVars" (dict "Chart" .Chart "Release" .Release "Values" .Values) | nindent 16 }}
                 {{- if .Values.config.metrics.enabled }}
                 - name: "KAFKA_CLIENT_CERT_PATH"
                   value: "/etc/gafaelfawr-kafka/user.crt"

--- a/applications/gafaelfawr/templates/cronjob-maintenance.yaml
+++ b/applications/gafaelfawr/templates/cronjob-maintenance.yaml
@@ -36,7 +36,7 @@ spec:
                 - "gafaelfawr"
                 - "maintenance"
               env:
-                {{- include "gafaelfawr.envVars" (dict "Release" .Release "Values" .Values) | nindent 16 }}
+                {{- include "gafaelfawr.envVars" (dict "Chart" .Chart "Release" .Release "Values" .Values) | nindent 16 }}
                 {{- if .Values.config.metrics.enabled }}
                 - name: "KAFKA_CLIENT_CERT_PATH"
                   value: "/etc/gafaelfawr-kafka/user.crt"

--- a/applications/gafaelfawr/templates/deployment-operator.yaml
+++ b/applications/gafaelfawr/templates/deployment-operator.yaml
@@ -42,7 +42,7 @@ spec:
             - "-m"
             - "gafaelfawr.operator"
           env:
-            {{- include "gafaelfawr.envVars" (dict "Release" .Release "Values" .Values) | nindent 12 }}
+            {{- include "gafaelfawr.envVars" (dict "Chart" .Chart "Release" .Release "Values" .Values) | nindent 12 }}
             {{- if .Values.config.metrics.enabled }}
             - name: "KAFKA_CLIENT_CERT_PATH"
               value: "/etc/gafaelfawr-kafka/user.crt"

--- a/applications/gafaelfawr/templates/deployment.yaml
+++ b/applications/gafaelfawr/templates/deployment.yaml
@@ -54,7 +54,7 @@ spec:
         {{- end }}
         - name: "gafaelfawr"
           env:
-            {{- include "gafaelfawr.envVars" (dict "Release" .Release "Values" .Values "sidecar" true) | nindent 12 }}
+            {{- include "gafaelfawr.envVars" (dict "Chart" .Chart "Release" .Release "Values" .Values "sidecar" true) | nindent 12 }}
             {{- if .Values.config.metrics.enabled }}
             - name: "KAFKA_CLIENT_CERT_PATH"
               value: "/etc/gafaelfawr-kafka/user.crt"

--- a/applications/gafaelfawr/templates/job-schema-update.yaml
+++ b/applications/gafaelfawr/templates/job-schema-update.yaml
@@ -79,7 +79,7 @@ spec:
               gafaelfawr update-schema
               touch /lifecycle/main-terminated
           env:
-            {{- include "gafaelfawr.envVars" (dict "Release" .Release "Values" .Values "sidecar" true) | nindent 12 }}
+            {{- include "gafaelfawr.envVars" (dict "Chart" .Chart "Release" .Release "Values" .Values "sidecar" true) | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
           {{- with .Values.resources }}

--- a/applications/gafaelfawr/values.yaml
+++ b/applications/gafaelfawr/values.yaml
@@ -51,6 +51,11 @@ config:
   # `config.internalDatabase` are true
   databaseUrl: null
 
+  # -- Whether to send trace and telemetry information to Sentry. This traces
+  # every call and therefore should only be enabled in non-production
+  # environments.
+  enableSentry: false
+
   # -- HTML footer to add to any login error page (will be enclosed in a <p>
   # tag).
   errorFooter: null


### PR DESCRIPTION
Update Gafaelfawr to the 12.2.0 release, which allows the new CADC authentication code to use the OpenID Connect userinfo route, hopefully allowing us to drop the old CADC-specific route. This release also fixes some performance issues and adds optional Sentry support, which will let us send traces, errors, and other telemetry to Sentry.