### PR TITLE
Changes for in-kind contribution `JAP-JPG-S3` from NAOJ

### DIFF
--- a/applications/fov-quicklook/.helmignore
+++ b/applications/fov-quicklook/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/applications/fov-quicklook/Chart.yaml
+++ b/applications/fov-quicklook/Chart.yaml
@@ -1,5 +1,8 @@
 apiVersion: v2
+appVersion: 0.1.0
 description: Full focal plane viewer
 name: fov-quicklook
+sources:
+- https://github.com/michitaro/rubin-fov-quicklook
 type: application
 version: 1.0.0

--- a/applications/fov-quicklook/Chart.yaml
+++ b/applications/fov-quicklook/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+description: Full focal plane viewer
+name: fov-quicklook
+type: application
+version: 1.0.0

--- a/applications/fov-quicklook/README.md
+++ b/applications/fov-quicklook/README.md
@@ -1,0 +1,10 @@
+# fov-quicklook
+
+Full focal plane viewer
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| global.host | string | Set by Argo CD | Host name for ingress |
+| global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |

--- a/applications/fov-quicklook/README.md
+++ b/applications/fov-quicklook/README.md
@@ -2,9 +2,30 @@
 
 Full focal plane viewer
 
+## Source Code
+
+* <https://github.com/michitaro/rubin-fov-quicklook>
+
 ## Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| global.host | string | Set by Argo CD | Host name for ingress |
-| global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
+| config.pathPrefix | string | `"/fov-quicklook"` | URL path prefix |
+| context_menu_templates | list | `[]` | Context menu templates for the frontend |
+| coordinator.resources.limits | object | `{"cpu":"4000m","memory":"256Mi"}` | Resource limits for the coordinator |
+| coordinator.resources.requests | object | `{"cpu":"100m","memory":"256Mi"}` | Resource requests for the coordinator |
+| db.resources.limits | object | `{"cpu":"2000m","memory":"256Mi"}` | Resource limits for the database |
+| db.resources.requests | object | `{"cpu":"100m","memory":"256Mi"}` | Resource requests for the database |
+| db_storage_class | string | `nil` | Storage class to use for the database |
+| frontend.resources.limits | object | `{"cpu":"8000m","memory":"512Mi"}` | Resource limits for the frontend |
+| frontend.resources.requests | object | `{"cpu":"100m","memory":"512Mi"}` | Resource requests for the frontend |
+| generator.replicas | int | `9` | Number of replicas for the generator |
+| generator.resources.limits | object | `{"cpu":"16000m","memory":"32Gi"}` | Resource limits for the generator |
+| generator.resources.requests | object | `{"cpu":"8000m","memory":"32Gi"}` | Resource requests for the generator |
+| generator.workdir.medium | string | `"Memory"` | Work directory type for the generator |
+| image.pullPolicy | string | `"Always"` | Pull policy for the fov-quicklook image |
+| image.repository | string | `"ghcr.io/michitaro/rubin-fov-viewer"` | Image to use in the fov-quicklook deployment |
+| image.tag | string | `"latest"` | Tag of image to use |
+| s3_tile | object | `{"bucket":"fov-quicklook-tile","endpoint":"sdfembs3.sdf.slac.stanford.edu:443","secure":true}` | S3 configuration for the tile storage |
+| use_gafaelfawr | bool | `true` | Use gafaelfawr to authenticate |
+| use_vault | bool | `true` | Use vault to store secrets |

--- a/applications/fov-quicklook/README.md
+++ b/applications/fov-quicklook/README.md
@@ -19,10 +19,12 @@ Full focal plane viewer
 | db_storage_class | string | `nil` | Storage class to use for the database |
 | frontend.resources.limits | object | `{"cpu":"8000m","memory":"512Mi"}` | Resource limits for the frontend |
 | frontend.resources.requests | object | `{"cpu":"100m","memory":"512Mi"}` | Resource requests for the frontend |
+| generator.mergedDir.sizeLimit | string | `"32Gi"` | Size limit for the merged directory |
 | generator.replicas | int | `9` | Number of replicas for the generator |
 | generator.resources.limits | object | `{"cpu":"16000m","memory":"32Gi"}` | Resource limits for the generator |
 | generator.resources.requests | object | `{"cpu":"8000m","memory":"32Gi"}` | Resource requests for the generator |
 | generator.workdir.medium | string | `"Memory"` | Work directory type for the generator |
+| generator.workdir.sizeLimit | string | `"32Gi"` | Size limit for the shared memory work directory |
 | image.pullPolicy | string | `"Always"` | Pull policy for the fov-quicklook image |
 | image.repository | string | `"ghcr.io/michitaro/rubin-fov-viewer"` | Image to use in the fov-quicklook deployment |
 | image.tag | string | `"latest"` | Tag of image to use |

--- a/applications/fov-quicklook/secrets.yaml
+++ b/applications/fov-quicklook/secrets.yaml
@@ -1,0 +1,24 @@
+s3_repository_access_key:
+  description: >-
+    The access key for the S3 bucket that contains the tile data.
+s3_repository_secret_key:
+  description: >-
+    The secret key for the S3 bucket that contains the tile data.
+db_password:
+  description: >-
+    The password for the PostgreSQL database that stores the metadata of the quicklook.
+  generate:
+    type: password
+"aws-credentials.ini":
+  description: >-
+    Google Cloud Storage credentials to the Butler data store, formatted using
+    AWS syntax for use with boto.
+  copy:
+    application: nublado
+    key: aws-credentials.ini
+"postgres-credentials.txt":
+  description: >-
+    PostgreSQL credentials in its pgpass format for the Butler database.
+  copy:
+    application: nublado
+    key: postgres-credentials.txt

