### PR TITLE
DM-48241: Disable Wobbly schema updates on idfprod

### DIFF
--- a/applications/wobbly/values-idfprod.yaml
+++ b/applications/wobbly/values-idfprod.yaml
@@ -1,7 +1,6 @@
 config:
   metrics:
     enabled: true
-  updateSchema: true
 cloudsql:
   enabled: true
   instanceConnectionName: "science-platform-stable-6994:us-central1:science-platform-stable-0c29612b"


### PR DESCRIPTION
The database has been deployed, so this is no longer needed.