### PR TITLE
[DM-48322] Update NodeAffinity for Kafka at usdfprod

### DIFF
--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -63,7 +63,7 @@ strimzi-kafka:
                   operator: In
                   values:
                     - sdfk8sn004
-                    - sdfk8sn005
+                    - sdfk8sn003
                     - sdfk8sn007
       podAntiAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
After the USDF outage sdfk8sn005 was cordoned and won'tbe available soon, as a consequence we are running Sasquatch at USDF with only 2 Kafka brokers. 

This PR updates de NodeAffinity to use sdfk8sn003 in the meantime.