### PR TITLE
DM-48870: Update to Gafaelfawr 12.5.2

### DIFF
--- a/applications/gafaelfawr/Chart.yaml
+++ b/applications/gafaelfawr/Chart.yaml
@@ -5,7 +5,7 @@ description: "Authentication and identity system"
 home: "https://gafaelfawr.lsst.io/"
 sources:
   - "https://github.com/lsst-sqre/gafaelfawr"
-appVersion: 12.5.0
+appVersion: 12.5.2
 
 dependencies:
   - name: "redis"


### PR DESCRIPTION
Fixes parsing of the Redis password when constructing URLs, allowing Gafaelfawr to work correctly with passwords containing special characters.