### PR TITLE
[DM-48286] Automate Chronograf and kapacitor backups

### DIFF
--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -108,7 +108,7 @@ Rubin Observatory's telemetry service
 | app-metrics.resources | object | See `values.yaml` | Kubernetes resources requests and limits |
 | app-metrics.tolerations | list | `[]` | Tolerations for pod assignment |
 | backup.affinity | object | `{}` | Affinity rules for the backups deployment pod |
-| backup.backupItems | list | `[{"enabled":false,"name":"influxdb-enterprise"},{"enabled":false,"name":"chronograf"},{"enabled":false,"name":"kapacitor"}]` | List of items to backup, must match the names in the sasquatch backup script |
+| backup.backupItems | list | `[{"enabled":false,"name":"chronograf","retention_days":7},{"enabled":false,"name":"kapacitor","retention_days":7},{"enabled":false,"name":"influxdb-enterprise-incremental"}]` | List of items to backup, must match the names in the sasquatch backup script |
 | backup.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the backups image |
 | backup.image.repository | string | `"ghcr.io/lsst-sqre/sasquatch"` | Image to use in the backups deployment |
 | backup.image.tag | string | The appVersion of the chart | Tag of image to use |

--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -108,12 +108,10 @@ Rubin Observatory's telemetry service
 | app-metrics.resources | object | See `values.yaml` | Kubernetes resources requests and limits |
 | app-metrics.tolerations | list | `[]` | Tolerations for pod assignment |
 | backup.affinity | object | `{}` | Affinity rules for the backups deployment pod |
+| backup.backupItems | list | `[{"enabled":false,"name":"influxdb-enterprise"},{"enabled":false,"name":"chronograf"},{"enabled":false,"name":"kapacitor"}]` | List of items to backup, must match the names in the sasquatch backup script |
 | backup.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the backups image |
 | backup.image.repository | string | `"ghcr.io/lsst-sqre/sasquatch"` | Image to use in the backups deployment |
 | backup.image.tag | string | The appVersion of the chart | Tag of image to use |
-| backup.items.chronograf | bool | `false` | Whether to backup Chronograf |
-| backup.items.influxdbEnterprise | bool | `false` | Whether to backup InfluxDB Enterprise |
-| backup.items.kapacitor | bool | `false` | Whether to backup Kapacitor |
 | backup.nodeSelector | object | `{}` | Node selection rules for the backups deployment pod |
 | backup.persistence.size | string | "100Gi" | Size of the data store to request, if enabled |
 | backup.persistence.storageClass | string | "" (empty string) to use the cluster default storage class | Storage class to use for the backups |

--- a/applications/sasquatch/charts/backup/README.md
+++ b/applications/sasquatch/charts/backup/README.md
@@ -7,12 +7,10 @@ Backup Sasquatch data
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules for the backups deployment pod |
+| backupItems | list | `[{"enabled":false,"name":"influxdb-enterprise"},{"enabled":false,"name":"chronograf"},{"enabled":false,"name":"kapacitor"}]` | List of items to backup, must match the names in the sasquatch backup script |
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the backups image |
 | image.repository | string | `"ghcr.io/lsst-sqre/sasquatch"` | Image to use in the backups deployment |
 | image.tag | string | The appVersion of the chart | Tag of image to use |
-| items.chronograf | bool | `false` | Whether to backup Chronograf |
-| items.influxdbEnterprise | bool | `false` | Whether to backup InfluxDB Enterprise |
-| items.kapacitor | bool | `false` | Whether to backup Kapacitor |
 | nodeSelector | object | `{}` | Node selection rules for the backups deployment pod |
 | persistence.size | string | "100Gi" | Size of the data store to request, if enabled |
 | persistence.storageClass | string | "" (empty string) to use the cluster default storage class | Storage class to use for the backups |

