### PR TITLE
[DM-48545] REST proxy Kafka topics should now be created in Sasquatch

### DIFF
--- a/applications/sasquatch/values-base.yaml
+++ b/applications/sasquatch/values-base.yaml
@@ -271,6 +271,8 @@ rest-proxy:
     "access.control.allow.origin": https://base-lsp.lsst.codes/love
   kafka:
     topics:
+      - lsst.obsenv.action
+      - lsst.obsenv.summary
     topicPrefixes:
       - lsst.obsenv
 

--- a/applications/sasquatch/values-base.yaml
+++ b/applications/sasquatch/values-base.yaml
@@ -271,10 +271,7 @@ rest-proxy:
     "access.control.allow.origin": https://base-lsp.lsst.codes/love
   kafka:
     topics:
-      - test.next-visit
     topicPrefixes:
-      - test
-      - lsst.dm
       - lsst.obsenv
 
 chronograf:

--- a/applications/sasquatch/values-summit.yaml
+++ b/applications/sasquatch/values-summit.yaml
@@ -566,9 +566,6 @@ rest-proxy:
       - lsst.backpack
       - lsst.obsenv
       - lsst.cp
-      - lsst.ATCamera
-      - lsst.CCCamera
-      - lsst.MTCamera
 
 chronograf:
   persistence:

--- a/applications/sasquatch/values-summit.yaml
+++ b/applications/sasquatch/values-summit.yaml
@@ -559,6 +559,7 @@ rest-proxy:
     "access.control.allow.origin": https://summit-lsp.lsst.codes/love,http://love01.cp.lsst.org
   kafka:
     topics:
+      - lsst.backpack.usgs_earthquake_data
       - lsst.obsenv.action
       - lsst.obsenv.summary
     topicPrefixes:

--- a/applications/sasquatch/values-summit.yaml
+++ b/applications/sasquatch/values-summit.yaml
@@ -558,6 +558,9 @@ rest-proxy:
   configurationOverrides:
     "access.control.allow.origin": https://summit-lsp.lsst.codes/love,http://love01.cp.lsst.org
   kafka:
+    topics:
+      - lsst.obsenv.action
+      - lsst.obsenv.summary
     topicPrefixes:
       - lsst.dm
       - lsst.backpack

--- a/applications/sasquatch/values-tucson-teststand.yaml
+++ b/applications/sasquatch/values-tucson-teststand.yaml
@@ -202,11 +202,8 @@ rest-proxy:
     "access.control.allow.origin": https://tucson-teststand.lsst.codes/love
   kafka:
     topics:
-      - test.next-visit
     topicPrefixes:
-      - test
       - lsst.obsenv
-      - lsst.dm
 
 chronograf:
   persistence:

--- a/applications/sasquatch/values-tucson-teststand.yaml
+++ b/applications/sasquatch/values-tucson-teststand.yaml
@@ -202,6 +202,8 @@ rest-proxy:
     "access.control.allow.origin": https://tucson-teststand.lsst.codes/love
   kafka:
     topics:
+      - lsst.obsenv.action
+      - lsst.obsenv.summary
     topicPrefixes:
       - lsst.obsenv
 


### PR DESCRIPTION
We disabled topic auto-creation in Kafka, so we need to create the topics managed by the REST Proxy.
Clean up some old configuration we don't need anymore for the REST Proxy.