### PR TITLE
DM-48957: Change defaults for secrets migration

### DIFF
--- a/applications/datalinker/README.md
+++ b/applications/datalinker/README.md
@@ -20,7 +20,6 @@ IVOA DataLink-based service and data discovery
 | config.pathPrefix | string | `"/api/datalink"` | URL path prefix for DataLink and related APIs |
 | config.pgUser | string | `"rubin"` | User to use from the PGPASSFILE if datalinker is using a direct Butler connection (`useButlerServer` is false) |
 | config.s3EndpointUrl | string | `"https://storage.googleapis.com"` | S3 endpoint URL (must be set if using S3) |
-| config.separateSecrets | bool | `false` | Whether to use the new secrets management scheme |
 | config.slackAlerts | bool | `false` | Whether to send certain serious alerts to Slack. If `true`, the `slack-webhook` secret must also be set. |
 | config.storageBackend | string | `"GCS"` | Storage backend to use (either `GCS` or `S3`) |
 | config.tapMetadataUrl | string | `"https://github.com/lsst/sdm_schemas/releases/download/1.2.0/datalink-columns.zip"` | URL containing TAP schema metadata used to construct queries |

--- a/applications/datalinker/templates/vault-secrets.yaml
+++ b/applications/datalinker/templates/vault-secrets.yaml
@@ -5,9 +5,5 @@ metadata:
   labels:
     {{- include "datalinker.labels" . | nindent 4 }}
 spec:
-{{- if .Values.config.separateSecrets }}
   path: "{{ .Values.global.vaultSecretsPath }}/datalinker"
-{{- else }}
-  path: "{{ .Values.global.vaultSecretsPath }}/butler-secret"
-{{- end }}
   type: Opaque

--- a/applications/datalinker/values-ccin2p3.yaml
+++ b/applications/datalinker/values-ccin2p3.yaml
@@ -1,3 +1,2 @@
 config:
-  separateSecrets: true
   tapMetadataUrl: "https://github.com/gabrimaine/sdm_schemas/releases/download/2.4.1/datalink-columns.zip"

--- a/applications/datalinker/values-idfdemo.yaml
+++ b/applications/datalinker/values-idfdemo.yaml
@@ -1,3 +1,2 @@
 config:
-  separateSecrets: true
   slackAlerts: true

--- a/applications/datalinker/values-idfdev.yaml
+++ b/applications/datalinker/values-idfdev.yaml
@@ -1,3 +1,2 @@
 config:
-  separateSecrets: true
   slackAlerts: true

--- a/applications/datalinker/values-idfint.yaml
+++ b/applications/datalinker/values-idfint.yaml
@@ -1,3 +1,2 @@
 config:
-  separateSecrets: true
   slackAlerts: true

--- a/applications/datalinker/values-idfprod.yaml
+++ b/applications/datalinker/values-idfprod.yaml
@@ -1,3 +1,2 @@
 config:
-  separateSecrets: true
   slackAlerts: true

--- a/applications/datalinker/values-usdfdev.yaml
+++ b/applications/datalinker/values-usdfdev.yaml
@@ -1,2 +1,0 @@
-config:
-  separateSecrets: true

--- a/applications/datalinker/values-usdfint.yaml
+++ b/applications/datalinker/values-usdfint.yaml
@@ -1,2 +1,0 @@
-config:
-  separateSecrets: true

--- a/applications/datalinker/values-usdfprod.yaml
+++ b/applications/datalinker/values-usdfprod.yaml
@@ -1,2 +1,0 @@
-config:
-  separateSecrets: true

--- a/applications/datalinker/values.yaml
+++ b/applications/datalinker/values.yaml
@@ -58,9 +58,6 @@ config:
   # -- S3 endpoint URL (must be set if using S3)
   s3EndpointUrl: "https://storage.googleapis.com"
 