--- a/applications/sasquatch/charts/backup/README.md
+++ b/applications/sasquatch/charts/backup/README.md
@@ -7,7 +7,7 @@ Backup Sasquatch data
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules for the backups deployment pod |
-| backupItems | list | `[{"enabled":false,"name":"influxdb-enterprise"},{"enabled":false,"name":"chronograf"},{"enabled":false,"name":"kapacitor"}]` | List of items to backup, must match the names in the sasquatch backup script |
+| backupItems | list | `[{"enabled":false,"name":"chronograf","retention_days":7},{"enabled":false,"name":"kapacitor","retention_days":7},{"enabled":false,"name":"influxdb-enterprise-incremental"}]` | List of items to backup, must match the names in the sasquatch backup script |
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the backups image |
 | image.repository | string | `"ghcr.io/lsst-sqre/sasquatch"` | Image to use in the backups deployment |
 | image.tag | string | The appVersion of the chart | Tag of image to use |

--- a/applications/sasquatch/charts/backup/templates/backup-cronjob.yaml
+++ b/applications/sasquatch/charts/backup/templates/backup-cronjob.yaml
@@ -18,6 +18,7 @@ spec:
           labels:
             {{- include "backup.selectorLabels" . | nindent 12 }}
         spec:
+          serviceAccountName: sasquatch-backup
           restartPolicy: OnFailure
           securityContext:
             runAsNonRoot: true

--- a/applications/sasquatch/charts/backup/templates/backup-cronjob.yaml
+++ b/applications/sasquatch/charts/backup/templates/backup-cronjob.yaml
@@ -29,18 +29,6 @@ spec:
           - name: backup
             persistentVolumeClaim:
               claimName: sasquatch-backup
-          {{- if .Values.items.chronograf }}
-          - name: chronograf
-            persistentVolumeClaim:
-              claimName: sasquatch-chronograf
-              readOnly: true
-          {{- end }}
-          {{- if .Values.items.kapacitor }}
-          - name: kapacitor
-            persistentVolumeClaim:
-              claimName: sasquatch-kapacitor
-              readOnly: true
-          {{- end }}
           containers:
           - name: sasquatch-backup
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -48,20 +36,15 @@ spec:
             volumeMounts:
             - name: backup
               mountPath: /backup
-            {{- if .Values.items.chronograf }}
-            - name: chronograf
-              mountPath: /chronograf
-            {{- end }}
-            {{- if .Values.items.kapacitor }}
-            - name: kapacitor
-              mountPath: /kapacitor
-            {{- end }}
             command:
             - /bin/sh
             - -c
             - backup.sh
             resources:
               {{- toYaml .Values.resources | nindent 14 }}
+            env:
+            - name: BACKUP_ITEMS
+              value: {{ .Values.backupItems | toJson | quote }}
           {{- with .Values.nodeSelector }}
           nodeSelector:
              {{- toYaml . | nindent 12 }}

--- a/applications/sasquatch/charts/backup/templates/role.yaml
+++ b/applications/sasquatch/charts/backup/templates/role.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sasquatch-backup
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]

--- a/applications/sasquatch/charts/backup/templates/rolebiding.yaml
+++ b/applications/sasquatch/charts/backup/templates/rolebiding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sasquatch-backup-binding
+subjects:
+  - kind: ServiceAccount
+    name: sasquatch-backup
+roleRef:
+  kind: Role
+  name: sasquatch-backup
+  apiGroup: rbac.authorization.k8s.io

--- a/applications/sasquatch/charts/backup/templates/serviceaccount.yaml
+++ b/applications/sasquatch/charts/backup/templates/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sasquatch-backup

--- a/applications/sasquatch/charts/backup/values.yaml
+++ b/applications/sasquatch/charts/backup/values.yaml
@@ -26,11 +26,13 @@ persistence:
 
 # -- List of items to backup, must match the names in the sasquatch backup script
 backupItems:
-  - name: "influxdb-enterprise"
-    enabled: false
   - name: "chronograf"
     enabled: false
+    retention_days: 7
   - name: "kapacitor"
+    enabled: false
+    retention_days: 7
+  - name: "influxdb-enterprise-incremental"
     enabled: false
 
 # -- Affinity rules for the backups deployment pod

--- a/applications/sasquatch/charts/backup/values.yaml
+++ b/applications/sasquatch/charts/backup/values.yaml
@@ -24,13 +24,14 @@ persistence:
   # @default -- "" (empty string) to use the cluster default storage class
   storageClass: ""
 