--- a/applications/fov-quicklook/templates/_helpers.tpl
+++ b/applications/fov-quicklook/templates/_helpers.tpl
@@ -1,0 +1,26 @@
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "fov-quicklook.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "fov-quicklook.labels" -}}
+helm.sh/chart: {{ include "fov-quicklook.chart" . }}
+{{ include "fov-quicklook.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "fov-quicklook.selectorLabels" -}}
+app.kubernetes.io/name: "fov-quicklook"
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/applications/fov-quicklook/templates/butler-config.yaml
+++ b/applications/fov-quicklook/templates/butler-config.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fov-quicklook-butler-config
+data:
+  data-repos.yaml: {{ .Values.butler_settings.data_repos | toYaml | quote }}

--- a/applications/fov-quicklook/templates/coordinator.yaml
+++ b/applications/fov-quicklook/templates/coordinator.yaml
@@ -1,0 +1,84 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fov-quicklook-coordinator
+spec:
+  strategy:
+    type: Recreate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: fov-quicklook-coordinator
+  template:
+    metadata:
+      labels:
+        app: fov-quicklook-coordinator
+    spec:
+      containers:
+        - name: fov-quicklook-coordinator
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          command:
+            - sh
+            - -c
+            - |
+              set -e
+              alembic upgrade head
+              exec python -m quicklook.coordinator.api
+          env:
+            {{- include "fov-quicklook.env.db" . | nindent 12 }}
+            {{- include "fov-quicklook.env.log-level" . | nindent 12 }}
+            {{- include "fov-quicklook.env.s3_tile" . | nindent 12 }}
+            {{- include "fov-quicklook.butler-settings.env" . | nindent 12 }}
+          volumeMounts:
+            {{- .Values.butler_settings.volume_mounts | toYaml | nindent 12 }}
+          ports:
+            - containerPort: 9501
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 9501
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 3
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+          resources: {{ toYaml .Values.coordinator.resources | nindent 12 }}
+      volumes:
+        {{- .Values.butler_settings.volumes | toYaml | nindent 8 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: fov-quicklook-coordinator
+spec:
+  selector:
+    app: fov-quicklook-coordinator
+  type: ClusterIP
+  ports:
+    - name: http
+      protocol: TCP
+      port: 9501
+      targetPort: 9501
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: fov-quicklook-coordinator-policy
+spec:
+  podSelector:
+    matchLabels:
+      app: fov-quicklook-coordinator
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: fov-quicklook-generator
+        - podSelector:
+            matchLabels:
+              app: fov-quicklook-frontend
+      ports:
+        - protocol: TCP
+          port: 9501

--- a/applications/fov-quicklook/templates/coordinator.yaml
+++ b/applications/fov-quicklook/templates/coordinator.yaml
@@ -32,6 +32,8 @@ spec:
             {{- include "fov-quicklook.butler-settings.env" . | nindent 12 }}
           volumeMounts:
             {{- .Values.butler_settings.volume_mounts | toYaml | nindent 12 }}
+            - name: tmp
+              mountPath: /tmp
           ports:
             - containerPort: 9501
           livenessProbe:
@@ -42,12 +44,20 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 3
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 1000
             runAsGroup: 1000
           resources: {{ toYaml .Values.coordinator.resources | nindent 12 }}
       volumes:
         {{- .Values.butler_settings.volumes | toYaml | nindent 8 }}
+        - name: tmp
+          emptyDir:
+            medium: Memory
 ---
 apiVersion: v1
 kind: Service

--- a/applications/fov-quicklook/templates/db.yaml
+++ b/applications/fov-quicklook/templates/db.yaml
@@ -1,0 +1,97 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fov-quicklook-db
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: fov-quicklook-db
+  template:
+    metadata:
+      labels:
+        app: fov-quicklook-db
+    spec:
+      initContainers:
+        - name: init-permissions
+          image: 'busybox'
+          command: ['sh', '-c', 'chown 999:999 /var/lib/postgresql/data']
+          volumeMounts:
+            - name: fov-quicklook-db
+              mountPath: /var/lib/postgresql/data
+      containers:
+        - name: fov-quicklook-db
+          image: 'postgres:16'
+          env:
+            - name: POSTGRES_USER
+              value: quicklook
+            - name: POSTGRES_DB
+              value: quicklook
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: fov-quicklook
+                  key: db_password
+          ports:
+            - containerPort: 5432
+          volumeMounts:
+            - name: fov-quicklook-db
+              mountPath: /var/lib/postgresql/data
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 999
+            runAsGroup: 999
+          resources: {{ toYaml .Values.db.resources | nindent 12 }}
+      volumes:
+        - name: fov-quicklook-db
+          persistentVolumeClaim:
+            claimName: fov-quicklook-db
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: fov-quicklook-db
+spec:
+  selector:
+    app: fov-quicklook-db
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: postgres
+      protocol: TCP
+      port: 5432
+      targetPort: 5432
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: fov-quicklook-db
+spec:
+  {{- if .Values.db_storage_class }}
+  storageClassName: {{ .Values.db_storage_class }}
+  {{- end }}
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: fov-quicklook-db-policy
+spec:
+  podSelector:
+    matchLabels:
+      app: fov-quicklook-db
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: fov-quicklook-coordinator
+        - podSelector:
+            matchLabels:
+              app: fov-quicklook-frontend
+      ports:
+        - protocol: TCP
+          port: 5432

--- a/applications/fov-quicklook/templates/db.yaml
+++ b/applications/fov-quicklook/templates/db.yaml
@@ -16,6 +16,14 @@ spec:
         - name: init-permissions
           image: 'busybox'
           command: ['sh', '-c', 'chown 999:999 /var/lib/postgresql/data && mkdir -p /var/run/postgresql && chown 999:999 /var/run/postgresql']
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+              add:
+                - "CHOWN"
+            readOnlyRootFilesystem: true
           volumeMounts:
             - name: fov-quicklook-db
               mountPath: /var/lib/postgresql/data

--- a/applications/fov-quicklook/templates/db.yaml
+++ b/applications/fov-quicklook/templates/db.yaml
@@ -15,10 +15,12 @@ spec:
       initContainers:
         - name: init-permissions
           image: 'busybox'
-          command: ['sh', '-c', 'chown 999:999 /var/lib/postgresql/data']
+          command: ['sh', '-c', 'chown 999:999 /var/lib/postgresql/data && mkdir -p /var/run/postgresql && chown 999:999 /var/run/postgresql']
           volumeMounts:
             - name: fov-quicklook-db
               mountPath: /var/lib/postgresql/data
+            - name: postgresql-run
+              mountPath: /var/run/postgresql
       containers:
         - name: fov-quicklook-db
           image: 'postgres:16'
@@ -37,15 +39,25 @@ spec:
           volumeMounts:
             - name: fov-quicklook-db
               mountPath: /var/lib/postgresql/data
+            - name: postgresql-run
+              mountPath: /var/run/postgresql
           securityContext:
             runAsNonRoot: true
             runAsUser: 999
             runAsGroup: 999
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+            readOnlyRootFilesystem: true
           resources: {{ toYaml .Values.db.resources | nindent 12 }}
       volumes:
         - name: fov-quicklook-db
           persistentVolumeClaim:
             claimName: fov-quicklook-db
+        - name: postgresql-run
+          emptyDir:
+            medium: Memory
 ---
 apiVersion: v1
 kind: Service

--- a/applications/fov-quicklook/templates/debug.yaml
+++ b/applications/fov-quicklook/templates/debug.yaml
@@ -87,4 +87,26 @@ template:
                   name: fov-quicklook-debug
                   port:
                     number: 8888
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: fov-quicklook-debug
+spec:
+  podSelector:
+    matchLabels:
+      app: fov-quicklook-debug
+  policyTypes:
+    - "Ingress"
+  ingress:
+    # Allow inbound access from pods (in any namespace) labeled
+    # gafaelfawr.lsst.io/ingress: true.
+    - from:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              gafaelfawr.lsst.io/ingress: "true"
+      ports:
+        - protocol: "TCP"
+          port: 8888
 {{- end }}

--- a/applications/fov-quicklook/templates/debug.yaml
+++ b/applications/fov-quicklook/templates/debug.yaml
@@ -1,0 +1,90 @@
+{{- if .Values.debug.jupyter }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fov-quicklook-debug
+  labels:
+    app: jupyter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: jupyter
+  template:
+    metadata:
+      labels:
+        app: jupyter
+    spec:
+      containers:
+      - name: jupyter
+        image: jupyter/base-notebook:latest
+        command: ["jupyter", "lab", "--ip=0.0.0.0", "--port=8888", "--no-browser", "--ServerApp.base_url={{ .Values.config.pathPrefix }}/debug", "--ServerApp.token=''", "--ServerApp.password=''"]
+        ports:
+        - containerPort: 8888
+        env:
+        - name: JUPYTER_ENABLE_LAB
+          value: "yes"
+        {{- include "fov-quicklook.env.s3_tile" . | nindent 8 }}
+        {{- with .Values.butler_settings }}
+        {{- range .envs }}
+        - name: {{ .name }}
+          value: {{ .value | quote }}
+        {{- end }}
+        volumeMounts:
+        {{- .volume_mounts | toYaml | nindent 8 }}
+        {{- end }}
+        - name: secret-volume
+          mountPath: /secret
+          readOnly: true
+        - name: empty
+          mountPath: /empty
+      volumes:
+      {{- .Values.butler_settings.volumes | toYaml | nindent 6 }}
+      - name: secret-volume
+        secret:
+          secretName: fov-quicklook
+      - name: empty
+        emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: fov-quicklook-debug
+  labels:
+    app: jupyter
+spec:
+  selector:
+    app: jupyter
+  ports:
+    - protocol: TCP
+      port: 8888
+      targetPort: 8888
+---
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
+metadata:
+  name: fov-quicklook-debug
+config:
+  username: {{ .Values.debug.username | quote }}
+  scopes:
+    all:
+      - "exec:notebook"
+  service: fov-quicklook-debug
+  loginRedirect: true
+  # baseUrl: {{ .Values.global.baseUrl | quote }}
+template:
+  metadata:
+    name: fov-quicklook-debug
+  spec:
+    rules:
+      - host: {{ .Values.global.host | quote }}
+        http:
+          paths:
+            - path: {{ .Values.config.pathPrefix }}/debug
+              pathType: Prefix
+              backend:
+                service:
+                  name: fov-quicklook-debug
+                  port:
+                    number: 8888
+{{- end }}

--- a/applications/fov-quicklook/templates/frontend.yaml
+++ b/applications/fov-quicklook/templates/frontend.yaml
@@ -77,6 +77,8 @@ spec:
       targetPort: 9500
 ---
 {{- if .Values.use_gafaelfawr }}
+# use_gafaelfawr: Controls whether to use the Gafaelfawr authentication system.
+# Set to true by default. Set to false only for local development clusters without Gafaelfawr.
 apiVersion: gafaelfawr.lsst.io/v1alpha1
 kind: GafaelfawrIngress
 metadata:
@@ -92,6 +94,28 @@ template:
     name: fov-quicklook-frontend
   spec:
     {{- include "quicklook.ingress.spec" . | nindent 4 }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: fov-quicklook-frontend
+spec:
+  podSelector:
+    matchLabels:
+      app: fov-quicklook-frontend
+  policyTypes:
+    - "Ingress"
+  ingress:
+    # Allow inbound access from pods (in any namespace) labeled
+    # gafaelfawr.lsst.io/ingress: true.
+    - from:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              gafaelfawr.lsst.io/ingress: "true"
+      ports:
+        - protocol: "TCP"
+          port: 9500
 {{- else }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/applications/fov-quicklook/templates/frontend.yaml
+++ b/applications/fov-quicklook/templates/frontend.yaml
@@ -1,0 +1,93 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fov-quicklook-frontend
+spec:
+  replicas: {{ .Values.frontend.replicas }}
+  selector:
+    matchLabels:
+      app: fov-quicklook-frontend
+  template:
+    metadata:
+      labels:
+        app: fov-quicklook-frontend
+    spec:
+      containers:
+        - name: fov-quicklook-frontend
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          command:
+            - sh
+            - -c
+            - |
+              exec python -m quicklook.frontend.api
+          env:
+            - name: QUICKLOOK_coordinator_base_url
+              value: http://fov-quicklook-coordinator:9501
+            - name: QUICKLOOK_frontend_app_prefix
+              value: {{ .Values.config.pathPrefix | quote }}
+            - name: QUICKLOOK_admin_page
+              value: {{ .Values.admin_page | quote }}
+            {{- include "fov-quicklook.env.db" . | nindent 12 }}
+            {{- include "fov-quicklook.env.log-level" . | nindent 12 }}
+            {{- include "fov-quicklook.env.s3_tile" . | nindent 12 }}
+            {{- include "fov-quicklook.butler-settings.env" . | nindent 12 }}
+            - name: QUICKLOOK_context_menu_templates
+              value: {{ .Values.context_menu_templates | toJson | quote }}
+          volumeMounts:
+            {{- .Values.butler_settings.volume_mounts | toYaml | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.config.pathPrefix }}/api/healthz
+              port: 9500
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 3
+          ports:
+            - containerPort: 9500
+          resources: {{ toYaml .Values.frontend.resources | nindent 12 }}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+      volumes:
+        {{- .Values.butler_settings.volumes | toYaml | nindent 8 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: fov-quicklook-frontend
+spec:
+  selector:
+    app: fov-quicklook-frontend
+  type: ClusterIP
+  ports:
+    - name: http
+      protocol: TCP
+      port: 9500
+      targetPort: 9500
+---
+{{- if .Values.use_gafaelfawr }}
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
+metadata:
+  name: fov-quicklook-frontend
+config:
+  scopes:
+    all:
+      - "read:image"
+  service: fov-quicklook-frontend
+  loginRedirect: true
+template:
+  metadata:
+    name: fov-quicklook-frontend
+  spec:
+    {{- include "quicklook.ingress.spec" . | nindent 4 }}
+{{- else }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: fov-quicklook-frontend
+spec:
+  {{- include "quicklook.ingress.spec" . | nindent 2 }}
+{{- end }}
+

--- a/applications/fov-quicklook/templates/frontend.yaml
+++ b/applications/fov-quicklook/templates/frontend.yaml
@@ -35,6 +35,8 @@ spec:
               value: {{ .Values.context_menu_templates | toJson | quote }}
           volumeMounts:
             {{- .Values.butler_settings.volume_mounts | toYaml | nindent 12 }}
+            - name: tmp
+              mountPath: /tmp
           livenessProbe:
             httpGet:
               path: {{ .Values.config.pathPrefix }}/api/healthz
@@ -46,11 +48,19 @@ spec:
             - containerPort: 9500
           resources: {{ toYaml .Values.frontend.resources | nindent 12 }}
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 1000
             runAsGroup: 1000
       volumes:
         {{- .Values.butler_settings.volumes | toYaml | nindent 8 }}
+        - name: tmp
+          emptyDir:
+            medium: Memory
 ---
 apiVersion: v1
 kind: Service

--- a/applications/fov-quicklook/templates/generator.yaml
+++ b/applications/fov-quicklook/templates/generator.yaml
@@ -51,7 +51,14 @@ spec:
             - mountPath: /tmp/quicklook/merged
               name: merged-dir
             {{- .Values.butler_settings.volume_mounts | toYaml | nindent 12 }}
+            - name: tmp
+              mountPath: /tmp
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 1000
             runAsGroup: 1000
@@ -63,6 +70,9 @@ spec:
         - name: merged-dir
           emptyDir: {}
         {{- .Values.butler_settings.volumes | toYaml | nindent 8 }}
+        - name: tmp
+          emptyDir:
+            medium: Memory
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/applications/fov-quicklook/templates/generator.yaml
+++ b/applications/fov-quicklook/templates/generator.yaml
@@ -67,8 +67,10 @@ spec:
         - name: shm
           emptyDir:
             medium: {{ .Values.generator.workdir.medium | quote }}
+            sizeLimit: {{ .Values.generator.workdir.sizeLimit | quote }}
         - name: merged-dir
-          emptyDir: {}
+          emptyDir:
+            sizeLimit: {{ .Values.generator.mergedDir.sizeLimit | quote }}
         {{- .Values.butler_settings.volumes | toYaml | nindent 8 }}
         - name: tmp
           emptyDir:

--- a/applications/fov-quicklook/templates/generator.yaml
+++ b/applications/fov-quicklook/templates/generator.yaml
@@ -1,0 +1,88 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fov-quicklook-generator
+  labels:
+    app: fov-quicklook-generator
+spec:
+  replicas: {{ .Values.generator.replicas }}
+  strategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: fov-quicklook-generator
+  template:
+    metadata:
+      labels:
+        app: fov-quicklook-generator
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - fov-quicklook-generator
+              topologyKey: "kubernetes.io/hostname"
+      containers:
+        - name: fov-quicklook-generator
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          command: ["python", "-u", "-m", "quicklook.generator.api"]
+          ports:
+            - containerPort: 9502
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 9502
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 3
+          env:
+            - name: QUICKLOOK_coordinator_base_url
+              value: http://fov-quicklook-coordinator:9501
+            {{- include "fov-quicklook.env.s3_tile" . | nindent 12 }}
+            {{- include "fov-quicklook.env.log-level" . | nindent 12 }}
+            {{- include "fov-quicklook.butler-settings.env" . | nindent 12 }}
+          volumeMounts:
+            - mountPath: /dev/shm/quicklook
+              name: shm
+            - mountPath: /tmp/quicklook/merged
+              name: merged-dir
+            {{- .Values.butler_settings.volume_mounts | toYaml | nindent 12 }}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+          resources: {{ toYaml .Values.generator.resources | nindent 12 }}
+      volumes:
+        - name: shm
+          emptyDir:
+            medium: {{ .Values.generator.workdir.medium | quote }}
+        - name: merged-dir
+          emptyDir: {}
+        {{- .Values.butler_settings.volumes | toYaml | nindent 8 }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: fov-quicklook-generator-policy
+spec:
+  podSelector:
+    matchLabels:
+      app: fov-quicklook-generator
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: fov-quicklook-coordinator
+        - podSelector:
+            matchLabels:
+              app: fov-quicklook-frontend
+        - podSelector:
+            matchLabels:
+              app: fov-quicklook-generator
+      ports:
+        - protocol: TCP
+          port: 9502

--- a/applications/fov-quicklook/templates/vault-secrets.yaml
+++ b/applications/fov-quicklook/templates/vault-secrets.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.use_vault }}
+apiVersion: ricoberger.de/v1alpha1
+kind: VaultSecret
+metadata:
+  name: fov-quicklook
+spec:
+  path: "{{ .Values.global.vaultSecretsPath }}/fov-quicklook"
+  type: Opaque
+  keys:
+    - s3_repository_access_key
+    - s3_repository_secret_key
+    - db_password
+    - aws-credentials.ini
+    - postgres-credentials.txt
+{{- end }}

--- a/applications/fov-quicklook/templates/vault-secrets.yaml
+++ b/applications/fov-quicklook/templates/vault-secrets.yaml
@@ -6,10 +6,4 @@ metadata:
 spec:
   path: "{{ .Values.global.vaultSecretsPath }}/fov-quicklook"
   type: Opaque
-  keys:
-    - s3_repository_access_key
-    - s3_repository_secret_key
-    - db_password
-    - aws-credentials.ini
-    - postgres-credentials.txt
 {{- end }}

--- a/applications/fov-quicklook/values-usdfdev.yaml
+++ b/applications/fov-quicklook/values-usdfdev.yaml
@@ -58,5 +58,5 @@ context_menu_templates:
       data = butler.get('%(dataType)', dataId)
     is_url: false
   - name: 'LSSTCam/Calexp mosaic'
-    template: 'https://usdf-rsp.slac.stanford.edu/rubintv/summit-usdf/lsstcam/event?key=lsstcam/%(day_obs|iso8601)/calexp_mosaic/%(exposure|sequence|zeropadding(6))/lsstcam_calexp_mosaic_%(day_obs|iso8601)_%(exposure|sequence|zeropadding(6)).jpg'
+    template: 'https://usdf-rsp-dev.slac.stanford.edu/rubintv/summit-usdf/lsstcam/event?key=lsstcam/%(day_obs|iso8601)/calexp_mosaic/%(exposure|sequence|zeropadding(6))/lsstcam_calexp_mosaic_%(day_obs|iso8601)_%(exposure|sequence|zeropadding(6)).jpg'
     is_url: true

--- a/applications/fov-quicklook/values-usdfdev.yaml
+++ b/applications/fov-quicklook/values-usdfdev.yaml
@@ -1,0 +1,62 @@
+frontend:
+  replicas: 4
+admin_page: true
+db_storage_class: wekafs--sdf-k8s01
+log_level: warning
+debug:
+  jupyter: true
+  username: koike
+butler_settings:
+  envs:
+    - name: DAF_BUTLER_REPOSITORY_INDEX
+      value: /var/run/fov-quicklook/config/data-repos.yaml
+    - name: AWS_SHARED_CREDENTIALS_FILE
+      value: "/var/run/fov-quicklook/secrets/aws-credentials.ini"
+    - name: PGUSER
+      value: "rubin"
+    - name: PGPASSFILE
+      value: "/var/run/fov-quicklook/secrets/postgres-credentials.txt"
+    - name: S3_ENDPOINT_URL
+      value: "https://s3dfrgw.slac.stanford.edu"
+    - name: LSST_DISABLE_BUCKET_VALIDATION
+      value: "1"
+    - name: LSST_RESOURCES_S3_PROFILE_embargo
+      value: "https://sdfembs3.sdf.slac.stanford.edu"
+  volumes:
+    - name: aws-credentials
+      secret:
+        secretName: fov-quicklook
+    - name: postgres-credentials
+      secret:
+        secretName: fov-quicklook
+    - name: butler-config
+      configMap:
+        name: fov-quicklook-butler-config
+  volume_mounts:
+    - name: aws-credentials
+      mountPath: /var/run/fov-quicklook/secrets/aws-credentials.ini
+      subPath: aws-credentials.ini
+    - name: postgres-credentials
+      mountPath: /var/run/fov-quicklook/secrets/postgres-credentials.txt
+      subPath: postgres-credentials.txt
+    - name: butler-config
+      mountPath: /var/run/fov-quicklook/config
+  data_repos:
+    embargo: "s3://embargo@rubin-summit-users/butler.yaml"
+context_menu_templates:
+  - name: 'UUID'
+    template: "%(uuid)"
+    is_url: false
+  - name: 'Data ID for Butler'
+    template: "{'exposure': %(exposure), 'detector': %(detector)}"
+    is_url: false
+  - name: 'Butler Snippet'
+    template: |
+      from lsst.daf.butler import Butler
+      butler = Butler('embargo')
+      dataId = {'exposure': %(exposure), 'detector': %(detector)}
+      data = butler.get('%(dataType)', dataId)
+    is_url: false
+  - name: 'LSSTCam/Calexp mosaic'
+    template: 'https://usdf-rsp.slac.stanford.edu/rubintv/summit-usdf/lsstcam/event?key=lsstcam/%(day_obs|iso8601)/calexp_mosaic/%(exposure|sequence|zeropadding(6))/lsstcam_calexp_mosaic_%(day_obs|iso8601)_%(exposure|sequence|zeropadding(6)).jpg'
+    is_url: true

--- a/applications/fov-quicklook/values.schema.json
+++ b/applications/fov-quicklook/values.schema.json
@@ -1,0 +1,299 @@
+{
+  "properties": {
+    "image": {
+      "$ref": "#/definitions/image_config"
+    },
+    "config": {
+      "$ref": "#/definitions/config"
+    },
+    "s3_tile": {
+      "$ref": "#/definitions/s3_config"
+    },
+    "use_vault": {
+      "type": "boolean"
+    },
+    "use_gafaelfawr": {
+      "type": "boolean"
+    },
+    "db_storage_class": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "default": null
+    },
+    "log_level": {
+      "type": "string",
+      "enum": [
+        "debug",
+        "info",
+        "warning",
+        "error",
+        "critical"
+      ],
+      "default": "info"
+    },
+    "debug": {
+      "$ref": "#/definitions/debug"
+    },
+    "butler_settings": {
+      "type": "object",
+      "properties": {
+        "envs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/envvar"
+          }
+        },
+        "volumes": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "volume_mounts": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "data_repos": {
+          "type": "object"
+        }
+      },
+      "required": [
+        "envs",
+        "volumes",
+        "volume_mounts",
+        "data_repos"
+      ],
+      "additionalProperties": false,
+      "default": {}
+    },
+    "admin_page": {
+      "type": "boolean",
+      "default": false
+    },
+    "global": {},
+    "coordinator": {
+      "type": "object",
+      "properties": {
+        "resources": {
+          "$ref": "#/definitions/resources"
+        }
+      },
+      "required": [
+        "resources"
+      ]
+    },
+    "frontend": {
+      "type": "object",
+      "properties": {
+        "replicas": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 1
+        },
+        "resources": {
+          "$ref": "#/definitions/resources"
+        }
+      },
+      "required": [
+        "resources"
+      ]
+    },
+    "db": {
+      "type": "object",
+      "properties": {
+        "resources": {
+          "$ref": "#/definitions/resources"
+        }
+      },
+      "required": [
+        "resources"
+      ]
+    },
+    "generator": {
+      "type": "object",
+      "properties": {
+        "resources": {
+          "$ref": "#/definitions/resources"
+        },
+        "workdir": {
+          "type": "object",
+          "properties": {
+            "medium": {
+              "type": "string",
+              "enum": [
+                "",
+                "Memory"
+              ]
+            }
+          },
+          "required": [
+            "medium"
+          ]
+        },
+        "replicas": {
+          "type": "integer",
+          "minimum": 1
+        }
+      },
+      "required": [
+        "resources",
+        "workdir",
+        "replicas"
+      ]
+    },
+    "context_menu_templates": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/context_menu_template"
+      },
+      "default": []
+    }
+  },
+  "required": [
+    "image",
+    "use_vault",
+    "use_gafaelfawr",
+    "coordinator",
+    "frontend",
+    "db",
+    "generator",
+    "context_menu_templates"
+  ],
+  "additionalProperties": false,
+  "definitions": {
+    "image_config": {
+      "type": "object",
+      "properties": {
+        "repository": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        },
+        "pullPolicy": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "repository",
+        "tag",
+        "pullPolicy"
+      ],
+      "additionalProperties": false
+    },
+    "config": {
+      "properties": {
+        "pathPrefix": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "pathPrefix"
+      ],
+      "additionalProperties": false
+    },
+    "s3_config": {
+      "properties": {
+        "endpoint": {
+          "type": "string"
+        },
+        "bucket": {
+          "type": "string"
+        },
+        "secure": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "endpoint",
+        "bucket",
+        "secure"
+      ],
+      "additionalProperties": false
+    },
+    "resources": {
+      "type": "object",
+      "properties": {
+        "requests": {
+          "type": "object",
+          "properties": {
+            "cpu": {
+              "type": "string"
+            },
+            "memory": {
+              "type": "string"
+            }
+          }
+        },
+        "limits": {
+          "type": "object",
+          "properties": {
+            "cpu": {
+              "type": "string"
+            },
+            "memory": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "cpu",
+            "memory"
+          ]
+        }
+      }
+    },
+    "debug": {
+      "type": "object",
+      "properties": {
+        "jupyter": {
+          "type": "boolean"
+        },
+        "username": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "jupyter",
+        "username"
+      ]
+    },
+    "context_menu_template": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "template": {
+          "type": "string"
+        },
+        "is_url": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "name",
+        "template",
+        "is_url"
+      ]
+    },
+    "envvar": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "value"
+      ]
+    }
+  }
+}

