### PR TITLE
DM-48143: Enable new SIAv2 over Butler application for usdf

### DIFF
--- a/applications/sia/values-usdfdev.yaml
+++ b/applications/sia/values-usdfdev.yaml
@@ -1,0 +1,10 @@
+config:
+
+  # Data (Butler) Collections
+  butlerDataCollections:
+    - config: "https://raw.githubusercontent.com/lsst-dm/dax_obscore/refs/heads/main/configs/embargo-sia.yaml"
+      label: "LSST.Embargo"
+      name: "embargo"
+      butler_type: "REMOTE"
+      repository: "https://usdf-rsp-dev.slac.stanford.edu/api/butler/repo/embargo/butler.yaml"
+      datalink_url: "https://usdf-rsp-dev.slac.stanford.edu/api/datalink/links?ID=butler%3A//embargo/{id}"

--- a/applications/sia/values-usdfint.yaml
+++ b/applications/sia/values-usdfint.yaml
@@ -1,0 +1,10 @@
+config:
+
+  # Data (Butler) Collections
+  butlerDataCollections:
+    - config: "https://raw.githubusercontent.com/lsst-dm/dax_obscore/refs/heads/main/configs/embargo-sia.yaml"
+      label: "LSST.Embargo"
+      name: "embargo"
+      butler_type: "REMOTE"
+      repository: "https://usdf-rsp-int.slac.stanford.edu/api/butler/repo/embargo/butler.yaml"
+      datalink_url: "https://usdf-rsp-int.slac.stanford.edu/api/datalink/links?ID=butler%3A//embargo/{id}"

--- a/applications/sia/values-usdfprod.yaml
+++ b/applications/sia/values-usdfprod.yaml
@@ -1,0 +1,10 @@
+config:
+
+  # Data (Butler) Collections
+  butlerDataCollections:
+    - config: "https://raw.githubusercontent.com/lsst-dm/dax_obscore/refs/heads/main/configs/embargo-sia.yaml"
+      label: "LSST.Embargo"
+      name: "embargo"
+      butler_type: "REMOTE"
+      repository: "https://usdf-rsp.slac.stanford.edu/api/butler/repo/embargo/butler.yaml"
+      datalink_url: "https://usdf-rsp.slac.stanford.edu/api/datalink/links?ID=butler%3A//embargo/{id}"

--- a/environments/values-usdfdev.yaml
+++ b/environments/values-usdfdev.yaml
@@ -33,7 +33,8 @@ applications:
   sasquatch: true
   schedview-snapshot: true
   semaphore: true
-  siav2: true
+  sia: true
+  siav2: false
   ssotap: true
   squareone: true
   strimzi: true


### PR DESCRIPTION
Changes include adding configurations for the usdf environments for the new SIAv2 over Butler application which will replace the previous CADC-based SIAv2 application & change to the usdfdev environment to enable it there.