-  # -- Whether to use the new secrets management scheme
-  separateSecrets: false
-
   # -- User to use from the PGPASSFILE if datalinker is using a direct Butler
   # connection (`useButlerServer` is false)
   pgUser: "rubin"

--- a/applications/nightreport/README.md
+++ b/applications/nightreport/README.md
@@ -26,7 +26,6 @@ Night report log service
 | fullnameOverride | string | `""` | Override the full name for resources (includes the release name) |
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
-| global.tsVaultSecretsPath | string | `""` | Relative path for tsVault secrets |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | image.pullPolicy | string | `"Always"` | Pull policy for the nightreport image |
 | image.repository | string | `"lsstts/nightreport"` | nightreport image to use |

--- a/applications/nightreport/templates/vault-secrets.yaml
+++ b/applications/nightreport/templates/vault-secrets.yaml
@@ -4,7 +4,7 @@ metadata:
   name: nightreport
   namespace: nightreport
 spec:
-  path: "{{- .Values.global.vaultSecretsPath }}{{ .Values.global.tsVaultSecretsPath }}/nightreport"
+  path: "{{- .Values.global.vaultSecretsPath }}/nightreport"
   type: Opaque
 ---
 apiVersion: ricoberger.de/v1alpha1

--- a/applications/nightreport/values-base.yaml
+++ b/applications/nightreport/values-base.yaml
@@ -6,5 +6,3 @@ config:
   site_id: base
 db:
   host: postgresdb01.ls.lsst.org
-global:
-  tsVaultSecretsPath: ""

--- a/applications/nightreport/values-summit.yaml
+++ b/applications/nightreport/values-summit.yaml
@@ -6,5 +6,3 @@ config:
   site_id: summit
 db:
   host: postgresdb01.cp.lsst.org
-global:
-  tsVaultSecretsPath: ""

--- a/applications/nightreport/values-tucson-teststand.yaml
+++ b/applications/nightreport/values-tucson-teststand.yaml
@@ -6,5 +6,3 @@ config:
   site_id: tucson
 db:
   host: postgresdb01.tu.lsst.org
-global:
-  tsVaultSecretsPath: ""

--- a/applications/nightreport/values.yaml
+++ b/applications/nightreport/values.yaml
@@ -108,6 +108,3 @@ global:
   # -- Base path for Vault secrets
   # @default -- Set by Argo CD
   vaultSecretsPath: ""
-
-  # -- Relative path for tsVault secrets
-  tsVaultSecretsPath: ""

--- a/applications/nublado/README.md
+++ b/applications/nublado/README.md
@@ -93,7 +93,7 @@ JupyterHub and custom spawner for the Rubin Science Platform
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
-| hub.internalDatabase | bool | `true` | Whether to use the cluster-internal PostgreSQL server instead of an external server. This is not used directly by the Nublado chart, but controls how the database password is managed. |
+| hub.internalDatabase | bool | `false` | Whether to use the cluster-internal PostgreSQL server instead of an external server. This is not used directly by the Nublado chart, but controls how the database password is managed. |
 | hub.minimumTokenLifetime | string | `jupyterhub.cull.maxAge` if lab culling is enabled, else none | Minimum remaining token lifetime when spawning a lab. The token cannot be renewed, so it should ideally live as long as the lab does. If the token has less remaining lifetime, the user will be redirected to reauthenticate before spawning a lab. |
 | hub.resources | object | See `values.yaml` | Resource limits and requests for the Hub |
 | hub.timeout.startup | int | `90` | Timeout for JupyterLab to start in seconds. Currently this sometimes takes over 60 seconds for reasons we don't understand. |
@@ -128,4 +128,4 @@ JupyterHub and custom spawner for the Rubin Science Platform
 | jupyterhub.scheduling.userPlaceholder.enabled | bool | `false` | Whether to spawn placeholder pods representing fake users to force autoscaling in advance of running out of resources |
 | jupyterhub.scheduling.userScheduler.enabled | bool | `false` | Whether the user scheduler should be enabled |
 | proxy.ingress.annotations | object | See `values.yaml` | Additional annotations to add to the proxy ingress (also used to talk to JupyterHub and all user labs) |
