### PR TITLE
DM-48241: Install Wobbly and update vo-cutouts on idfprod

### DIFF
--- a/applications/sasquatch/values-idfprod.yaml
+++ b/applications/sasquatch/values-idfprod.yaml
@@ -95,3 +95,4 @@ app-metrics:
   apps:
     - gafaelfawr
     - mobu
+    - wobbly

--- a/applications/wobbly/values-idfprod.yaml
+++ b/applications/wobbly/values-idfprod.yaml
@@ -1,0 +1,8 @@
+config:
+  metrics:
+    enabled: true
+  updateSchema: true
+cloudsql:
+  enabled: true
+  instanceConnectionName: "science-platform-stable-6994:us-central1:science-platform-stable-0c29612b"
+  serviceAccount: "wobbly@science-platform-stable-6994.iam.gserviceaccount.com"

--- a/environments/values-idfprod.yaml
+++ b/environments/values-idfprod.yaml
@@ -35,3 +35,4 @@ applications:
   telegraf-ds: true
   times-square: true
   vo-cutouts: true
+  wobbly: true


### PR DESCRIPTION
Install Wobbly, enable its metrics reporting, add it to the Sasquatch configuration, and upgrade vo-cutouts to the version that uses Wobbly on idfprod.