### PR TITLE
DM-4866: Enable Sentry telemetry in SIAv2 application

### DIFF
--- a/applications/sia/Chart.yaml
+++ b/applications/sia/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.1.5
+appVersion: 0.1.6
 description: Simple Image Access (SIA) IVOA Service using Butler
 name: sia
 sources:

--- a/applications/sia/README.md
+++ b/applications/sia/README.md
@@ -13,10 +13,12 @@ Simple Image Access (SIA) IVOA Service using Butler
 | affinity | object | `{}` | Affinity rules for the sia deployment pod |
 | config.butlerDataCollections | list | `[]` | List of data (Butler) Collections Expected attributes: `config`, `label`, `name`, `butler_type`, `repository` & `datalink_url` |
 | config.directButlerEnabled | bool | `false` | Whether direct butler access is enabled |
+| config.enableSentry | bool | `false` | Whether to send trace and telemetry information to Sentry. This traces every call and therefore should only be enabled in non-production environments. |
 | config.logLevel | string | `"INFO"` | Logging level |
 | config.logProfile | string | `"production"` | Logging profile (`production` for JSON, `development` for human-friendly) |
 | config.pathPrefix | string | `"/api/sia"` | URL path prefix |
 | config.pgUser | string | `"rubin"` | User to use from the PGPASSFILE if sia is using a direct Butler connection |
+| config.sentryTracesSampleRate | float | `0` |  |
 | config.slackAlerts | bool | `false` | Whether to send alerts and status to Slack. |
 | fullnameOverride | string | `""` | Override the full name for resources (includes the release name) |
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |

--- a/applications/sia/secrets.yaml
+++ b/applications/sia/secrets.yaml
@@ -21,3 +21,7 @@ slack-webhook:
   copy:
     application: mobu
     key: app-alert-webhook
+sentry-dsn:
+  description: >-
+    DSN URL to which Sentry trace and error logging will be sent.
+  if: config.enableSentry

--- a/applications/sia/templates/deployment.yaml
+++ b/applications/sia/templates/deployment.yaml
@@ -57,10 +57,14 @@ spec:
             - name: "http"
               containerPort: 8080
               protocol: "TCP"
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: http
           readinessProbe:
             httpGet:
-              path: {{ .Values.config.pathPrefix }}
-              port: "http"
+              path: /healthcheck
+              port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:
@@ -82,6 +86,17 @@ spec:
               value: "/etc/butler/secrets/postgres-credentials.txt"
             - name: "GOOGLE_APPLICATION_CREDENTIALS"
               value: "/tmp/secrets/butler-gcs-idf-creds.json"
+            {{- end }}
+            {{- if .Values.config.enableSentry }}
+            - name: "SIA_SENTRY_DSN"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "sia.fullname" . }}
+                  key: "sentry-dsn"
+            - name: "SIA_SENTRY_TRACES_SAMPLE_RATE"
+              value: {{ .Values.config.sentryTracesSampleRate | quote }}
+            - name: "SIA_ENVIRONMENT_NAME"
+              value: {{ .Values.global.host }}
             {{- end }}
           {{- if .Values.config.directButlerEnabled }}
           volumeMounts:

--- a/applications/sia/values-idfdev.yaml
+++ b/applications/sia/values-idfdev.yaml
@@ -8,3 +8,6 @@ config:
       butler_type: "REMOTE"
       repository: "https://data-dev.lsst.cloud/api/butler/repo/dp02/butler.yaml"
       datalink_url: "https://data-dev.lsst.cloud/api/datalink/links?ID=butler%3A//dp02/{id}"
+
+  enableSentry: true
+  sentryTracesSampleRate: 1

--- a/applications/sia/values-idfint.yaml
+++ b/applications/sia/values-idfint.yaml
@@ -8,3 +8,6 @@ config:
       butler_type: "REMOTE"
       repository: "https://data-int.lsst.cloud/api/butler/repo/dp02/butler.yaml"
       datalink_url: "https://data-int.lsst.cloud/api/datalink/links?ID=butler%3A//dp02/{id}"
+
+  enableSentry: true
+  sentryTracesSampleRate: 1

--- a/applications/sia/values.yaml
+++ b/applications/sia/values.yaml
@@ -47,6 +47,13 @@ config:
   # connection
   pgUser: "rubin"
 
+  # -- Whether to send trace and telemetry information to Sentry. This traces
+  # every call and therefore should only be enabled in non-production
+  # environments.
+  enableSentry: false
+
+  # Sentry tracing sample rate
+  sentryTracesSampleRate: 0.0
 
 ingress:
   # -- Additional annotations for the ingress rule


### PR DESCRIPTION
### Summary

PR to enable Sentry telemetry for the SIAv2 application. Sentry parameters are read from ENV variables, similar to other config values. The approach follows the implementation of other apps, like times-square gafaelfawr and mobu

### Checklist
- Ensure the Sentry DSN is properly added for each environment where we enable sentry