-| secrets.templateSecrets | bool | `false` | Whether to use the new secrets management mechanism. If enabled, the Vault nublado secret will be split into a nublado secret for JupyterHub and a nublado-lab-secret secret used as a source for secret values for the user's lab. |
+| secrets.templateSecrets | bool | `true` | Whether to use the new secrets management mechanism. If enabled, the Vault nublado secret will be split into a nublado secret for JupyterHub and a nublado-lab-secret secret used as a source for secret values for the user's lab. |

--- a/applications/nublado/values-base.yaml
+++ b/applications/nublado/values-base.yaml
@@ -97,14 +97,8 @@ controller:
         - containerPath: "/data/lsstdata/BTS/auxtel"
           volumeName: "auxtel"
 
-hub:
-  internalDatabase: false
-
 jupyterhub:
   hub:
     db:
       upgrade: true
       url: "postgresql://nublado3@postgresdb01.ls.lsst.org/nublado3"
-
-secrets:
-  templateSecrets: true

--- a/applications/nublado/values-ccin2p3.yaml
+++ b/applications/nublado/values-ccin2p3.yaml
@@ -81,7 +81,3 @@ jupyterhub:
     timeout: 432000
     every: 300
     maxAge: 604800
-hub:
-  internalDatabase: false
-secrets:
-  templateSecrets: true

--- a/applications/nublado/values-idfdemo.yaml
+++ b/applications/nublado/values-idfdemo.yaml
@@ -69,11 +69,7 @@ jupyterhub:
   hub:
     db:
       url: "postgresql://nublado@cloud-sql-proxy.nublado/nublado"
-hub:
-  internalDatabase: false
 cloudsql:
   enabled: true
   instanceConnectionName: "science-platform-demo-9e05:us-central1:science-platform-demo-a4dbbf96"
   serviceAccount: "nublado@science-platform-demo-9e05.iam.gserviceaccount.com"
-secrets:
-  templateSecrets: true

--- a/applications/nublado/values-idfdev.yaml
+++ b/applications/nublado/values-idfdev.yaml
@@ -84,11 +84,7 @@ jupyterhub:
     db:
       upgrade: true
       url: "postgresql://nublado@cloud-sql-proxy.nublado/nublado"
-hub:
-  internalDatabase: false
 cloudsql:
   enabled: true
   instanceConnectionName: "science-platform-dev-7696:us-central1:science-platform-dev-e9e11de2"
   serviceAccount: "nublado@science-platform-dev-7696.iam.gserviceaccount.com"
-secrets:
-  templateSecrets: true

--- a/applications/nublado/values-idfint.yaml
+++ b/applications/nublado/values-idfint.yaml
@@ -109,11 +109,7 @@ jupyterhub:
       url: "postgresql://nublado@cloud-sql-proxy.nublado/nublado"
       upgrade: true
 
-hub:
-  internalDatabase: false
 cloudsql:
   enabled: true
   instanceConnectionName: "science-platform-int-dc5d:us-central1:science-platform-int-8f439af2"
   serviceAccount: "nublado@science-platform-int-dc5d.iam.gserviceaccount.com"
-secrets:
-  templateSecrets: true

--- a/applications/nublado/values-idfprod.yaml
+++ b/applications/nublado/values-idfprod.yaml
@@ -88,12 +88,7 @@ jupyterhub:
       url: "postgresql://nublado@cloud-sql-proxy.nublado/nublado"
       upgrade: true
 
-hub:
-  internalDatabase: false
-
 cloudsql:
   enabled: true
   instanceConnectionName: "science-platform-stable-6994:us-central1:science-platform-stable-0c29612b"
   serviceAccount: "nublado@science-platform-stable-6994.iam.gserviceaccount.com"
