### PR TITLE
DM-48088: Bump Gafaelfawr version to 12.3.0

### DIFF
--- a/applications/gafaelfawr/Chart.yaml
+++ b/applications/gafaelfawr/Chart.yaml
@@ -5,7 +5,7 @@ description: "Authentication and identity system"
 home: "https://gafaelfawr.lsst.io/"
 sources:
   - "https://github.com/lsst-sqre/gafaelfawr"
-appVersion: 12.2.0
+appVersion: 12.3.0
 
 dependencies:
   - name: "redis"


### PR DESCRIPTION
Allows an empty list of scopes in a `GafaelfawrIngress`, which we want to use for Wobbly. Also fixes a harmless error from the Kopf health check.