### PR TITLE
DM-48199: Update to Wobbly 0.2.1, re-enable metrics

### DIFF
--- a/applications/wobbly/Chart.yaml
+++ b/applications/wobbly/Chart.yaml
@@ -5,7 +5,7 @@ version: 1.0.0
 description: "IVOA UWS database storage"
 sources:
   - https://github.com/lsst-sqre/wobbly
-appVersion: 0.2.0
+appVersion: 0.2.1
 
 annotations:
   phalanx.lsst.io/docs: |

--- a/applications/wobbly/values-idfdev.yaml
+++ b/applications/wobbly/values-idfdev.yaml
@@ -1,3 +1,6 @@
+config:
+  metrics:
+    enabled: true
 cloudsql:
   enabled: true
   instanceConnectionName: "science-platform-dev-7696:us-central1:science-platform-dev-e9e11de2"

--- a/applications/wobbly/values-idfint.yaml
+++ b/applications/wobbly/values-idfint.yaml
@@ -1,3 +1,6 @@
+config:
+  metrics:
+    enabled: true
 cloudsql:
   enabled: true
   instanceConnectionName: "science-platform-int-dc5d:us-central1:science-platform-int-8f439af2"


### PR DESCRIPTION
Update to Wobbly 0.2.1, which disables strict certificate validation when submitting metrics since the current Strimzi certificates for Sasquatch do not pass it. Re-enable metrics on idfdev and idfint.