### PR TITLE
DM-47814: Allow turning off central repo export in Prompt Processing

### DIFF
--- a/applications/prompt-proto-service-hsc/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-hsc/values-usdfdev-prompt-processing.yaml
@@ -39,7 +39,8 @@ prompt-proto-service:
     endpointUrl: https://usdf-rsp-dev.slac.stanford.edu/sasquatch-rest-proxy
     auth_env: false
 
-  # A cache efficiency workaround breaks on RC2 tests; see DM-43205.
-  cacheCalibs: false
+  debug:
+    # A cache efficiency workaround breaks on RC2 tests; see DM-43205.
+    cacheCalibs: false
 
   fullnameOverride: "prompt-proto-service-hsc"

--- a/applications/prompt-proto-service-latiss/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfdev-prompt-processing.yaml
@@ -40,7 +40,8 @@ prompt-proto-service:
     endpointUrl: https://usdf-rsp-dev.slac.stanford.edu/sasquatch-rest-proxy
     auth_env: false
 
-  # A cache efficiency workaround breaks when mixing observing dates; see DM-43205, DM-43913.
-  cacheCalibs: false
+  debug:
+    # A cache efficiency workaround breaks when mixing observing dates; see DM-43205, DM-43913.
+    cacheCalibs: false
 
   fullnameOverride: "prompt-proto-service-latiss"

--- a/applications/prompt-proto-service-lsstcomcam/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/values-usdfdev-prompt-processing.yaml
@@ -39,7 +39,8 @@ prompt-proto-service:
     endpointUrl: https://usdf-rsp-dev.slac.stanford.edu/sasquatch-rest-proxy
     auth_env: false
 
-  # A cache efficiency workaround breaks when mixing observing dates; see DM-43205, DM-43913.
-  cacheCalibs: false
+  debug:
+    # A cache efficiency workaround breaks when mixing observing dates; see DM-43205, DM-43913.
+    cacheCalibs: false
 
   fullnameOverride: "prompt-proto-service-lsstcomcam"

--- a/charts/prompt-proto-service/README.md
+++ b/charts/prompt-proto-service/README.md
@@ -22,8 +22,8 @@ Event-driven processing of camera images
 | cache.maxFilters | int | `20` | The maximum number of datasets of a given type the service might load if the filter is unknown. Should be greater than or equal to the number of filters that have e.g. flats or transmission curves. |
 | cache.patchesPerImage | int | `4` | A factor by which to multiply `baseSize` for templates and other patch-based datasets. |
 | cache.refcatsPerImage | int | `4` | A factor by which to multiply `baseSize` for refcat datasets. |
-| cacheCalibs | bool | `true` | Whether or not calibs should be cached between runs of a pod. This is a temporary flag that should only be unset in specific circumstances, and only in the development environment. |
 | containerConcurrency | int | `1` | The number of Knative requests that can be handled simultaneously by one container |
+| debug.cacheCalibs | bool | `true` | Whether or not calibs should be cached between runs of a pod. This is a temporary flag that should only be unset in specific circumstances, and only in the development environment. |
 | fullnameOverride | string | `"prompt-proto-service"` | Override the full name for resources (includes the release name) |
 | image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
 | image.repository | string | `"ghcr.io/lsst-dm/prompt-service"` | Image to use in the PP deployment |

--- a/charts/prompt-proto-service/README.md
+++ b/charts/prompt-proto-service/README.md
@@ -24,6 +24,7 @@ Event-driven processing of camera images
 | cache.refcatsPerImage | int | `4` | A factor by which to multiply `baseSize` for refcat datasets. |
 | containerConcurrency | int | `1` | The number of Knative requests that can be handled simultaneously by one container |
 | debug.cacheCalibs | bool | `true` | Whether or not calibs should be cached between runs of a pod. This is a temporary flag that should only be unset in specific circumstances, and only in the development environment. |
+| debug.exportOutputs | bool | `true` | Whether or not pipeline outputs should be exported to the central repo. This flag does not turn off APDB writes or alert generation; those must be handled at the pipeline level or by setting up an alternative destination. |
 | fullnameOverride | string | `"prompt-proto-service"` | Override the full name for resources (includes the release name) |
 | image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
 | image.repository | string | `"ghcr.io/lsst-dm/prompt-service"` | Image to use in the PP deployment |

--- a/charts/prompt-proto-service/templates/prompt-proto-service.yaml
+++ b/charts/prompt-proto-service/templates/prompt-proto-service.yaml
@@ -122,7 +122,7 @@ spec:
         - name: FILTERS_WITH_CALIBS
           value: {{ .Values.cache.maxFilters | toString | quote }}
         - name: DEBUG_CACHE_CALIBS
-          value: {{ if .Values.cacheCalibs }}'1'{{ else }}'0'{{ end }}
+          value: {{ if .Values.debug.cacheCalibs }}'1'{{ else }}'0'{{ end }}
         volumeMounts:
         - mountPath: /tmp-butler
           name: ephemeral

--- a/charts/prompt-proto-service/templates/prompt-proto-service.yaml
+++ b/charts/prompt-proto-service/templates/prompt-proto-service.yaml
@@ -123,6 +123,8 @@ spec:
           value: {{ .Values.cache.maxFilters | toString | quote }}
         - name: DEBUG_CACHE_CALIBS
           value: {{ if .Values.debug.cacheCalibs }}'1'{{ else }}'0'{{ end }}
+        - name: DEBUG_EXPORT_OUTPUTS
+          value: {{ if .Values.debug.exportOutputs }}'1'{{ else }}'0'{{ end }}
         volumeMounts:
         - mountPath: /tmp-butler
           name: ephemeral

--- a/charts/prompt-proto-service/values.yaml
+++ b/charts/prompt-proto-service/values.yaml
@@ -168,9 +168,10 @@ fullnameOverride: "prompt-proto-service"
 # -- The number of Knative requests that can be handled simultaneously by one container
 containerConcurrency: 1
 
-# -- Whether or not calibs should be cached between runs of a pod.
-# This is a temporary flag that should only be unset in specific circumstances, and only in the development environment.
-cacheCalibs: true
+debug:
+  # -- Whether or not calibs should be cached between runs of a pod.
+  # This is a temporary flag that should only be unset in specific circumstances, and only in the development environment.
+  cacheCalibs: true
 
 # -- Kubernetes YAML configs for extra container volume(s).
 # Any volumes required by other config options are automatically handled by the Helm chart.

--- a/charts/prompt-proto-service/values.yaml
+++ b/charts/prompt-proto-service/values.yaml
@@ -172,6 +172,9 @@ debug:
   # -- Whether or not calibs should be cached between runs of a pod.
   # This is a temporary flag that should only be unset in specific circumstances, and only in the development environment.
   cacheCalibs: true
+  # -- Whether or not pipeline outputs should be exported to the central repo.
+  # This flag does not turn off APDB writes or alert generation; those must be handled at the pipeline level or by setting up an alternative destination.
+  exportOutputs: true
 
 # -- Kubernetes YAML configs for extra container volume(s).
 # Any volumes required by other config options are automatically handled by the Helm chart.


### PR DESCRIPTION
This PR adds a debugging flag to Prompt Processing that prevents it from exporting to the central repo or Sasquatch.