### PR TITLE
[DM-48533] Make message key format configuration default

### DIFF
--- a/applications/sasquatch/charts/kafdrop/values.yaml
+++ b/applications/sasquatch/charts/kafdrop/values.yaml
@@ -47,7 +47,7 @@ existingSecret: ""
 
 # -- Command line arguments to Kafdrop
 # @default -- See `values.yaml`
-cmdArgs: "--message.format=AVRO --topic.deleteEnabled=false --topic.createEnabled=false"
+cmdArgs: "--message.format=AVRO --message.keyFormat=DEFAULT --topic.deleteEnabled=false --topic.createEnabled=false"
 
 service:
   # -- Additional annotations to add to the service

--- a/applications/sasquatch/values-base.yaml
+++ b/applications/sasquatch/values-base.yaml
@@ -251,7 +251,6 @@ telegraf-kafka-consumer:
       debug: true
 
 kafdrop:
-  cmdArgs: "--message.format=AVRO --message.keyFormat=DEFAULT --topic.deleteEnabled=false --topic.createEnabled=false"
   ingress:
     enabled: true
     hostname: base-lsp.lsst.codes

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -120,7 +120,7 @@ telegraf-kafka-consumer:
         [ "lsst.Test.*" ]
 
 kafdrop:
-  cmdArgs: "--message.format=AVRO --topic.deleteEnabled=true --topic.createEnabled=true"
+  cmdArgs: "--message.format=AVRO --message.keyFormat=DEFAULT --topic.deleteEnabled=true --topic.createEnabled=true"
   ingress:
     enabled: true
     hostname: data-dev.lsst.cloud

--- a/applications/sasquatch/values-summit.yaml
+++ b/applications/sasquatch/values-summit.yaml
@@ -546,7 +546,6 @@ telegraf-kafka-consumer:
 
 
 kafdrop:
-  cmdArgs: "--message.format=AVRO --message.keyFormat=DEFAULT --topic.deleteEnabled=false --topic.createEnabled=false"
   ingress:
     enabled: true
     hostname: summit-lsp.lsst.codes

--- a/applications/sasquatch/values-tucson-teststand.yaml
+++ b/applications/sasquatch/values-tucson-teststand.yaml
@@ -189,7 +189,6 @@ telegraf-kafka-consumer:
       memory: "1Gi"
 
 kafdrop:
-  cmdArgs: "--message.format=AVRO --message.keyFormat=DEFAULT --topic.deleteEnabled=false --topic.createEnabled=false"
   ingress:
     enabled: true
     hostname: tucson-teststand.lsst.codes


### PR DESCRIPTION
The Control System Kafka topics now have a key that has DEAULT format.

The configuration `--message.keyFormat=DEFAULT` can be used to set this by default when displaying messages in the kafdrop UI. It doesn't take effect for Kafka topics that don't have a key.

This PR use the DEFAULT key format in all Sasquatch environments now.