### PR TITLE
[DM-48357] Add InfluxDB OSS backups to Sasquatch

### DIFF
--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -108,7 +108,7 @@ Rubin Observatory's telemetry service
 | app-metrics.resources | object | See `values.yaml` | Kubernetes resources requests and limits |
 | app-metrics.tolerations | list | `[]` | Tolerations for pod assignment |
 | backup.affinity | object | `{}` | Affinity rules for the backups deployment pod |
-| backup.backupItems | list | `[{"enabled":false,"name":"chronograf","retention_days":7},{"enabled":false,"name":"kapacitor","retention_days":7},{"enabled":false,"name":"influxdb-enterprise-incremental"}]` | List of items to backup, must match the names in the sasquatch backup script |
+| backup.backupItems | list | `[{"enabled":false,"name":"chronograf","retention_days":7},{"enabled":false,"name":"kapacitor","retention_days":7},{"enabled":false,"name":"influxdb-enterprise-incremental"},{"enabled":false,"name":"influxdb-oss","retention_days":3}]` | List of items to backup, must match the names in the sasquatch backup script |
 | backup.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the backups image |
 | backup.image.repository | string | `"ghcr.io/lsst-sqre/sasquatch"` | Image to use in the backups deployment |
 | backup.image.tag | string | The appVersion of the chart | Tag of image to use |

--- a/applications/sasquatch/charts/backup/README.md
+++ b/applications/sasquatch/charts/backup/README.md
@@ -7,7 +7,7 @@ Backup Sasquatch data
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules for the backups deployment pod |
-| backupItems | list | `[{"enabled":false,"name":"chronograf","retention_days":7},{"enabled":false,"name":"kapacitor","retention_days":7},{"enabled":false,"name":"influxdb-enterprise-incremental"}]` | List of items to backup, must match the names in the sasquatch backup script |
+| backupItems | list | `[{"enabled":false,"name":"chronograf","retention_days":7},{"enabled":false,"name":"kapacitor","retention_days":7},{"enabled":false,"name":"influxdb-enterprise-incremental"},{"enabled":false,"name":"influxdb-oss","retention_days":3}]` | List of items to backup, must match the names in the sasquatch backup script |
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the backups image |
 | image.repository | string | `"ghcr.io/lsst-sqre/sasquatch"` | Image to use in the backups deployment |
 | image.tag | string | The appVersion of the chart | Tag of image to use |

--- a/applications/sasquatch/charts/backup/values.yaml
+++ b/applications/sasquatch/charts/backup/values.yaml
@@ -10,7 +10,7 @@ image:
 
   # -- Tag of image to use
   # @default -- The appVersion of the chart
-  tag: "1.1.0"
+  tag: "1.2.0"
 
 # -- Schedule for executing the sasquatch backup script
 # @default -- "0 3 * * *"

--- a/applications/sasquatch/charts/backup/values.yaml
+++ b/applications/sasquatch/charts/backup/values.yaml
@@ -34,6 +34,9 @@ backupItems:
     retention_days: 7
   - name: "influxdb-enterprise-incremental"
     enabled: false
+  - name: "influxdb-oss"
+    enabled: false
+    retention_days: 3
 
 # -- Affinity rules for the backups deployment pod
 affinity: {}

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -163,9 +163,6 @@ app-metrics:
 
 backup:
   enabled: true
-  image:
-    tag: tickets-dm-48357
-    pullPolicy: Always
   persistence:
     size: 500Gi
     storageClass: standard

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -163,6 +163,9 @@ app-metrics:
 
 backup:
   enabled: true
+  image:
+    tag: tickets-dm-48357
+    pullPolicy: Always
   persistence:
     size: 500Gi
     storageClass: standard
@@ -175,3 +178,6 @@ backup:
       retention_days: 3
     - name: "influxdb-enterprise-incremental"
       enabled: true
+    - name: "influxdb-oss"
+      enabled: true
+      retention_days: 3


### PR DESCRIPTION
Add InfluxDB OSS backups to Sasquatch. This is useful for teststands and IDF deployments where Sasquatch uses an InfluxDB OSS instance.
