### PR TITLE
DM-47593: Enable Gafaelfawr caching for Butler server

### DIFF
--- a/applications/butler/templates/ingress-authenticated.yaml
+++ b/applications/butler/templates/ingress-authenticated.yaml
@@ -5,6 +5,9 @@ metadata:
   labels:
     {{- include "butler.labels" . | nindent 4 }}
 config:
+  # The Butler server often services large numbers of small requests,
+  # so this cache reduces the load on Gafaelfawr.
+  authCacheDuration: 5m
   baseUrl: {{ .Values.global.baseUrl | quote }}
   scopes:
     all:


### PR DESCRIPTION
Butler clients often make large numbers of small requests using the same access token.  Enabling this cache avoids hitting the Gafaelfawr service repeatedly for these requests, reducing load on the service and improving request latency.