-secrets:
-  templateSecrets: true

--- a/applications/nublado/values-roe.yaml
+++ b/applications/nublado/values-roe.yaml
@@ -51,7 +51,13 @@ proxy:
       nginx.ingress.kubernetes.io/proxy-read-timeout: "50s"
       nginx.ingress.kubernetes.io/client-max-body-size: "50m"
 
+hub:
+  internalDatabase: true
+
 jupyterhub:
   hub:
     db:
       upgrade: true
+
+secrets:
+  templateSecrets: false

--- a/applications/nublado/values-summit.yaml
+++ b/applications/nublado/values-summit.yaml
@@ -137,14 +137,8 @@ controller:
         - containerPath: "/data/lsstdata/base/maintel"
           volumeName: "lsstdata-base-lsstcam"
 
-hub:
-  internalDatabase: false
-
 jupyterhub:
   hub:
     db:
       upgrade: true
       url: "postgresql://nublado3@postgresdb01.cp.lsst.org/nublado3"
-
-secrets:
-  templateSecrets: true

--- a/applications/nublado/values-tucson-teststand.yaml
+++ b/applications/nublado/values-tucson-teststand.yaml
@@ -100,14 +100,8 @@ controller:
         - containerPath: "/data/lsstdata/TTS/comcam"
           volumeName: "comcam"
 
-hub:
-  internalDatabase: false
-
 jupyterhub:
   hub:
     db:
       upgrade: true
       url: "postgresql://nublado3@postgresdb01.tu.lsst.org/nublado3"
-
-secrets:
-  templateSecrets: true

--- a/applications/nublado/values-usdfdev.yaml
+++ b/applications/nublado/values-usdfdev.yaml
@@ -140,6 +140,3 @@ jupyterhub:
 
 hub:
   internalDatabase: true
-
-secrets:
-  templateSecrets: true

--- a/applications/nublado/values-usdfint.yaml
+++ b/applications/nublado/values-usdfint.yaml
@@ -140,6 +140,3 @@ jupyterhub:
 
 hub:
   internalDatabase: true
-
-secrets:
-  templateSecrets: true

--- a/applications/nublado/values-usdfprod.yaml
+++ b/applications/nublado/values-usdfprod.yaml
@@ -136,3 +136,9 @@ jupyterhub:
   cull:
     timeout: 432000  # 5 days
     maxAge: 691200  # 8 days
+
+hub:
+  internalDatabase: true
+
+secrets:
+  templateSecrets: false

--- a/applications/nublado/values.yaml
+++ b/applications/nublado/values.yaml
@@ -399,7 +399,7 @@ hub:
   # -- Whether to use the cluster-internal PostgreSQL server instead of an
   # external server. This is not used directly by the Nublado chart, but
   # controls how the database password is managed.
-  internalDatabase: true
+  internalDatabase: false
 
   # -- Minimum remaining token lifetime when spawning a lab. The token cannot
   # be renewed, so it should ideally live as long as the lab does. If the
@@ -658,7 +658,7 @@ secrets:
   # Vault nublado secret will be split into a nublado secret for JupyterHub
   # and a nublado-lab-secret secret used as a source for secret values for the
   # user's lab.
-  templateSecrets: false
+  templateSecrets: true
 
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.

--- a/applications/obsloctap/README.md
+++ b/applications/obsloctap/README.md
@@ -13,7 +13,7 @@ Publish observing schedule
 | config.obsplanLimit | int | `1000` | limit for obsplan query |
 | config.obsplanTimeSpan | int | `24` | time span, if a time is provided in the query how man hours to look back |
 | config.persistentVolumeClaims | list | `[]` | PersistentVolumeClaims to create. |
-| config.separateSecrets | bool | `false` | Whether to use the new secrets management scheme |
+| config.separateSecrets | bool | `true` | Whether to use the new secrets management scheme |
 | config.volume_mounts | list | `[]` | Mount points for additional volumes |
 | config.volumes | list | `[]` | Additional volumes to attach |
 | environment | object | `{}` | Environment variables (e.g. butler configuration/auth parms) for panel |

