### PR TITLE
DM-48614: Deploy Unfurlbot 0.5.0

### DIFF
--- a/applications/unfurlbot/Chart.yaml
+++ b/applications/unfurlbot/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "0.4.0"
+appVersion: "0.5.0"
 description: Squarebot backend that unfurls Jira issues.
 name: unfurlbot
 sources:

--- a/applications/unfurlbot/README.md
+++ b/applications/unfurlbot/README.md
@@ -16,6 +16,8 @@ Squarebot backend that unfurls Jira issues.
 | config.jiraUrl | string | `"https://rubinobs.atlassian.net/"` | Jira base URL |
 | config.logLevel | string | `"INFO"` | Logging level: "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL" |
 | config.redisUrl | string | `"redis://unfurlbot-redis:6379/0"` | URL to the local redis instance |
+| config.slackDebounceTime | string | `"600"` | Time (second) before an unfurl can be made to the same channel/thread for a given token |
+| config.slackTriggerMessageTtl | string | `"60"` | Time (seconds) after which a triggering Slack message is considered stale and ignored. |
 | config.topics.slackAppMention | string | `"lsst.square-events.squarebot.slack.app.mention"` | Kafka topic name for the Slack `app_mention` events |
 | config.topics.slackMessageChannels | string | `"lsst.square-events.squarebot.slack.message.channels"` | Kafka topic name for the Slack `message.channels` events (public channels) |
 | config.topics.slackMessageGroups | string | `"lsst.square-events.squarebot.slack.message.groups"` | Kafka topic name for the Slack `message.groups` events (private channels) |

--- a/applications/unfurlbot/templates/configmap.yaml
+++ b/applications/unfurlbot/templates/configmap.yaml
@@ -17,3 +17,5 @@ data:
   UNFURLBOT_REDIS_URL: {{ .Values.config.redisUrl | quote }}
   UNFURLBOT_JIRA_ROOT_URL: {{ .Values.config.jiraUrl | quote }}
   UNFURLBOT_JIRA_TIMEOUT: {{ .Values.config.jiraTimeout | quote }}
+  UNFURLBOT_SLACK_TRIGGER_MESSAGE_TTL: {{ .Values.config.slackTriggerMessageTtl | quote }}
+  UNFURLBOT_SLACK_DEBOUNCE_TIME: {{ .Values.config.slackDebounceTime | quote }}

--- a/applications/unfurlbot/values.yaml
+++ b/applications/unfurlbot/values.yaml
@@ -43,6 +43,12 @@ config:
     # direct messages)
     slackMessageMpim: "lsst.square-events.squarebot.slack.message.mpim"
 
+  # -- Time (seconds) after which a triggering Slack message is considered stale and ignored.
+  slackTriggerMessageTtl: "60"
+
+  # -- Time (second) before an unfurl can be made to the same channel/thread for a given token
+  slackDebounceTime: "600"
+
   # -- Jira base URL
   jiraUrl: "https://rubinobs.atlassian.net/"
 


### PR DESCRIPTION
This version has improved logging and avoids unfurling based on stale Slack messages.