### PR TITLE
DM-48786: Bump Gafaelfawr version to 12.5.0

### DIFF
--- a/applications/gafaelfawr/Chart.yaml
+++ b/applications/gafaelfawr/Chart.yaml
@@ -5,7 +5,7 @@ description: "Authentication and identity system"
 home: "https://gafaelfawr.lsst.io/"
 sources:
   - "https://github.com/lsst-sqre/gafaelfawr"
-appVersion: 12.4.0
+appVersion: 12.5.0
 
 dependencies:
   - name: "redis"


### PR DESCRIPTION
This release has various fixes for quota and rate limiting support, including better logging and metrics.