### PR TITLE
DM-48199: Fix KafkaAccess for Wobbly

### DIFF
--- a/applications/wobbly/templates/kafka-access.yaml
+++ b/applications/wobbly/templates/kafka-access.yaml
@@ -2,7 +2,7 @@
 apiVersion: access.strimzi.io/v1alpha1
 kind: KafkaAccess
 metadata:
-  name: "gafaelfawr-kafka"
+  name: "wobbly-kafka"
 spec:
   kafka:
     name: "sasquatch"


### PR DESCRIPTION
A cut and paste error put Gafaelfawr in the name instead of Wobbly.