### PR TITLE
DM-48199: Deploy Wobbly on idfint

### DIFF
--- a/applications/wobbly/values-idfint.yaml
+++ b/applications/wobbly/values-idfint.yaml
@@ -1,0 +1,4 @@
+cloudsql:
+  enabled: true
+  instanceConnectionName: "science-platform-int-dc5d:us-central1:science-platform-int-8f439af2"
+  serviceAccount: "wobbly@science-platform-int-dc5d.iam.gserviceaccount.com"

--- a/environments/values-idfint.yaml
+++ b/environments/values-idfint.yaml
@@ -37,3 +37,4 @@ applications:
   telegraf-ds: true
   times-square: true
   vo-cutouts: true
+  wobbly: true


### PR DESCRIPTION
Enable Wobbly on idfint so that the new vo-cutouts can be deployed and switch to using Wobbly as a backing store.