--- a/applications/fov-quicklook/values.schema.json
+++ b/applications/fov-quicklook/values.schema.json
@@ -128,10 +128,24 @@
                 "",
                 "Memory"
               ]
+            },
+            "sizeLimit": {
+              "type": "string"
             }
           },
           "required": [
             "medium"
+          ]
+        },
+        "mergedDir": {
+          "type": "object",
+          "properties": {
+            "sizeLimit": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "sizeLimit"
           ]
         },
         "replicas": {
@@ -142,6 +156,7 @@
       "required": [
         "resources",
         "workdir",
+        "mergedDir",
         "replicas"
       ]
     },

--- a/applications/fov-quicklook/values.yaml
+++ b/applications/fov-quicklook/values.yaml
@@ -1,0 +1,14 @@
+# Default values for fov-quicklook.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# The following will be set by parameters injected by Argo CD and should not
+# be set in the individual environment values files.
+global:
+  # -- Host name for ingress
+  # @default -- Set by Argo CD
+  host: null
+
+  # -- Base path for Vault secrets
+  # @default -- Set by Argo CD
+  vaultSecretsPath: null

--- a/applications/fov-quicklook/values.yaml
+++ b/applications/fov-quicklook/values.yaml
@@ -1,14 +1,80 @@
-# Default values for fov-quicklook.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
+# -- Use vault to store secrets
+use_vault: true
 
