### PR TITLE
DM-47889: Increase timeout for Butler server readiness check

### DIFF
--- a/applications/butler/templates/deployment.yaml
+++ b/applications/butler/templates/deployment.yaml
@@ -41,6 +41,7 @@ spec:
             httpGet:
               path: "/"
               port: "http"
+            timeoutSeconds: 10
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:


### PR DESCRIPTION
Under extreme load, it can easily take more than a second for the Butler server to respond to a request.  The previous default value of 1s was causing the Butler server to be restarted unnecessarily.