### PR TITLE
Change OIDC provider in the cadc-tap config to base path

### DIFF
--- a/charts/cadc-tap/README.md
+++ b/charts/cadc-tap/README.md
@@ -31,12 +31,12 @@ IVOA TAP service
 | config.pg.host | string | None, must be set if backend is `pg` | Host to connect to |
 | config.pg.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the TAP image |
 | config.pg.image.repository | string | `"ghcr.io/lsst-sqre/tap-postgres-service"` | TAP image to use |
-| config.pg.image.tag | string | `"1.18.6"` | Tag of TAP image to use |
+| config.pg.image.tag | string | `"1.19.0"` | Tag of TAP image to use |
 | config.pg.username | string | None, must be set if backend is `pg` | Username to connect with |
 | config.qserv.host | string | `"mock-db:3306"` (the mock QServ) | QServ hostname:port to connect to |
 | config.qserv.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the TAP image |
 | config.qserv.image.repository | string | `"ghcr.io/lsst-sqre/lsst-tap-service"` | TAP image to use |
-| config.qserv.image.tag | string | `"2.4.7"` | Tag of TAP image to use |
+| config.qserv.image.tag | string | `"2.5.0"` | Tag of TAP image to use |
 | config.qserv.jdbcParams | string | `""` | Extra JDBC connection parameters |
 | config.qserv.passwordEnabled | bool | false | Whether the Qserv database is password protected |
 | config.tapSchemaAddress | string | `"cadc-tap-schema-db:3306"` | Address to a MySQL database containing TAP schema data |
@@ -78,7 +78,7 @@ IVOA TAP service
 | uws.affinity | object | `{}` | Affinity rules for the UWS database pod |
 | uws.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the UWS database image |
 | uws.image.repository | string | `"ghcr.io/lsst-sqre/lsst-tap-uws-db"` | UWS database image to use |
-| uws.image.tag | string | `"2.4.7"` | Tag of UWS database image to use |
+| uws.image.tag | string | `"2.5.0"` | Tag of UWS database image to use |
 | uws.nodeSelector | object | `{}` | Node selection rules for the UWS database pod |
 | uws.podAnnotations | object | `{}` | Annotations for the UWS databse pod |
 | uws.resources | object | See `values.yaml` | Resource limits and requests for the UWS database pod |

--- a/charts/cadc-tap/templates/configmap.yaml
+++ b/charts/cadc-tap/templates/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "cadc-tap.labels" . | nindent 4 }}
 data:
   cadc-registry.properties: |
-    ivo://ivoa.net/sso#OpenID = {{ .Values.global.baseUrl }}/auth/cadc
+    ivo://ivoa.net/sso#OpenID = {{ .Values.global.baseUrl }}
   catalina.properties: |
     # tomcat properties
     tomcat.connector.connectionTimeout=20000

--- a/charts/cadc-tap/values.yaml
+++ b/charts/cadc-tap/values.yaml
@@ -71,7 +71,7 @@ config:
       pullPolicy: "IfNotPresent"
 
       # -- Tag of TAP image to use
-      tag: "1.18.6"
+      tag: "1.19.0"
 
   qserv:
     # -- QServ hostname:port to connect to
@@ -89,7 +89,7 @@ config:
       pullPolicy: "IfNotPresent"
 
       # -- Tag of TAP image to use
-      tag: "2.4.7"
+      tag: "2.5.0"
 
     # -- Whether the Qserv database is password protected
     # @default -- false
@@ -195,7 +195,7 @@ uws:
     pullPolicy: "IfNotPresent"
 
     # -- Tag of UWS database image to use
-    tag: "2.4.7"
+    tag: "2.5.0"
 
   # -- Resource limits and requests for the UWS database pod
   # @default -- See `values.yaml`


### PR DESCRIPTION
**Summary:**
CADC have modified the way the OIDC discovery works with the newer release of cadc-gms & the `StandardIdentityProvider` that we use. The discovery service will look for the .well-known oidc endpoint at the wrong location (auth/cadc/..)
This update to phalanx changes the OIDC issuer location to the base path. This requires a newer release of Gafaelfawr, and as part of this PR we update the version of tap-postgres and lsst-tap-service to a version that includes the new cadc-gms releases with the OIDC discovery mechanism.

In this PR we:
- Update tap-postgres to 1.19.0
- Update lsst-tap-service to 2.5.0
- Change the ivo://ivoa.net/sso#OpenID setting in cadc-tap

**Jira issue:**
https://rubinobs.atlassian.net/browse/DM-47788

**Tested:**
Tested using https://github.com/stvoutsin/rspvalidator