-# The following will be set by parameters injected by Argo CD and should not
-# be set in the individual environment values files.
-global:
-  # -- Host name for ingress
-  # @default -- Set by Argo CD
-  host: null
+# -- Use gafaelfawr to authenticate
+use_gafaelfawr: true
 
-  # -- Base path for Vault secrets
-  # @default -- Set by Argo CD
-  vaultSecretsPath: null
+image:
+  # -- Image to use in the fov-quicklook deployment
+  repository: ghcr.io/michitaro/rubin-fov-viewer
+
+  # -- Pull policy for the fov-quicklook image
+  pullPolicy: Always
+
+  # -- Tag of image to use
+  tag: latest
+
+config:
+  # -- URL path prefix
+  pathPrefix: /fov-quicklook
+
+# -- S3 configuration for the tile storage
+s3_tile:
+  endpoint: sdfembs3.sdf.slac.stanford.edu:443
+  secure: true
+  bucket: fov-quicklook-tile
+
+# -- Storage class to use for the database
+db_storage_class: null
+
+coordinator:
+  resources:
+    # -- Resource requests for the coordinator
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    # -- Resource limits for the coordinator
+    limits:
+      cpu: 4000m
+      memory: 256Mi
+
+frontend:
+  resources:
+    # -- Resource requests for the frontend
+    requests:
+      cpu: 100m
+      memory: 512Mi
+    # -- Resource limits for the frontend
+    limits:
+      cpu: 8000m
+      memory: 512Mi
+
+db:
+  resources:
+    # -- Resource requests for the database
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    # -- Resource limits for the database
+    limits:
+      cpu: 2000m
+      memory: 256Mi
+
+generator:
+  resources:
+    # -- Resource requests for the generator
+    requests:
+      cpu: 8000m
+      memory: 32Gi
+    # -- Resource limits for the generator
+    limits:
+      cpu: 16000m
+      memory: 32Gi
+  workdir:
+    # -- Work directory type for the generator
+    medium: Memory
+  # -- Number of replicas for the generator
+  replicas: 9
+
+# -- Context menu templates for the frontend
+context_menu_templates: []

