### PR TITLE
DM-48495: Update to Gafaelfawr 12.4.0

### DIFF
--- a/applications/gafaelfawr/Chart.yaml
+++ b/applications/gafaelfawr/Chart.yaml
@@ -5,10 +5,14 @@ description: "Authentication and identity system"
 home: "https://gafaelfawr.lsst.io/"
 sources:
   - "https://github.com/lsst-sqre/gafaelfawr"
-appVersion: 12.3.2
+appVersion: 12.4.0
 
 dependencies:
   - name: "redis"
+    version: 1.0.15
+    repository: "https://lsst-sqre.github.io/charts/"
+  - name: "redis"
+    alias: "redis-ephemeral"
     version: 1.0.15
     repository: "https://lsst-sqre.github.io/charts/"
 

--- a/applications/gafaelfawr/README.md
+++ b/applications/gafaelfawr/README.md
@@ -103,18 +103,26 @@ Authentication and identity system
 | operator.resources | object | See `values.yaml` | Resource limits and requests for the Gafaelfawr Kubernetes operator. The limits are artificially higher since the operator pod is also where we manually run `gafaelfawr audit --fix`, which requires more CPU and memory. |
 | operator.tolerations | list | `[]` | Tolerations for the token management pod |
 | podAnnotations | object | `{}` | Annotations for the Gafaelfawr frontend pod |
-| redis.affinity | object | `{}` | Affinity rules for the Redis pod |
+| redis-ephemeral.affinity | object | `{}` | Affinity rules for the ephemeral Redis pod |
+| redis-ephemeral.config.secretKey | string | `"redis-password"` | Key inside secret from which to get the Redis password (do not change) |
+| redis-ephemeral.config.secretName | string | `"gafaelfawr"` | Name of secret containing Redis password (do not change) |
+| redis-ephemeral.nodeSelector | object | `{}` | Node selection rules for the ephemeral Redis pod |
+| redis-ephemeral.persistence.enabled | bool | `false` | Whether to persist Redis storage of ephemeral data. This should always be false. |
+| redis-ephemeral.podAnnotations | object | `{}` | Pod annotations for the ephemeral Redis pod |
+| redis-ephemeral.resources | object | See `values.yaml` | Resource limits and requests for the ephemeral Redis pod |
+| redis-ephemeral.tolerations | list | `[]` | Tolerations for the ephemeral Redis pod |
+| redis.affinity | object | `{}` | Affinity rules for the persistent Redis pod |
 | redis.config.secretKey | string | `"redis-password"` | Key inside secret from which to get the Redis password (do not change) |
 | redis.config.secretName | string | `"gafaelfawr"` | Name of secret containing Redis password (do not change) |
-| redis.nodeSelector | object | `{}` | Node selection rules for the Redis pod |
+| redis.nodeSelector | object | `{}` | Node selection rules for the persistent Redis pod |
 | redis.persistence.accessMode | string | `"ReadWriteOnce"` | Access mode of storage to request |
 | redis.persistence.enabled | bool | `true` | Whether to persist Redis storage and thus tokens. Setting this to false will use `emptyDir` and reset all tokens on every restart. Only use this for a test deployment. |
 | redis.persistence.size | string | `"1Gi"` | Amount of persistent storage to request |
 | redis.persistence.storageClass | string | `""` | Class of storage to request |
 | redis.persistence.volumeClaimName | string | `""` | Use an existing PVC, not dynamic provisioning. If this is set, the size, storageClass, and accessMode settings are ignored. |
