### PR TITLE
[DM-48910]  Review Kafka controllers node IDs assignment

### DIFF
--- a/applications/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
@@ -5,10 +5,8 @@ metadata:
   name: controller
   labels:
     strimzi.io/cluster: {{ .Values.cluster.name }}
-  {{- with .Values.kafkaController.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+    strimzi.io/next-node-ids: "[3,4,5]"
 spec:
   replicas: {{ .Values.kafka.replicas }}
   roles:
@@ -37,7 +35,7 @@ metadata:
   labels:
     strimzi.io/cluster: {{ .Values.cluster.name }}
   annotations:
-    strimzi.io/next-node-ids: "[0-99]"
+    strimzi.io/next-node-ids: "[0,1,2]"
 spec:
   replicas: {{ .Values.kafka.replicas }}
   roles:
@@ -66,7 +64,7 @@ metadata:
   labels:
     strimzi.io/cluster: {{ .Values.cluster.name }}
   annotations:
-    strimzi.io/next-node-ids: "[6-99]"
+    strimzi.io/next-node-ids: "[6,7,8]"
 spec:
   replicas: {{ .Values.kafka.replicas }}
   roles:

--- a/applications/sasquatch/values-base.yaml
+++ b/applications/sasquatch/values-base.yaml
@@ -70,8 +70,6 @@ strimzi-kafka:
     enabled: true
   kafkaController:
     enabled: true
-    annotations:
-      strimzi.io/next-node-ids: "(3,4,5)"
     resources:
       requests:
         memory: 8Gi

--- a/applications/sasquatch/values-summit.yaml
+++ b/applications/sasquatch/values-summit.yaml
@@ -56,8 +56,6 @@ strimzi-kafka:
     enabled: true
   kafkaController:
     enabled: true
-    annotations:
-      strimzi.io/next-node-ids: "(3,4,5)"
     resources:
       requests:
         memory: 8Gi


### PR DESCRIPTION
This PR fixes the annotation to assign node IDs in the KafkaNodepools and tries to uniformize the IDs across the different Sasquatch environments, the following rule seems to work:

- Always assign IDs 3,4,5 to controllers in all Sasquatch environments. 
- Assign IDs 0,1,2 to brokers deployed on default storage.
- Assign IDs 6,7,8 to brokers deployed on local storage.

The story behind this is that originally we had the broker IDs 0,1,2 and controller IDs 3,4,5 everywhere.
Then we [migrated the Kafka brokers](https://sasquatch.lsst.io/developer-guide/broker-migration.html) in some Sasquatch environmets (BTS, Summit and USDF) to use local storage. 
The broker migration process creates new brokers with IDs 6,7,8 and remove the old brokers with IDs 0,1,2 after the migration.

