### PR TITLE
DM-48184: Bump Wobbly to 0.2.0, add maintenance CronJob

### DIFF
--- a/applications/wobbly/Chart.yaml
+++ b/applications/wobbly/Chart.yaml
@@ -5,7 +5,7 @@ version: 1.0.0
 description: "IVOA UWS database storage"
 sources:
   - https://github.com/lsst-sqre/wobbly
-appVersion: 0.1.0
+appVersion: 0.2.0
 
 annotations:
   phalanx.lsst.io/docs: |

--- a/applications/wobbly/README.md
+++ b/applications/wobbly/README.md
@@ -38,6 +38,9 @@ IVOA UWS database storage
 | image.repository | string | `"ghcr.io/lsst-sqre/wobbly"` | Image to use in the wobbly deployment |
 | image.tag | string | The appVersion of the chart | Tag of image to use |
 | ingress.annotations | object | `{}` | Additional annotations for the ingress rule |
+| maintenance.cleanupSeconds | int | 86400 (1 day) | How long to keep old jobs around before deleting them |
+| maintenance.deadlineSeconds | int | 300 (5 minutes) | How long the job is allowed to run before it will be terminated |
+| maintenance.schedule | string | `"10 * * * *"` | Cron schedule string for Wobbly periodic maintenance (in UTC) |
 | nodeSelector | object | `{}` | Node selection rules for the wobbly deployment pod |
 | podAnnotations | object | `{}` | Annotations for the wobbly deployment pod |
 | replicaCount | int | `1` | Number of web deployment pods to start |

