### PR TITLE
[DM-48369] Automate restore of InfluxDB OSS backups in Sasquatch

### DIFF
--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -117,7 +117,7 @@ Rubin Observatory's telemetry service
 | backup.persistence.storageClass | string | "" (empty string) to use the cluster default storage class | Storage class to use for the backups |
 | backup.podAnnotations | object | `{}` | Annotations for the backups deployment pod |
 | backup.resources | object | `{}` | Resource limits and requests for the backups deployment pod |
-| backup.restoreItems | list | `[{"backupDate":"","enabled":false,"name":"influxdb-oss-full"}]` | List of items to restore using the sasquatch restore script name must match an item in backupItems backupDate must be in the "YYYY-MM-DD" format |
+| backup.restoreItems | list | `[{"backupTimestamp":"","enabled":false,"name":"influxdb-oss-full"}]` | List of items to restore using the sasquatch restore script name must match an item in backupItems backupTimestamp must be in the YYYYMMDDTHHMMSSZ format |
 | backup.schedule | string | "0 3 * * *" | Schedule for executing the sasquatch backup script |
 | backup.tolerations | list | `[]` | Tolerations for the backups deployment pod |
 | influxdb-enterprise.bootstrap.auth.secretName | string | `"sasquatch"` | Enable authentication of the data nodes using this secret, by creating a username and password for an admin account. The secret must contain keys `username` and `password`. |

--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -117,6 +117,7 @@ Rubin Observatory's telemetry service
 | backup.persistence.storageClass | string | "" (empty string) to use the cluster default storage class | Storage class to use for the backups |
 | backup.podAnnotations | object | `{}` | Annotations for the backups deployment pod |
 | backup.resources | object | `{}` | Resource limits and requests for the backups deployment pod |
+| backup.restoreItems | list | `[{"backupDate":"","enabled":false,"name":"influxdb-oss"}]` | List of items to restore using the sasquatch restore script name must match an item in backupItems backupDate must be in the "YYYY-MM-DD" format |
 | backup.schedule | string | "0 3 * * *" | Schedule for executing the sasquatch backup script |
 | backup.tolerations | list | `[]` | Tolerations for the backups deployment pod |
 | influxdb-enterprise.bootstrap.auth.secretName | string | `"sasquatch"` | Enable authentication of the data nodes using this secret, by creating a username and password for an admin account. The secret must contain keys `username` and `password`. |

--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -108,7 +108,7 @@ Rubin Observatory's telemetry service
 | app-metrics.resources | object | See `values.yaml` | Kubernetes resources requests and limits |
 | app-metrics.tolerations | list | `[]` | Tolerations for pod assignment |
 | backup.affinity | object | `{}` | Affinity rules for the backups deployment pod |
-| backup.backupItems | list | `[{"enabled":false,"name":"chronograf","retention_days":7},{"enabled":false,"name":"kapacitor","retention_days":7},{"enabled":false,"name":"influxdb-enterprise-incremental"},{"enabled":false,"name":"influxdb-oss","retention_days":3}]` | List of items to backup, must match the names in the sasquatch backup script |
+| backup.backupItems | list | `[{"enabled":false,"name":"chronograf","retentionDays":7},{"enabled":false,"name":"kapacitor","retentionDays":7},{"enabled":false,"name":"influxdb-enterprise-incremental"},{"enabled":false,"name":"influxdb-oss","retentionDays":3}]` | List of items to backup using the sasquatch backup script |
 | backup.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the backups image |
 | backup.image.repository | string | `"ghcr.io/lsst-sqre/sasquatch"` | Image to use in the backups deployment |
 | backup.image.tag | string | The appVersion of the chart | Tag of image to use |

--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -108,7 +108,7 @@ Rubin Observatory's telemetry service
 | app-metrics.resources | object | See `values.yaml` | Kubernetes resources requests and limits |
 | app-metrics.tolerations | list | `[]` | Tolerations for pod assignment |
 | backup.affinity | object | `{}` | Affinity rules for the backups deployment pod |
