### PR TITLE
DM-48838: Increase resources for Nublado controller

### DIFF
--- a/applications/nublado/values.yaml
+++ b/applications/nublado/values.yaml
@@ -36,10 +36,10 @@ controller:
   resources:
     limits:
       cpu: "1"
-      memory: "200Mi"
+      memory: "400Mi"
     requests:
       cpu: "0.05"
-      memory: "120Mi"
+      memory: "200Mi"
 
   # -- Whether to enable Slack alerts. If set to true, `slack_webhook` must be
   # set in the corresponding Nublado Vault secret.


### PR DESCRIPTION
We would have run out of memory in the Nublado controller with a 1,000 pod scale test. Increase both the limits and the requests to give us more breathing room.