--- a/applications/obsloctap/values-usdfdev.yaml
+++ b/applications/obsloctap/values-usdfdev.yaml
@@ -11,6 +11,7 @@ environment:
   obsloctapVaultPrefix: secret/rubin/usdf-butler/postgres
 
 config:
+  separateSecrets: false
   volumes:
     - name: sdf-group-rubin
       persistentVolumeClaim:
@@ -31,7 +32,6 @@ config:
 
 image:
   pullPolicy: Always
-
 
 controller:
   config:

--- a/applications/obsloctap/values.yaml
+++ b/applications/obsloctap/values.yaml
@@ -27,7 +27,7 @@ config:
   persistentVolumeClaims: []
 
   # -- Whether to use the new secrets management scheme
-  separateSecrets: false
+  separateSecrets: true
 
   # -- limit for obsplan query
   obsplanLimit: 1000

--- a/applications/plot-navigator/README.md
+++ b/applications/plot-navigator/README.md
@@ -11,7 +11,7 @@ Plot-navigator
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | config.persistentVolumeClaims | list | `[]` | PersistentVolumeClaims to create. |
-| config.separateSecrets | bool | `false` | Whether to use the new secrets management scheme |
+| config.separateSecrets | bool | `true` | Whether to use the new secrets management scheme |
 | config.volume_mounts | list | `[]` | Mount points for additional volumes |
 | config.volumes | list | `[]` | Additional volumes to attach |
 | environment | object | `{}` | Environment variables (e.g. butler configuration/auth parms) for the nextjs server |

--- a/applications/plot-navigator/values-usdfdev.yaml
+++ b/applications/plot-navigator/values-usdfdev.yaml
@@ -5,6 +5,7 @@ environment:
   BUCKET_URL: "https://s3dfrgw.slac.stanford.edu/"
 
 config:
+  separateSecrets: false
   persistentVolumeClaims:
     - name: sdf-group-rubin
       storageClassName: sdf-group-rubin

--- a/applications/plot-navigator/values-usdfint.yaml
+++ b/applications/plot-navigator/values-usdfint.yaml
@@ -5,6 +5,7 @@ environment:
   BUCKET_URL: "https://s3dfrgw.slac.stanford.edu/"
 
 config:
+  separateSecrets: false
   persistentVolumeClaims:
     - name: sdf-group-rubin
       storageClassName: sdf-group-rubin

--- a/applications/plot-navigator/values-usdfprod.yaml
+++ b/applications/plot-navigator/values-usdfprod.yaml
@@ -5,6 +5,7 @@ environment:
   BUCKET_URL: "https://s3dfrgw.slac.stanford.edu/"
 
 config:
+  separateSecrets: false
   persistentVolumeClaims:
     - name: sdf-group-rubin
       storageClassName: sdf-group-rubin

--- a/applications/plot-navigator/values.yaml
+++ b/applications/plot-navigator/values.yaml
@@ -24,7 +24,7 @@ config:
   persistentVolumeClaims: []
 
   # -- Whether to use the new secrets management scheme
-  separateSecrets: false
+  separateSecrets: true
 
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.

--- a/applications/production-tools/README.md
+++ b/applications/production-tools/README.md
@@ -11,7 +11,6 @@ A collection of utility pages for monitoring data processing.
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules for the production-tools deployment pod |
-| config.separateSecrets | bool | `false` | Whether to use the new secrets management scheme |
 | environment | object | `{}` |  |
 | fullnameOverride | string | `""` | Override the full name for resources (includes the release name) |
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |

--- a/applications/production-tools/templates/vault-secrets.yaml
+++ b/applications/production-tools/templates/vault-secrets.yaml
@@ -5,11 +5,7 @@ metadata:
   labels:
     {{- include "production-tools.labels" . | nindent 4 }}
 spec:
