### PR TITLE
DM-48165: Invalid Prompt Processing config for LATISS-prod

### DIFF
--- a/applications/prompt-proto-service-hsc-gpu/README.md
+++ b/applications/prompt-proto-service-hsc-gpu/README.md
@@ -14,7 +14,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 |-----|------|---------|-------------|
 | prompt-proto-service.additionalVolumeMounts | list | `[]` | Kubernetes YAML configs for extra container volume(s). Any volumes required by other config options are automatically handled by the Helm chart. |
 | prompt-proto-service.affinity | object | `{}` | Affinity rules for the prompt processing pods |
-| prompt-proto-service.alerts.server | string | `"usdf-alert-stream-dev-broker-0.lsst.cloud:9094"` | Server address for the alert stream |
+| prompt-proto-service.alerts.server | string | `"usdf-alert-stream-dev.lsst.cloud:9094"` | Server address for the alert stream |
 | prompt-proto-service.alerts.topic | string | None, must be set | Topic name where alerts will be sent |
 | prompt-proto-service.alerts.username | string | `"kafka-admin"` | Username for sending alerts to the alert stream |
 | prompt-proto-service.apdb.config | string | None, must be set | URL to a serialized APDB configuration, or the "label:" prefix followed by the indexed name of such a config. |

--- a/applications/prompt-proto-service-hsc-gpu/values.yaml
+++ b/applications/prompt-proto-service-hsc-gpu/values.yaml
@@ -105,7 +105,7 @@ prompt-proto-service:
     # -- Username for sending alerts to the alert stream
     username: "kafka-admin"
     # -- Server address for the alert stream
-    server: "usdf-alert-stream-dev-broker-0.lsst.cloud:9094"
+    server: "usdf-alert-stream-dev.lsst.cloud:9094"
     # -- Topic name where alerts will be sent
     # @default -- None, must be set
     topic: ""

--- a/applications/prompt-proto-service-hsc/README.md
+++ b/applications/prompt-proto-service-hsc/README.md
@@ -14,7 +14,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 |-----|------|---------|-------------|
 | prompt-proto-service.additionalVolumeMounts | list | `[]` | Kubernetes YAML configs for extra container volume(s). Any volumes required by other config options are automatically handled by the Helm chart. |
 | prompt-proto-service.affinity | object | `{}` | Affinity rules for the prompt processing pods |
-| prompt-proto-service.alerts.server | string | `"usdf-alert-stream-dev-broker-0.lsst.cloud:9094"` | Server address for the alert stream |
+| prompt-proto-service.alerts.server | string | `"usdf-alert-stream-dev.lsst.cloud:9094"` | Server address for the alert stream |
 | prompt-proto-service.alerts.topic | string | None, must be set | Topic name where alerts will be sent |
 | prompt-proto-service.alerts.username | string | `"kafka-admin"` | Username for sending alerts to the alert stream |
 | prompt-proto-service.apdb.config | string | None, must be set | URL to a serialized APDB configuration, or the "label:" prefix followed by the indexed name of such a config. |

--- a/applications/prompt-proto-service-hsc/values.yaml
+++ b/applications/prompt-proto-service-hsc/values.yaml
@@ -106,7 +106,7 @@ prompt-proto-service:
     # -- Username for sending alerts to the alert stream
     username: "kafka-admin"
     # -- Server address for the alert stream
-    server: "usdf-alert-stream-dev-broker-0.lsst.cloud:9094"
+    server: "usdf-alert-stream-dev.lsst.cloud:9094"
     # -- Topic name where alerts will be sent
     # @default -- None, must be set
     topic: ""

--- a/applications/prompt-proto-service-latiss/README.md
+++ b/applications/prompt-proto-service-latiss/README.md
@@ -14,7 +14,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 |-----|------|---------|-------------|
 | prompt-proto-service.additionalVolumeMounts | list | `[]` | Kubernetes YAML configs for extra container volume(s). Any volumes required by other config options are automatically handled by the Helm chart. |
 | prompt-proto-service.affinity | object | `{}` | Affinity rules for the prompt processing pods |
