### PR TITLE
Summit Sasquatch fixes

### DIFF
--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -38,8 +38,8 @@ Rubin Observatory's telemetry service
 | influxdb-enterprise.enabled | bool | `false` | Whether to use influxdb-enterprise |
 | influxdb.config.continuous_queries.enabled | bool | `false` | Whether continuous queries are enabled |
 | influxdb.config.coordinator.log-queries-after | string | `"15s"` | Maximum duration a query can run before InfluxDB logs it as a slow query |
-| influxdb.config.coordinator.max-concurrent-queries | int | `1000` | Maximum number of running queries allowed on the instance (0 is unlimited) |
-| influxdb.config.coordinator.query-timeout | string | `"30s"` | Maximum duration a query is allowed to run before it is killed |
+| influxdb.config.coordinator.max-concurrent-queries | int | `500` | Maximum number of running queries allowed on the instance (0 is unlimited) |
+| influxdb.config.coordinator.query-timeout | string | `"15s"` | Maximum duration a query is allowed to run before it is killed |
 | influxdb.config.coordinator.write-timeout | string | `"1h"` | Duration a write request waits before timeout is returned to the caller |
 | influxdb.config.data.cache-max-memory-size | int | `0` | Maximum size a shared cache can reach before it starts rejecting writes |
 | influxdb.config.data.max-series-per-database | int | `0` | Maximum number of series allowed per database before writes are dropped. Change the setting to 0 to allow an unlimited number of series per database. |

--- a/applications/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
@@ -5,6 +5,10 @@ metadata:
   name: controller
   labels:
     strimzi.io/cluster: {{ .Values.cluster.name }}
+  {{- with .Values.kafkaController.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.kafka.replicas }}
   roles:

--- a/applications/sasquatch/values-base.yaml
+++ b/applications/sasquatch/values-base.yaml
@@ -70,6 +70,8 @@ strimzi-kafka:
     enabled: true
   kafkaController:
     enabled: true
+    annotations:
+      strimzi.io/next-node-ids: "(3,4,5)"
     resources:
       requests:
         memory: 8Gi

--- a/applications/sasquatch/values-summit.yaml
+++ b/applications/sasquatch/values-summit.yaml
@@ -103,12 +103,15 @@ strimzi-kafka:
         requiredDuringSchedulingIgnoredDuringExecution:
           nodeSelectorTerms:
             - matchExpressions:
-                - key: kubernetes.io/hostname
+                - key: kafka-broker
                   operator: In
                   values:
-                    - yagan17
-                    - yagan18
-                    - yagan19
+                    - "true"
+    tolerations:
+      - key: "kafka-broker"
+        operator: "Equal"
+        value: "true"
+        effect: "NoSchedule"
 influxdb:
   persistence:
     storageClass: rook-ceph-block

--- a/applications/sasquatch/values-summit.yaml
+++ b/applications/sasquatch/values-summit.yaml
@@ -115,6 +115,8 @@ strimzi-kafka:
         value: "true"
         effect: "NoSchedule"
 influxdb:
+  image:
+    tag: "1.8.10"
   persistence:
     storageClass: rook-ceph-block
     size: 5Ti

--- a/applications/sasquatch/values-summit.yaml
+++ b/applications/sasquatch/values-summit.yaml
@@ -56,6 +56,8 @@ strimzi-kafka:
     enabled: true
   kafkaController:
     enabled: true
+    annotations:
+      strimzi.io/next-node-ids: "(3,4,5)"
     resources:
       requests:
         memory: 8Gi

--- a/applications/sasquatch/values.yaml
+++ b/applications/sasquatch/values.yaml
@@ -125,10 +125,10 @@ influxdb:
 
       # -- Maximum number of running queries allowed on the instance (0 is
       # unlimited)
-      max-concurrent-queries: 1000
+      max-concurrent-queries: 500
 
       # -- Maximum duration a query is allowed to run before it is killed
-      query-timeout: "30s"
+      query-timeout: "15s"
 
       # -- Maximum duration a query can run before InfluxDB logs it as a slow
       # query


### PR DESCRIPTION
After OS and k8s upgrades at the Summit we had problems restarting Kafka, we had to fix the nodeAffinity configuration for the kafka brokers and also pin the Kafka controller node IDs.

Also we had to rollback InfluxDB OSS after what looks like a bug on version 1.11.8