### PR TITLE
Use unconstrained block to ignore misc surveys in Prompt Processing.

### DIFF
--- a/applications/prompt-proto-service-lsstcomcam/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/values-usdfprod-prompt-processing.yaml
@@ -29,47 +29,33 @@ prompt-proto-service:
           - ${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCam/ApPipe.yaml
           - ${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCam/SingleFrame.yaml
           - ${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCam/Isr.yaml
-        - survey: BLOCK-T75  # giant donuts
-          pipelines: []
-        - survey: BLOCK-T88  # optics alignment
-          pipelines: []
-        - survey: BLOCK-T215  # twilight flats
-          pipelines: []
-        - survey: BLOCK-T216  # twilight flats
-          pipelines: []
         - survey: BLOCK-T246  # instrument checkout
           pipelines: ['${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCam/Isr-cal.yaml']
-        - survey: BLOCK-T249  # AOS alignment
-          pipelines: []
-        - survey: BLOCK-T250  # TMA daytime checkout
-          pipelines: []
         # Manual observations during SV blocks
-        - {survey: BLOCK-T306, pipelines: []}
-        - {survey: BLOCK-T307, pipelines: []}
-        - {survey: BLOCK-T308, pipelines: []}
-        - {survey: BLOCK-T309, pipelines: []}
-        - {survey: BLOCK-T310, pipelines: []}
-        - {survey: BLOCK-T311, pipelines: []}
-        - {survey: BLOCK-T312, pipelines: []}
+        - survey: BLOCK-T306
+          pipelines: []
+        - survey: BLOCK-T307
+          pipelines: []
+        - survey: BLOCK-T308
+          pipelines: []
+        - survey: BLOCK-T309
+          pipelines: []
+        - survey: BLOCK-T310
+          pipelines: []
+        - survey: BLOCK-T311
+          pipelines: []
+        - survey: BLOCK-T312
+          pipelines: []
+        # Miscellaneous scripts, not always images
         - {survey: "", pipelines: []}
+        # Ignore anything else
+        - {pipelines: []}
       preprocessing: |-
         - survey: BLOCK-320
           pipelines: ['${PROMPT_PROCESSING_DIR}/pipelines/LSSTComCam/Preprocessing.yaml']
-        - {survey: BLOCK-T75, pipelines: []}
-        - {survey: BLOCK-T88, pipelines: []}
-        - {survey: BLOCK-T215, pipelines: []}
-        - {survey: BLOCK-T216, pipelines: []}
-        - {survey: BLOCK-T246, pipelines: []}
-        - {survey: BLOCK-T249, pipelines: []}
-        - {survey: BLOCK-T250, pipelines: []}
-        - {survey: BLOCK-T306, pipelines: []}
-        - {survey: BLOCK-T307, pipelines: []}
-        - {survey: BLOCK-T308, pipelines: []}
-        - {survey: BLOCK-T309, pipelines: []}
-        - {survey: BLOCK-T310, pipelines: []}
-        - {survey: BLOCK-T311, pipelines: []}
-        - {survey: BLOCK-T312, pipelines: []}
         - {survey: "", pipelines: []}
+        # No preprocessing for anything else
+        - {pipelines: []}
     calibRepo: s3://rubin-summit-users
 
   s3:


### PR DESCRIPTION
This PR simplifies the Prompt Processing pipelines config with a new feature in version 4.10.