### PR TITLE
DM-48733: Noteburst in `idfint` and `idfprod`

### DIFF
--- a/applications/noteburst/values-idfint.yaml
+++ b/applications/noteburst/values-idfint.yaml
@@ -1,0 +1,16 @@
+config:
+  logLevel: "DEBUG"
+  worker:
+    workerCount: 1
+    identities:
+      - username: "bot-noteburst001"
+      - username: "bot-noteburst002"
+      - username: "bot-noteburst003"
+      - username: "bot-noteburst004"
+      - username: "bot-noteburst005"
+      - username: "bot-noteburst006"
+
+# Use SSD for Redis storage.
+redis:
+  persistence:
+    storageClass: "premium-rwo"

--- a/applications/noteburst/values-idfprod.yaml
+++ b/applications/noteburst/values-idfprod.yaml
@@ -1,0 +1,15 @@
+config:
+  worker:
+    workerCount: 1
+    identities:
+      - username: "bot-noteburst001"
+      - username: "bot-noteburst002"
+      - username: "bot-noteburst003"
+      - username: "bot-noteburst004"
+      - username: "bot-noteburst005"
+      - username: "bot-noteburst006"
+
+# Use SSD for Redis storage.
+redis:
+  persistence:
+    storageClass: "premium-rwo"

--- a/applications/squareone/values-idfint.yaml
+++ b/applications/squareone/values-idfint.yaml
@@ -5,6 +5,7 @@ config:
   siteName: "Rubin Science Platform @ data-int"
   docsBaseUrl: "https://rsp.lsst.io/v/idfint"
   semaphoreUrl: "https://data-int.lsst.cloud/semaphore"
+  timesSquareUrl: "https://data-int.lsst.cloud/times-square/api"
   coManageRegistryUrl: "https://id-int.lsst.cloud"
   apiAspectPageMdx: |
     # Rubin Science Platform APIs

--- a/applications/squareone/values-idfprod.yaml
+++ b/applications/squareone/values-idfprod.yaml
@@ -7,6 +7,7 @@ config:
   siteName: "Rubin Science Platform"
   docsBaseUrl: "https://rsp.lsst.io"
   semaphoreUrl: "https://data.lsst.cloud/semaphore"
+  timesSquareUrl: "https://data.lsst.cloud/times-square/api"
   coManageRegistryUrl: "https://id.lsst.cloud"
   plausibleDomain: "data.lsst.cloud"
   enableSentry: true

--- a/environments/values-idfint.yaml
+++ b/environments/values-idfint.yaml
@@ -19,6 +19,7 @@ applications:
   ghostwriter: true
   hips: true
   mobu: true
+  noteburst: true
   nublado: true
   portal: true
   sasquatch: true

--- a/environments/values-idfprod.yaml
+++ b/environments/values-idfprod.yaml
@@ -20,6 +20,7 @@ applications:
   ghostwriter: true
   hips: true
   mobu: true
+  noteburst: true
   nublado: true
   portal: true
   sasquatch: true


### PR DESCRIPTION
* Enable Noteburst in `idfint` and `idfprod`
* Add the times-square URL to Squareone in `idfint` and `idfprod`

Note that the default Times Square scope is `exec:admin`, and the template api scope is `exec:notebook` in both envs already. This means that only admins will be able to execute notebooks. It does allow anyone with `exce:notebook` to render any templates though, until we [change the template render routes in the ingress](https://github.com/lsst-sqre/phalanx/pull/4172)