### PR TITLE
DM-48326: Allow risky ingress annotations

### DIFF
--- a/applications/ingress-nginx/README.md
+++ b/applications/ingress-nginx/README.md
@@ -14,6 +14,7 @@ Ingress controller
 |-----|------|---------|-------------|
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | ingress-nginx.controller.allowSnippetAnnotations | bool | `true` | Allow Ingress resources to add NGINX configuration snippets. This is required by Gafaelfawr. |
+| ingress-nginx.controller.config.annotations-risk-level | string | `"Critical"` | Level of dangerous annotations allowed. Must be set to `Critical` to allow snippets. |
 | ingress-nginx.controller.config.compute-full-forwarded-for | string | `"true"` | Put the complete path in `X-Forwarded-For`, not just the last hop, so that the client IP will be exposed to Gafaelfawr |
 | ingress-nginx.controller.config.proxy-body-size | string | `"100m"` | Maximum size of the client request body (needs to be large enough to allow table uploads) |
 | ingress-nginx.controller.config.server-snippet | string | See `values.yaml` | Add additional per-server configuration used by Gafaelfawr to report errors from the authorization layer |

--- a/applications/ingress-nginx/values.yaml
+++ b/applications/ingress-nginx/values.yaml
@@ -7,6 +7,10 @@ ingress-nginx:
     allowSnippetAnnotations: true
 
     config:
+      # -- Level of dangerous annotations allowed. Must be set to `Critical`
+      # to allow snippets.
+      annotations-risk-level: "Critical"
+
       # -- Put the complete path in `X-Forwarded-For`, not just the last hop,
       # so that the client IP will be exposed to Gafaelfawr
       compute-full-forwarded-for: "true"


### PR DESCRIPTION
The new version of ingress-nginx requires setting the annotation risk level to `Critical` to allow arbitrary snippets, which are used by Gafaelfawr.