### PR TITLE
DM-45901: Update data-dev Butler to use postgres DNS name

### DIFF
--- a/applications/butler/values-idfdev.yaml
+++ b/applications/butler/values-idfdev.yaml
@@ -3,7 +3,8 @@ image:
 
 config:
   dp02ClientServerIsDefault: true
-  dp02PostgresUri: postgresql://butler@10.161.0.4:5432/dp02
+  # butler-registry-dp02-dev Google Cloud SQL instance in science-platform-dev
+  dp02PostgresUri: postgresql://butler@dp02.rsp-sql-dev.internal:5432/dp02
   s3EndpointUrl: "https://storage.googleapis.com"
   repositories:
     dp02: "file:///opt/lsst/butler/config/dp02.yaml"


### PR DESCRIPTION
Use a domain name instead of an IP address for Butler on data-dev.