### PR TITLE
DM-48661: Upgrade SIA to 0.1.6 and fix issue with SIA_ENVIRONMENT_NAME missing

### DIFF
--- a/applications/sia/Chart.yaml
+++ b/applications/sia/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.1.5
+appVersion: 0.1.6
 description: Simple Image Access (SIA) IVOA Service using Butler
 name: sia
 sources:

--- a/applications/sia/templates/deployment.yaml
+++ b/applications/sia/templates/deployment.yaml
@@ -57,15 +57,21 @@ spec:
             - name: "http"
               containerPort: 8080
               protocol: "TCP"
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: http
           readinessProbe:
             httpGet:
-              path: {{ .Values.config.pathPrefix }}
-              port: "http"
+              path: /healthcheck
+              port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:
             - name: "SIA_BUTLER_DATA_COLLECTIONS"
               value: {{ .Values.config.butlerDataCollections | toJson | quote }}
+            - name: "SIA_ENVIRONMENT_NAME"
+              value: {{ .Values.global.host }}
             {{- if .Values.config.slackAlerts }}
             - name: "SIA_SLACK_WEBHOOK"
               valueFrom:
@@ -91,8 +97,6 @@ spec:
                   key: "sentry-dsn"
             - name: "SIA_SENTRY_TRACES_SAMPLE_RATE"
               value: {{ .Values.config.sentryTracesSampleRate | quote }}
-            - name: "SIA_ENVIRONMENT_NAME"
-              value: {{ .Values.global.host }}
             {{- end }}
           {{- if .Values.config.directButlerEnabled }}
           volumeMounts:


### PR DESCRIPTION
Upgrades SIA to version 0.1.6 and fixes issue where SIA_ENVIRONMENT_NAME is now required by the sia application, but in phalanx was dependent on sentryEnabled being set to True