-items:
-  # -- Whether to backup Chronograf
-  chronograf: false
-  # -- Whether to backup Kapacitor
-  kapacitor: false
-  # -- Whether to backup InfluxDB Enterprise
-  influxdbEnterprise: false
+# -- List of items to backup, must match the names in the sasquatch backup script
+backupItems:
+  - name: "influxdb-enterprise"
+    enabled: false
+  - name: "chronograf"
+    enabled: false
+  - name: "kapacitor"
+    enabled: false
 
 # -- Affinity rules for the backups deployment pod
 affinity: {}

--- a/applications/sasquatch/charts/backup/values.yaml
+++ b/applications/sasquatch/charts/backup/values.yaml
@@ -10,7 +10,7 @@ image:
 
   # -- Tag of image to use
   # @default -- The appVersion of the chart
-  tag: "1.0.0"
+  tag: "1.1.0"
 
 # -- Schedule for executing the sasquatch backup script
 # @default -- "0 3 * * *"

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -169,7 +169,8 @@ backup:
   persistence:
     size: 500Gi
     storageClass: standard
-  items:
-    chronograf: false
-    kapacitor: false
-    influxdbEnterprise: true
+  backupItems:
+    - name: "influxdb-enterprise"
+      enabled: true
+    - name: "chronograf"
+      enabled: true

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -170,9 +170,11 @@ backup:
     size: 500Gi
     storageClass: standard
   backupItems:
-    - name: "influxdb-enterprise"
-      enabled: true
     - name: "chronograf"
       enabled: true
+      retention_days: 3
     - name: "kapacitor"
+      enabled: true
+      retention_days: 3
+    - name: "influxdb-enterprise-incremental"
       enabled: true

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -174,3 +174,5 @@ backup:
       enabled: true
     - name: "chronograf"
       enabled: true
+    - name: "kapacitor"
+      enabled: true

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -163,9 +163,6 @@ app-metrics:
 
 backup:
   enabled: true
-  image:
-    pullPolicy: "Always"
-    tag: tickets-DM-48286
   persistence:
     size: 500Gi
     storageClass: standard

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -165,6 +165,7 @@ backup:
   enabled: true
   image:
     pullPolicy: "Always"
+    tag: tickets-DM-48286
   persistence:
     size: 500Gi
     storageClass: standard

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -371,7 +371,6 @@ backup:
   persistence:
     size: 100Ti
     storageClass: wekafs--sdf-k8s01
-  items:
-    chronograf: false
-    kapacitor: false
-    influxdbEnterprise: true
+  backupItems:
+    - name: influxdb-enterprise
+      enabled: true

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -372,5 +372,5 @@ backup:
     size: 100Ti
     storageClass: wekafs--sdf-k8s01
   backupItems:
-    - name: influxdb-enterprise
+    - name: influxdb-enterprise-incremental
       enabled: true


### PR DESCRIPTION
Chronograf and Kapacitor don’t have an application level backup tool. 

An alternative is to backup their PVs or specifically the  BoltDB file which holds all the application configuration including dashboards in the case of Chronograf and alert rules in the case of kapacitor.

One complication is that we cannot mount their PVs in the `sasquatch-backup` Pod because they are ReadWriteOnce. 

We investigated using kubernetes Volume Snaphots which could be a good option for backups in all our environments, but that's not currently available at USDF and our Telescope environments. Velero could be perhaps the best option but that's a larger project.

A more pragmatic solution is to use the kubectl tool to copy the BoltDB file from the application, and this approach works in all environments.  

This PR adds Chronograf and Kapacitor backups to the Sasquatch backup CronJob using the kubectl tool copy the relevant files and implements an optional backup retention parameter.

The output from the backup Job looks like:

```
Backing up Chronograf...
Backup completed successfully at /backup/chronograf-2025-01-06.
Cleaning up backups older than 3 day(s)...
Backing up Kapacitor...
Backup completed successfully at /backup/kapacitor-2025-01-06.
Cleaning up backups older than 3 day(s)...
Backing up InfluxDB Enterprise (incremental backup)...
Backup completed successfully at /backup/sasquatch-influxdb-enterprise-backup
```

The PR that adds Chronograf and Kapacitor backups to the backup script is  https://github.com/lsst-sqre/sasquatch/pull/52 

 

