### PR TITLE
DM-48193: Tweak documentation for another Nublado value

### DIFF
--- a/applications/nublado/README.md
+++ b/applications/nublado/README.md
@@ -100,7 +100,7 @@ JupyterHub and custom spawner for the Rubin Science Platform
 | jupyterhub.cull.users | bool | `false` | Whether to log out the user (from JupyterHub) when culling their lab |
 | jupyterhub.hub.authenticatePrometheus | bool | `false` | Whether to require metrics requests to be authenticated |
 | jupyterhub.hub.baseUrl | string | `"/nb"` | Base URL on which JupyterHub listens |
-| jupyterhub.hub.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"runAsGroup":1000,"runAsUser":1000}` | Security context for JupyterHub container |
+| jupyterhub.hub.containerSecurityContext | object | See `values.yaml` | Security context for JupyterHub container |
 | jupyterhub.hub.db.password | string | Comes from nublado-secret | Database password (not used) |
 | jupyterhub.hub.db.type | string | `"postgres"` | Type of database to use |
 | jupyterhub.hub.db.upgrade | bool | `false` | Whether to automatically update DB schema at Hub start |

--- a/applications/nublado/values.yaml
+++ b/applications/nublado/values.yaml
@@ -463,6 +463,7 @@ jupyterhub:
       url: "postgresql://nublado3@postgres.postgres/jupyterhub"
 
     # -- Security context for JupyterHub container
+    # @default -- See `values.yaml`
     containerSecurityContext:
       runAsUser: 1000
       runAsGroup: 1000


### PR DESCRIPTION
Set a custom documentation default value for another Nublado setting to reduce the switch of the values table.