--- a/applications/fov-quicklook/values.yaml
+++ b/applications/fov-quicklook/values.yaml
@@ -73,6 +73,11 @@ generator:
   workdir:
     # -- Work directory type for the generator
     medium: Memory
+    # -- Size limit for the shared memory work directory
+    sizeLimit: 32Gi
+  mergedDir:
+    # -- Size limit for the merged directory
+    sizeLimit: 32Gi
   # -- Number of replicas for the generator
   replicas: 9
 

--- a/docs/applications/fov-quicklook/index.rst
+++ b/docs/applications/fov-quicklook/index.rst
@@ -1,0 +1,16 @@
+.. px-app:: fov-quicklook
+
+#######################################
+fov-quicklook — Full focal plane viewer
+#######################################
+
+.. jinja:: fov-quicklook
+   :file: applications/_summary.rst.jinja
+
+Guides
+======
+
+.. toctree::
+   :maxdepth: 1
+
+   values

--- a/docs/applications/fov-quicklook/values.md
+++ b/docs/applications/fov-quicklook/values.md
@@ -1,0 +1,12 @@
+```{px-app-values} fov-quicklook
+```
+
+# fov-quicklook Helm values reference
+
+Helm values reference table for the {px-app}`fov-quicklook` application.
+
+```{include} ../../../applications/fov-quicklook/README.md
+---
+start-after: "## Values"
+---
+```