-| backup.backupItems | list | `[{"enabled":false,"name":"chronograf","retentionDays":7},{"enabled":false,"name":"kapacitor","retentionDays":7},{"enabled":false,"name":"influxdb-enterprise-incremental"},{"enabled":false,"name":"influxdb-oss","retentionDays":3}]` | List of items to backup using the sasquatch backup script |
+| backup.backupItems | list | `[{"enabled":false,"name":"chronograf","retentionDays":7},{"enabled":false,"name":"kapacitor","retentionDays":7},{"enabled":false,"name":"influxdb-enterprise-incremental"},{"enabled":false,"name":"influxdb-oss-full","retentionDays":3}]` | List of items to backup using the sasquatch backup script |
 | backup.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the backups image |
 | backup.image.repository | string | `"ghcr.io/lsst-sqre/sasquatch"` | Image to use in the backups deployment |
 | backup.image.tag | string | The appVersion of the chart | Tag of image to use |
@@ -117,7 +117,7 @@ Rubin Observatory's telemetry service
 | backup.persistence.storageClass | string | "" (empty string) to use the cluster default storage class | Storage class to use for the backups |
 | backup.podAnnotations | object | `{}` | Annotations for the backups deployment pod |
 | backup.resources | object | `{}` | Resource limits and requests for the backups deployment pod |
-| backup.restoreItems | list | `[{"backupDate":"","enabled":false,"name":"influxdb-oss"}]` | List of items to restore using the sasquatch restore script name must match an item in backupItems backupDate must be in the "YYYY-MM-DD" format |
+| backup.restoreItems | list | `[{"backupDate":"","enabled":false,"name":"influxdb-oss-full"}]` | List of items to restore using the sasquatch restore script name must match an item in backupItems backupDate must be in the "YYYY-MM-DD" format |
 | backup.schedule | string | "0 3 * * *" | Schedule for executing the sasquatch backup script |
 | backup.tolerations | list | `[]` | Tolerations for the backups deployment pod |
 | influxdb-enterprise.bootstrap.auth.secretName | string | `"sasquatch"` | Enable authentication of the data nodes using this secret, by creating a username and password for an admin account. The secret must contain keys `username` and `password`. |

--- a/applications/sasquatch/charts/backup/README.md
+++ b/applications/sasquatch/charts/backup/README.md
@@ -7,7 +7,7 @@ Backup Sasquatch data
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules for the backups deployment pod |
-| backupItems | list | `[{"enabled":false,"name":"chronograf","retention_days":7},{"enabled":false,"name":"kapacitor","retention_days":7},{"enabled":false,"name":"influxdb-enterprise-incremental"},{"enabled":false,"name":"influxdb-oss","retention_days":3}]` | List of items to backup, must match the names in the sasquatch backup script |
+| backupItems | list | `[{"enabled":false,"name":"chronograf","retentionDays":7},{"enabled":false,"name":"kapacitor","retentionDays":7},{"enabled":false,"name":"influxdb-enterprise-incremental"},{"enabled":false,"name":"influxdb-oss","retentionDays":3}]` | List of items to backup using the sasquatch backup script |
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the backups image |
 | image.repository | string | `"ghcr.io/lsst-sqre/sasquatch"` | Image to use in the backups deployment |
 | image.tag | string | The appVersion of the chart | Tag of image to use |

--- a/applications/sasquatch/charts/backup/README.md
+++ b/applications/sasquatch/charts/backup/README.md
@@ -16,5 +16,6 @@ Backup Sasquatch data
 | persistence.storageClass | string | "" (empty string) to use the cluster default storage class | Storage class to use for the backups |
 | podAnnotations | object | `{}` | Annotations for the backups deployment pod |
 | resources | object | `{}` | Resource limits and requests for the backups deployment pod |
