### PR TITLE
DM-48326: Bump Gafaelfawr version to 12.3.2

### DIFF
--- a/applications/gafaelfawr/Chart.yaml
+++ b/applications/gafaelfawr/Chart.yaml
@@ -5,7 +5,7 @@ description: "Authentication and identity system"
 home: "https://gafaelfawr.lsst.io/"
 sources:
   - "https://github.com/lsst-sqre/gafaelfawr"
-appVersion: 12.3.1
+appVersion: 12.3.2
 
 dependencies:
   - name: "redis"


### PR DESCRIPTION
This release of Gafaelfawr fixes another issue with generating auth-url annotations for `Ingress` resources by avoiding commas in the `delegate_scope` parameter.