### PR TITLE
DM-48127: Add Slack alerting support to safir starters

### DIFF
--- a/starters/fastapi-safir-uws/secrets.yaml
+++ b/starters/fastapi-safir-uws/secrets.yaml
@@ -7,3 +7,11 @@ redis-password:
     value.
   generate:
     type: password
+slack-webhook:
+  description: >-
+    Slack web hook used to report internal errors to Slack. This secret may be
+    changed at any time.
+  if: config.slackAlerts
+  copy:
+    application: mobu
+    key: app-alert-webhook

--- a/starters/fastapi-safir-uws/templates/db-worker-deployment.yaml
+++ b/starters/fastapi-safir-uws/templates/db-worker-deployment.yaml
@@ -38,6 +38,13 @@ spec:
                 secretKeyRef:
                   name: "<CHARTNAME>"
                   key: "redis-password"
+            {{- if .Values.config.slackAlerts }}
+            - name: "<CHARTENVPREFIX>_SLACK_WEBHOOK"
+              valueFrom:
+                secretKeyRef:
+                  name: "<CHARTNAME>"
+                  key: "slack-webhook"
+            {{- end }}
           envFrom:
             - configMapRef:
                 name: "<CHARTNAME>"

--- a/starters/fastapi-safir-uws/templates/deployment.yaml
+++ b/starters/fastapi-safir-uws/templates/deployment.yaml
@@ -35,6 +35,13 @@ spec:
                 secretKeyRef:
                   name: "<CHARTNAME>"
                   key: "redis-password"
+            {{- if .Values.config.slackAlerts }}
+            - name: "<CHARTENVPREFIX>_SLACK_WEBHOOK"
+              valueFrom:
+                secretKeyRef:
+                  name: "<CHARTNAME>"
+                  key: "slack-webhook"
+            {{- end }}
           envFrom:
             - configMapRef:
                 name: "<CHARTNAME>"

--- a/starters/fastapi-safir-uws/values.yaml
+++ b/starters/fastapi-safir-uws/values.yaml
@@ -25,6 +25,9 @@ config:
   # @default -- None, must be set
   serviceAccount: null
 
+  # -- Whether to send Slack alerts for unexpected failures
+  slackAlerts: false
+
   # -- URL for the GCS bucket for results (must start with `s3` or `gs`)
   # @default -- None, must be set
   storageBucketUrl: null

--- a/starters/fastapi-safir/secrets.yaml
+++ b/starters/fastapi-safir/secrets.yaml
@@ -1,0 +1,8 @@
+slack-webhook:
+  description: >-
+    Slack web hook used to report internal errors to Slack. This secret may be
+    changed at any time.
+  if: config.slackAlerts
+  copy:
+    application: mobu
+    key: app-alert-webhook

--- a/starters/fastapi-safir/templates/deployment.yaml
+++ b/starters/fastapi-safir/templates/deployment.yaml
@@ -26,6 +26,14 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: {{ .Chart.Name }}
+          {{- if .Values.config.slackAlerts }}
+          env:
+            - name: "<CHARTENVPREFIX>_SLACK_WEBHOOK"
+              valueFrom:
+                secretKeyRef:
+                  name: "<CHARTNAME>"
+                  key: "slack-webhook"
+          {{- end }}
           envFrom:
             - configMapRef:
                 name: "<CHARTNAME>"

--- a/starters/fastapi-safir/templates/vault-secrets.yaml
+++ b/starters/fastapi-safir/templates/vault-secrets.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.config.slackAlerts -}}
+apiVersion: ricoberger.de/v1alpha1
+kind: VaultSecret
+metadata:
+  name: "<CHARTNAME>"
+  labels:
+    {{- include "<CHARTNAME>.labels" . | nindent 4 }}
+spec:
+  path: "{{ .Values.global.vaultSecretsPath }}/<CHARTNAME>"
+  type: Opaque
+{{- end }}

--- a/starters/fastapi-safir/values.yaml
+++ b/starters/fastapi-safir/values.yaml
@@ -27,6 +27,9 @@ config:
   # -- URL path prefix
   pathPrefix: "/<CHARTNAME>"
 
+  # -- Whether to send Slack alerts for unexpected failures
+  slackAlerts: false
+
 ingress:
   # -- Additional annotations for the ingress rule
   annotations: {}


### PR DESCRIPTION
Add support for optional Slack alerting, disabled by default, to the fastapi-safir and fastapi-safir-app starters, since otherwise I have to manually add it to each new application and forget.