### PR TITLE
Set Summit job lifetime to 2 hours.

### DIFF
--- a/applications/uws/values-summit.yaml
+++ b/applications/uws/values-summit.yaml
@@ -3,6 +3,7 @@ csc_shared:
 uws-api-server:
   targetCluster: "summit"
   hostname: summit-lsp.lsst.codes
+  ttlSecondsAfterFinished: 7200
   image:
     tag: latest
   logLevel: INFO


### PR DESCRIPTION
This limits spam in the status channel from all the failed jobs.