### PR TITLE
DM-46178: Use new query system in Prompt Processing

### DIFF
--- a/applications/prompt-proto-service-hsc/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-hsc/values-usdfdev-prompt-processing.yaml
@@ -43,8 +43,4 @@ prompt-proto-service:
     endpointUrl: https://usdf-rsp-dev.slac.stanford.edu/sasquatch-rest-proxy
     auth_env: false
 
-  debug:
-    # A cache efficiency workaround breaks on RC2 tests; see DM-43205.
-    cacheCalibs: false
-
   fullnameOverride: "prompt-proto-service-hsc"

--- a/applications/prompt-proto-service-latiss/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfdev-prompt-processing.yaml
@@ -44,8 +44,4 @@ prompt-proto-service:
     endpointUrl: https://usdf-rsp-dev.slac.stanford.edu/sasquatch-rest-proxy
     auth_env: false
 
-  debug:
-    # A cache efficiency workaround breaks when mixing observing dates; see DM-43205, DM-43913.
-    cacheCalibs: false
-
   fullnameOverride: "prompt-proto-service-latiss"

--- a/applications/prompt-proto-service-lsstcomcam/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/values-usdfdev-prompt-processing.yaml
@@ -43,8 +43,4 @@ prompt-proto-service:
     endpointUrl: https://usdf-rsp-dev.slac.stanford.edu/sasquatch-rest-proxy
     auth_env: false
 
-  debug:
-    # A cache efficiency workaround breaks when mixing observing dates; see DM-43205, DM-43913.
-    cacheCalibs: false
-
   fullnameOverride: "prompt-proto-service-lsstcomcam"

--- a/charts/prompt-proto-service/README.md
+++ b/charts/prompt-proto-service/README.md
@@ -22,7 +22,6 @@ Event-driven processing of camera images
 | cache.patchesPerImage | int | `4` | A factor by which to multiply `baseSize` for templates and other patch-based datasets. |
 | cache.refcatsPerImage | int | `4` | A factor by which to multiply `baseSize` for refcat datasets. |
 | containerConcurrency | int | `1` | The number of Knative requests that can be handled simultaneously by one container |
-| debug.cacheCalibs | bool | `true` | Whether or not calibs should be cached between runs of a pod. This is a temporary flag that should only be unset in specific circumstances, and only in the development environment. |
 | debug.exportOutputs | bool | `true` | Whether or not pipeline outputs should be exported to the central repo. This flag does not turn off APDB writes or alert generation; those must be handled at the pipeline level or by setting up an alternative destination. |
 | fullnameOverride | string | `"prompt-proto-service"` | Override the full name for resources (includes the release name) |
 | image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |

--- a/charts/prompt-proto-service/templates/prompt-proto-service.yaml
+++ b/charts/prompt-proto-service/templates/prompt-proto-service.yaml
@@ -123,8 +123,6 @@ spec:
           value: {{ .Values.cache.refcatsPerImage | toString | quote }}
         - name: PATCHES_PER_IMAGE
           value: {{ .Values.cache.patchesPerImage | toString | quote }}
-        - name: DEBUG_CACHE_CALIBS
-          value: {{ if .Values.debug.cacheCalibs }}'1'{{ else }}'0'{{ end }}
         - name: DEBUG_EXPORT_OUTPUTS
           value: {{ if .Values.debug.exportOutputs }}'1'{{ else }}'0'{{ end }}
         volumeMounts:

--- a/charts/prompt-proto-service/values.yaml
+++ b/charts/prompt-proto-service/values.yaml
@@ -173,9 +173,6 @@ fullnameOverride: "prompt-proto-service"
 containerConcurrency: 1
 
 debug:
-  # -- Whether or not calibs should be cached between runs of a pod.
-  # This is a temporary flag that should only be unset in specific circumstances, and only in the development environment.
-  cacheCalibs: true
   # -- Whether or not pipeline outputs should be exported to the central repo.
   # This flag does not turn off APDB writes or alert generation; those must be handled at the pipeline level or by setting up an alternative destination.
   exportOutputs: true


### PR DESCRIPTION
This PR removes a Prompt Processing debugging flag that was sometimes needed to get correct results with the old calib-handling code removed on lsst-dm/prompt_processing#249.