+| restoreItems | list | `[{"backupDate":"","enabled":false,"name":"influxdb-oss"}]` | List of items to restore using the sasquatch restore script name must match an item in backupItems backupDate must be in the "YYYY-MM-DD" format |
 | schedule | string | "0 3 * * *" | Schedule for executing the sasquatch backup script |
 | tolerations | list | `[]` | Tolerations for the backups deployment pod |

--- a/applications/sasquatch/charts/backup/README.md
+++ b/applications/sasquatch/charts/backup/README.md
@@ -7,7 +7,7 @@ Backup Sasquatch data
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules for the backups deployment pod |
-| backupItems | list | `[{"enabled":false,"name":"chronograf","retentionDays":7},{"enabled":false,"name":"kapacitor","retentionDays":7},{"enabled":false,"name":"influxdb-enterprise-incremental"},{"enabled":false,"name":"influxdb-oss","retentionDays":3}]` | List of items to backup using the sasquatch backup script |
+| backupItems | list | `[{"enabled":false,"name":"chronograf","retentionDays":7},{"enabled":false,"name":"kapacitor","retentionDays":7},{"enabled":false,"name":"influxdb-enterprise-incremental"},{"enabled":false,"name":"influxdb-oss-full","retentionDays":3}]` | List of items to backup using the sasquatch backup script |
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the backups image |
 | image.repository | string | `"ghcr.io/lsst-sqre/sasquatch"` | Image to use in the backups deployment |
 | image.tag | string | The appVersion of the chart | Tag of image to use |
@@ -16,6 +16,6 @@ Backup Sasquatch data
 | persistence.storageClass | string | "" (empty string) to use the cluster default storage class | Storage class to use for the backups |
 | podAnnotations | object | `{}` | Annotations for the backups deployment pod |
 | resources | object | `{}` | Resource limits and requests for the backups deployment pod |
-| restoreItems | list | `[{"backupDate":"","enabled":false,"name":"influxdb-oss"}]` | List of items to restore using the sasquatch restore script name must match an item in backupItems backupDate must be in the "YYYY-MM-DD" format |
+| restoreItems | list | `[{"backupDate":"","enabled":false,"name":"influxdb-oss-full"}]` | List of items to restore using the sasquatch restore script name must match an item in backupItems backupDate must be in the "YYYY-MM-DD" format |
 | schedule | string | "0 3 * * *" | Schedule for executing the sasquatch backup script |
 | tolerations | list | `[]` | Tolerations for the backups deployment pod |

--- a/applications/sasquatch/charts/backup/README.md
+++ b/applications/sasquatch/charts/backup/README.md
@@ -16,6 +16,6 @@ Backup Sasquatch data
 | persistence.storageClass | string | "" (empty string) to use the cluster default storage class | Storage class to use for the backups |
 | podAnnotations | object | `{}` | Annotations for the backups deployment pod |
 | resources | object | `{}` | Resource limits and requests for the backups deployment pod |
-| restoreItems | list | `[{"backupDate":"","enabled":false,"name":"influxdb-oss-full"}]` | List of items to restore using the sasquatch restore script name must match an item in backupItems backupDate must be in the "YYYY-MM-DD" format |
+| restoreItems | list | `[{"backupTimestamp":"","enabled":false,"name":"influxdb-oss-full"}]` | List of items to restore using the sasquatch restore script name must match an item in backupItems backupTimestamp must be in the YYYYMMDDTHHMMSSZ format |
 | schedule | string | "0 3 * * *" | Schedule for executing the sasquatch backup script |
 | tolerations | list | `[]` | Tolerations for the backups deployment pod |