-{{- if .Values.config.separateSecrets }}
   path: "{{ .Values.global.vaultSecretsPath }}/production-tools"
-{{- else }}
-  path: "{{ .Values.global.vaultSecretsPath }}/butler-secret"
-{{- end }}
   type: Opaque
 ---
 apiVersion: ricoberger.de/v1alpha1

--- a/applications/production-tools/values-idfint.yaml
+++ b/applications/production-tools/values-idfint.yaml
@@ -3,5 +3,3 @@ environment:
   LOG_BUCKET: "drp-us-central1-logging"
   LOG_PREFIX: "Panda-RubinLog"
   WEB_CONCURRENCY: "4"
-config:
-  separateSecrets: true

--- a/applications/production-tools/values.yaml
+++ b/applications/production-tools/values.yaml
@@ -32,10 +32,6 @@ ingress:
   # -- Additional annotations for the ingress rule
   annotations: {}
 
-config:
-  # -- Whether to use the new secrets management scheme
-  separateSecrets: false
-
 # -- Resource limits and requests for the production-tools deployment pod
 resources: {}
 

--- a/applications/rubintv-dev/README.md
+++ b/applications/rubintv-dev/README.md
@@ -12,7 +12,6 @@ Real-time display front end development application
 |-----|------|---------|-------------|
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
-| global.tsVaultSecretsPath | string | `""` | Relative path for tsVault secrets |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | redis.affinity | object | `{}` | Affinity rules for the Redis pod |
 | redis.config.secretKey | string | `"redis-password"` | Key inside secret from which to get the Redis password (do not change) |
@@ -41,7 +40,6 @@ Real-time display front end development application
 | rubintv.imagePullSecrets | list | See `values.yaml` | Image pull secrets. |
 | rubintv.ingress.annotations | object | `{}` | Additional annotations to add to the ingress |
 | rubintv.nameOverride | string | `""` | Override the base name for resources |
-| rubintv.separateSecrets | bool | `false` | Whether to use the new secrets management scheme |
 | rubintv.siteTag | string | `""` | A special tag for letting the scripts know where they are running.  Must be overridden at each site |
 | rubintv.workers.affinity | object | `{}` | Affinity rules for the rubintv-dev worker pods |
 | rubintv.workers.debug | bool | `false` | If set to true, enable more verbose logging. |

--- a/applications/rubintv-dev/values-summit.yaml
+++ b/applications/rubintv-dev/values-summit.yaml
@@ -4,8 +4,6 @@ rubintv:
   imagePullSecrets:
   - name: pull-secret
 
-  separateSecrets: true
-
   frontend:
     debug: true
     env:
@@ -56,6 +54,3 @@ rubintv:
       limits:
         cpu: 1.0
         memory: 2.5G
-
-global:
-  tsVaultSecretsPath: ""

--- a/applications/rubintv-dev/values.yaml
+++ b/applications/rubintv-dev/values.yaml
@@ -14,9 +14,6 @@ rubintv:
   imagePullSecrets: []
   # Each entry is of the form: { name: pull-secret-name }
 
-  # -- Whether to use the new secrets management scheme
-  separateSecrets: false
-
   frontend:
     # -- If set to true, enable more verbose logging.
     debug: false
@@ -188,7 +185,6 @@ redis:
   # -- Affinity rules for the Redis pod
   affinity: {}
 
-
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:
@@ -203,6 +199,3 @@ global:
   # -- Base path for Vault secrets
   # @default -- Set by Argo CD
   vaultSecretsPath: ""
-
-  # -- Relative path for tsVault secrets
-  tsVaultSecretsPath: ""

--- a/applications/rubintv/README.md
+++ b/applications/rubintv/README.md
@@ -12,7 +12,6 @@ Real-time display front end
 |-----|------|---------|-------------|
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
-| global.tsVaultSecretsPath | string | `""` | Relative path for tsVault secrets |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | redis.affinity | object | `{}` | Affinity rules for the Redis pod |
 | redis.config.secretKey | string | `"redis-password"` | Key inside secret from which to get the Redis password (do not change) |
