### PR TITLE
DM-48961: Remove update-deps-no-hashes Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,19 +46,3 @@ update-deps:
 	    --output-file requirements/dev.txt requirements/dev.in
 	uv pip compile -p 3.11 --upgrade --universal --generate-hashes	\
 	    --output-file requirements/tox.txt requirements/tox.in
-
-# Useful for testing against a Git version of Safir.
-.PHONY: update-deps-no-hashes
-update-deps-no-hashes:
-	pip install --upgrade uv
-	uv pip compile --upgrade --universal				\
-	    --output-file requirements/main.txt pyproject.toml
-	uv pip compile --upgrade --universal				\
-	    --output-file requirements/dev.txt requirements/dev.in
-	uv pip compile --upgrade --universal				\
-	    --output-file requirements/tox.txt requirements/tox.in
-
-.PHONY: lint
-lint:
-	tox -e lint
-	phalanx application lint tasso


### PR DESCRIPTION
Remove the update-deps-no-hashes Makefile target, which is no longer needed now that we're using uv. Delete a stray addition of a lint target to the Makefile that appears to have been added by mistake.