### PR TITLE
Update Prompt Processing to 4.10.0 and pull in configs from Argo

### DIFF
--- a/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
@@ -14,7 +14,7 @@ prompt-proto-service:
   image:
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: 4.9.0
+    tag: 4.10.0
 
   instrument:
     pipelines:

--- a/applications/prompt-proto-service-lsstcomcam/README.md
+++ b/applications/prompt-proto-service-lsstcomcam/README.md
@@ -37,8 +37,8 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.instrument.skymap | string | `"lsst_cells_v1"` | Skymap to use with the instrument |
 | prompt-proto-service.knative.cpuLimit | int | `1` | The maximum cpu cores for the full pod (see `containerConcurrency`). |
 | prompt-proto-service.knative.cpuRequest | int | `1` | The cpu cores requested for the full pod (see `containerConcurrency`). |
-| prompt-proto-service.knative.ephemeralStorageLimit | string | `"5Gi"` | The maximum storage space allowed for each container (mostly local Butler). This allocation is for the full pod (see `containerConcurrency`) |
-| prompt-proto-service.knative.ephemeralStorageRequest | string | `"5Gi"` | The storage space reserved for each container (mostly local Butler). This allocation is for the full pod (see `containerConcurrency`) |
+| prompt-proto-service.knative.ephemeralStorageLimit | string | `"8Gi"` | The maximum storage space allowed for each container (mostly local Butler). This allocation is for the full pod (see `containerConcurrency`) |
+| prompt-proto-service.knative.ephemeralStorageRequest | string | `"8Gi"` | The storage space reserved for each container (mostly local Butler). This allocation is for the full pod (see `containerConcurrency`) |
 | prompt-proto-service.knative.gpu | bool | `false` | GPUs enabled. |
 | prompt-proto-service.knative.gpuRequest | int | `0` | The number of GPUs to request for the full pod (see `containerConcurrency`). |
 | prompt-proto-service.knative.idleTimeout | int | `900` | Maximum time that a container can send nothing to Knative (seconds). This is only useful if the container runs async workers. If 0, idle timeout is ignored. |

--- a/applications/prompt-proto-service-lsstcomcam/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/values-usdfprod-prompt-processing.yaml
@@ -25,8 +25,6 @@ prompt-proto-service:
           - ${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCam/ApPipe.yaml
           - ${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCam/SingleFrame.yaml
           - ${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCam/Isr.yaml
-        - survey: BLOCK-T60  # optics alignment
-          pipelines: []
         - survey: BLOCK-T75  # giant donuts
           pipelines: []
         - survey: BLOCK-T88  # optics alignment
@@ -35,27 +33,37 @@ prompt-proto-service:
           pipelines: []
         - survey: BLOCK-T216  # twilight flats
           pipelines: []
-        - survey: BLOCK-T219  # pretty pictures
-          pipeliens: []
         - survey: BLOCK-T246  # instrument checkout
           pipelines: ['${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCam/Isr-cal.yaml']
         - survey: BLOCK-T249  # AOS alignment
           pipelines: []
         - survey: BLOCK-T250  # TMA daytime checkout
           pipelines: []
+        - {survey: BLOCK-T306, pipelines: []}  # Manual observations during SV block
+        - {survey: BLOCK-T307, pipelines: []}  # Manual observations during SV block
+        - {survey: BLOCK-T308, pipelines: []}  # Manual observations during SV block
+        - {survey: BLOCK-T309, pipelines: []}  # Manual observations during SV block
+        - {survey: BLOCK-T310, pipelines: []}  # Manual observations during SV block
+        - {survey: BLOCK-T311, pipelines: []}  # Manual observations during SV block
+        - {survey: BLOCK-T312, pipelines: []}  # Manual observations during SV block
         - {survey: "", pipelines: []}
       preprocessing: |-
         - survey: BLOCK-320
           pipelines: ['${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCam/Preprocessing.yaml']
-        - {survey: BLOCK-T60, pipelines: []}
         - {survey: BLOCK-T75, pipelines: []}
         - {survey: BLOCK-T88, pipelines: []}
         - {survey: BLOCK-T215, pipelines: []}
         - {survey: BLOCK-T216, pipelines: []}
-        - {survey: BLOCK-T219, pipelines: []}
         - {survey: BLOCK-T246, pipelines: []}
         - {survey: BLOCK-T249, pipelines: []}
         - {survey: BLOCK-T250, pipelines: []}
+        - {survey: BLOCK-T306, pipelines: []}
+        - {survey: BLOCK-T307, pipelines: []}
+        - {survey: BLOCK-T308, pipelines: []}
+        - {survey: BLOCK-T309, pipelines: []}
+        - {survey: BLOCK-T310, pipelines: []}
+        - {survey: BLOCK-T311, pipelines: []}
+        - {survey: BLOCK-T312, pipelines: []}
         - {survey: "", pipelines: []}
     calibRepo: s3://rubin-summit-users
 

--- a/applications/prompt-proto-service-lsstcomcam/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/values-usdfprod-prompt-processing.yaml
@@ -15,7 +15,7 @@ prompt-proto-service:
   image:
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: 4.9.0
+    tag: 4.10.0
 
   instrument:
     pipelines:

--- a/applications/prompt-proto-service-lsstcomcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/values.yaml
@@ -131,10 +131,10 @@ prompt-proto-service:
     cpuLimit: 1
     # -- The storage space reserved for each container (mostly local Butler).
     # This allocation is for the full pod (see `containerConcurrency`)
-    ephemeralStorageRequest: "5Gi"
+    ephemeralStorageRequest: "8Gi"
     # -- The maximum storage space allowed for each container (mostly local Butler).
     # This allocation is for the full pod (see `containerConcurrency`)
-    ephemeralStorageLimit: "5Gi"
+    ephemeralStorageLimit: "8Gi"
     # -- GPUs enabled.
     gpu: false
     # -- The number of GPUs to request for the full pod (see `containerConcurrency`).


### PR DESCRIPTION
This PR updates our Prompt Processing version, and makes permanent some survey and resource settings that have already been deployed through Argo.