@@ -41,7 +40,7 @@ Real-time display front end
 | rubintv.imagePullSecrets | list | See `values.yaml` | Image pull secrets. |
 | rubintv.ingress.annotations | object | `{}` | Additional annotations to add to the ingress |
 | rubintv.nameOverride | string | `""` | Override the base name for resources |
-| rubintv.separateSecrets | bool | `false` | Whether to use the new secrets management scheme |
+| rubintv.separateSecrets | bool | `true` | Whether to use the new secrets management scheme |
 | rubintv.siteTag | string | `""` | A special tag for letting the scripts know where they are running.  Must be overridden at each site |
 | rubintv.workers.affinity | object | `{}` | Affinity rules for the rubintv worker pods |
 | rubintv.workers.debug | bool | `false` | If set to true, enable more verbose logging. |

--- a/applications/rubintv/values-base.yaml
+++ b/applications/rubintv/values-base.yaml
@@ -1,6 +1,5 @@
 rubintv:
   siteTag: "base"
-  separateSecrets: true
 
   imagePullSecrets:
   - name: pull-secret
@@ -37,6 +36,3 @@ rubintv:
       limits:
         cpu: 2.0
         memory: "8Gi"
-
-global:
-  tsVaultSecretsPath: ""

--- a/applications/rubintv/values-summit.yaml
+++ b/applications/rubintv/values-summit.yaml
@@ -4,8 +4,6 @@ rubintv:
   imagePullSecrets:
   - name: pull-secret
 
-  separateSecrets: true
-
   frontend:
     debug: true
     env:
@@ -55,6 +53,3 @@ rubintv:
       limits:
         cpu: 1.0
         memory: 2.5G
-
-global:
-  tsVaultSecretsPath: ""

--- a/applications/rubintv/values-tucson-teststand.yaml
+++ b/applications/rubintv/values-tucson-teststand.yaml
@@ -1,6 +1,5 @@
 rubintv:
   siteTag: "tucson"
-  separateSecrets: true
 
   imagePullSecrets:
   - name: pull-secret
@@ -37,6 +36,3 @@ rubintv:
       limits:
         cpu: 2.0
         memory: "8Gi"
-
-global:
-  tsVaultSecretsPath: ""

--- a/applications/rubintv/values-usdfdev.yaml
+++ b/applications/rubintv/values-usdfdev.yaml
@@ -1,5 +1,6 @@
 rubintv:
   siteTag: "usdf-dev"
+  separateSecrets: false
 
   imagePullSecrets:
   - name: pull-secret

--- a/applications/rubintv/values-usdfprod.yaml
+++ b/applications/rubintv/values-usdfprod.yaml
@@ -1,5 +1,6 @@
 rubintv:
   siteTag: "usdf-prod"
+  separateSecrets: false
 
   imagePullSecrets:
   - name: pull-secret

--- a/applications/rubintv/values.yaml
+++ b/applications/rubintv/values.yaml
@@ -15,7 +15,7 @@ rubintv:
   # Each entry is of the form: { name: pull-secret-name }
 
   # -- Whether to use the new secrets management scheme
-  separateSecrets: false
+  separateSecrets: true
 
   frontend:
     # -- If set to true, enable more verbose logging.
@@ -197,7 +197,6 @@ redis:
   # -- Affinity rules for the Redis pod
   affinity: {}
 
-
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:
@@ -212,6 +211,3 @@ global:
   # -- Base path for Vault secrets
   # @default -- Set by Argo CD
   vaultSecretsPath: ""
-
-  # -- Relative path for tsVault secrets
-  tsVaultSecretsPath: ""