-| redis.podAnnotations | object | `{}` | Pod annotations for the Redis pod |
-| redis.resources | object | See `values.yaml` | Resource limits and requests for the Redis pod |
-| redis.tolerations | list | `[]` | Tolerations for the Redis pod |
+| redis.podAnnotations | object | `{}` | Pod annotations for the persistent Redis pod |
+| redis.resources | object | See `values.yaml` | Resource limits and requests for the persistent Redis pod |
+| redis.tolerations | list | `[]` | Tolerations for the persistent Redis pod |
 | replicaCount | int | `1` | Number of web frontend pods to start |
 | resources | object | See `values.yaml` | Resource limits and requests for the Gafaelfawr frontend pod |
 | tolerations | list | `[]` | Tolerations for the Gafaelfawr frontend pod |

--- a/applications/gafaelfawr/templates/_helpers.tpl
+++ b/applications/gafaelfawr/templates/_helpers.tpl
@@ -115,7 +115,9 @@ Common environment variables
     secretKeyRef:
       name: "gafaelfawr"
       key: "redis-password"
-- name: "GAFAELFAWR_REDIS_URL"
+- name: "GAFAELFAWR_REDIS_EPHEMERAL_URL"
+  value: "redis://gafaelfawr-redis-ephemeral.{{ .Release.Namespace }}:6379/0"
+- name: "GAFAELFAWR_REDIS_PERSISTENT_URL"
   value: "redis://gafaelfawr-redis.{{ .Release.Namespace }}:6379/0"
 - name: "GAFAELFAWR_SESSION_SECRET"
   valueFrom:

--- a/applications/gafaelfawr/templates/cronjob-audit.yaml
+++ b/applications/gafaelfawr/templates/cronjob-audit.yaml
@@ -22,6 +22,7 @@ spec:
             {{- include "gafaelfawr.selectorLabels" . | nindent 12 }}
             app.kubernetes.io/component: "audit"
             gafaelfawr-redis-client: "true"
+            gafaelfawr-redis-ephemeral-client: "true"
         spec:
           restartPolicy: "Never"
           automountServiceAccountToken: false

--- a/applications/gafaelfawr/templates/cronjob-maintenance.yaml
+++ b/applications/gafaelfawr/templates/cronjob-maintenance.yaml
@@ -21,6 +21,7 @@ spec:
             {{- include "gafaelfawr.selectorLabels" . | nindent 12 }}
             app.kubernetes.io/component: "maintenance"
             gafaelfawr-redis-client: "true"
+            gafaelfawr-redis-ephemeral-client: "true"
         spec:
           restartPolicy: "Never"
           automountServiceAccountToken: false

