### PR TITLE
DM-48127: Update the fastapi-safir-uws starter

### DIFF
--- a/starters/fastapi-safir-uws/secrets.yaml
+++ b/starters/fastapi-safir-uws/secrets.yaml
@@ -1,7 +1,3 @@
-database-password:
-  description: >-
-    Password used to authenticate to the PostgreSQL database used to store job
-    information. This password may be changed at any time.
 redis-password:
   description: >-
     Password used to authenticate to the internal Redis server, deployed as

--- a/starters/fastapi-safir-uws/templates/configmap.yaml
+++ b/starters/fastapi-safir-uws/templates/configmap.yaml
@@ -6,15 +6,13 @@ metadata:
     {{- include "<CHARTNAME>.labels" . | nindent 4 }}
 data:
   <CHARTENVPREFIX>_ARQ_QUEUE_URL: "redis://<CHARTNAME>-redis.{{ .Release.Namespace }}"
-  {{- if .Values.cloudsql.enabled }}
-  <CHARTENVPREFIX>_DATABASE_URL: "postgresql://<CHARTNAME>@localhost/<CHARTNAME>"
-  {{- end }}
   <CHARTENVPREFIX>_GRACE_PERIOD: {{ .Values.config.gracePeriod | quote }}
   <CHARTENVPREFIX>_LIFETIME: {{ .Values.config.lifetime | quote }}
+  <CHARTENVPREFIX>_LOG_LEVEL: {{ .Values.config.loglevel | quote }}
+  <CHARTENVPREFIX>_PATH_PREFIX: {{ .Values.config.pathPrefix | quote }}
+  <CHARTENVPREFIX>_PROFILE: {{ .Values.config.logProfile | quote }}
   <CHARTENVPREFIX>_SERVICE_ACCOUNT: {{ required "config.serviceAccount must be set" .Values.config.serviceAccount | quote }}
   <CHARTENVPREFIX>_STORAGE_URL: {{ required "config.storageBucketUrl must be set" .Values.config.storageBucketUrl | quote }}
   <CHARTENVPREFIX>_SYNC_TIMEOUT: {{ .Values.config.syncTimeout | quote }}
   <CHARTENVPREFIX>_TIMEOUT: {{ .Values.config.timeout | quote }}
-  <CHARTENVPREFIX>_LOG_LEVEL: {{ .Values.config.loglevel | quote }}
-  <CHARTENVPREFIX>_PATH_PREFIX: {{ .Values.config.pathPrefix | quote }}
-  <CHARTENVPREFIX>_PROFILE: {{ .Values.config.logProfile | quote }}
+  <CHARTENVPREFIX>_WOBBLY_URL: "{{ .Values.global.baseUrl }}/wobbly"

--- a/starters/fastapi-safir-uws/templates/db-worker-deployment.yaml
+++ b/starters/fastapi-safir-uws/templates/db-worker-deployment.yaml
@@ -26,32 +26,8 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.cloudsql.enabled }}
-      serviceAccountName: "<CHARTNAME>"
-      {{- else }}
       automountServiceAccountToken: false
-      {{- end }}
       containers:
-        {{- if .Values.cloudsql.enabled }}
-        - name: "cloud-sql-proxy"
-          command:
-            - "/cloud_sql_proxy"
-            - "-ip_address_types=PRIVATE"
-            - "-log_debug_stdout=true"
-            - "-structured_logs=true"
-            - "-instances={{ required "cloudsql.instanceConnectionName must be specified" .Values.cloudsql.instanceConnectionName }}=tcp:5432"
-          image: "{{ .Values.cloudsql.image.repository }}:{{ .Values.cloudsql.image.tag }}"
-          imagePullPolicy: {{ .Values.cloudsql.image.pullPolicy | quote }}
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - "all"
-            readOnlyRootFilesystem: true
-            runAsNonRoot: true
-            runAsUser: 65532
-            runAsGroup: 65532
-        {{- end }}
         - name: "db-worker"
           command:
             - "arq"
@@ -62,11 +38,6 @@ spec:
                 secretKeyRef:
                   name: "<CHARTNAME>"
                   key: "redis-password"
-            - name: "<CHARTENVPREFIX>_DATABASE_PASSWORD"
-              valueFrom:
-                secretKeyRef:
-                  name: "<CHARTNAME>"
-                  key: "database-password"
           envFrom:
             - configMapRef:
                 name: "<CHARTNAME>"

--- a/starters/fastapi-safir-uws/templates/deployment.yaml
+++ b/starters/fastapi-safir-uws/templates/deployment.yaml
@@ -26,36 +26,8 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.cloudsql.enabled }}
       serviceAccountName: "<CHARTNAME>"
-      {{- else }}
-      automountServiceAccountToken: false
-      {{- end }}
       containers:
-        {{- if .Values.cloudsql.enabled }}
-        - name: "cloud-sql-proxy"
-          command:
-            - "/cloud_sql_proxy"
-            - "-ip_address_types=PRIVATE"
-            - "-log_debug_stdout=true"
-            - "-structured_logs=true"
-            - "-instances={{ required "cloudsql.instanceConnectionName must be specified" .Values.cloudsql.instanceConnectionName }}=tcp:5432"
-          image: "{{ .Values.cloudsql.image.repository }}:{{ .Values.cloudsql.image.tag }}"
-          imagePullPolicy: {{ .Values.cloudsql.image.pullPolicy | quote }}
-          {{- with .Values.cloudsql.resources }}
-          resources:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - "all"
-            readOnlyRootFilesystem: true
-            runAsNonRoot: true
-            runAsUser: 65532
-            runAsGroup: 65532
-        {{- end }}
         - name: "<CHARTNAME>"
           env:
             - name: "<CHARTENVPREFIX>_ARQ_QUEUE_PASSWORD"
@@ -63,11 +35,6 @@ spec:
                 secretKeyRef:
                   name: "<CHARTNAME>"
                   key: "redis-password"
-            - name: "<CHARTENVPREFIX>_DATABASE_PASSWORD"
-              valueFrom:
-                secretKeyRef:
-                  name: "<CHARTNAME>"
-                  key: "database-password"
           envFrom:
             - configMapRef:
                 name: "<CHARTNAME>"

--- a/starters/fastapi-safir-uws/templates/serviceaccount.yaml
+++ b/starters/fastapi-safir-uws/templates/serviceaccount.yaml
@@ -1,4 +1,3 @@
-{{- if (or .Values.config.serviceAccount .Values.cloudsql.enabled) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -7,4 +6,3 @@ metadata:
     {{- include "<CHARTNAME>.labels" . | nindent 4 }}
   annotations:
     iam.gke.io/gcp-service-account: {{ required "config.serviceAccount must be set to a valid Google service account" .Values.config.serviceAccount | quote }}
-{{- end }}

--- a/starters/fastapi-safir-uws/templates/worker-deployment.yaml
+++ b/starters/fastapi-safir-uws/templates/worker-deployment.yaml
@@ -26,11 +26,7 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.config.serviceAccount }}
       serviceAccountName: "<CHARTNAME>"
-      {{- else }}
-      automountServiceAccountToken: false
-      {{- end }}
       containers:
         - name: "worker"
           env:

--- a/starters/fastapi-safir-uws/values.yaml
+++ b/starters/fastapi-safir-uws/values.yaml
@@ -3,6 +3,12 @@
 # Declare variables to be passed into your templates.
 
 config:
+  # -- Grace period in seconds to wait for worker jobs to finish
+  gracePeriod: 60
+
+  # -- Lifetime of job results in Safir `parse_timedelta` format
+  lifetime: "30d"
+
   # -- Choose from the text form of Python logging levels
   loglevel: "INFO"
 
@@ -13,19 +19,9 @@ config:
   # -- URL path prefix for the API
   pathPrefix: "/api/<CHARTNAME>"
 
-  # -- URL for the PostgreSQL database if Cloud SQL is not in use
-  # @default -- None, must be set if `cloudsql.enabled` is false
-  databaseUrl: null
-
-  # -- Grace period in seconds to wait for worker jobs to finish
-  gracePeriod: 60
-
-  # -- Lifetime of job results in Safir `parse_timedelta` format
-  lifetime: "30d"
-
   # -- Google service account with an IAM binding to the Kubernetes service
-  # account for the application. Must have the `cloudsql.client` role, access
-  # to write to the GCS bucket, and ability to sign URLs as itself
+  # account for the application. Must have access to write to the GCS bucket
+  # and ability to sign URLs as itself
   # @default -- None, must be set
   serviceAccount: null
 
@@ -75,35 +71,6 @@ frontend:
 
   # -- Tolerations for the <CHARTNAME> frontend pod
   tolerations: []
-
-cloudsql:
-  # -- Enable the Cloud SQL Auth Proxy sidecar, used with Cloud SQL databases
-  # on Google Cloud
-  enabled: false
-
-  image:
-    # -- Cloud SQL Auth Proxy image to use
-    repository: "gcr.io/cloudsql-docker/gce-proxy"
-
-    # -- Cloud SQL Auth Proxy tag to use
-    tag: "1.37.2"
-
-    # -- Pull policy for Cloud SQL Auth Proxy images
-    pullPolicy: "IfNotPresent"
-
-  # -- Instance connection name for a Cloud SQL PostgreSQL instance
-  # @default -- None, must be set if Cloud SQL is used
-  instanceConnectionName: null
-
-  # -- Resource limits and requests for the Cloud SQL Proxy container
-  # @default -- See `values.yaml`
-  resources:
-    limits:
-      cpu: "100m"
-      memory: "20Mi"
-    requests:
-      cpu: "5m"
-      memory: "7Mi"
 
 worker:
   # -- Number of <CHARTNAME> worker pods to start


### PR DESCRIPTION
Simplify the fastapi-safir-uws starter now that each UWS application no longer needs to manage its own database. Make the configuration for the GCS service account unconditional, since currently Safir only supports putting job results in a GCS bucket and using presigned URLs.