### PR TITLE
DM-48700: mobu - terminationGracePeriodSeconds

### DIFF
--- a/applications/mobu/README.md
+++ b/applications/mobu/README.md
@@ -38,4 +38,5 @@ Continuous integration testing
 | nodeSelector | object | `{}` | Node selector rules for the mobu frontend pod |
 | podAnnotations | object | `{}` | Annotations for the mobu frontend pod |
 | resources | object | See `values.yaml` | Resource limits and requests for the mobu frontend pod |
+| terminationGracePeriodSeconds | string | See `values.yaml` | Number of seconds for k8s to send SIGKILL after sending SIGTERM |
 | tolerations | list | `[]` | Tolerations for the mobu frontend pod |

--- a/applications/mobu/templates/deployment.yaml
+++ b/applications/mobu/templates/deployment.yaml
@@ -23,6 +23,9 @@ spec:
         {{- include "mobu.selectorLabels" . | nindent 8 }}
     spec:
       automountServiceAccountToken: false
+      {{- if .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           env:

--- a/applications/mobu/tests/termination_grace_period_test.yaml
+++ b/applications/mobu/tests/termination_grace_period_test.yaml
@@ -1,0 +1,21 @@
+suite: terminationGracePeriod set
+tests:
+  - it: "Should set terminationGracePeriod in the deployment pod spec"
+    template: "deployment.yaml"
+    set:
+      terminationGracePeriodSeconds: 500
+      global:
+        host: "example.com"
+    asserts:
+      - equal:
+          path: "spec.template.spec.terminationGracePeriodSeconds"
+          value: 500
+  - it: "Should set terminationGracePeriod in the deployment pod spec"
+    template: "deployment.yaml"
+    set:
+      terminationGracePeriodSeconds: null
+      global:
+        host: "example.com"
+    asserts:
+      - notExists:
+          path: "spec.template.spec.terminationGracePeriodSeconds"

--- a/applications/mobu/values.yaml
+++ b/applications/mobu/values.yaml
@@ -90,6 +90,10 @@ resources:
     cpu: "50m"
     memory: "1Gi"
 
+# -- Number of seconds for k8s to send SIGKILL after sending SIGTERM
+# @default -- See `values.yaml`
+terminationGracePeriodSeconds: null
+
 # -- Annotations for the mobu frontend pod
 podAnnotations: {}
 


### PR DESCRIPTION
Add ability to specify a time for k8s to wait before killing mobu pods in the pod termination lifecycle.

For scale testing, with a lot of Nublado containers started, it can take a while for them all to shut down.