### PR TITLE
DM-48421: Deploy Times Square on usdfprod

### DIFF
--- a/applications/noteburst/values-usdfprod.yaml
+++ b/applications/noteburst/values-usdfprod.yaml
@@ -1,0 +1,33 @@
+replicaCount: 3
+
+config:
+  worker:
+    workerCount: 3
+    # There are 20 bot accounts allocated to noteburst.
+    identities:
+      - username: "bot-noteburst01"
+      - username: "bot-noteburst02"
+      - username: "bot-noteburst03"
+      - username: "bot-noteburst04"
+      - username: "bot-noteburst05"
+      - username: "bot-noteburst06"
+      - username: "bot-noteburst07"
+      - username: "bot-noteburst08"
+      - username: "bot-noteburst09"
+      - username: "bot-noteburst10"
+      - username: "bot-noteburst11"
+      - username: "bot-noteburst12"
+      - username: "bot-noteburst13"
+      - username: "bot-noteburst14"
+      - username: "bot-noteburst15"
+      - username: "bot-noteburst16"
+      - username: "bot-noteburst17"
+      - username: "bot-noteburst18"
+      - username: "bot-noteburst19"
+      - username: "bot-noteburst20"
+    imageSelector: "weekly"
+
+# Use SSD for Redis storage.
+redis:
+  persistence:
+    storageClass: "wekafs--sdf-k8s01"

--- a/applications/postgres/values-usdfprod.yaml
+++ b/applications/postgres/values-usdfprod.yaml
@@ -11,4 +11,5 @@ timessquare_db:
   user: "timessquare"
   db: "timessquare"
 
+postgresVolumeSize: "2Gi"
 postgresStorageClass: "wekafs--sdf-k8s01"

--- a/applications/postgres/values-usdfprod.yaml
+++ b/applications/postgres/values-usdfprod.yaml
@@ -1,11 +1,14 @@
 jupyterhub_db:
-  user: 'jovyan'
-  db: 'jupyterhub'
+  user: "jovyan"
+  db: "jupyterhub"
 nublado3_db:
-  user: 'nublado3'
-  db: 'nublado3'
+  user: "nublado3"
+  db: "nublado3"
 gafaelfawr_db:
-  user: 'gafaelfawr'
-  db: 'gafaelfawr'
+  user: "gafaelfawr"
+  db: "gafaelfawr"
+timessquare_db:
+  user: "timessquare"
+  db: "timessquare"
 
-postgresStorageClass: 'wekafs--sdf-k8s01'
+postgresStorageClass: "wekafs--sdf-k8s01"

--- a/applications/squareone/values-usdfprod.yaml
+++ b/applications/squareone/values-usdfprod.yaml
@@ -2,3 +2,5 @@ replicaCount: 3
 config:
   siteName: "Rubin Science Platform"
   semaphoreUrl: "https://usdf-rsp.slac.stanford.edu/semaphore"
+ingress:
+  timesSquareScope: "exec:notebook"

--- a/applications/squareone/values-usdfprod.yaml
+++ b/applications/squareone/values-usdfprod.yaml
@@ -2,5 +2,6 @@ replicaCount: 3
 config:
   siteName: "Rubin Science Platform"
   semaphoreUrl: "https://usdf-rsp.slac.stanford.edu/semaphore"
+  timesSquareUrl: "https://usdf-rsp.slac.stanford.edu/times-square/api"
 ingress:
   timesSquareScope: "exec:notebook"

--- a/applications/times-square/values-usdfprod.yaml
+++ b/applications/times-square/values-usdfprod.yaml
@@ -1,0 +1,18 @@
+replicaCount:
+  api: 2
+  worker: 2
+config:
+  databaseUrl: "postgresql://timessquare@postgres.postgres/timessquare"
+  githubAppId: "1112177"
+  enableGitHubApp: "True"
+cloudsql:
+  enabled: false
+redis:
+  persistence:
+    storageClass: "wekafs--sdf-k8s01"
+    size: "64Gi"
+  resources:
+    requests:
+      memory: "8Gi"
+    limits:
+      memory: "24Gi"

--- a/environments/values-usdfprod.yaml
+++ b/environments/values-usdfprod.yaml
@@ -19,6 +19,7 @@ applications:
   livetap: true
   mobu: true
   narrativelog: true
+  noteburst: true
   nublado: true
   plot-navigator: true
   portal: true
@@ -32,3 +33,4 @@ applications:
   squareone: true
   strimzi: true
   tap: true
+  times-square: true


### PR DESCRIPTION
This deploys Times Square on the production USDF RSP. This will become the new primary deployment of Times Square. This should be merged after https://github.com/lsst-sqre/phalanx/pull/4083 which will deploy Times Square 0.15.0.

- Adds timessquare to the postgres database
- Adds values for timessquare at usdfprod
- Adds values for noteburst at usdfprod
- Adds the ingress for `/times-square/` to Squareone