### PR TITLE
DM-48622: Document how to block notebook spawns

### DIFF
--- a/docs/applications/nublado/block-spawns.rst
+++ b/docs/applications/nublado/block-spawns.rst
@@ -1,0 +1,63 @@
+#####################################
+Blocking spawns of new user notebooks
+#####################################
+
+In some cases, we may want to block spawns of new user Nublado pods.
+For example, if the system is very overloaded, we may want to temporarily disable new pod creation.
+We may also want to disable spawning of new pods before the start of planned maintenance.
+
+Blocking spawns via quota
+=========================
+
+Gafaelfawr_ tracks user quotas, including notebook quotas.
+Part of the user notebook quota is a boolean flag, ``spawn``, that specifies whether that user can spawn new labs.
+Lab spawns for either a group or for all users by default can be disabled by setting that flag to false.
+
+This can be done via the user quota settings in the :file:`values-{environment}.yaml` file for Gafaelfawr for a given environment and applied with Phalanx (see `the Gafaelfawr quota documentation <https://gafaelfawr.lsst.io/user-guide/helm.html#quotas>`__), but usually one does not want to disable spawning permanently.
+It's more common to want to disable spawns temporarily.
+
+To do this, an environment administrator can use a Gafaelfawr quota override.
+This is a separate, temporary Gafaelfawr quota configuration that overrides the default quotas if it applies.
+
+To set a quota override, first create a user token with ``admin:token`` scope.
+This token has full administrative access to the Phalanx environment, so treat it with caution.
+
+Then, using that token, run a command such as the following:
+
+.. prompt:: bash
+
+   curl -X PUT -H 'Authorization: bearer <token>' \
+       -H 'Content-Type: application/json' \
+       -d '{"default": {"notebook": {"cpu": 0, "memory": 0, "spawn": false}}}' \
+       https://<base-url>/auth/api/v1/quota-overrides
+
+This sets an override notebook quota that disables spawning for all users.
+
+To allow members of an admin group to spawn notebooks anyway, add that group to the ``bypass`` key.
+For example, the ``-d`` argument to :command:`curl` might look like this:
+
+.. code-block:: json
+
+   {"bypass": ["g_admins"], "default": {"notebook": {"cpu": 0, "memory": 0, "spawn": false}}}
+
+In this case, all members of ``g_admins`` will ignore all quotas, including the notebook quota that disables spawns (and also any default quotas configured elsewhere).
+
+Alternately, you can block notebook spawns for only members of a specific group with JSON such as this:
+
+.. code-block:: json
+
+   {"default": {}, "groups": {"g_users": {"notebook": {"cpu": 0, "memory": 0, "spawn": false}}}}
+
+This will disable spawning only for members of the ``g_users`` group.
+
+Blocking spawns by stopping JupyterHub
+======================================
+
+A more comprehensive way to block all notebook spawns is to stop JupyterHub entirely.
+You can do this by going into Argo CD, choosing the ``nublado`` application, and then deleting the Kubernetes deployment named ``hub``.
+
+This will prevent anyone from spawning notebooks or interacting with JupyterHub, but it will always affect all users with no bypass mechanism.
+It will also break other functionality, such as returning to an already-running lab, and may cause problems for running user labs since they are no longer able to contact JupyterHub.
+
+This should therefore only be used in emergencies or when the entire Nublado environment is being brought down.
+Use quota overrides instead for finer-grained control of spawning.

--- a/docs/applications/nublado/index.rst
+++ b/docs/applications/nublado/index.rst
@@ -4,11 +4,14 @@
 nublado — JupyterHub/JupyterLab for RSP
 #######################################
 
-The ``nublado`` application provides a JupyterHub and JupyterLab interface for Rubin Science Platform users.
-It also deploys a Kubernetes controller that, besides creating user lab pods, prepulls lab images and can provide per-user WebDAV file servers.
+The Nublado application provides a JupyterHub and JupyterLab interface for Rubin Science Platform users.
+It includes a Kubernetes controller that, besides creating user lab pods, prepulls lab images and can provide per-user WebDAV file servers.
 
-The JupyterHub component and its proxy is deployed via `Zero to JupyterHub <https://hub.jupyter.org/helm-chart/>`__ with a custom configuration.
-Alongside it, the Nublado controller is deployed by the same application as a separate FastAPI service.
+The JupyterHub component and its proxy are deployed via `Zero to JupyterHub <https://hub.jupyter.org/helm-chart/>`__ with a custom configuration.
+The Nublado controller is deployed alongside it as a separate FastAPI service.
+
+Nublado user pods are created under the ``nublado-users`` Argo CD application.
+WebDAV file servers are created in the ``fileservers`` Kubernetes namespace and the ``nublado-fileservers`` Argo CD application.
 
 .. jinja:: nublado
    :file: applications/_summary.rst.jinja
