### PR TITLE
DM-48199: Add standard labels to KafkaAccess resources

### DIFF
--- a/applications/gafaelfawr/templates/configmap.yaml
+++ b/applications/gafaelfawr/templates/configmap.yaml
@@ -2,14 +2,14 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: "gafaelfawr"
-  labels:
-    {{- include "gafaelfawr.labels" . | nindent 4 }}
   {{- if .Values.config.updateSchema }}
   annotations:
     helm.sh/hook: "pre-install,pre-upgrade"
     helm.sh/hook-delete-policy: "before-hook-creation"
     helm.sh/hook-weight: "0"
   {{- end }}
+  labels:
+    {{- include "gafaelfawr.labels" . | nindent 4 }}
 data:
   gafaelfawr.yaml: |
     {{- toYaml .Values.config | nindent 4 }}

--- a/applications/gafaelfawr/templates/kafka-access.yaml
+++ b/applications/gafaelfawr/templates/kafka-access.yaml
@@ -3,6 +3,8 @@ apiVersion: access.strimzi.io/v1alpha1
 kind: KafkaAccess
 metadata:
   name: "gafaelfawr-kafka"
+  labels:
+    {{- include "gafaelfawr.labels" . | nindent 4 }}
 spec:
   kafka:
     name: "sasquatch"

--- a/applications/ook/templates/kafkaaccess.yaml
+++ b/applications/ook/templates/kafkaaccess.yaml
@@ -2,6 +2,8 @@ apiVersion: access.strimzi.io/v1alpha1
 kind: KafkaAccess
 metadata:
   name: {{ include "ook.fullname" . }}-kafka
+  labels:
+    {{- include "ook.labels" . | nindent 4 }}
 spec:
   kafka:
     name: sasquatch

--- a/applications/squarebot/templates/kafkaaccess.yaml
+++ b/applications/squarebot/templates/kafkaaccess.yaml
@@ -2,6 +2,8 @@ apiVersion: access.strimzi.io/v1alpha1
 kind: KafkaAccess
 metadata:
   name: {{ include "squarebot.fullname" . }}-kafka
+  labels:
+    {{- include "squarebot.labels" . | nindent 4 }}
 spec:
   kafka:
     name: sasquatch

--- a/applications/templatebot/templates/kafkaaccess.yaml
+++ b/applications/templatebot/templates/kafkaaccess.yaml
@@ -2,6 +2,8 @@ apiVersion: access.strimzi.io/v1alpha1
 kind: KafkaAccess
 metadata:
   name: templatebot-kafka
+  labels:
+    {{- include "templatebot.labels" . | nindent 4 }}
 spec:
   kafka:
     name: sasquatch

--- a/applications/wobbly/templates/kafka-access.yaml
+++ b/applications/wobbly/templates/kafka-access.yaml
@@ -3,6 +3,8 @@ apiVersion: access.strimzi.io/v1alpha1
 kind: KafkaAccess
 metadata:
   name: "wobbly-kafka"
+  labels:
+    {{- include "wobbly.labels" . | nindent 4 }}
 spec:
   kafka:
     name: "sasquatch"


### PR DESCRIPTION
Be consistent about adding standard labels to all resources and add them to the `KafkaAccess` resources as well.