### PR TITLE
DM-48168: Allow excluding applications from secrets sync

### DIFF
--- a/src/phalanx/cli.py
+++ b/src/phalanx/cli.py
@@ -615,6 +615,13 @@ def secrets() -> None:
     help="Path to root of Phalanx configuration.",
 )
 @click.option(
+    "--exclude",
+    "-e",
+    default=[],
+    multiple=True,
+    help="Ignore Vault entries for the given applications.",
+)
+@click.option(
     "--secrets",
     type=click.Path(path_type=Path),
     default=None,
@@ -622,7 +629,11 @@ def secrets() -> None:
 )
 @_report_usage_errors
 def secrets_audit(
-    environment: str, *, config: Path | None, secrets: Path | None
+    environment: str,
+    *,
+    config: Path | None,
+    exclude: list[str],
+    secrets: Path | None,
 ) -> None:
     """Audit secrets for an environment.
 
@@ -644,7 +655,7 @@ def secrets_audit(
     static_secrets = StaticSecrets.from_path(secrets) if secrets else None
     factory = Factory(config)
     secrets_service = factory.create_secrets_service()
-    report = secrets_service.audit(environment, static_secrets)
+    report = secrets_service.audit(environment, set(exclude), static_secrets)
     if report:
         sys.stdout.write(report)
         sys.exit(1)
@@ -799,6 +810,13 @@ def secrets_static_template(environment: str, *, config: Path | None) -> None:
     help="Delete any unexpected secrets in Vault.",
 )
 @click.option(
+    "--exclude",
+    "-e",
+    default=[],
+    multiple=True,
+    help="Ignore Vault entries for the given applications.",
+)
+@click.option(
     "--regenerate",
     default=False,
     is_flag=True,
@@ -816,6 +834,7 @@ def secrets_sync(
     *,
     config: Path | None,
     delete: bool,
+    exclude: list[str],
     regenerate: bool,
     secrets: Path | None,
 ) -> None:
@@ -840,7 +859,11 @@ def secrets_sync(
     factory = Factory(config)
     secrets_service = factory.create_secrets_service()
     secrets_service.sync(
-        environment, static_secrets, regenerate=regenerate, delete=delete
+        environment,
+        set(exclude),
+        static_secrets,
+        regenerate=regenerate,
+        delete=delete,
     )
 
 

--- a/src/phalanx/models/environments.py
+++ b/src/phalanx/models/environments.py
@@ -366,10 +366,20 @@ class Environment(EnvironmentBaseConfig):
         """Return all enabled applications in sorted order."""
         return sorted(self.applications.values(), key=lambda a: a.name)
 
-    def all_secrets(self) -> list[Secret]:
-        """Return all secrets regardless of application."""
+    def all_secrets(self, exclude: set[str] | None = None) -> list[Secret]:
+        """Return all secrets regardless of application.
+
+        Parameters
+        ----------
+        exclude
+            Applications whose secrets should be excluded.
+        """
+        if not exclude:
+            exclude = set()
         secrets: list[Secret] = []
         for application in self.all_applications():
+            if application.name in exclude:
+                continue
             secrets.extend(application.secrets.values())
         return secrets
 

--- a/src/phalanx/services/secrets.py
+++ b/src/phalanx/services/secrets.py
@@ -100,6 +100,7 @@ class SecretsService:
     def audit(
         self,
         env_name: str,
+        exclude: set[str],
         static_secrets: StaticSecrets | None = None,
     ) -> str:
         """Compare existing secrets to configuration and report problems.
@@ -114,6 +115,8 @@ class SecretsService:
         ----------
         env_name
             Name of the environment to audit.
+        exclude
+            Applications to exclude from the audit.
         static_secrets
             User-provided static secrets.
 
@@ -134,9 +137,9 @@ class SecretsService:
 
         # Retrieve all the current secrets from Vault and resolve all of the
         # secrets.
-        secrets = environment.all_secrets()
+        secrets = environment.all_secrets(exclude)
         try:
-            vault_secrets = vault_client.get_environment_secrets()
+            vault_secrets = vault_client.get_environment_secrets(exclude)
         except VaultNotFoundError:
             vault_secrets = {}
         try:
@@ -237,6 +240,7 @@ class SecretsService:
     def sync(
         self,
         env_name: str,
+        exclude: set[str],
         static_secrets: StaticSecrets | None = None,
         *,
         regenerate: bool = False,
@@ -256,6 +260,8 @@ class SecretsService:
         ----------
         env_name
             Name of the environment.
+        exclude
+            Applications to exclude from the sync.
         static_secrets
             User-provided static secrets.
         regenerate
@@ -267,9 +273,9 @@ class SecretsService:
         if not static_secrets:
             static_secrets = self._get_onepassword_secrets(environment)
         vault_client = self._get_vault_client(environment, static_secrets)
-        secrets = environment.all_secrets()
+        secrets = environment.all_secrets(exclude)
         try:
-            vault_secrets = vault_client.get_environment_secrets()
+            vault_secrets = vault_client.get_environment_secrets(exclude)
         except VaultNotFoundError:
             vault_secrets = {}
 

--- a/src/phalanx/storage/vault.py
+++ b/src/phalanx/storage/vault.py
@@ -234,16 +234,27 @@ class VaultClient:
             role_id=role_id, policies=r["data"]["token_policies"]
         )
 
-    def get_environment_secrets(self) -> dict[str, dict[str, SecretStr]]:
+    def get_environment_secrets(
+        self, exclude: set[str] | None = None
+    ) -> dict[str, dict[str, SecretStr]]:
         """Get the secrets for an environment currently stored in Vault.
+
+        Parameters
+        ----------
+        exclude
+            Applications to exclude, ignoring their Vault entries.
 
         Returns
         -------
         dict of dict
             Mapping from application to secret key to its secret from Vault.
         """
+        if not exclude:
+            exclude = set()
         vault_secrets = {}
         for application in self.list_application_secrets():
+            if application in exclude:
+                continue
             with suppress(VaultNotFoundError):
                 vault_secret = self.get_application_secret(application)
                 vault_secrets[application] = vault_secret


### PR DESCRIPTION
Sometimes we'll want to perform a secrets sync without affecting a particular application, such as when we're doing experiments with that application or when we want to run `--delete` but not affect that application. Add an `--exclude` flag to both secrets sync and secrets audit.

This currently excludes the application entirely, as if it doesn't exist, and therefore may interfere with copy directives. We can do something more sophisticated later if that ends up being a problem.