--- a/charts/rubintv/README.md
+++ b/charts/rubintv/README.md
@@ -24,7 +24,6 @@ Real-time display front end
 | fullnameOverride | string | `""` | Override the full name for resources (includes the release name) |
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
-| global.tsVaultSecretsPath | string | `""` | Relative path for tsVault secrets |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | imagePullSecrets | list | See `values.yaml` | Image pull secrets. |
 | ingress.annotations | object | `{}` | Additional annotations to add to the ingress |
@@ -41,7 +40,7 @@ Real-time display front end
 | redis.podAnnotations | object | `{}` | Pod annotations for the Redis pod |
 | redis.resources | object | See `values.yaml` | Resource limits and requests for the Redis pod |
 | redis.tolerations | list | `[]` | Tolerations for the Redis pod |
-| separateSecrets | bool | `false` | Whether to use the new secrets management scheme |
+| separateSecrets | bool | `true` | Whether to use the new secrets management scheme |
 | siteTag | string | `""` | A special tag for letting the scripts know where they are running.  Must be overridden at each site |
 | workers.affinity | object | `{}` | Affinity rules for the rubintv worker pods |
 | workers.debug | bool | `false` | If set to true, enable more verbose logging. |

--- a/charts/rubintv/templates/vault-secrets.yaml
+++ b/charts/rubintv/templates/vault-secrets.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "rubintv.labels" . | nindent 4 }}
 spec:
-  path: "{{ .Values.global.vaultSecretsPath }}{{ .Values.global.tsVaultSecretsPath }}/rubintv"
+  path: "{{ .Values.global.vaultSecretsPath }}/rubintv"
   type: "Opaque"
 ---
 {{- if (not .Values.separateSecrets) }}

--- a/charts/rubintv/values.yaml
+++ b/charts/rubintv/values.yaml
@@ -16,7 +16,7 @@ imagePullSecrets: []
 # Each entry is of the form: { name: pull-secret-name }
 
 # -- Whether to use the new secrets management scheme
-separateSecrets: false
+separateSecrets: true
 
 frontend:
   # -- If set to true, enable more verbose logging.
@@ -202,7 +202,6 @@ redis:
   # -- Affinity rules for the Redis pod
   affinity: {}
 
-
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:
@@ -217,6 +216,3 @@ global:
   # -- Base path for Vault secrets
   # @default -- Set by Argo CD
   vaultSecretsPath: ""
-
-  # -- Relative path for tsVault secrets
-  tsVaultSecretsPath: ""

--- a/docs/admin/migrating-secrets.rst
+++ b/docs/admin/migrating-secrets.rst
@@ -176,14 +176,10 @@ Switch to the new secrets tree
    On your working branch, add the necessary settings for those applications to their :file:`values-{environment}.yaml` files for your environment.
    Applications to review:
 
-   - :px-app:`datalinker` (``config.separateSecrets``)
-   - :px-app:`nightreport` (``global.tsVaultSecretsPath``)
-   - :px-app:`nublado` (``hub.internalDatabase``, ``secrets.templateSecrets``)
+   - :px-app:`nublado` (``secrets.templateSecrets``)
    - :px-app:`obsloctap` (``config.separateSecrets``)
    - :px-app:`plot-navigator` (``config.separateSecrets``)
-   - :px-app:`production-tools` (``config.separateSecrets``)
-   - :px-app:`rubintv` (``rubintv.separateSecrets``, ``global.tsVaultSecretsPath``)
-   - :px-app:`rubintv-dev` (``rubintv.separateSecrets``, ``global.tsVaultSecretsPath``)
+   - :px-app:`rubintv` (``rubintv.separateSecrets``)
 
 #. You're now ready to test the new secrets tree.
    You can do this on a branch that contains the changes you made above.


### PR DESCRIPTION
Change all of the application chart defaults to assume that the secrets migration has been done. Delete support for the old secrets structure everywhere that this is possible. Leave it in place for the few places that RoE or the USDF is still using the old secrets paths.