### PR TITLE
DM-48326: Switch some Gafaelfawr routes to another path type

### DIFF
--- a/applications/gafaelfawr/templates/ingress.yaml
+++ b/applications/gafaelfawr/templates/ingress.yaml
@@ -33,14 +33,14 @@ spec:
                   number: 8080
           {{- if .Values.config.oidcServer.enabled }}
           - path: "/.well-known/jwks.json"
-            pathType: Exact
+            pathType: ImplementationSpecific
             backend:
               service:
                 name: "gafaelfawr"
                 port:
                   number: 8080
           - path: "/.well-known/openid-configuration"
-            pathType: Exact
+            pathType: ImplementationSpecific
             backend:
               service:
                 name: "gafaelfawr"


### PR DESCRIPTION
The new ingress-nginx doesn't allow `.` in paths of `pathType` `Exact`. The workaround is to use `ImplementationSpecific`. Do this for `/.well-known` paths for Gafaelfawr.

See https://github.com/kubernetes/ingress-nginx/issues/11176.