### PR TITLE
DM-48241: Fix schema update for Wobbly

### DIFF
--- a/applications/wobbly/templates/job-schema-update.yaml
+++ b/applications/wobbly/templates/job-schema-update.yaml
@@ -87,6 +87,24 @@ spec:
                 secretKeyRef:
                   name: "wobbly"
                   key: "database-password"
+            {{- if .Values.config.metrics.enabled }}
+            - name: "KAFKA_BOOTSTRAP_SERVERS"
+              valueFrom:
+                secretKeyRef:
+                  name: "wobbly-kafka"
+                  key: "bootstrapServers"
+            - name: "KAFKA_CLIENT_CERT_PATH"
+              value: "/etc/wobbly-kafka/user.crt"
+            - name: "KAFKA_CLIENT_KEY_PATH"
+              value: "/etc/wobbly-kafka/user.key"
+            - name: "KAFKA_CLUSTER_CA_PATH"
+              value: "/etc/wobbly-kafka/ca.crt"
+            - name: "KAFKA_SECURITY_PROTOCOL"
+              valueFrom:
+                secretKeyRef:
+                  name: "wobbly-kafka"
+                  key: "securityProtocol"
+            {{- end }}
           envFrom:
             - configMapRef:
                 name: "wobbly"
@@ -105,6 +123,20 @@ spec:
           volumeMounts:
             - name: "lifecycle"
               mountPath: "/lifecycle"
+            {{- if .Values.config.metrics.enabled }}
+            - name: "kafka"
+              mountPath: "/etc/wobbly-kafka/ca.crt"
+              readOnly: true
+              subPath: "ssl.truststore.crt"
+            - name: "kafka"
+              mountPath: "/etc/wobbly-kafka/user.crt"
+              readOnly: true
+              subPath: "ssl.keystore.crt"
+            - name: "kafka"
+              mountPath: "/etc/wobbly-kafka/user.key"
+              readOnly: true
+              subPath: "ssl.keystore.key"
+            {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -121,4 +153,9 @@ spec:
       volumes:
         - name: "lifecycle"
           emptyDir: {}
+        {{- if .Values.config.metrics.enabled }}
+        - name: "kafka"
+          secret:
+            secretName: "wobbly-kafka"
+        {{- end }}
 {{- end }}


### PR DESCRIPTION
The Wobbly schema update job didn't have the Kafka configuration and does try to initialize it.