### PR TITLE
Enable Sentry for TAP

### DIFF
--- a/applications/livetap/README.md
+++ b/applications/livetap/README.md
@@ -15,6 +15,7 @@ IVOA TAP service
 | cadc-tap.config.pg.database | string | `"lsstdb1"` | Postgres database to connect to |
 | cadc-tap.config.pg.host | string | `"mock-pg:5432"` (the mock pg) | Postgres hostname:port to connect to |
 | cadc-tap.config.pg.username | string | `"rubin"` | Postgres username to use to connect |
+| cadc-tap.config.sentryEnabled | bool | `false` | Whether Sentry is enabled in this environment |
 | cadc-tap.config.serviceName | string | `"livetap"` | Name of the service from Gafaelfawr's perspective |
 | cadc-tap.config.vaultSecretName | string | `"livetap"` | Vault secret name: the final key in the vault path |
 | cadc-tap.ingress.path | string | `"live"` | Ingress path that should be routed to this service |

--- a/applications/livetap/values.yaml
+++ b/applications/livetap/values.yaml
@@ -10,6 +10,9 @@ cadc-tap:
     # -- Name of the service from Gafaelfawr's perspective
     serviceName: "livetap"
 
+    # -- Whether Sentry is enabled in this environment
+    sentryEnabled: false
+
     pg:
       # -- Postgres hostname:port to connect to
       # @default -- `"mock-pg:5432"` (the mock pg)

--- a/applications/ssotap/README.md
+++ b/applications/ssotap/README.md
@@ -15,6 +15,7 @@ IVOA TAP service for Solar System Objects
 | cadc-tap.config.pg.database | string | `"dp03_catalogs"` | Postgres database to connect to |
 | cadc-tap.config.pg.host | string | `"usdf-pg-catalogs.slac.stanford.edu:5432"` | Postgres hostname:port to connect to |
 | cadc-tap.config.pg.username | string | `"dp03"` | Postgres username to use to connect |
+| cadc-tap.config.sentryEnabled | bool | `false` | Whether Sentry is enabled in this environment |
 | cadc-tap.config.serviceName | string | `"ssotap"` | Name of the service from Gafaelfawr's perspective |
 | cadc-tap.config.vaultSecretName | string | `"ssotap"` | Vault secret name: the final key in the vault path |
 | cadc-tap.ingress.path | string | `"ssotap"` | Ingress path that should be routed to this service |

--- a/applications/ssotap/values.yaml
+++ b/applications/ssotap/values.yaml
@@ -10,6 +10,9 @@ cadc-tap:
     # -- Name of the service from Gafaelfawr's perspective
     serviceName: "ssotap"
 
+    # -- Whether Sentry is enabled in this environment
+    sentryEnabled: false
+
     pg:
       # -- Postgres hostname:port to connect to
       host: "usdf-pg-catalogs.slac.stanford.edu:5432"

--- a/applications/tap/README.md
+++ b/applications/tap/README.md
@@ -12,6 +12,7 @@ IVOA TAP service
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | cadc-tap.config.backend | string | `"qserv"` | What type of backend? |
+| cadc-tap.config.sentryEnabled | bool | `false` | Whether Sentry is enabled in this environment |
 | cadc-tap.config.serviceName | string | `"tap"` | Name of the service from Gafaelfawr's perspective |
 | cadc-tap.config.vaultSecretName | string | `"tap"` | Vault secret name: the final key in the vault path |
 | cadc-tap.ingress.path | string | `"tap"` | Ingress path that should be routed to this service |

--- a/applications/tap/secrets-idfdev.yaml
+++ b/applications/tap/secrets-idfdev.yaml
@@ -5,3 +5,7 @@ qserv-password:
   description: >-
     Password for the QServ database server
   if: cadc-tap.config.qserv.passwordEnabled
+sentry-dsn:
+  description: >-
+    DSN URL to which Sentry trace and error logging will be sent.
+  if: cadc-tap.config.sentryEnabled

--- a/applications/tap/secrets-idfint.yaml
+++ b/applications/tap/secrets-idfint.yaml
@@ -5,3 +5,7 @@ qserv-password:
   description: >-
     Password for the QServ database server
   if: cadc-tap.config.qserv.passwordEnabled
+sentry-dsn:
+  description: >-
+    DSN URL to which Sentry trace and error logging will be sent.
+  if: cadc-tap.config.sentryEnabled

--- a/applications/tap/secrets.yaml
+++ b/applications/tap/secrets.yaml
@@ -2,3 +2,7 @@
   description: >-
     Google service account credentials used to write async job output to
     Google Cloud Storage.
+sentry-dsn:
+  description: >-
+    DSN URL to which Sentry trace and error logging will be sent.
+  if: cadc-tap.config.enableSentry

--- a/applications/tap/values-idfint.yaml
+++ b/applications/tap/values-idfint.yaml
@@ -9,6 +9,9 @@ cadc-tap:
       jdbcParams: "?enabledTLSProtocols=TLSv1.3"
       passwordEnabled: true
 
+    sentryEnabled: true
+    sentryTracesSampleRate: "0.1"
+
   cloudsql:
     enabled: true
     instanceConnectionName: "science-platform-int-dc5d:us-central1:science-platform-int-8f439af2"

--- a/applications/tap/values.yaml
+++ b/applications/tap/values.yaml
@@ -13,6 +13,9 @@ cadc-tap:
     # -- Name of the service from Gafaelfawr's perspective
     serviceName: "tap"
 
+    # -- Whether Sentry is enabled in this environment
+    sentryEnabled: false
+
   serviceAccount:
     # -- Name of the Kubernetes `ServiceAccount`, used for CloudSQL access
     name: "tap"

