### PR TITLE
DM-48326: Avoid variables in proxy-redirect-{from,to}

### DIFF
--- a/charts/cadc-tap/templates/tap-ingress-anonymous.yaml
+++ b/charts/cadc-tap/templates/tap-ingress-anonymous.yaml
@@ -16,8 +16,8 @@ template:
       nginx.ingress.kubernetes.io/proxy-send-timeout: "900"
       nginx.ingress.kubernetes.io/proxy-read-timeout: "900"
       nginx.ingress.kubernetes.io/rewrite-target: "/tap/$1"
-      nginx.ingress.kubernetes.io/proxy-redirect-from: "http://$host/tap/"
-      nginx.ingress.kubernetes.io/proxy-redirect-to: "https://$host/api/{{ .Values.ingress.path }}/"
+      nginx.ingress.kubernetes.io/proxy-redirect-from: "http://{{ .Values.global.host }}/tap/"
+      nginx.ingress.kubernetes.io/proxy-redirect-to: "https://{{ .Values.global.host }}/api/{{ .Values.ingress.path }}/"
       nginx.ingress.kubernetes.io/ssl-redirect: "true"
       nginx.ingress.kubernetes.io/use-regex: "true"
       nginx.ingress.kubernetes.io/configuration-snippet: |

--- a/charts/cadc-tap/templates/tap-ingress-authenticated.yaml
+++ b/charts/cadc-tap/templates/tap-ingress-authenticated.yaml
@@ -24,8 +24,8 @@ template:
       nginx.ingress.kubernetes.io/proxy-send-timeout: "1800"
       nginx.ingress.kubernetes.io/proxy-read-timeout: "1800"
       nginx.ingress.kubernetes.io/rewrite-target: "/tap/$2"
-      nginx.ingress.kubernetes.io/proxy-redirect-from: "http://$host/tap/"
-      nginx.ingress.kubernetes.io/proxy-redirect-to: "https://$host/api/{{ .Values.ingress.path }}/"
+      nginx.ingress.kubernetes.io/proxy-redirect-from: "http://{{ .Values.global.host }}/tap/"
+      nginx.ingress.kubernetes.io/proxy-redirect-to: "https://{{ .Values.global.host }}/api/{{ .Values.ingress.path }}/"
       nginx.ingress.kubernetes.io/ssl-redirect: "true"
       nginx.ingress.kubernetes.io/use-regex: "true"
       nginx.ingress.kubernetes.io/configuration-snippet: |


### PR DESCRIPTION
The new version of ingress-nginx now rejects variables in the `proxy-redirect-from` and `proxy-redirect-to` annotations since they contain the invalid character `$`. Instead use the global values setting containing the base hostname.