--- a/docs/applications/rsp.rst
+++ b/docs/applications/rsp.rst
@@ -12,6 +12,7 @@ Argo CD project: ``rsp``
    butler/index
    consdbtap/index
    datalinker/index
+   fov-quicklook/index
    hips/index
    hoverdrive/index
    jira-data-proxy/index

--- a/environments/README.md
+++ b/environments/README.md
@@ -26,6 +26,7 @@
 | applications.exposurelog | bool | `false` | Enable the exposurelog application |
 | applications.fastapi-bootcamp | bool | `false` | Enable the fastapi-bootcamp application |
 | applications.flink | bool | `false` | Enable the flink application |
+| applications.fov-quicklook | bool | `false` | Enable the fov-quicklook application |
 | applications.gafaelfawr | bool | `true` | Enable the Gafaelfawr application. This is required by Phalanx since most other applications use `GafaelfawrIngress` |
 | applications.ghostwriter | bool | `false` | Enable the ghostwriter application |
 | applications.giftless | bool | `false` | Enable the giftless application |

--- a/environments/README.md
+++ b/environments/README.md
@@ -26,7 +26,7 @@
 | applications.exposurelog | bool | `false` | Enable the exposurelog application |
 | applications.fastapi-bootcamp | bool | `false` | Enable the fastapi-bootcamp application |
 | applications.flink | bool | `false` | Enable the flink application |