-| prompt-proto-service.alerts.server | string | `"usdf-alert-stream-dev-broker-0.lsst.cloud:9094"` | Server address for the alert stream |
+| prompt-proto-service.alerts.server | string | `"usdf-alert-stream-dev.lsst.cloud:9094"` | Server address for the alert stream |
 | prompt-proto-service.alerts.topic | string | None, must be set | Topic name where alerts will be sent |
 | prompt-proto-service.alerts.username | string | `"kafka-admin"` | Username for sending alerts to the alert stream |
 | prompt-proto-service.apdb.config | string | None, must be set | URL to a serialized APDB configuration, or the "label:" prefix followed by the indexed name of such a config. |

--- a/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
@@ -33,8 +33,10 @@ prompt-proto-service:
         - {survey: cwfs, pipelines: []}
         - {survey: cwfs-focus-sweep, pipelines: []}
         - {survey: spec-survey, pipelines: []}
-        - {survey: BLOCK-271, pipelines: []}  # photon transfer curve calibrations
-        - {survey: BLOCK-295, pipelines: []}  # the daily calibration sequence as of May 27, 2024
+        # photon transfer curve calibrations
+        - {survey: BLOCK-271, pipelines: []}
+        # the daily calibration sequence as of May 27, 2024
+        - {survey: BLOCK-295, pipelines: []}
         - {survey: "", pipelines: []}
       preprocessing: |-
         - survey: BLOCK-306

--- a/applications/prompt-proto-service-latiss/values.yaml
+++ b/applications/prompt-proto-service-latiss/values.yaml
@@ -105,7 +105,7 @@ prompt-proto-service:
     # -- Username for sending alerts to the alert stream
     username: "kafka-admin"
     # -- Server address for the alert stream
-    server: "usdf-alert-stream-dev-broker-0.lsst.cloud:9094"
+    server: "usdf-alert-stream-dev.lsst.cloud:9094"
     # -- Topic name where alerts will be sent
     # @default -- None, must be set
     topic: ""

--- a/applications/prompt-proto-service-lsstcam/README.md
+++ b/applications/prompt-proto-service-lsstcam/README.md
@@ -14,7 +14,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 |-----|------|---------|-------------|
 | prompt-proto-service.additionalVolumeMounts | list | `[]` | Kubernetes YAML configs for extra container volume(s). Any volumes required by other config options are automatically handled by the Helm chart. |
 | prompt-proto-service.affinity | object | `{}` | Affinity rules for the prompt processing pods |
-| prompt-proto-service.alerts.server | string | `"usdf-alert-stream-dev-broker-0.lsst.cloud:9094"` | Server address for the alert stream |
+| prompt-proto-service.alerts.server | string | `"usdf-alert-stream-dev.lsst.cloud:9094"` | Server address for the alert stream |
 | prompt-proto-service.alerts.topic | string | None, must be set | Topic name where alerts will be sent |
 | prompt-proto-service.alerts.username | string | `"kafka-admin"` | Username for sending alerts to the alert stream |
 | prompt-proto-service.apdb.config | string | None, must be set | URL to a serialized APDB configuration, or the "label:" prefix followed by the indexed name of such a config. |

--- a/applications/prompt-proto-service-lsstcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcam/values.yaml
@@ -106,7 +106,7 @@ prompt-proto-service:
     # -- Username for sending alerts to the alert stream
     username: "kafka-admin"
     # -- Server address for the alert stream
-    server: "usdf-alert-stream-dev-broker-0.lsst.cloud:9094"
+    server: "usdf-alert-stream-dev.lsst.cloud:9094"
     # -- Topic name where alerts will be sent
     # @default -- None, must be set
     topic: ""

--- a/applications/prompt-proto-service-lsstcomcam/README.md
+++ b/applications/prompt-proto-service-lsstcomcam/README.md
@@ -14,7 +14,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 |-----|------|---------|-------------|
 | prompt-proto-service.additionalVolumeMounts | list | `[]` | Kubernetes YAML configs for extra container volume(s). Any volumes required by other config options are automatically handled by the Helm chart. |
 | prompt-proto-service.affinity | object | `{}` | Affinity rules for the prompt processing pods |