--- a/applications/sasquatch/charts/backup/templates/restore-cronjob.yaml
+++ b/applications/sasquatch/charts/backup/templates/restore-cronjob.yaml
@@ -1,0 +1,56 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: sasquatch-restore
+  labels:
+    {{- include "backup.labels" . | nindent 4 }}
+spec:
+  schedule: "0 0 31 2 *"  # Non-triggering schedule, ensure it won't run automatically
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        metadata:
+          {{- if .Values.podAnnotations }}
+          annotations:
+            {{ toYaml .Values.podAnnotations | nindent 12 }}
+          {{- end }}
+          labels:
+            {{- include "backup.selectorLabels" . | nindent 12 }}
+        spec:
+          serviceAccountName: sasquatch-backup
+          restartPolicy: Never
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+          volumes:
+          - name: backup
+            persistentVolumeClaim:
+              claimName: sasquatch-backup
+          containers:
+          - name: sasquatch-backup
+            image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+            imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+            volumeMounts:
+            - name: backup
+              mountPath: /backup
+            command:
+            - /bin/sh
+            - -c
+            - restore.sh
+            resources:
+              {{- toYaml .Values.resources | nindent 14 }}
+            env:
+            - name: RESTORE_ITEMS
+              value: {{ .Values.restoreItems | toJson | quote }}
+          {{- with .Values.nodeSelector }}
+          nodeSelector:
+             {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}

--- a/applications/sasquatch/charts/backup/values.yaml
+++ b/applications/sasquatch/charts/backup/values.yaml
@@ -10,7 +10,7 @@ image:
 
   # -- Tag of image to use
   # @default -- The appVersion of the chart
-  tag: "1.2.0"
+  tag: "1.3.0"
 
 # -- Schedule for executing the sasquatch backup script
 # @default -- "0 3 * * *"

--- a/applications/sasquatch/charts/backup/values.yaml
+++ b/applications/sasquatch/charts/backup/values.yaml
@@ -38,6 +38,14 @@ backupItems:
     enabled: false
     retentionDays: 3
 
+# -- List of items to restore using the sasquatch restore script
+# name must match an item in backupItems
+# backupDate must be in the "YYYY-MM-DD" format
+restoreItems:
+  - name: "influxdb-oss"
+    enabled: false
+    backupDate: ""
+
 # -- Affinity rules for the backups deployment pod
 affinity: {}
 

--- a/applications/sasquatch/charts/backup/values.yaml
+++ b/applications/sasquatch/charts/backup/values.yaml
@@ -24,19 +24,19 @@ persistence:
   # @default -- "" (empty string) to use the cluster default storage class
   storageClass: ""
 
-# -- List of items to backup, must match the names in the sasquatch backup script
+# -- List of items to backup using the sasquatch backup script
 backupItems:
   - name: "chronograf"
     enabled: false
-    retention_days: 7
+    retentionDays: 7
   - name: "kapacitor"
     enabled: false
-    retention_days: 7
+    retentionDays: 7
   - name: "influxdb-enterprise-incremental"
     enabled: false
   - name: "influxdb-oss"
     enabled: false
-    retention_days: 3
+    retentionDays: 3
 
 # -- Affinity rules for the backups deployment pod
 affinity: {}

--- a/applications/sasquatch/charts/backup/values.yaml
+++ b/applications/sasquatch/charts/backup/values.yaml
@@ -40,11 +40,11 @@ backupItems:
 
 # -- List of items to restore using the sasquatch restore script
 # name must match an item in backupItems
-# backupDate must be in the "YYYY-MM-DD" format
+# backupTimestamp must be in the YYYYMMDDTHHMMSSZ format
 restoreItems:
   - name: "influxdb-oss-full"
     enabled: false
-    backupDate: ""
+    backupTimestamp: ""
 
 # -- Affinity rules for the backups deployment pod
 affinity: {}

--- a/applications/sasquatch/charts/backup/values.yaml
+++ b/applications/sasquatch/charts/backup/values.yaml
@@ -34,7 +34,7 @@ backupItems:
     retentionDays: 7
   - name: "influxdb-enterprise-incremental"
     enabled: false
-  - name: "influxdb-oss"
+  - name: "influxdb-oss-full"
     enabled: false
     retentionDays: 3
 
