### PR TITLE
DM-48516: Update TAP image to version 2.6.0

### DIFF
--- a/charts/cadc-tap/README.md
+++ b/charts/cadc-tap/README.md
@@ -36,7 +36,7 @@ IVOA TAP service
 | config.qserv.host | string | `"mock-db:3306"` (the mock QServ) | QServ hostname:port to connect to |
 | config.qserv.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the TAP image |
 | config.qserv.image.repository | string | `"ghcr.io/lsst-sqre/lsst-tap-service"` | TAP image to use |
-| config.qserv.image.tag | string | `"2.5.0"` | Tag of TAP image to use |
+| config.qserv.image.tag | string | `"2.6.0"` | Tag of TAP image to use |
 | config.qserv.jdbcParams | string | `""` | Extra JDBC connection parameters |
 | config.qserv.passwordEnabled | bool | false | Whether the Qserv database is password protected |
 | config.serviceName | string | None, must be set | Name of the service from Gafaelfawr's perspective, used for metrics reporting |
@@ -79,7 +79,7 @@ IVOA TAP service
 | uws.affinity | object | `{}` | Affinity rules for the UWS database pod |
 | uws.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the UWS database image |
 | uws.image.repository | string | `"ghcr.io/lsst-sqre/lsst-tap-uws-db"` | UWS database image to use |
-| uws.image.tag | string | `"2.5.0"` | Tag of UWS database image to use |
+| uws.image.tag | string | `"2.6.0"` | Tag of UWS database image to use |
 | uws.nodeSelector | object | `{}` | Node selection rules for the UWS database pod |
 | uws.podAnnotations | object | `{}` | Annotations for the UWS databse pod |
 | uws.resources | object | See `values.yaml` | Resource limits and requests for the UWS database pod |

--- a/charts/cadc-tap/values.yaml
+++ b/charts/cadc-tap/values.yaml
@@ -89,7 +89,7 @@ config:
       pullPolicy: "IfNotPresent"
 
       # -- Tag of TAP image to use
-      tag: "2.5.0"
+      tag: "2.6.0"
 
     # -- Whether the Qserv database is password protected
     # @default -- false
@@ -200,7 +200,7 @@ uws:
     pullPolicy: "IfNotPresent"
 
     # -- Tag of UWS database image to use
-    tag: "2.5.0"
+    tag: "2.6.0"
 
   # -- Resource limits and requests for the UWS database pod
   # @default -- See `values.yaml`


### PR DESCRIPTION
## Summary

Upgrade TAP service image to version 2.6.0

## What's Changed in TAP Service

* Fix Dockerfile warning about Label by @stvoutsin in https://github.com/lsst-sqre/lsst-tap-service/pull/123
* DM-48516: JobDAO class from opencadc adapted to fix issue with LAST param in joblist by @stvoutsin in https://github.com/lsst-sqre/lsst-tap-service/pull/121
* Prepare release 2.6.0 by @stvoutsin in https://github.com/lsst-sqre/lsst-tap-service/pull/124


**Full Changelog**: https://github.com/lsst-sqre/lsst-tap-service/compare/2.5.0...2.6.0