### PR TITLE
DM-48485: Add entries to the cadc-registry config to address errors in logs

### DIFF
--- a/charts/cadc-tap/templates/configmap.yaml
+++ b/charts/cadc-tap/templates/configmap.yaml
@@ -7,6 +7,10 @@ metadata:
 data:
   cadc-registry.properties: |
     ivo://ivoa.net/sso#OpenID = {{ .Values.global.baseUrl }}
+
+    # Ignore this, it's only here to satisfy the availability check.
+    ivo://ivoa.net/std/CDP#proxy-1.0 = ivo://{{ .Values.global.baseUrl }}/cred
+    ivo://ivoa.net/sso#tls-with-password = {{ .Values.global.baseUrl }}
   catalina.properties: |
     # tomcat properties
     tomcat.connector.connectionTimeout=20000


### PR DESCRIPTION
**Summary**
We've been getting errors in our logs for a while that look like this:

```
java.util.NoSuchElementException: not found: ivo://ivoa.net/sso#tls-with-password
java.util.NoSuchElementException: not found: ivo://ivoa.net/std/CDP#proxy-1.0
```
These errors don't seem to have any effect on our service which behaves fine, however probably good to address so that we're not getting exception stack traces in our logs. 

**Fix**
Add ivoids for the auth methods that are missing. 
I'm not sure why Cadc look for these even though we don't define credential delegation auth in our security methods, but judging from how these are defined in various implementations of their TAP service these seem to have an effect regardless if not used.
For example in https://github.com/opencadc/science-platform/blob/5ca7890f9636493d9327a82562251bcc5f1778ac/deployment/helm/cavern/config/cadc-registry.properties#L15:

```
# Ignore this, it's only here to satisfy the availability check.
ivo://ivoa.net/std/CDP#proxy-1.0 = ivo://cadc.nrc.ca/cred
```
This implies that they are just there for the /availability check so I think we're safe to add them here.

**Jira Issue**
https://rubinobs.atlassian.net/browse/DM-48485

**Tests**
Tested via https://github.com/stvoutsin/rspvalidator