### PR TITLE
DM-48004: Add resource limits for sia deployment

### DIFF
--- a/applications/sia/values.yaml
+++ b/applications/sia/values.yaml
@@ -66,7 +66,13 @@ podAnnotations: {}
 
 # -- Resource limits and requests for the sia deployment pod
 # @default -- See `values.yaml`
-resources: {}
+resources:
+  requests:
+    cpu: 2.0
+    memory: "2Gi"
+  limits:
+    cpu: 8.0
+    memory: "32Gi"
 
 # -- Tolerations for the sia deployment pod
 tolerations: []


### PR DESCRIPTION
Added resources for SIAv2 application. This may need to be revisited after we get a better idea of what these need to be exactly, along with what row limits we will have and pod replicas etc. 
Currently there is a bug or feature which may be redesigned in the client/server butler which currently fetches and caches a lot more data then needed. So the current usage may not represent the actual expected usage in the future. In any case with things as they stand data-int is using 24 Gb of mem,

For this reason to start with I'm with 30 Gb of RAM same as the resource limits for TAP.