-| applications.fov-quicklook | bool | `false` | Enable the fov-quicklook application |
+| applications.fov-quicklook | bool | `false` | Switch to enable the fov-quicklook application in specific environments (off by default) |
 | applications.gafaelfawr | bool | `true` | Enable the Gafaelfawr application. This is required by Phalanx since most other applications use `GafaelfawrIngress` |
 | applications.ghostwriter | bool | `false` | Enable the ghostwriter application |
 | applications.giftless | bool | `false` | Enable the giftless application |

--- a/environments/templates/applications/rsp/fov-quicklook.yaml
+++ b/environments/templates/applications/rsp/fov-quicklook.yaml
@@ -19,15 +19,13 @@ spec:
   source:
     path: "applications/fov-quicklook"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ or (index .Values "revisions" "fov-quicklook") .Values.targetRevision | quote }}
+    targetRevision: {{ .Values.targetRevision | quote }}
     helm:
       parameters:
-        - name: "global.baseUrl"
-          value: "https://{{ .Values.fqdn }}"
-        - name: "global.environmentName"
-          value: {{ .Values.name | quote }}
         - name: "global.host"
           value: {{ .Values.fqdn | quote }}
+        - name: "global.baseUrl"
+          value: "https://{{ .Values.fqdn }}"
         - name: "global.vaultSecretsPath"
           value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:

