### PR TITLE
DM-48733: times-square - New template render route

### DIFF
--- a/applications/times-square/templates/ingress-templates.yaml
+++ b/applications/times-square/templates/ingress-templates.yaml
@@ -16,6 +16,7 @@ template:
     name: "{{ template "times-square.fullname" . }}-templates"
     {{- with .Values.ingress.annotations }}
     annotations:
+      nginx.ingress.kubernetes.io/use-regex: "true"
       {{- toYaml . | nindent 6 }}
     {{- end }}
   spec:
@@ -23,7 +24,14 @@ template:
       - host: {{ required "global.host must be set" .Values.global.host | quote }}
         http:
           paths:
-            - path: "{{- .Values.ingress.path -}}/v1/github/rendered/lsst-sqre/nublado-seeds/"
+            - path: "{{- .Values.ingress.path -}}/v1/pages/.*/rendered"
+              pathType: "ImplementationSpecific"
+              backend:
+                service:
+                  name: {{ template "times-square.fullname" . }}
+                  port:
+                    number: {{ .Values.service.port }}
+            - path: "{{- .Values.ingress.path -}}/v1/github"
               pathType: "Prefix"
               backend:
                 service:

--- a/applications/times-square/templates/ingress-templates.yaml
+++ b/applications/times-square/templates/ingress-templates.yaml
@@ -16,7 +16,6 @@ template:
     name: "{{ template "times-square.fullname" . }}-templates"
     {{- with .Values.ingress.annotations }}
     annotations:
-      nginx.ingress.kubernetes.io/use-regex: "true"
       {{- toYaml . | nindent 6 }}
     {{- end }}
   spec:
@@ -24,14 +23,7 @@ template:
       - host: {{ required "global.host must be set" .Values.global.host | quote }}
         http:
           paths:
-            - path: "{{- .Values.ingress.path -}}/v1/pages/.*/rendered"
-              pathType: "ImplementationSpecific"
-              backend:
-                service:
-                  name: {{ template "times-square.fullname" . }}
-                  port:
-                    number: {{ .Values.service.port }}
-            - path: "{{- .Values.ingress.path -}}/v1/github"
+            - path: "{{- .Values.ingress.path -}}/v1/github/rendered/lsst-sqre/nublado-seeds/"
               pathType: "Prefix"
               backend:
                 service:

--- a/applications/times-square/values-idfdev.yaml
+++ b/applications/times-square/values-idfdev.yaml
@@ -1,5 +1,6 @@
 image:
   pullPolicy: Always
+  tag: tickets-DM-48733-release
 ingress:
   defaultScope: "exec:admin"
 config:


### PR DESCRIPTION
A new endpoint was added to expose template rendering for a GitHub notebook template at a different path that includes the GitHub URL path for the notebook. This updates the template rendering `GafaelfawrIngress` to restrict rendering to only `lsst-sqre/nublado-seeds` repo notebooks.

Once this is merged, notebook-from-portal-query functionality won't work with any lab image that doesn't also have an `rsp-jupyter-extensions` package with [this change](https://github.com/lsst-sqre/rsp-jupyter-extensions/pull/42).