### PR TITLE
DM-48199: Disable Wobbly metrics reporting for now

### DIFF
--- a/applications/wobbly/values-idfdev.yaml
+++ b/applications/wobbly/values-idfdev.yaml
@@ -1,6 +1,3 @@
-config:
-  metrics:
-    enabled: true
 cloudsql:
   enabled: true
   instanceConnectionName: "science-platform-dev-7696:us-central1:science-platform-dev-e9e11de2"

--- a/applications/wobbly/values-idfint.yaml
+++ b/applications/wobbly/values-idfint.yaml
@@ -1,6 +1,3 @@
-config:
-  metrics:
-    enabled: true
 cloudsql:
   enabled: true
   instanceConnectionName: "science-platform-int-dc5d:us-central1:science-platform-int-8f439af2"


### PR DESCRIPTION
Connecting to Kafka fails due to missing information in the Kafka certificates for Sasquatch. Turning off metrics reporting for now until that's fixed.