### PR TITLE
DM-48448: Update Squareone with documentation link for Times Square

### DIFF
--- a/applications/squareone/Chart.yaml
+++ b/applications/squareone/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
     url: https://github.com/jonathansick
 
 # The default version tag of the squareone docker image
-appVersion: "0.14.0"
+appVersion: "0.15.0"

--- a/applications/squareone/README.md
+++ b/applications/squareone/README.md
@@ -19,6 +19,7 @@ Squareone is the homepage UI for the Rubin Science Platform.
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
 | config.apiAspectPageMdx | string | See `values.yaml` | MDX content for the `/api-aspect` page |
 | config.coManageRegistryUrl | string | `nil` | URL to the COmanage registry, if the environment uses COmanage for identity. @default null disables the COmanage integration |
+| config.docsBaseUrl | string | `"https://rsp.lsst.io"` | Base URL for user documentation (excludes trailing slash) |
 | config.docsPageMdx | string | See `values.yaml` | MDX content for the `/docs` page |
 | config.emailVerifiedPageMdx | string | See `values.yaml` | MDX content for the `/enrollment/thanks-for-verifying` page |
 | config.pendingApprovalPageMdx | string | See `values.yaml` | MDX content for the `/enrollment/pending-approval` page |

--- a/applications/squareone/templates/configmap.yaml
+++ b/applications/squareone/templates/configmap.yaml
@@ -9,6 +9,7 @@ data:
     siteName: {{ .Values.config.siteName | quote }}
     baseUrl: {{ .Values.global.baseUrl | quote }}
     siteDescription: {{ .Values.config.siteDescription | quote }}
+    docsBaseUrl: {{ .Values.config.docsBaseUrl | quote }}
     {{- if .Values.config.semaphoreUrl }}
     semaphoreUrl: {{ .Values.config.semaphoreUrl | quote }}
     {{- end}}

--- a/applications/squareone/values-base.yaml
+++ b/applications/squareone/values-base.yaml
@@ -1,2 +1,3 @@
 config:
   siteName: "Rubin Science Platform @ Base"
+  docsBaseUrl: "https://rsp.lsst.io/v/base"

--- a/applications/squareone/values-idfdev.yaml
+++ b/applications/squareone/values-idfdev.yaml
@@ -7,6 +7,7 @@ ingress:
 
 config:
   siteName: "Rubin Science Platform @ data-dev"
+  docsBaseUrl: "https://rsp.lsst.io/v/idfdev"
   semaphoreUrl: "https://data-dev.lsst.cloud/semaphore"
   timesSquareUrl: "https://data-dev.lsst.cloud/times-square/api"
   coManageRegistryUrl: "https://id-dev.lsst.cloud"

--- a/applications/squareone/values-idfint.yaml
+++ b/applications/squareone/values-idfint.yaml
@@ -3,6 +3,7 @@ ingress:
 
 config:
   siteName: "Rubin Science Platform @ data-int"
+  docsBaseUrl: "https://rsp.lsst.io/v/idfint"
   semaphoreUrl: "https://data-int.lsst.cloud/semaphore"
   coManageRegistryUrl: "https://id-int.lsst.cloud"
   apiAspectPageMdx: |

--- a/applications/squareone/values-idfprod.yaml
+++ b/applications/squareone/values-idfprod.yaml
@@ -5,6 +5,7 @@ ingress:
 
 config:
   siteName: "Rubin Science Platform"
+  docsBaseUrl: "https://rsp.lsst.io"
   semaphoreUrl: "https://data.lsst.cloud/semaphore"
   coManageRegistryUrl: "https://id.lsst.cloud"
   plausibleDomain: "data.lsst.cloud"

--- a/applications/squareone/values-summit.yaml
+++ b/applications/squareone/values-summit.yaml
@@ -1,2 +1,3 @@
 config:
   siteName: "Rubin Science Platform @ Summit"
+  docsBaseUrl: "https://rsp.lsst.io/v/summit"

--- a/applications/squareone/values-tucson-teststand.yaml
+++ b/applications/squareone/values-tucson-teststand.yaml
@@ -1,2 +1,3 @@
 config:
   siteName: "Rubin Science Platform @ Tucson"
+  docsBaseUrl: "https://rsp.lsst.io/v/tucson-teststand"

--- a/applications/squareone/values-usdfdev.yaml
+++ b/applications/squareone/values-usdfdev.yaml
@@ -3,5 +3,6 @@ config:
   siteName: "Rubin Science Platform"
   semaphoreUrl: "https://usdf-rsp-dev.slac.stanford.edu/semaphore"
   timesSquareUrl: "https://usdf-rsp-dev.slac.stanford.edu/times-square/api"
+  docsBaseUrl: "https://rsp.lsst.io/v/usdfdev"
 ingress:
   timesSquareScope: "exec:notebook"

--- a/applications/squareone/values-usdfint.yaml
+++ b/applications/squareone/values-usdfint.yaml
@@ -2,4 +2,5 @@ replicaCount: 3
 config:
   siteName: "Rubin Science Platform"
   semaphoreUrl: "https://usdf-rsp-int.slac.stanford.edu/semaphore"
+  docsBaseUrl: "https://rsp.lsst.io/v/usdfint"
   timesSquareUrl: "https://usdf-rsp-int.slac.stanford.edu/times-square/api"

--- a/applications/squareone/values-usdfprod.yaml
+++ b/applications/squareone/values-usdfprod.yaml
@@ -3,5 +3,6 @@ config:
   siteName: "Rubin Science Platform"
   semaphoreUrl: "https://usdf-rsp.slac.stanford.edu/semaphore"
   timesSquareUrl: "https://usdf-rsp.slac.stanford.edu/times-square/api"
+  docsBaseUrl: "https://rsp.lsst.io/v/usdfprod"
 ingress:
   timesSquareScope: "exec:notebook"

--- a/applications/squareone/values.yaml
+++ b/applications/squareone/values.yaml
@@ -65,6 +65,9 @@ config:
   siteDescription: |
     Access Rubin Observatory Legacy Survey of Space and Time data.
 
+  # -- Base URL for user documentation (excludes trailing slash)
+  docsBaseUrl: "https://rsp.lsst.io"
+
   # -- URL to the Semaphore (user notifications) API service.
   # @default null disables the Semaphore integration
   semaphoreUrl: null


### PR DESCRIPTION
This PR updates Squareone to 0.15.0, which adds a link in Times Square to the user documentation for that environment. This change also adds a new configuration, `docsBaseUrl` pointing to the base URL in rsp.lsst.io for a given environment's user documentation.