### PR TITLE
DM-45901: Update data-dev Butler to point to new DB

### DIFF
--- a/applications/butler/values-idfdev.yaml
+++ b/applications/butler/values-idfdev.yaml
@@ -3,7 +3,7 @@ image:
 
 config:
   dp02ClientServerIsDefault: true
-  dp02PostgresUri: postgresql://postgres@sqlproxy-butler-int.sqlproxy-cross-project:5432/dp02
+  dp02PostgresUri: postgresql://butler@10.161.0.4:5432/dp02
   s3EndpointUrl: "https://storage.googleapis.com"
   repositories:
     dp02: "file:///opt/lsst/butler/config/dp02.yaml"


### PR DESCRIPTION
A new postgres 16 database instance has been set up for the DP02 butler on data-dev