### PR TITLE
DM-47837: Fix GafaelfawrIngress for TAP services

### DIFF
--- a/applications/livetap/README.md
+++ b/applications/livetap/README.md
@@ -15,9 +15,9 @@ IVOA TAP service
 | cadc-tap.config.pg.database | string | `"lsstdb1"` | Postgres database to connect to |
 | cadc-tap.config.pg.host | string | `"mock-pg:5432"` (the mock pg) | Postgres hostname:port to connect to |
 | cadc-tap.config.pg.username | string | `"rubin"` | Postgres username to use to connect |
+| cadc-tap.config.service | string | `"livetap"` | Name of the service from Gafaelfawr's perspective |
 | cadc-tap.config.vaultSecretName | string | `"livetap"` | Vault secret name: the final key in the vault path |
 | cadc-tap.ingress.path | string | `"live"` | Ingress path that should be routed to this service |
-| cadc-tap.service | string | `"livetap"` | Name of the service from Gafaelfawr's perspective |
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |

--- a/applications/livetap/values.yaml
+++ b/applications/livetap/values.yaml
@@ -7,6 +7,9 @@ cadc-tap:
     # -- What type of backend?
     backend: "pg"
 
+    # -- Name of the service from Gafaelfawr's perspective
+    service: "livetap"
+
     pg:
       # -- Postgres hostname:port to connect to
       # @default -- `"mock-pg:5432"` (the mock pg)
@@ -20,9 +23,6 @@ cadc-tap:
 
     # -- Vault secret name: the final key in the vault path
     vaultSecretName: "livetap"
-
-  # -- Name of the service from Gafaelfawr's perspective
-  service: "livetap"
 
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.

--- a/applications/ssotap/README.md
+++ b/applications/ssotap/README.md
@@ -15,9 +15,9 @@ IVOA TAP service for Solar System Objects
 | cadc-tap.config.pg.database | string | `"dp03_catalogs"` | Postgres database to connect to |
 | cadc-tap.config.pg.host | string | `"usdf-pg-catalogs.slac.stanford.edu:5432"` | Postgres hostname:port to connect to |
 | cadc-tap.config.pg.username | string | `"dp03"` | Postgres username to use to connect |
+| cadc-tap.config.service | string | `"ssotap"` | Name of the service from Gafaelfawr's perspective |
 | cadc-tap.config.vaultSecretName | string | `"ssotap"` | Vault secret name: the final key in the vault path |
 | cadc-tap.ingress.path | string | `"ssotap"` | Ingress path that should be routed to this service |
-| cadc-tap.service | string | `"ssotap"` | Name of the service from Gafaelfawr's perspective |
 | cadc-tap.serviceAccount.name | string | `"ssotap"` | Name of the Kubernetes `ServiceAccount`, used for CloudSQL access |
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |

--- a/applications/ssotap/values.yaml
+++ b/applications/ssotap/values.yaml
@@ -7,6 +7,9 @@ cadc-tap:
     # -- What type of backend?
     backend: "pg"
 
+    # -- Name of the service from Gafaelfawr's perspective
+    service: "ssotap"
+
     pg:
       # -- Postgres hostname:port to connect to
       host: "usdf-pg-catalogs.slac.stanford.edu:5432"
@@ -23,9 +26,6 @@ cadc-tap:
   serviceAccount:
     # -- Name of the Kubernetes `ServiceAccount`, used for CloudSQL access
     name: "ssotap"
-
-  # -- Name of the service from Gafaelfawr's perspective
-  service: "ssotap"
 
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.

--- a/applications/tap/README.md
+++ b/applications/tap/README.md
@@ -12,10 +12,10 @@ IVOA TAP service
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | cadc-tap.config.backend | string | `"qserv"` | What type of backend? |
+| cadc-tap.config.serviceName | string | `"tap"` | Name of the service from Gafaelfawr's perspective |
 | cadc-tap.config.vaultSecretName | string | `"tap"` | Vault secret name: the final key in the vault path |
 | cadc-tap.ingress.path | string | `"tap"` | Ingress path that should be routed to this service |
 | cadc-tap.serviceAccount.name | string | `"tap"` | Name of the Kubernetes `ServiceAccount`, used for CloudSQL access |
-| cadc-tap.serviceName | string | `"tap"` | Name of the service from Gafaelfawr's perspective |
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |

--- a/applications/tap/values.yaml
+++ b/applications/tap/values.yaml
@@ -10,12 +10,12 @@ cadc-tap:
     # -- Vault secret name: the final key in the vault path
     vaultSecretName: "tap"
 
+    # -- Name of the service from Gafaelfawr's perspective
+    serviceName: "tap"
+
   serviceAccount:
     # -- Name of the Kubernetes `ServiceAccount`, used for CloudSQL access
     name: "tap"
-
-  # -- Name of the service from Gafaelfawr's perspective
-  serviceName: "tap"
 
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.


### PR DESCRIPTION
Move the setting of the service name to the correct location so that the GafaelfawrIngress resources are generated correctly for TAP services.