### PR TITLE
DM-47986: Add support for Slack alerting in Wobbly

### DIFF
--- a/applications/wobbly/README.md
+++ b/applications/wobbly/README.md
@@ -29,6 +29,7 @@ IVOA UWS database storage
 | config.metrics.schemaManager.suffix | string | `""` | Suffix to add to all registered subjects. This is sometimes useful for experimentation during development. |
 | config.pathPrefix | string | `"/wobbly"` | URL path prefix |
 | config.services | list | See `values.yaml` | Services allowed to use Wobbly for their backend |
+| config.slackAlerts | bool | `true` | Whether to send Slack alerts for unexpected failures |
 | config.updateSchema | bool | `false` | Whether to automatically update the Wobbly database schema |
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |

--- a/applications/wobbly/templates/deployment.yaml
+++ b/applications/wobbly/templates/deployment.yaml
@@ -85,6 +85,13 @@ spec:
                   name: "wobbly-kafka"
                   key: "securityProtocol"
             {{- end }}
+            {{- if .Values.config.slackAlerts }}
+            - name: "WOBBLY_SLACK_WEBHOOK"
+              valueFrom:
+                secretKeyRef:
+                  name: "wobbly"
+                  key: "slack-webhook"
+            {{- end }}
           envFrom:
             - configMapRef:
                 name: "wobbly"

--- a/applications/wobbly/values.yaml
+++ b/applications/wobbly/values.yaml
@@ -36,6 +36,9 @@ config:
   services:
     - "vo-cutouts"
 
+  # -- Whether to send Slack alerts for unexpected failures
+  slackAlerts: true
+
   # -- Whether to automatically update the Wobbly database schema
   updateSchema: false
 


### PR DESCRIPTION
Some of the bits for Slack alerting were present in the Wobbly chart, but it wasn't plumbed through or configured. Do the remaining steps.