### PR TITLE
[DM-46938] Automate InfluxDB Enterprise application level backups

### DIFF
--- a/applications/sasquatch/Chart.yaml
+++ b/applications/sasquatch/Chart.yaml
@@ -56,6 +56,9 @@ dependencies:
   - name: square-events
     condition: squareEvents.enabled
     version: 1.0.0
+  - name: backup
+    condition: backup.enabled
+    version: 1.0.0
   - name: app-metrics
     condition: app-metrics.enabled
     version: 1.0.0

--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -20,6 +20,7 @@ Rubin Observatory's telemetry service
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | app-metrics.apps | list | `[]` | The apps to create configuration for. |
 | app-metrics.enabled | bool | `false` | Enable the app-metrics subchart with topic, user, and telegraf configurations |
+| backup.enabled | bool | `false` | Whether to enable Sasquatch backups |
 | chronograf.enabled | bool | `true` | Whether Chronograf is enabled |
 | chronograf.env | object | See `values.yaml` | Additional environment variables for Chronograf |
 | chronograf.envFromSecret | string | `"sasquatch"` | Name of secret to use. The keys `generic_client_id`, `generic_client_secret`, and `token_secret` should be set. |
@@ -104,6 +105,20 @@ Rubin Observatory's telemetry service
 | app-metrics.replicaCount | int | `3` | Number of Telegraf replicas. Multiple replicas increase availability. |
 | app-metrics.resources | object | See `values.yaml` | Kubernetes resources requests and limits |
 | app-metrics.tolerations | list | `[]` | Tolerations for pod assignment |
+| backup.affinity | object | `{}` | Affinity rules for the backups deployment pod |
+| backup.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the backups image |
+| backup.image.repository | string | `"ghcr.io/lsst-sqre/sasquatch"` | Image to use in the backups deployment |
+| backup.image.tag | string | The appVersion of the chart | Tag of image to use |
+| backup.items.chronograf | bool | `false` | Whether to backup Chronograf |
+| backup.items.influxdbEnterprise | bool | `false` | Whether to backup InfluxDB Enterprise |
+| backup.items.kapacitor | bool | `false` | Whether to backup Kapacitor |
+| backup.nodeSelector | object | `{}` | Node selection rules for the backups deployment pod |
+| backup.persistence.size | string | "100Gi" | Size of the data store to request, if enabled |
+| backup.persistence.storageClass | string | "" (empty string) to use the cluster default storage class | Storage class to use for the backups |
+| backup.podAnnotations | object | `{}` | Annotations for the backups deployment pod |
+| backup.resources | object | `{}` | Resource limits and requests for the backups deployment pod |
+| backup.schedule | string | "0 3 * * *" | Schedule for executing the sasquatch backup script |
+| backup.tolerations | list | `[]` | Tolerations for the backups deployment pod |
 | influxdb-enterprise.bootstrap.auth.secretName | string | `"sasquatch"` | Enable authentication of the data nodes using this secret, by creating a username and password for an admin account. The secret must contain keys `username` and `password`. |
 | influxdb-enterprise.bootstrap.ddldml.configMap | string | Do not run DDL or DML | A config map containing DDL and DML that define databases, retention policies, and inject some data.  The keys `ddl` and `dml` must exist, even if one of them is empty.  DDL is executed before DML to ensure databases and retention policies exist. |
 | influxdb-enterprise.bootstrap.ddldml.resources | object | `{}` | Kubernetes resources and limits for the bootstrap job |

--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -34,6 +34,7 @@ Rubin Observatory's telemetry service
 | chronograf.persistence.enabled | bool | `true` | Whether to enable persistence for Chronograf data |
 | chronograf.persistence.size | string | `"100Gi"` | Size of data store to request, if enabled |
 | chronograf.resources | object | See `values.yaml` | Kubernetes resource requests and limits for Chronograf |
+| chronograf.updateStrategy.type | string | `"Recreate"` | Deployment strategy, use recreate with persistence enabled |
 | influxdb-enterprise.enabled | bool | `false` | Whether to use influxdb-enterprise |
 | influxdb.config.continuous_queries.enabled | bool | `false` | Whether continuous queries are enabled |
 | influxdb.config.coordinator.log-queries-after | string | `"15s"` | Maximum duration a query can run before InfluxDB logs it as a slow query |
