### PR TITLE
DM-48139: Separate Wobbly ingresses

### DIFF
--- a/applications/wobbly/templates/ingress-admin.yaml
+++ b/applications/wobbly/templates/ingress-admin.yaml
@@ -1,21 +1,18 @@
 apiVersion: gafaelfawr.lsst.io/v1alpha1
 kind: GafaelfawrIngress
 metadata:
-  name: "wobbly"
+  name: "wobbly-admin"
   labels:
     {{- include "wobbly.labels" . | nindent 4 }}
 config:
   baseUrl: {{ .Values.global.baseUrl | quote }}
-  onlyServices:
-    {{- range .Values.config.services }}
-    - {{ . | quote }}
-    {{- end }}
   scopes:
-    all: []
+    all:
+      - "exec:admin"
   service: "wobbly"
 template:
   metadata:
-    name: "wobbly"
+    name: "wobbly-admin"
     {{- with .Values.ingress.annotations }}
     annotations:
       {{- toYaml . | nindent 6 }}

--- a/applications/wobbly/templates/ingress-service.yaml
+++ b/applications/wobbly/templates/ingress-service.yaml
@@ -1,0 +1,34 @@
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
+metadata:
+  name: "wobbly-service"
+  labels:
+    {{- include "wobbly.labels" . | nindent 4 }}
+config:
+  baseUrl: {{ .Values.global.baseUrl | quote }}
+  onlyServices:
+    {{- range .Values.config.services }}
+    - {{ . | quote }}
+    {{- end }}
+  scopes:
+    all: []
+  service: "wobbly"
+template:
+  metadata:
+    name: "wobbly-service"
+    {{- with .Values.ingress.annotations }}
+    annotations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  spec:
+    rules:
+      - host: {{ required "global.host must be set" .Values.global.host | quote }}
+        http:
+          paths:
+            - path: "{{ .Values.config.pathPrefix }}/jobs"
+              pathType: "Prefix"
+              backend:
+                service:
+                  name: "wobbly"
+                  port:
+                    number: 8080

--- a/applications/wobbly/values-idfdev.yaml
+++ b/applications/wobbly/values-idfdev.yaml
@@ -1,6 +1,3 @@
-config:
-  updateSchema: true
-
 cloudsql:
   enabled: true
   instanceConnectionName: "science-platform-dev-7696:us-central1:science-platform-dev-e9e11de2"


### PR DESCRIPTION
Create a separate ingress for services accessing Wobbly under the `/jobs` route and protect the rest of the routes with a conventional ingress that requires the `exec:admin` scope. This includes the OpenAPI schema as well as the `/admin` routes.