--- a/environments/templates/applications/rsp/fov-quicklook.yaml
+++ b/environments/templates/applications/rsp/fov-quicklook.yaml
@@ -1,0 +1,36 @@
+{{- if (index .Values "applications" "fov-quicklook") -}}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "fov-quicklook"
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: "fov-quicklook"
+  namespace: "argocd"
+  finalizers:
+    - "resources-finalizer.argocd.argoproj.io"
+spec:
+  destination:
+    namespace: "fov-quicklook"
+    server: "https://kubernetes.default.svc"
+  project: "rsp"
+  source:
+    path: "applications/fov-quicklook"
+    repoURL: {{ .Values.repoUrl | quote }}
+    targetRevision: {{ or (index .Values "revisions" "fov-quicklook") .Values.targetRevision | quote }}
+    helm:
+      parameters:
+        - name: "global.baseUrl"
+          value: "https://{{ .Values.fqdn }}"
+        - name: "global.environmentName"
+          value: {{ .Values.name | quote }}
+        - name: "global.host"
+          value: {{ .Values.fqdn | quote }}
+        - name: "global.vaultSecretsPath"
+          value: {{ .Values.vaultPathPrefix | quote }}
+      valueFiles:
+        - "values.yaml"
+        - "values-{{ .Values.name }}.yaml"
+{{- end -}}

--- a/environments/values-usdfdev.yaml
+++ b/environments/values-usdfdev.yaml
@@ -18,6 +18,7 @@ applications:
   datalinker: true
   exposurelog: true
   exposure-checker: true
+  fov-quicklook: true
   grafana: true
   rubin-rag: true
   jira-data-proxy: true

--- a/environments/values.yaml
+++ b/environments/values.yaml
@@ -97,6 +97,9 @@ applications:
   # -- Enable the flink application
   flink: false
 
+  # -- Enable the fov-quicklook application
+  fov-quicklook: false
+
   # -- Enable the Gafaelfawr application. This is required by Phalanx since
   # most other applications use `GafaelfawrIngress`
   gafaelfawr: true

--- a/environments/values.yaml
+++ b/environments/values.yaml
@@ -96,8 +96,7 @@ applications:
 
   # -- Enable the flink application
   flink: false
-
-  # -- Enable the fov-quicklook application
+  # -- Switch to enable the fov-quicklook application in specific environments (off by default)
   fov-quicklook: false
 
   # -- Enable the Gafaelfawr application. This is required by Phalanx since


### PR DESCRIPTION
These changes are for the in-kind contribution JAP-JPG-S3.

I'm discussing the following points with @ktlim :

* The tile generator should be a `deployment` instead of `daemonset`
* Postgres password should be managed within the phalanx secret framework. 