@@ -75,6 +76,7 @@ Rubin Observatory's telemetry service
 | kapacitor.persistence.enabled | bool | `true` | Whether to enable Kapacitor data persistence |
 | kapacitor.persistence.size | string | `"100Gi"` | Size of storage to request if enabled |
 | kapacitor.resources | object | See `values.yaml` | Kubernetes resource requests and limits for Kapacitor |
+| kapacitor.strategy.type | string | `"Recreate"` | Deployment strategy, use recreate with persistence enabled |
 | rest-proxy.enabled | bool | `false` | Whether to enable the REST proxy |
 | squareEvents.enabled | bool | `false` | Enable the Square Events subchart with topic and user configurations |
 | strimzi-kafka.connect.enabled | bool | `true` | Whether Kafka Connect is enabled |

--- a/applications/sasquatch/charts/backup/.helmignore
+++ b/applications/sasquatch/charts/backup/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/applications/sasquatch/charts/backup/Chart.yaml
+++ b/applications/sasquatch/charts/backup/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+appVersion: 0.1.0
+description: Backup Sasquatch data
+name: backup
+type: application
+version: 1.0.0

--- a/applications/sasquatch/charts/backup/README.md
+++ b/applications/sasquatch/charts/backup/README.md
@@ -1,0 +1,22 @@
+# backup
+
+Backup Sasquatch data
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Affinity rules for the backups deployment pod |
+| image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the backups image |
+| image.repository | string | `"ghcr.io/lsst-sqre/sasquatch"` | Image to use in the backups deployment |
+| image.tag | string | The appVersion of the chart | Tag of image to use |
+| items.chronograf | bool | `false` | Whether to backup Chronograf |
+| items.influxdbEnterprise | bool | `false` | Whether to backup InfluxDB Enterprise |
+| items.kapacitor | bool | `false` | Whether to backup Kapacitor |
+| nodeSelector | object | `{}` | Node selection rules for the backups deployment pod |
+| persistence.size | string | "100Gi" | Size of the data store to request, if enabled |
+| persistence.storageClass | string | "" (empty string) to use the cluster default storage class | Storage class to use for the backups |
+| podAnnotations | object | `{}` | Annotations for the backups deployment pod |
+| resources | object | `{}` | Resource limits and requests for the backups deployment pod |
+| schedule | string | "0 3 * * *" | Schedule for executing the sasquatch backup script |
+| tolerations | list | `[]` | Tolerations for the backups deployment pod |

