### PR TITLE
tickets/DM-48297-2

### DIFF
--- a/applications/auxtel/values-base.yaml
+++ b/applications/auxtel/values-base.yaml
@@ -223,7 +223,6 @@ atptg:
   resources:
     limits:
       cpu: 900m
-      memory: 2000Mi
     requests:
       cpu: 90m
       memory: 265Mi

--- a/applications/simonyitel/values-base.yaml
+++ b/applications/simonyitel/values-base.yaml
@@ -153,7 +153,6 @@ mtm1m3-sim:
   resources:
     limits:
       cpu: 1000m
-      memory: 10000Mi
     requests:
       cpu: 100m
       memory: 1000Mi
@@ -275,7 +274,6 @@ mtptg:
   resources:
     limits:
       cpu: 1200m
-      memory: 6000Mi
     requests:
       cpu: 120m
       memory: 1500Mi


### PR DESCRIPTION
BTS: Temporarily remove atptg, mtptg and mtm1m3 memory limits.