### PR TITLE
DM-48495: Lift some ingress-nginx settings into values.yaml

### DIFF
--- a/applications/ingress-nginx/README.md
+++ b/applications/ingress-nginx/README.md
@@ -16,7 +16,9 @@ Ingress controller
 | ingress-nginx.controller.allowSnippetAnnotations | bool | `true` | Allow Ingress resources to add NGINX configuration snippets. This is required by Gafaelfawr. |
 | ingress-nginx.controller.config.annotations-risk-level | string | `"Critical"` | Level of dangerous annotations allowed. Must be set to `Critical` to allow snippets. |
 | ingress-nginx.controller.config.compute-full-forwarded-for | string | `"true"` | Put the complete path in `X-Forwarded-For`, not just the last hop, so that the client IP will be exposed to Gafaelfawr |
+| ingress-nginx.controller.config.large-client-header-buffers | string | `"4 64k"` | Size and number of the buffers used to read HTTP headers from clients. Increase this from its default size in case clients send large cookies. |
 | ingress-nginx.controller.config.proxy-body-size | string | `"100m"` | Maximum size of the client request body (needs to be large enough to allow table uploads) |
+| ingress-nginx.controller.config.proxy-buffer-size | string | `"64k"` | Maximum size of the buffer used to read HTTP headers from the backend or auth subrequest handler. This needs to be larger than the default because Gafaelfawr reflects all of the user's cookies other than the Gafaelfawr one. |
 | ingress-nginx.controller.config.server-snippet | string | See `values.yaml` | Add additional per-server configuration used by Gafaelfawr to report errors from the authorization layer |
 | ingress-nginx.controller.config.ssl-redirect | string | `"true"` | Redirect all non-SSL access to SSL |
 | ingress-nginx.controller.config.use-forwarded-headers | string | `"true"` | Enable the `X-Forwarded-For` processing |

--- a/applications/ingress-nginx/values-base.yaml
+++ b/applications/ingress-nginx/values-base.yaml
@@ -1,7 +1,4 @@
 ingress-nginx:
   controller:
-    config:
-      large-client-header-buffers: "4 64k"
-      proxy-buffer-size: "64k"
     service:
       loadBalancerIP: "139.229.151.155"

--- a/applications/ingress-nginx/values-ccin2p3.yaml
+++ b/applications/ingress-nginx/values-ccin2p3.yaml
@@ -9,9 +9,6 @@ ingress-nginx:
         value: "qserv"
         effect: "NoSchedule"
 
-    config:
-      large-client-header-buffers: "4 64k"
-      proxy-buffer-size: "64k"
     service:
       externalIPs:
         - 134.158.237.2

--- a/applications/ingress-nginx/values-idfdemo.yaml
+++ b/applications/ingress-nginx/values-idfdemo.yaml
@@ -2,7 +2,5 @@ ingress-nginx:
   controller:
     config:
       error-log-level: "error"
-      large-client-header-buffers: "4 64k"
-      proxy-buffer-size: "64k"
     service:
       loadBalancerIP: "34.72.37.126"

--- a/applications/ingress-nginx/values-idfdev.yaml
+++ b/applications/ingress-nginx/values-idfdev.yaml
@@ -2,7 +2,5 @@ ingress-nginx:
   controller:
     config:
       error-log-level: "error"
-      large-client-header-buffers: "4 64k"
-      proxy-buffer-size: "64k"
     service:
       loadBalancerIP: "35.225.112.77"

--- a/applications/ingress-nginx/values-idfint.yaml
+++ b/applications/ingress-nginx/values-idfint.yaml
@@ -1,7 +1,4 @@
 ingress-nginx:
   controller:
-    config:
-      large-client-header-buffers: "4 64k"
-      proxy-buffer-size: "64k"
     service:
       loadBalancerIP: "35.238.192.49"

--- a/applications/ingress-nginx/values-idfprod.yaml
+++ b/applications/ingress-nginx/values-idfprod.yaml
@@ -1,7 +1,4 @@
 ingress-nginx:
   controller:
-    config:
-      large-client-header-buffers: "4 64k"
-      proxy-buffer-size: "64k"
     service:
       loadBalancerIP: "35.202.181.164"

--- a/applications/ingress-nginx/values-roe.yaml
+++ b/applications/ingress-nginx/values-roe.yaml
@@ -2,8 +2,6 @@ ingress-nginx:
   controller:
     kind: DaemonSet
     config:
-      large-client-header-buffers: "4 64k"
-      proxy-buffer-size: "64k"
       use-proxy-protocol: "false"
       enable-health-monitor: "false"
     service:

--- a/applications/ingress-nginx/values-summit.yaml
+++ b/applications/ingress-nginx/values-summit.yaml
@@ -1,7 +1,4 @@
 ingress-nginx:
   controller:
-    config:
-      large-client-header-buffers: "4 64k"
-      proxy-buffer-size: "64k"
     service:
       loadBalancerIP: "139.229.160.150"

--- a/applications/ingress-nginx/values-tucson-teststand.yaml
+++ b/applications/ingress-nginx/values-tucson-teststand.yaml
@@ -1,7 +1,4 @@
 ingress-nginx:
   controller:
-    config:
-      large-client-header-buffers: "4 64k"
-      proxy-buffer-size: "64k"
     service:
       loadBalancerIP: "140.252.146.50"

--- a/applications/ingress-nginx/values-usdfdev.yaml
+++ b/applications/ingress-nginx/values-usdfdev.yaml
@@ -1,8 +1,5 @@
 ingress-nginx:
   controller:
-    config:
-      large-client-header-buffers: "4 64k"
-      proxy-buffer-size: "64k"
     service:
       externalTrafficPolicy: Local
       loadBalancerIP: "134.79.138.113"

--- a/applications/ingress-nginx/values-usdfprod.yaml
+++ b/applications/ingress-nginx/values-usdfprod.yaml
@@ -1,8 +1,5 @@
 ingress-nginx:
   controller:
-    config:
-      large-client-header-buffers: "4 64k"
-      proxy-buffer-size: "64k"
     service:
       externalTrafficPolicy: Local
     podLabels:

--- a/applications/ingress-nginx/values.yaml
+++ b/applications/ingress-nginx/values.yaml
@@ -15,9 +15,20 @@ ingress-nginx:
       # so that the client IP will be exposed to Gafaelfawr
       compute-full-forwarded-for: "true"
 
+      # -- Size and number of the buffers used to read HTTP headers from
+      # clients. Increase this from its default size in case clients send
+      # large cookies.
+      large-client-header-buffers: "4 64k"
+
       # -- Maximum size of the client request body (needs to be large enough
       # to allow table uploads)
       proxy-body-size: "100m"
+
+      # -- Maximum size of the buffer used to read HTTP headers from the
+      # backend or auth subrequest handler. This needs to be larger than the
+      # default because Gafaelfawr reflects all of the user's cookies other
+      # than the Gafaelfawr one.
+      proxy-buffer-size: "64k"
 
       # -- Redirect all non-SSL access to SSL
       ssl-redirect: "true"


### PR DESCRIPTION
Move the `large-client-header-buffers` and `proxy-buffer-size` settings into `values.yaml` from the per-environment settings files, since we generally want those settings everywhere. This only changes configuration for minikube, roundtable-dev, and roundtable.

These settings increase the buffer size used to read client HTTP headers and response HTTP headers from proxied services, including Gafaelfawr. We saw errors without this setting in environments where the user has large cookies exceeding the 4KB default buffer size limit, such as USDF.