--- a/applications/sasquatch/charts/backup/templates/_helpers.tpl
+++ b/applications/sasquatch/charts/backup/templates/_helpers.tpl
@@ -1,0 +1,26 @@
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "backup.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "backup.labels" -}}
+helm.sh/chart: {{ include "backup.chart" . }}
+{{ include "backup.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "backup.selectorLabels" -}}
+app.kubernetes.io/name: "backup"
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/applications/sasquatch/charts/backup/templates/backup-cronjob.yaml
+++ b/applications/sasquatch/charts/backup/templates/backup-cronjob.yaml
@@ -1,0 +1,71 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: sasquatch-backup
+  labels:
+    {{- include "backup.labels" . | nindent 4 }}
+spec:
+  schedule: {{ .Values.schedule | quote }}
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          {{- if .Values.podAnnotations }}
+          annotations:
+            {{ toYaml .Values.podAnnotations | nindent 12 }}
+          {{- end }}
+          labels:
+            {{- include "backup.selectorLabels" . | nindent 12 }}
+        spec:
+          restartPolicy: OnFailure
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+          volumes:
+          - name: backup
+            persistentVolumeClaim:
+              claimName: sasquatch-backup
+          {{- if .Values.items.chronograf }}
+          - name: chronograf
+            persistentVolumeClaim:
+              claimName: sasquatch-chronograf
+              readOnly: true
+          {{- end }}
+          {{- if .Values.items.kapacitor }}
+          - name: kapacitor
+            persistentVolumeClaim:
+              claimName: sasquatch-kapacitor
+              readOnly: true
+          {{- end }}
+          containers:
+          - name: sasquatch-backup
+            image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+            imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+            volumeMounts:
+            - name: backup
+              mountPath: /backup
+            {{- if .Values.items.chronograf }}
+            - name: chronograf
+              mountPath: /chronograf
+            {{- end }}
+            {{- if .Values.items.kapacitor }}
+            - name: kapacitor
+              mountPath: /kapacitor
+            {{- end }}
+            command:
+            - /bin/sh
+            - -c
+            - backup.sh
+            resources:
+              {{- toYaml .Values.resources | nindent 14 }}
+          {{- with .Values.nodeSelector }}
+          nodeSelector:
+             {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}

--- a/applications/sasquatch/charts/backup/templates/backup-pvc.yaml
+++ b/applications/sasquatch/charts/backup/templates/backup-pvc.yaml
@@ -1,0 +1,11 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: sasquatch-backup
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}

--- a/applications/sasquatch/charts/backup/values.yaml
+++ b/applications/sasquatch/charts/backup/values.yaml
@@ -1,0 +1,48 @@
+# Default values for backups.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  # -- Image to use in the backups deployment
+  repository: "ghcr.io/lsst-sqre/sasquatch"
+  # -- Pull policy for the backups image
+  pullPolicy: "IfNotPresent"
+
+  # -- Tag of image to use
+  # @default -- The appVersion of the chart
+  tag: tickets-dm-46938
+
+# -- Schedule for executing the sasquatch backup script
+# @default -- "0 3 * * *"
+schedule: "0 3 * * *"
+
+persistence:
+  # -- Size of the data store to request, if enabled
+  # @default -- "100Gi"
+  size: "100Gi"
+  # -- Storage class to use for the backups
+  # @default -- "" (empty string) to use the cluster default storage class
+  storageClass: ""
+
+items:
+  # -- Whether to backup Chronograf
+  chronograf: false
+  # -- Whether to backup Kapacitor
+  kapacitor: false
+  # -- Whether to backup InfluxDB Enterprise
+  influxdbEnterprise: false
+
+# -- Affinity rules for the backups deployment pod
+affinity: {}
+
+# -- Node selection rules for the backups deployment pod
+nodeSelector: {}
+
+# -- Annotations for the backups deployment pod
+podAnnotations: {}
+
+# -- Resource limits and requests for the backups deployment pod
+resources: {}
+
+# -- Tolerations for the backups deployment pod
+tolerations: []

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -160,3 +160,15 @@ app-metrics:
     - gafaelfawr
     - mobu
     - wobbly
+
+backup:
+  enabled: true
+  image:
+    pullPolicy: "Always"
+  persistence:
+    size: 500Gi
+    storageClass: standard
+  items:
+    chronograf: false
+    kapacitor: false
+    influxdbEnterprise: true

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -365,3 +365,13 @@ chronograf:
 
 kapacitor:
   influxURL: http://sasquatch-influxdb-enterprise-data.sasquatch:8086
+
+backup:
+  enabled: true
+  persistence:
+    size: 100Ti
+    storageClass: wekafs--sdf-k8s01
+  items:
+    chronograf: false
+    kapacitor: false
+    influxdbEnterprise: true

--- a/applications/sasquatch/values.yaml
+++ b/applications/sasquatch/values.yaml
@@ -183,6 +183,10 @@ chronograf:
     # -- Docker tag to use for Chronograf
     tag: 1.10.5
 
+  updateStrategy:
+    # -- Deployment strategy, use recreate with persistence enabled
+    type: "Recreate"
+
   persistence:
     # -- Whether to enable persistence for Chronograf data
     enabled: true
@@ -238,6 +242,10 @@ kapacitor:
 
     # -- Tag to use for Kapacitor
     tag: 1.7.6
+
+  strategy:
+    # -- Deployment strategy, use recreate with persistence enabled
+    type: "Recreate"
 
   persistence:
     # -- Whether to enable Kapacitor data persistence

--- a/applications/sasquatch/values.yaml
+++ b/applications/sasquatch/values.yaml
@@ -276,6 +276,10 @@ squareEvents:
   # -- Enable the Square Events subchart with topic and user configurations
   enabled: false
 
+backup:
+  # -- Whether to enable Sasquatch backups
+  enabled: false
+
 global:
   # -- Base URL for the environment
   # @default -- Set by Argo CD


### PR DESCRIPTION
This PR implements the backup sub chart in Sasquatch, with creates a PVC and a CronJob to execute the InfluxDB Enterprise backup tools from the sasquatch-backup pod. 

Chronograf and Kapacitor backups are disabled at the moment until we have the functionality to snapshot PVs at USDF.