--- a/applications/wobbly/templates/cronjob-maintenance.yaml
+++ b/applications/wobbly/templates/cronjob-maintenance.yaml
@@ -1,0 +1,164 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: "wobbly-maintenance"
+  labels:
+    {{- include "wobbly.labels" . | nindent 4 }}
+spec:
+  schedule: {{ .Values.maintenance.schedule | quote }}
+  concurrencyPolicy: "Forbid"
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: {{ .Values.maintenance.deadlineSeconds }}
+      ttlSecondsAfterFinished: {{ .Values.maintenance.cleanupSeconds }}
+      template:
+        metadata:
+          {{- with .Values.podAnnotations }}
+          annotations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          labels:
+            {{- include "wobbly.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: "maintenance"
+        spec:
+          {{- with .Values.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.cloudsql.enabled }}
+          serviceAccountName: "wobbly"
+          {{- else }}
+          automountServiceAccountToken: false
+          {{- end }}
+          containers:
+            {{- if .Values.cloudsql.enabled }}
+            - name: "cloud-sql-proxy"
+              # Running the sidecar as normal causes it to keep running and
+              # thus the Pod never exits, the Job never finishes, and the hook
+              # blocks the sync. Have the main pod signal the sidecar by
+              # writing to a file on a shared emptyDir file system, and use a
+              # simple watcher loop in shell in the sidecar container to
+              # terminate the proxy when the main container finishes.
+              #
+              # Based on https://stackoverflow.com/questions/41679364/
+              command:
+                - "/bin/sh"
+                - "-c"
+                - |
+                  /cloud_sql_proxy -ip_address_types=PRIVATE -log_debug_stdout=true -structured_logs=true -instances={{ required "cloudsql.instanceConnectionName must be specified" .Values.cloudsql.instanceConnectionName }}=tcp:5432 &
+                  PID=$!
+                  while true; do
+                    if [[ -f "/lifecycle/main-terminated" ]]; then
+                      kill $PID
+                      exit 0
+                    fi
+                    sleep 1
+                  done
+              image: "{{ .Values.cloudsql.image.repository }}:{{ .Values.cloudsql.image.tag }}{{ .Values.cloudsql.image.schemaUpdateTagSuffix }}"
+              imagePullPolicy: {{ .Values.cloudsql.image.pullPolicy | quote }}
+              {{- with .Values.cloudsql.resources }}
+              resources:
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - "all"
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                runAsUser: 65532
+                runAsGroup: 65532
+              volumeMounts:
+                - name: "lifecycle"
+                  mountPath: "/lifecycle"
+            {{- end }}
+            - name: {{ .Chart.Name }}
+              command:
+                - "/bin/sh"
+                - "-c"
+                - |
+                  wobbly expire
+                  touch /lifecycle/main-terminated
+              env:
+                - name: "WOBBLY_DATABASE_PASSWORD"
+                  valueFrom:
+                    secretKeyRef:
+                      name: "wobbly"
+                      key: "database-password"
+                {{- if .Values.config.slackAlerts }}
+                - name: "WOBBLY_SLACK_WEBHOOK"
+                  valueFrom:
+                    secretKeyRef:
+                      name: "wobbly"
+                      key: "slack-webhook"
+                {{- end }}
+                {{- if .Values.config.metrics.enabled }}
+                - name: "KAFKA_BOOTSTRAP_SERVERS"
+                  valueFrom:
+                    secretKeyRef:
+                      name: "wobbly-kafka"
+                      key: "bootstrapServers"
+                - name: "KAFKA_CLIENT_CERT_PATH"
+                  value: "/etc/wobbly-kafka/user.crt"
+                - name: "KAFKA_CLIENT_KEY_PATH"
+                  value: "/etc/wobbly-kafka/user.key"
+                - name: "KAFKA_CLUSTER_CA_PATH"
+                  value: "/etc/wobbly-kafka/ca.crt"
+                - name: "KAFKA_SECURITY_PROTOCOL"
+                  valueFrom:
+                    secretKeyRef:
+                      name: "wobbly-kafka"
+                      key: "securityProtocol"
+                {{- end }}
+              envFrom:
+                - configMapRef:
+                    name: "wobbly"
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              resources:
+                {{- toYaml .Values.resources | nindent 16 }}
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - "all"
+                readOnlyRootFilesystem: true
+              volumeMounts:
+                - name: "lifecycle"
+                  mountPath: "/lifecycle"
+                {{- if .Values.config.metrics.enabled }}
+                - name: "kafka"
+                  mountPath: "/etc/wobbly-kafka/ca.crt"
+                  readOnly: true
+                  subPath: "ssl.truststore.crt"
+                - name: "kafka"
+                  mountPath: "/etc/wobbly-kafka/user.crt"
+                  readOnly: true
+                  subPath: "ssl.keystore.crt"
+                - name: "kafka"
+                  mountPath: "/etc/wobbly-kafka/user.key"
+                  readOnly: true
+                  subPath: "ssl.keystore.key"
+                {{- end }}
+          {{- with .Values.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          restartPolicy: "Never"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+          {{- with .Values.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 8 }}
+          {{- end }}
+          volumes:
+            - name: "lifecycle"
+              emptyDir: {}
+            {{- if .Values.config.metrics.enabled }}
+            - name: "kafka"
+              secret:
+                secretName: "wobbly-kafka"
+            {{- end }}

--- a/applications/wobbly/templates/deployment.yaml
+++ b/applications/wobbly/templates/deployment.yaml
@@ -61,7 +61,7 @@ spec:
                   name: "wobbly"
                   key: "database-password"
             {{- if .Values.config.slackAlerts }}
-            - name: "CUTOUT_SLACK_WEBHOOK"
+            - name: "WOBBLY_SLACK_WEBHOOK"
               valueFrom:
                 secretKeyRef:
                   name: "wobbly"
@@ -84,13 +84,6 @@ spec:
                 secretKeyRef:
                   name: "wobbly-kafka"
                   key: "securityProtocol"
-            {{- end }}
-            {{- if .Values.config.slackAlerts }}
-            - name: "WOBBLY_SLACK_WEBHOOK"
-              valueFrom:
-                secretKeyRef:
-                  name: "wobbly"
-                  key: "slack-webhook"
             {{- end }}
           envFrom:
             - configMapRef:
@@ -147,14 +140,14 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
         runAsGroup: 1000
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .Values.config.metrics.enabled }}
       volumes:
         - name: "kafka"

--- a/applications/wobbly/values.yaml
+++ b/applications/wobbly/values.yaml
@@ -127,6 +127,18 @@ cloudsql:
       cpu: "5m"
       memory: "7Mi"
 
+maintenance:
+  # -- Cron schedule string for Wobbly periodic maintenance (in UTC)
+  schedule: "10 * * * *"
+
+  # -- How long the job is allowed to run before it will be terminated
+  # @default -- 300 (5 minutes)
+  deadlineSeconds: 300
+
+  # -- How long to keep old jobs around before deleting them
+  # @default -- 86400 (1 day)
+  cleanupSeconds: 86400
+
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:


### PR DESCRIPTION
Upgrade Wobbly to 0.2.0 and add a maintenance `CronJob` that runs `wobbly expire` to delete all jobs that have passed their expiration times. Use the same requests and limits as the main Wobbly pod for simplicity.

Delete a stray environment variable from the main Wobbly deployment that was left over from cut and paste.