### PR TITLE
Improve Phalanx installation instructions

### DIFF
--- a/docs/admin/installation.rst
+++ b/docs/admin/installation.rst
@@ -3,10 +3,17 @@ Installing a Phalanx environment
 ################################
 
 Once you have :doc:`created the configuration for your new environment <create-environment>` and :doc:`set up secrets <secrets-setup>`, you are ready to do the installation.
-Before starting this process, ensure that you have met the :doc:`requirements to run Phalanx <requirements>`.
 
 If you are setting up an environment that will be running a 1Password Connect server for itself, you will need to take special bootstrapping steps.
 See :px-app-bootstrap:`onepassword-connect` for more information.
+
+.. attention::
+
+   Before starting this process, ensure that you have met the :doc:`requirements to run Phalanx <requirements>`.
+
+   If you get a message indicating that Argo CD login has failed, this usually indicates that you have too old of a version of the ``argocd`` command-line tool installed.
+   Update it ``argocd`` and try again.
+   See :ref:`admin-tooling` for more details.
 
 Installing Phalanx
 ==================
@@ -15,6 +22,8 @@ Follow these steps to install Phalanx.
 These can be run repeatedly to reinstall Phalanx over an existing deployment.
 
 #. Create a Vault AppRole that will be used by Vault Secrets Operator.
+   This will invalidate any existing AppRole for that environment.
+
    Set the ``VAULT_TOKEN`` environment variable to a token with the ability to create new AppRoles (for SQuaRE clusters, use the admin token), and then run:
 
    .. prompt:: bash
@@ -23,11 +32,15 @@ These can be run repeatedly to reinstall Phalanx over an existing deployment.
 
    Unset ``VAULT_TOKEN`` when this command finishes.
 
-   Be aware that this will invalidate any existing AppRole for that environment.
-
 #. Set the environment variables ``VAULT_ROLE_ID`` and ``VAULT_SECRET_ID`` to the Role ID and Secret ID printed out by that command.
-   Don't store these anywhere.
-   If you repeat the installation from scratch, just generate new role and secret IDs.
+   Do not otherwise store these values.
+   If you need to start over, return to the previous step and generate new values.
+
+#. If you are doing a complete reinstallation of a Phalanx instance, such as when the Kubernetes cluster has been completely destroyed and recreated, you may want to regenerate all generated secrets.
+   This ensures that any left-over or leaked secrets that do not come from your static secrets store are invalidated.
+
+   To do this, run :command:`phalanx secrets sync --regenerate <environment>`.
+   This will invalidate all existing Gafaelfawr tokens and will require redoing portions of the Sasquatch setup.
 
 #. Ensure that your default Kubernetes cluster for :command:`kubectl` and :command:`helm` is set to point to the Kubernetes cluster into which you want to install the Phalanx environment.
    You can verify this with :command:`kubectl config current-context`.
@@ -41,10 +54,12 @@ These can be run repeatedly to reinstall Phalanx over an existing deployment.
    You will be prompted to confirm that you want to proceed.
 
 #. If the installation is using a dynamically-assigned IP address, you will need to set up the A record (and AAAA record if using IPv6) in DNS once that address has been assigned.
+
    Wait until the ``ingress-nginx`` application has been installed, which happens after Argo CD has been installed but before most applications are synced.
    Then, wait for it to be assigned an external IP address.
    Obtain that IP address with :command:`kubectl get -n ingress-nginx service` (look for the external IP).
    Then, set the A record in DNS for your environment to that address.
+
    For installations that are intended to be long-lived and that can reliably request the same address, add that IP address to the :file:`values-{environment}.yaml` file in :file:`applications/ingress-nginx` for your environment.
    The setting to use is ``ingress-nginx.controller.service.loadBalancerIP``.
    This ensures that ingress-nginx will always request that address.
@@ -52,15 +67,9 @@ These can be run repeatedly to reinstall Phalanx over an existing deployment.
 #. If you are deploying on Google Cloud Platform, consider converting the dynamically-assigned IP address to a static IP.
    You can do this in the GCP console under :menuselection:`VPC Network -> IP addresses`.
 
-#. If you are doing a complete reinstallation of a Phalanx instance (e.g. Kubernetes has been completely destroyed and the cluster recreated), you may wish to run ``phalanx secrets sync --regenerate`` in order to recreate any randomly-generated secrets, rather than using the set from the previous installation.
-
 #. Debug any problems during installation.
    The most common source of problems are errors or missing configuration in the :file:`values-{environment}.yaml` files you created for each application.
    You can safely run the installer repeatedly as you debug and fix issues.
-
-   * If you get a message indicating that ``argocd`` plaintext login has failed, the actual error is that your local ``argocd`` executable is obsolete.
-     Update ``argocd`` and try again.
-     To see the version of the client that is currently tested, search for ``argocd-linux`` in `.github/workflows/ci.yaml <https://github.com/lsst-sqre/phalanx/blob/main/.github/workflows/ci.yaml>`__.
 
 Using a Vault token rather than AppRole
 =======================================

--- a/docs/admin/requirements.rst
+++ b/docs/admin/requirements.rst
@@ -49,7 +49,10 @@ This setup is also required to install or maintain a Phalanx environment.
 For installing an environment, you will also need the following tools:
 
 - Argo CD's command-line tool.
-  It may be necessary to update this regularly to match the version of Argo CD that Phalanx, since Argo CD tends to break backward compatibility for its command-line API.
+  See the `Argo CD installation instructions <https://argo-cd.readthedocs.io/en/stable/cli_installation/>`__ for download details.
+
+  It is often necessary to update this tool to match the version of Argo CD that Phalanx is using
+  Argo CD tends to break backward compatibility for its command-line API.
   To see the version of the client that is currently tested, search for ``argocd-linux`` in `.github/workflows/ci.yaml <https://github.com/lsst-sqre/phalanx/blob/main/.github/workflows/ci.yaml>`__.
 
   .. warning::
@@ -58,6 +61,8 @@ For installing an environment, you will also need the following tools:
      All Argo CD applications should be managed through Phalanx and the ``science-platform`` app of apps.
 
 - The Vault command-line client.
+  See the `Vault installation instructions <https://developer.hashicorp.com/vault/install>`__ for download details.
+
   Any recent version of the client should work.
   To see the version currently used for testing, search for ``vault_`` in `.github/workflows/ci.yaml <https://github.com/lsst-sqre/phalanx/blob/main/.github/workflows/ci.yaml>`__.
 


### PR DESCRIPTION
Fix the order of operations to be something more sensible, and move the caution about having a recent version of the Argo CD client up front. Add more details about how to install Argo CD and the Vault client to the prerequisites page.