### PR TITLE
[DM-48329] Enable Chronograf and Kapacitor backups at USDF and Summit

### DIFF
--- a/applications/sasquatch/values-summit.yaml
+++ b/applications/sasquatch/values-summit.yaml
@@ -523,3 +523,16 @@ chronograf:
 kapacitor:
   persistence:
     storageClass: rook-ceph-block
+
+backup:
+  enabled: true
+  persistence:
+    size: 100Gi
+    storageClass: rook-ceph-block
+  backupItems:
+    - name: chronograf
+      enabled: true
+      retention_days: 7
+    - name: kapacitor
+      enabled: true
+      retention_days: 7

--- a/applications/sasquatch/values-usdfdev.yaml
+++ b/applications/sasquatch/values-usdfdev.yaml
@@ -185,3 +185,16 @@ chronograf:
     GENERIC_API_KEY: sub
     PUBLIC_URL: https://usdf-rsp-dev.slac.stanford.edu/
     STATUS_FEED_URL: https://raw.githubusercontent.com/lsst-sqre/rsp_broadcast/main/jsonfeeds/usdfdev.json
+
+backup:
+  enabled: true
+  persistence:
+    size: 1Ti
+    storageClass: wekafs--sdf-k8s01
+  backupItems:
+    - name: "chronograf"
+      enabled: true
+      retention_days: 7
+    - name: "kapacitor"
+      enabled: true
+      retention_days: 7

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -372,5 +372,11 @@ backup:
     size: 100Ti
     storageClass: wekafs--sdf-k8s01
   backupItems:
+    - name: chronograf
+      enabled: true
+      retention_days: 7
+    - name: kapacitor
+      enabled: true
+      retention_days: 7
     - name: influxdb-enterprise-incremental
       enabled: true


### PR DESCRIPTION
Following the implementation of DM-48286 to  Automate Chronograf and kapacitor backups enable backups at Summit and USDF