### PR TITLE
DM-48116: Fix ingress/tls indentation issue with argo-cd values files

### DIFF
--- a/applications/argocd/values-ccin2p3.yaml
+++ b/applications/argocd/values-ccin2p3.yaml
@@ -21,5 +21,5 @@ argo-cd:
 
   server:
     ingress:
-      hostnmae: "data-dev.lsst.eu"
+      hostname: "data-dev.lsst.eu"
       tls: false

--- a/applications/argocd/values-ccin2p3.yaml
+++ b/applications/argocd/values-ccin2p3.yaml
@@ -22,4 +22,4 @@ argo-cd:
   server:
     ingress:
       hostnmae: "data-dev.lsst.eu"
-    tls: false
+      tls: false

--- a/applications/argocd/values-minikube.yaml
+++ b/applications/argocd/values-minikube.yaml
@@ -6,7 +6,7 @@ argo-cd:
   server:
     ingress:
       hostname: "minikube.lsst.codes"
-    tls: false
+      tls: false
     resources: {}
 
   controller:

--- a/applications/argocd/values-roe.yaml
+++ b/applications/argocd/values-roe.yaml
@@ -8,4 +8,4 @@ argo-cd:
   server:
     ingress:
       hostname: "rsp.lsst.ac.uk"
-    tls: false
+      tls: false

--- a/applications/argocd/values-usdf-tel-rsp.yaml
+++ b/applications/argocd/values-usdf-tel-rsp.yaml
@@ -41,4 +41,4 @@ argo-cd:
   server:
     ingress:
       hostname: "usdf-tel-rsp.slac.stanford.edu"
-    tls: false
+      tls: false

--- a/applications/argocd/values-usdfdev-alert-stream-broker.yaml
+++ b/applications/argocd/values-usdfdev-alert-stream-broker.yaml
@@ -40,4 +40,4 @@ argo-cd:
     ingress:
       hostname: "k8s.slac.stanford.edu"
       path: "/usdf-alert-stream-broker-dev/argo-cd"
-    tls: false
+      tls: false

--- a/applications/argocd/values-usdfdev-prompt-processing.yaml
+++ b/applications/argocd/values-usdfdev-prompt-processing.yaml
@@ -43,4 +43,4 @@ argo-cd:
     ingress:
       hostname: "k8s.slac.stanford.edu"
       path: "/usdf-prompt-processing-dev/argo-cd"
-    tls: false
+      tls: false

--- a/applications/argocd/values-usdfint.yaml
+++ b/applications/argocd/values-usdfint.yaml
@@ -64,4 +64,4 @@ argo-cd:
   server:
     ingress:
       hostname: "usdf-rsp-int.slac.stanford.edu"
-    tls: false
+      tls: false

--- a/applications/argocd/values-usdfprod-prompt-processing.yaml
+++ b/applications/argocd/values-usdfprod-prompt-processing.yaml
@@ -42,4 +42,4 @@ argo-cd:
     ingress:
       hostname: "k8s.slac.stanford.edu"
       path: "/usdf-prompt-processing/argo-cd"
-    tls: false
+      tls: false

--- a/applications/argocd/values-usdfprod.yaml
+++ b/applications/argocd/values-usdfprod.yaml
@@ -61,4 +61,4 @@ argo-cd:
   server:
     ingress:
       hostname: "usdf-rsp.slac.stanford.edu"
-    tls: false
+      tls: false


### PR DESCRIPTION
**Summary**
There was an indentation issue which showed up recently at the roe environment when they tried to synchronize. The symptoms were that argo-cd failed to synchronize, with error referring to ` letsencypt-dns`. Upon further investigation it seems that the `tls: false` was missplaced, and should be under `ingress` rather than `server`.

This PR addresses the issue by fixing the indentation to match the expected nesting of the ingress setting.

**How was this tested**
Tested on the ROE environments (test & prod) and it works, they can now synchronize argo-cd successfully