### PR TITLE
Upgrade InfluxDB OSS to 1.11.8

### DIFF
--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -51,7 +51,7 @@ Rubin Observatory's telemetry service
 | influxdb.config.http.max-row-limit | int | `0` | Maximum number of rows the system can return from a non-chunked query (0 is unlimited) |
 | influxdb.config.logging.level | string | `"debug"` | Logging level |
 | influxdb.enabled | bool | `true` | Whether InfluxDB is enabled |
-| influxdb.image.tag | string | `"1.8.10"` | InfluxDB image tag |
+| influxdb.image.tag | string | `"1.11.8"` | InfluxDB image tag |
 | influxdb.ingress.annotations | object | See `values.yaml` | Annotations to add to the ingress |
 | influxdb.ingress.className | string | `"nginx"` | Ingress class to use |
 | influxdb.ingress.enabled | bool | `false` | Whether to enable the InfluxDB ingress |
@@ -62,6 +62,10 @@ Rubin Observatory's telemetry service
 | influxdb.persistence.enabled | bool | `true` | Whether to use persistent volume claims. By default, `storageClass` is undefined, choosing the default provisioner (standard on GKE). |
 | influxdb.persistence.size | string | 1TiB for teststand deployments | Persistent volume size |
 | influxdb.resources | object | See `values.yaml` | Kubernetes resource requests and limits |
+| influxdb.securityContext.fsGroup | int | `1500` |  |
+| influxdb.securityContext.runAsGroup | int | `1500` |  |
+| influxdb.securityContext.runAsNonRoot | bool | `true` |  |
+| influxdb.securityContext.runAsUser | int | `1500` |  |
 | influxdb.setDefaultUser.enabled | bool | `true` | Whether the default InfluxDB user is set |
 | influxdb.setDefaultUser.user.existingSecret | string | `"sasquatch"` | Use `influxdb-user` and `influxdb-password` keys from this secret |
 | kafdrop.enabled | bool | `true` | Whether Kafdrop is enabled |

--- a/applications/sasquatch/values.yaml
+++ b/applications/sasquatch/values.yaml
@@ -36,7 +36,7 @@ influxdb:
 
   image:
     # -- InfluxDB image tag
-    tag: "1.8.10"
+    tag: "1.11.8"
 
   persistence:
     # -- Whether to use persistent volume claims. By default, `storageClass`
@@ -77,6 +77,12 @@ influxdb:
     # -- Path for the ingress
     # @default -- `"/influxdb(/\|$)(.*)"`
     path: "/influxdb(/|$)(.*)"
+
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1500
+    runAsGroup: 1500
+    fsGroup: 1500
 
   # See https://docs.influxdata.com/influxdb/v1.8/administration/config
   config:


### PR DESCRIPTION
- Upgrade InfluxDB OSS to 1.11.8 by default to all Sasquatch instances.
- The 1.11.8 docker image runs with the influxdb user and group, so add securityContext configuration with fsGroup so the PV is mounted with the right permissions.