### PR TITLE
sasquatch: enable mobu app metrics capabilities in idfint

### DIFF
--- a/applications/sasquatch/values-idfint.yaml
+++ b/applications/sasquatch/values-idfint.yaml
@@ -164,3 +164,4 @@ app-metrics:
   enabled: true
   apps:
     - gafaelfawr
+    - mobu


### PR DESCRIPTION
They were already enabled in idfprod