### PR TITLE
DM-48326: Bump Gafaelfawr version to 12.3.1

### DIFF
--- a/applications/gafaelfawr/Chart.yaml
+++ b/applications/gafaelfawr/Chart.yaml
@@ -5,7 +5,7 @@ description: "Authentication and identity system"
 home: "https://gafaelfawr.lsst.io/"
 sources:
   - "https://github.com/lsst-sqre/gafaelfawr"
-appVersion: 12.3.0
+appVersion: 12.3.1
 
 dependencies:
   - name: "redis"


### PR DESCRIPTION
Includes the Gafaelfawr fix to generate auth-url annotations that comply with the restrictions of the current ingress-nginx.