### PR TITLE
DM-48268: Upgrade SIA Chart to version 0.1.5

### DIFF
--- a/applications/sia/Chart.yaml
+++ b/applications/sia/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.1.4
+appVersion: 0.1.5
 description: Simple Image Access (SIA) IVOA Service using Butler
 name: sia
 sources:


### PR DESCRIPTION
Changes include upgrading the dependencies of SIAv2:
https://github.com/lsst-sqre/sia/pull/24

Mainly this is relevant for the `dax_obscore` & `daf_butler` updated versions which includes some performance updates.
