### PR TITLE
Fix up telegraf-app-metrics label

### DIFF
--- a/applications/sasquatch/charts/app-metrics/templates/telegraf-deployment.yaml
+++ b/applications/sasquatch/charts/app-metrics/templates/telegraf-deployment.yaml
@@ -4,7 +4,7 @@ kind: Deployment
 metadata:
   name: sasquatch-telegraf-app-metrics
   labels:
-    app.kubernetes.io/name: sasquatch-telegraf-app-metrics
+    app.kubernetes.io/name: sasquatch-telegraf
     app.kubernetes.io/instance: sasquatch-telegraf-app-metrics
     app.kubernetes.io/part-of: sasquatch
 spec:


### PR DESCRIPTION
- We expect the app.kubernetes.io/name: sasquatch-telegraf label in all Telegraf deployments.