@@ -42,7 +42,7 @@ backupItems:
 # name must match an item in backupItems
 # backupDate must be in the "YYYY-MM-DD" format
 restoreItems:
-  - name: "influxdb-oss"
+  - name: "influxdb-oss-full"
     enabled: false
     backupDate: ""
 

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -163,9 +163,6 @@ app-metrics:
 
 backup:
   enabled: true
-  image:
-    tag: tickets-DM-48369
-    pullPolicy: Always
   persistence:
     size: 500Gi
     storageClass: standard

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -163,6 +163,9 @@ app-metrics:
 
 backup:
   enabled: true
+  image:
+    tag: tickets-DM-48369
+    pullPolicy: Always
   persistence:
     size: 500Gi
     storageClass: standard
@@ -178,3 +181,7 @@ backup:
     - name: "influxdb-oss"
       enabled: true
       retentionDays: 3
+  restoreItems:
+    - name: "influxdb-oss"
+      enabled: true
+      backupDate: "2025-01-10"

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -169,12 +169,12 @@ backup:
   backupItems:
     - name: "chronograf"
       enabled: true
-      retention_days: 3
+      retentionDays: 3
     - name: "kapacitor"
       enabled: true
-      retention_days: 3
+      retentionDays: 3
     - name: "influxdb-enterprise-incremental"
       enabled: true
     - name: "influxdb-oss"
       enabled: true
-      retention_days: 3
+      retentionDays: 3

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -178,10 +178,10 @@ backup:
       retentionDays: 3
     - name: "influxdb-enterprise-incremental"
       enabled: true
-    - name: "influxdb-oss"
+    - name: "influxdb-oss-full"
       enabled: true
       retentionDays: 3
   restoreItems:
-    - name: "influxdb-oss"
+    - name: "influxdb-oss-full"
       enabled: true
       backupDate: "2025-01-10"

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -184,4 +184,4 @@ backup:
   restoreItems:
     - name: "influxdb-oss-full"
       enabled: true
-      backupDate: "2025-01-10"
+      backupTimestamp: "20250113T030120Z"

--- a/applications/sasquatch/values-summit.yaml
+++ b/applications/sasquatch/values-summit.yaml
@@ -532,7 +532,7 @@ backup:
   backupItems:
     - name: chronograf
       enabled: true
-      retention_days: 7
+      retentionDays: 7
     - name: kapacitor
       enabled: true
-      retention_days: 7
+      retentionDays: 7

--- a/applications/sasquatch/values-usdfdev.yaml
+++ b/applications/sasquatch/values-usdfdev.yaml
@@ -194,7 +194,7 @@ backup:
   backupItems:
     - name: "chronograf"
       enabled: true
-      retention_days: 7
+      retentionDays: 7
     - name: "kapacitor"
       enabled: true
-      retention_days: 7
+      retentionDays: 7

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -374,9 +374,9 @@ backup:
   backupItems:
     - name: chronograf
       enabled: true
-      retention_days: 7
+      retentionDays: 7
     - name: kapacitor
       enabled: true
-      retention_days: 7
+      retentionDays: 7
     - name: influxdb-enterprise-incremental
       enabled: true


### PR DESCRIPTION
We assume that sasquatch-backup CronJob for `influxdb-oss-full` is enabled and creating backup items following the configured schedule, for example:

``` 
backupItems:
  - name: "influxdb-oss-full"
    enabled: true
    retentionDays: 3
```

The Job logs show the Backup contents,  where we identify the latest backup we want to restore from:

```
Backup contents:
649M	/backup/sasquatch-influxdb-oss-full-20250113T030120Z
```

We add the  restore configuration, and sync the `sasquatch-restore` CronJob in Argo CD

```
restoreItems:
    - name: "influxdb-oss-full"
      enabled: true
      backupTimestamp: "20250113T030120Z"
```

From where we can run a `sasquatch-restore` Job.

The restore script is implemented in this PR https://github.com/lsst-sqre/sasquatch/pull/56