--- a/charts/cadc-tap/README.md
+++ b/charts/cadc-tap/README.md
@@ -36,9 +36,10 @@ IVOA TAP service
 | config.qserv.host | string | `"mock-db:3306"` (the mock QServ) | QServ hostname:port to connect to |
 | config.qserv.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the TAP image |
 | config.qserv.image.repository | string | `"ghcr.io/lsst-sqre/lsst-tap-service"` | TAP image to use |
-| config.qserv.image.tag | string | `"2.8.0"` | Tag of TAP image to use |
+| config.qserv.image.tag | string | `"2.9.0"` | Tag of TAP image to use |
 | config.qserv.jdbcParams | string | `""` | Extra JDBC connection parameters |
 | config.qserv.passwordEnabled | bool | false | Whether the Qserv database is password protected |
+| config.sentryEnabled | bool | `false` | Whether Sentry is enabled in this environment |
 | config.serviceName | string | None, must be set | Name of the service from Gafaelfawr's perspective, used for metrics reporting |
 | config.tapSchemaAddress | string | `"cadc-tap-schema-db:3306"` | Address to a MySQL database containing TAP schema data |
 | config.vaultSecretName | string | `""` | Vault secret name, this is appended to the global path to find the vault secrets associated with this deployment. |
@@ -79,7 +80,7 @@ IVOA TAP service
 | uws.affinity | object | `{}` | Affinity rules for the UWS database pod |
 | uws.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the UWS database image |
 | uws.image.repository | string | `"ghcr.io/lsst-sqre/lsst-tap-uws-db"` | UWS database image to use |
-| uws.image.tag | string | `"2.8.0"` | Tag of UWS database image to use |
+| uws.image.tag | string | `"2.9.0"` | Tag of UWS database image to use |
 | uws.nodeSelector | object | `{}` | Node selection rules for the UWS database pod |
 | uws.podAnnotations | object | `{}` | Annotations for the UWS databse pod |
 | uws.resources | object | See `values.yaml` | Resource limits and requests for the UWS database pod |

--- a/charts/cadc-tap/templates/tap-deployment.yaml
+++ b/charts/cadc-tap/templates/tap-deployment.yaml
@@ -98,16 +98,35 @@ spec:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: "/etc/creds/google_creds.json"
             {{- if eq .Values.config.gcsBucketType "S3" }}
-            - name: AWS_SECRET_ACCESS_KEY
+            - name: "AWS_SECRET_ACCESS_KEY"
               valueFrom:
                 secretKeyRef:
-                  name: cadc-tap
+                  name: "cadc-tap"
                   key: "AWS_SECRET_ACCESS_KEY"
-            - name: AWS_ACCESS_KEY_ID
+            - name: "AWS_ACCESS_KEY_ID"
               valueFrom:
                 secretKeyRef:
-                  name: cadc-tap
+                  name: "cadc-tap"
                   key: "AWS_ACCESS_KEY_ID"
+            {{- end }}
+            {{- if .Values.config.sentryEnabled }}
+            - name: "SENTRY_TRACES_SAMPLE_RATE"
+              value: "{{ .Values.config.sentryTracesSampleRate }}"
+            - name: "SENTRY_ENVIRONMENT"
+              value: {{ .Values.global.host }}
+            - name: "SENTRY_RELEASE"
+              {{- if eq .Values.config.backend "pg" }}
+              value: "{{ .Values.config.pg.image.tag }}"
+              {{- else if eq .Values.config.backend "qserv" }}
+              value: "{{ .Values.config.qserv.image.tag }}"
+              {{- else }}
+              value: "{{ .Chart.AppVersion }}"
+              {{- end }}
+            - name: "SENTRY_DSN"
+              valueFrom:
+                secretKeyRef:
+                  name: "cadc-tap"
+                  key: "sentry-dsn"
             {{- end }}
             - name: DATALINK_PAYLOAD_URL
               value: "{{ .Values.config.datalinkPayloadUrl }}"

--- a/charts/cadc-tap/values.yaml
+++ b/charts/cadc-tap/values.yaml
@@ -89,7 +89,7 @@ config:
       pullPolicy: "IfNotPresent"
 
       # -- Tag of TAP image to use
-      tag: "2.8.0"
+      tag: "2.9.0"
 
     # -- Whether the Qserv database is password protected
     # @default -- false
@@ -123,6 +123,9 @@ config:
   # -- Vault secret name, this is appended to the global path to find the
   # vault secrets associated with this deployment.
   vaultSecretName: ""
+
+  # -- Whether Sentry is enabled in this environment
+  sentryEnabled: false
 
 mockdb:
   # -- Spin up a container to pretend to be the database.
@@ -200,7 +203,7 @@ uws:
     pullPolicy: "IfNotPresent"
 
     # -- Tag of UWS database image to use
-    tag: "2.8.0"
+    tag: "2.9.0"
 
   # -- Resource limits and requests for the UWS database pod
   # @default -- See `values.yaml`


### PR DESCRIPTION
## Description

Enable Sentry error logging and tracing for TAP service. 
Enables for idfint & idfdev. If left disabled TAP services for other environments should continue to work without any noticeable change.

## Jira Issue

https://rubinobs.atlassian.net/browse/DM-48801

## Related PR in TAP service

https://github.com/lsst-sqre/lsst-tap-service/pull/127

## Tests

I've tested on an dev & int with SENTRY_DSN enabled, and then the same build with SENTRY_DSN disabled in phalanx to ensure that tracing doesn't get sent in the second case

## TODO Before merge

Set image of TAP service to new release before merging