@@ -22,6 +25,7 @@ Guides
    bootstrap
    upgrade
    major-upgrade
+   block-spawns
    updating-recommended
    troubleshoot
    values

--- a/docs/applications/nublado/major-upgrade.rst
+++ b/docs/applications/nublado/major-upgrade.rst
@@ -1,5 +1,5 @@
 ###############################
-Nublado Major Version Migration
+Nublado major version migration
 ###############################
 
 Currently we only discuss nublado v2 to nublado v3 migration; when the

--- a/docs/applications/nublado/updating-recommended.rst
+++ b/docs/applications/nublado/updating-recommended.rst
@@ -1,18 +1,18 @@
-##############################################
-Updating the recommended Notebook Aspect image
-##############################################
+############################################
+Update the recommended Notebook Aspect image
+############################################
 
 The ``recommended`` tag for JupyterLab images is usually a recent weekly image.
 The image tagged ``recommended`` is guaranteed by SQuaRE to be compatible with other services and materials, such as tutorial or system testing notebooks, that we make available on RSP deployments.
 
-This document explains the process for moving the ``recommended`` tag, and how to make an image that is *not* tagged ``recommended`` the default image, which is sometimes required, particularly in Telescope and Site environments.
+This document explains the process for moving the ``recommended`` tag.
+It also documents how to make an image that is *not* tagged ``recommended`` the default image, which is sometimes required, particularly in Telescope and Site environments.
 
 Tagging a new container version
 --------------------------------
 
 When a new version has been approved (after passing through its prior QA and sign-off gates), the ``recommended`` tag must be updated to point to the new version.
-
-To do this, run the GitHub retag workflow for https://github.com/lsst-sqre/sciplat-lab repository, as follows:
+To do this, run the GitHub retag workflow for https://github.com/lsst-sqre/sciplat-lab repository as follows:
 
 #. Go to `the retag workflow page <https://github.com/lsst-sqre/sciplat-lab/actions/workflows/retag.yaml>`__.
 #. Click :guilabel:`Run workflow`.
@@ -31,15 +31,18 @@ Tags are global per container image repository (that is, ``docker.io/sciplat-lab
 It is quite often the case that Telescope and Site, in particular, needs the image that is recommended by default for a given environment to vary, because their environments may not be running the same XML cycle.
 
 To change the default image to a new tag, you must do the following.
-Locate the JupyterLab Controller configuration for the environment you're working with.
-This will be in the Phalanx GitHub repository at ``/applications/nublado/`` and will be the ``values-<instance>.yaml`` file there.
-In that file, you should find the key ``controller.config.images.recommendedTag``.
-If you do not find it, then that environment is currently using ``recommended`` as its default image.
 
-Set this key (creating it if necessary) to whatever string represents the correct recommended-by-default image for that instance.
-For instance, for a Telescope and Site environment, this will likely look something like ``recommended_c0032``.
-Create a pull request against https://github.com/lsst-sqre/phalanx that updates the tag.
-Once this change is merged, sync the nublado application (using Argo CD) in the affected environments.
+#. Locate the JupyterLab Controller configuration for the environment you're working with.
+   This will be in the Phalanx GitHub repository at ``/applications/nublado/`` and will be the :file:`values-{environment}.yaml` file there.
+   In that file, you should find the key ``controller.config.images.recommendedTag``.
+   If you do not find it, then that environment is currently using ``recommended`` as its default image.
 
-You do not have to wait for a maintenance window to do this, since the change is low risk, although it will result in a very brief outage for Notebook Aspect lab spawning while the JupyterLab Controller is restarted.
-It may take a few minutes for the image pulling to complete, but after that interval, the menu will be correct again.
+#. Set this key (creating it if necessary) to whatever string represents the correct recommended-by-default image for that instance.
+   For instance, for a Telescope and Site environment, this will likely look something like ``recommended_c0032``.
+
+#. Create a pull request against https://github.com/lsst-sqre/phalanx that updates this setting.
+
+#. Once this change is merged, sync the nublado application (using Argo CD) in the affected environments.
+
+You do not have to wait for a maintenance window to do this, since the change is low risk.
+It will, however, result in a very brief outage for Notebook Aspect lab spawning while the JupyterLab Controller is restarted.


### PR DESCRIPTION
Add a documentation page explaining how to block Nublado notebook spawns via quota overrides. Also mention stopping JupyterHub for completeness.