--- a/applications/gafaelfawr/templates/deployment-operator.yaml
+++ b/applications/gafaelfawr/templates/deployment-operator.yaml
@@ -23,6 +23,7 @@ spec:
         {{- include "gafaelfawr.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: "operator"
         gafaelfawr-redis-client: "true"
+        gafaelfawr-redis-ephemeral-client: "true"
     spec:
       serviceAccountName: "gafaelfawr-operator"
       containers:

--- a/applications/gafaelfawr/templates/deployment.yaml
+++ b/applications/gafaelfawr/templates/deployment.yaml
@@ -21,6 +21,7 @@ spec:
         {{- include "gafaelfawr.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: "frontend"
         gafaelfawr-redis-client: "true"
+        gafaelfawr-redis-ephemeral-client: "true"
     spec:
       {{- if .Values.cloudsql.enabled }}
       serviceAccountName: "gafaelfawr"

--- a/applications/gafaelfawr/templates/job-schema-update.yaml
+++ b/applications/gafaelfawr/templates/job-schema-update.yaml
@@ -21,6 +21,7 @@ spec:
         {{- include "gafaelfawr.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: "schema-update"
         gafaelfawr-redis-client: "true"
+        gafaelfawr-redis-ephemeral-client: "true"
     spec:
       {{- if .Values.cloudsql.enabled }}
       serviceAccountName: "gafaelfawr"

--- a/applications/gafaelfawr/values.yaml
+++ b/applications/gafaelfawr/values.yaml
@@ -417,6 +417,42 @@ operator:
   # -- Affinity rules for the token management pod
   affinity: {}
 
+redis-ephemeral:
+  config:
+    # -- Name of secret containing Redis password (do not change)
+    secretName: "gafaelfawr"
+
+    # -- Key inside secret from which to get the Redis password (do not
+    # change)
+    secretKey: "redis-password"
+
+  persistence:
+    # -- Whether to persist Redis storage of ephemeral data. This should
+    # always be false.
+    enabled: false
+
+  # -- Resource limits and requests for the ephemeral Redis pod
+  # @default -- See `values.yaml`
+  resources:
+    limits:
+      cpu: "1"
+      memory: "40Mi"
+    requests:
+      cpu: "50m"
+      memory: "15Mi"
+
+  # -- Affinity rules for the ephemeral Redis pod
+  affinity: {}
+
+  # -- Node selection rules for the ephemeral Redis pod
+  nodeSelector: {}
+
+  # -- Pod annotations for the ephemeral Redis pod
+  podAnnotations: {}
+
+  # -- Tolerations for the ephemeral Redis pod
+  tolerations: []
+
 redis:
   config:
     # -- Name of secret containing Redis password (do not change)
@@ -445,7 +481,7 @@ redis:
     # size, storageClass, and accessMode settings are ignored.
     volumeClaimName: ""
 
-  # -- Resource limits and requests for the Redis pod
+  # -- Resource limits and requests for the persistent Redis pod
   # @default -- See `values.yaml`
   resources:
     limits:
@@ -455,17 +491,17 @@ redis:
       cpu: "50m"
       memory: "15Mi"
 
-  # -- Pod annotations for the Redis pod
-  podAnnotations: {}
+  # -- Affinity rules for the persistent Redis pod
+  affinity: {}
 
-  # -- Node selection rules for the Redis pod
+  # -- Node selection rules for the persistent Redis pod
   nodeSelector: {}
 
-  # -- Tolerations for the Redis pod
-  tolerations: []
+  # -- Pod annotations for the persistent Redis pod
+  podAnnotations: {}
 
-  # -- Affinity rules for the Redis pod
-  affinity: {}
+  # -- Tolerations for the persistent Redis pod
+  tolerations: []
 
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.

--- a/applications/ingress-nginx/values.yaml
+++ b/applications/ingress-nginx/values.yaml
@@ -41,6 +41,12 @@ ingress-nginx:
       # @default -- See `values.yaml`
       server-snippet: |
         set $auth_error_body '';
+        set $auth_ratelimit_limit '';
+        set $auth_ratelimit_remaining '';
+        set $auth_ratelimit_reset '';
+        set $auth_ratelimit_resource '';
+        set $auth_ratelimit_used '';
+        set $auth_retry_after '';
         set $auth_status '';
         set $auth_www_authenticate '';
         location @autherror {
@@ -49,6 +55,16 @@ ingress-nginx:
             add_header Cache-Control "no-cache, must-revalidate" always;
             add_header WWW-Authenticate $auth_www_authenticate always;
             return 400 $auth_error_body;
+          }
+          if ($auth_status = 429) {
+            add_header Cache-Control "no-cache, must-revalidate" always;
+            add_header Retry-After $auth_retry_after always;
+            add_header X-RateLimit-Limit $auth_ratelimit_limit always;
+            add_header X-RateLimit-Remaining $auth_ratelimit_remaining always;
+            add_header X-RateLimit-Reset $auth_ratelimit_reset always;
+            add_header X-RateLimit-Resource $auth_ratelimit_resource always;
+            add_header X-RateLimit-Used $auth_ratelimit_used always;
+            return 429 $auth_error_body;
           }
           add_header Cache-Control "no-cache, must-revalidate" always;
           add_header WWW-Authenticate $auth_www_authenticate always;


### PR DESCRIPTION
Update to Gafaelfawr 12.4.0, which includes new support for API rate limiting and therefore new ingress-nginx integration. This release also requires a separate ephemeral Redis for Gafaelfawr.