-| prompt-proto-service.alerts.server | string | `"usdf-alert-stream-dev-broker-0.lsst.cloud:9094"` | Server address for the alert stream |
+| prompt-proto-service.alerts.server | string | `"usdf-alert-stream-dev.lsst.cloud:9094"` | Server address for the alert stream |
 | prompt-proto-service.alerts.topic | string | `""` | Topic name where alerts will be sent |
 | prompt-proto-service.alerts.username | string | `"kafka-admin"` | Username for sending alerts to the alert stream |
 | prompt-proto-service.apdb.config | string | None, must be set | URL to a serialized APDB configuration, or the "label:" prefix followed by the indexed name of such a config. |

--- a/applications/prompt-proto-service-lsstcomcam/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/values-usdfprod-prompt-processing.yaml
@@ -67,9 +67,7 @@ prompt-proto-service:
   imageNotifications:
     kafkaClusterAddress: prompt-processing-2-kafka-bootstrap.kafka:9092
     topic: rubin-summit-notification
-    # Scheduler adds an extra 60-80-second delay for first visit in a sequence,
-    # and files can take up to 20 seconds to arrive. Scheduler delay associated
-    # with CWFS engineering data, should not apply to other cameras.
+    # Copied over from LATISS, works well empirically
     imageTimeout: 110
 
   apdb:

--- a/applications/prompt-proto-service-lsstcomcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/values.yaml
@@ -105,7 +105,7 @@ prompt-proto-service:
     # -- Username for sending alerts to the alert stream
     username: "kafka-admin"
     # -- Server address for the alert stream
-    server: "usdf-alert-stream-dev-broker-0.lsst.cloud:9094"
+    server: "usdf-alert-stream-dev.lsst.cloud:9094"
     # -- Topic name where alerts will be sent
     topic: ""
 

--- a/applications/prompt-proto-service-lsstcomcamsim/README.md
+++ b/applications/prompt-proto-service-lsstcomcamsim/README.md
@@ -14,7 +14,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 |-----|------|---------|-------------|
 | prompt-proto-service.additionalVolumeMounts | list | `[]` | Kubernetes YAML configs for extra container volume(s). Any volumes required by other config options are automatically handled by the Helm chart. |
 | prompt-proto-service.affinity | object | `{}` | Affinity rules for the prompt processing pods |
-| prompt-proto-service.alerts.server | string | `"usdf-alert-stream-dev-broker-0.lsst.cloud:9094"` | Server address for the alert stream |
+| prompt-proto-service.alerts.server | string | `"usdf-alert-stream-dev.lsst.cloud:9094"` | Server address for the alert stream |
 | prompt-proto-service.alerts.topic | string | None, must be set | Topic name where alerts will be sent |
 | prompt-proto-service.alerts.username | string | `"kafka-admin"` | Username for sending alerts to the alert stream |
 | prompt-proto-service.apdb.config | string | None, must be set | URL to a serialized APDB configuration, or the "label:" prefix followed by the indexed name of such a config. |

--- a/applications/prompt-proto-service-lsstcomcamsim/values.yaml
+++ b/applications/prompt-proto-service-lsstcomcamsim/values.yaml
@@ -107,7 +107,7 @@ prompt-proto-service:
     # -- Username for sending alerts to the alert stream
     username: "kafka-admin"
     # -- Server address for the alert stream
-    server: "usdf-alert-stream-dev-broker-0.lsst.cloud:9094"
+    server: "usdf-alert-stream-dev.lsst.cloud:9094"
     # -- Topic name where alerts will be sent
     # @default -- None, must be set
     topic: ""


### PR DESCRIPTION
This PR updates the Prompt Processing pipelines config for LATISS to a form that won't get garbled by Argo, and also updates the Kafka config for all instances. No other bitrot was found compared to the (recently active) ComCamSim config.

There are two changes I've avoided making on this PR:
- We expect to migrate to the embargo rack before observations begin, but there's no concrete timeframe for doing so. The migration will be handled on #3815.
- I've not put in a "catch-all" config block until we have a clearer picture of what next season's nextVisit messages will look like. We may not need one at all.