### PR TITLE
DM-48644: Squareone update with Apps menu

### DIFF
--- a/applications/squareone/Chart.yaml
+++ b/applications/squareone/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
     url: https://github.com/jonathansick
 
 # The default version tag of the squareone docker image
-appVersion: "0.17.0"
+appVersion: "0.18.0"

--- a/applications/squareone/README.md
+++ b/applications/squareone/README.md
@@ -18,10 +18,12 @@ Squareone is the homepage UI for the Rubin Science Platform.
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
 | config.apiAspectPageMdx | string | See `values.yaml` | MDX content for the `/api-aspect` page |
+| config.appLinks | list | `[{"href":"/argo-cd/","internal":false,"label":"Argo CD"}]` | App menu items |
 | config.coManageRegistryUrl | string | `nil` | URL to the COmanage registry, if the environment uses COmanage for identity. @default null disables the COmanage integration |
 | config.docsBaseUrl | string | `"https://rsp.lsst.io"` | Base URL for user documentation (excludes trailing slash) |
 | config.docsPageMdx | string | See `values.yaml` | MDX content for the `/docs` page |
 | config.emailVerifiedPageMdx | string | See `values.yaml` | MDX content for the `/enrollment/thanks-for-verifying` page |
+| config.enableAppsMenu | bool | `false` | Enable the App menu |
 | config.enableSentry | bool | See `values.yaml` | Enable Sentry |
 | config.pendingApprovalPageMdx | string | See `values.yaml` | MDX content for the `/enrollment/pending-approval` page |
 | config.pendingVerificationPageMdx | string | See `values.yaml` | MDX content for the `/enrollment/pending-confirmation` |

--- a/applications/squareone/templates/configmap.yaml
+++ b/applications/squareone/templates/configmap.yaml
@@ -37,3 +37,6 @@ data:
     sentryReplaysSessionSampleRate: {{ .Values.config.sentryReplaysSessionSampleRate }}
     sentryReplaysOnErrorSampleRate: {{ .Values.config.sentryReplaysOnErrorSampleRate }}
     sentryDebug: {{ .Values.config.sentryDebug }}
+    enableAppsMenu: {{ .Values.config.enableAppsMenu }}
+    appLinks:
+      {{- toYaml .Values.config.appLinks | nindent 6 }}

--- a/applications/squareone/values-idfdev.yaml
+++ b/applications/squareone/values-idfdev.yaml
@@ -28,3 +28,11 @@ config:
   enableSentry: true
   sentryTracesSampleRate: 1.0
   sentryReplaysOnErrorSampleRate: 1.0
+  enableAppsMenu: true
+  appLinks:
+    - label: "Times Square"
+      href: "/times-square/"
+      internal: true
+    - label: "Argo CD"
+      href: "/argo-cd/"
+      internal: false

--- a/applications/squareone/values-usdfdev.yaml
+++ b/applications/squareone/values-usdfdev.yaml
@@ -7,5 +7,13 @@ config:
   enableSentry: true
   sentryTracesSampleRate: 1.0
   sentryReplaysOnErrorSampleRate: 1.0
+  enableAppsMenu: true
+  appLinks:
+    - label: "Times Square"
+      href: "/times-square/"
+      internal: true
+    - label: "Argo CD"
+      href: "/argo-cd/"
+      internal: false
 ingress:
   timesSquareScope: "exec:notebook"

--- a/applications/squareone/values.yaml
+++ b/applications/squareone/values.yaml
@@ -356,6 +356,15 @@ config:
   # @default -- See `values.yaml`
   sentryDebug: false
 
+  # -- Enable the App menu
+  enableAppsMenu: false
+
+  # -- App menu items
+  appLinks:
+    - label: "Argo CD"
+      href: "/argo-cd/"
+      internal: false
+
 # Global parameters are set by parameters injected by the Argo CD Application
 # and should not be set in the individual environment values files.
 global:


### PR DESCRIPTION
This new version of Squareone features a re-engineered primary navigation with a configurable "Apps" menu for linking to apps like Times Square in the project RSPs.

See PR: https://github.com/lsst-sqre/squareone/pull/179