### PR TITLE
DM-48977: Adapt mobu chart to current style

### DIFF
--- a/applications/mobu/README.md
+++ b/applications/mobu/README.md
@@ -28,7 +28,6 @@ Continuous integration testing
 | config.sentryEnvironment | string | `nil` | The environment to report to Sentry |
 | config.sentryTracesSampleConfig | float | `0` | Sentry tracing config: a float to specify a percentage, or "errors" to send all transactions with errors. |
 | config.slackAlerts | bool | `true` | Whether to send alerts and status to Slack. |
-| fullnameOverride | string | `""` | Override the full name for resources (includes the release name) |
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
@@ -36,9 +35,8 @@ Continuous integration testing
 | image.repository | string | `"ghcr.io/lsst-sqre/mobu"` | mobu image to use |
 | image.tag | string | The appVersion of the chart | Tag of mobu image to use |
 | ingress.annotations | object | `{}` | Additional annotations to add to the ingress |
-| nameOverride | string | `""` | Override the base name for resources |
 | nodeSelector | object | `{}` | Node selector rules for the mobu frontend pod |
 | podAnnotations | object | `{}` | Annotations for the mobu frontend pod |
 | resources | object | See `values.yaml` | Resource limits and requests for the mobu frontend pod |
-| terminationGracePeriodSeconds | string | See `values.yaml` | Number of seconds for k8s to send SIGKILL after sending SIGTERM |
+| terminationGracePeriodSeconds | string | Use the Kubernetes default | Number of seconds for Kubernetes to send SIGKILL after sending SIGTERM |
 | tolerations | list | `[]` | Tolerations for the mobu frontend pod |

--- a/applications/mobu/templates/_helpers.tpl
+++ b/applications/mobu/templates/_helpers.tpl
@@ -1,28 +1,4 @@
-{{/*
-Expand the name of the chart.
-*/}}
-{{- define "mobu.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
-*/}}
-{{- define "mobu.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-
+{{/* vim: set filetype=mustache: */}}
 {{/*
 Create chart name and version as used by the chart label.
 */}}
@@ -34,9 +10,7 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "mobu.labels" -}}
-app.kubernetes.io/name: {{ include "mobu.name" . }}
 helm.sh/chart: {{ include "mobu.chart" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -47,6 +21,6 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Selector labels
 */}}
 {{- define "mobu.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "mobu.name" . }}
+app.kubernetes.io/name: "mobu"
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}

--- a/applications/mobu/templates/configmap.yaml
+++ b/applications/mobu/templates/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "mobu.fullname" . }}
+  name: "mobu"
   labels:
     {{- include "mobu.labels" . | nindent 4 }}
 data:

--- a/applications/mobu/templates/deployment.yaml
+++ b/applications/mobu/templates/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "mobu.fullname" . }}
+  name: "mobu"
   labels:
     {{- include "mobu.labels" . | nindent 4 }}
 spec:
@@ -33,7 +33,7 @@ spec:
             - name: "MOBU_ALERT_HOOK"
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "mobu.fullname" . }}-secret
+                  name: "mobu"
                   key: "ALERT_HOOK"
             {{- end }}
             - name: "MOBU_ENVIRONMENT_URL"
@@ -41,37 +41,37 @@ spec:
             - name: "MOBU_GAFAELFAWR_TOKEN"
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "mobu.fullname" . }}-gafaelfawr-token
+                  name: "mobu-gafaelfawr-token"
                   key: "token"
             - name: "MOBU_SENTRY_ENVIRONMENT"
               value: {{ .Values.global.environmentName }}
             - name: "MOBU_SENTRY_DSN"
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "mobu.fullname" . }}-secret
+                  name: "mobu"
                   key: "sentry-dsn"
             {{- if .Values.config.githubRefreshApp }}
             - name: "MOBU_GITHUB_REFRESH_APP_WEBHOOK_SECRET"
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "mobu.fullname" . }}-secret
+                  name: "mobu"
                   key: "github-refresh-app-webhook-secret"
             {{- end}}
             {{- if .Values.config.githubCiApp }}
             - name: "MOBU_GITHUB_CI_APP_ID"
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "mobu.fullname" . }}-secret
+                  name: "mobu"
                   key: "github-ci-app-id"
             - name: "MOBU_GITHUB_CI_APP_PRIVATE_KEY"
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "mobu.fullname" . }}-secret
+                  name: "mobu"
                   key: "github-ci-app-private-key"
             - name: "MOBU_GITHUB_CI_APP_WEBHOOK_SECRET"
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "mobu.fullname" . }}-secret
+                  name: "mobu"
                   key: "github-ci-app-webhook-secret"
             {{- end}}
             {{- if .Values.config.metrics.enabled }}

--- a/applications/mobu/templates/gafaelfawr-token.yaml
+++ b/applications/mobu/templates/gafaelfawr-token.yaml
@@ -1,7 +1,7 @@
 apiVersion: gafaelfawr.lsst.io/v1alpha1
 kind: GafaelfawrServiceToken
 metadata:
-  name: {{ include "mobu.fullname" . }}-gafaelfawr-token
+  name: "mobu-gafaelfawr-token"
   labels:
     {{- include "mobu.labels" . | nindent 4 }}
 spec:

--- a/applications/mobu/templates/ingress-github-ci.yaml
+++ b/applications/mobu/templates/ingress-github-ci.yaml
@@ -2,7 +2,7 @@
 apiVersion: gafaelfawr.lsst.io/v1alpha1
 kind: GafaelfawrIngress
 metadata:
-  name: {{ template "mobu.fullname" . }}-github-ci
+  name: "mobu-github-ci"
   labels:
     {{- include "mobu.labels" . | nindent 4 }}
 config:
@@ -11,7 +11,7 @@ config:
     anonymous: true
 template:
   metadata:
-    name: {{ template "mobu.fullname" . }}-github-ci
+    name: "mobu-github-ci"
     {{- with .Values.ingress.annotations }}
     annotations:
       {{- toYaml . | nindent 6 }}
@@ -25,7 +25,7 @@ template:
               pathType: "Prefix"
               backend:
                 service:
-                  name: {{ template "mobu.fullname" . }}
+                  name: "mobu"
                   port:
                     number: 8080
 {{- end }}

--- a/applications/mobu/templates/ingress-github-refresh.yaml
+++ b/applications/mobu/templates/ingress-github-refresh.yaml
@@ -2,7 +2,7 @@
 apiVersion: gafaelfawr.lsst.io/v1alpha1
 kind: GafaelfawrIngress
 metadata:
-  name: {{ template "mobu.fullname" . }}-github-refresh
+  name: "mobu-github-refresh"
   labels:
     {{- include "mobu.labels" . | nindent 4 }}
 config:
@@ -11,7 +11,7 @@ config:
     anonymous: true
 template:
   metadata:
-    name: {{ template "mobu.fullname" . }}-github-refresh
+    name: "mobu-github-refresh"
     {{- with .Values.ingress.annotations }}
     annotations:
       {{- toYaml . | nindent 6 }}
@@ -25,7 +25,7 @@ template:
               pathType: "Prefix"
               backend:
                 service:
-                  name: {{ template "mobu.fullname" . }}
+                  name: "mobu"
                   port:
                     number: 8080
 {{- end }}

--- a/applications/mobu/templates/ingress.yaml
+++ b/applications/mobu/templates/ingress.yaml
@@ -1,7 +1,7 @@
 apiVersion: gafaelfawr.lsst.io/v1alpha1
 kind: GafaelfawrIngress
 metadata:
-  name: {{ template "mobu.fullname" . }}
+  name: "mobu"
   labels:
     {{- include "mobu.labels" . | nindent 4 }}
 config:
@@ -13,7 +13,7 @@ config:
   service: "mobu"
 template:
   metadata:
-    name: {{ template "mobu.fullname" . }}
+    name: "mobu"
     {{- with .Values.ingress.annotations }}
     annotations:
       {{- toYaml . | nindent 6 }}
@@ -27,6 +27,6 @@ template:
               pathType: "Prefix"
               backend:
                 service:
-                  name: {{ template "mobu.fullname" . }}
+                  name: "mobu"
                   port:
                     number: 8080

--- a/applications/mobu/templates/networkpolicy.yaml
+++ b/applications/mobu/templates/networkpolicy.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ include "mobu.fullname" . }}
+  name: "mobu"
 spec:
   podSelector:
     matchLabels:

--- a/applications/mobu/templates/service.yaml
+++ b/applications/mobu/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "mobu.fullname" . }}
+  name: "mobu"
   labels:
     {{- include "mobu.labels" . | nindent 4 }}
 spec:

--- a/applications/mobu/templates/vault-secrets.yaml
+++ b/applications/mobu/templates/vault-secrets.yaml
@@ -2,7 +2,7 @@
 apiVersion: ricoberger.de/v1alpha1
 kind: VaultSecret
 metadata:
-  name: {{ template "mobu.fullname" . }}-secret
+  name: "mobu"
   labels:
     {{- include "mobu.labels" . | nindent 4 }}
 spec:

--- a/applications/mobu/tests/github_ci_app_enabled_test.yaml
+++ b/applications/mobu/tests/github_ci_app_enabled_test.yaml
@@ -15,7 +15,7 @@ set:
     host: "example.com"
 tests:
   - it: "Should create an anonymous ingress"
-    template: "ingress-github-ci-app.yaml"
+    template: "ingress-github-ci.yaml"
     asserts:
       - containsDocument:
           kind: "GafaelfawrIngress"

--- a/applications/mobu/tests/github_refresh_app_enabled_test.yaml
+++ b/applications/mobu/tests/github_refresh_app_enabled_test.yaml
@@ -9,7 +9,7 @@ set:
     host: "example.com"
 tests:
   - it: "Should create an anonymous ingress"
-    template: "ingress-github-refresh-app.yaml"
+    template: "ingress-github-refresh.yaml"
     asserts:
       - containsDocument:
           kind: "GafaelfawrIngress"

--- a/applications/mobu/values.yaml
+++ b/applications/mobu/values.yaml
@@ -1,11 +1,5 @@
 # Default values for mobu.
 
-# -- Override the base name for resources
-nameOverride: ""
-
-# -- Override the full name for resources (includes the release name)
-fullnameOverride: ""
-
 image:
   # -- mobu image to use
   repository: "ghcr.io/lsst-sqre/mobu"
@@ -43,6 +37,18 @@ config:
   # @default -- disabled.
   githubCiApp: null
 
+  # -- Log level. Set to 'DEBUG' to include the output from all flocks in the
+  # main mobu log.
+  logLevel: INFO
+
+  # -- Prefix for mobu's API routes.
+  pathPrefix: "/mobu"
+
+  # -- One of 'production' or 'development'. 'production' configures structured
+  # JSON logging, and 'development' configures unstructured human readable
+  # logging.
+  profile: production
+
   # -- The environment to report to Sentry
   sentryEnvironment: null
 
@@ -50,20 +56,8 @@ config:
   # send all transactions with errors.
   sentryTracesSampleConfig: 0.0
 
-  # -- Log level. Set to 'DEBUG' to include the output from all flocks in the
-  # main mobu log.
-  logLevel: INFO
-
-  # -- One of 'production' or 'development'. 'production' configures structured
-  # JSON logging, and 'development' configures unstructured human readable
-  # logging.
-  profile: production
-
   # -- Whether to send alerts and status to Slack.
   slackAlerts: true
-
-  # -- Prefix for mobu's API routes.
-  pathPrefix: "/mobu"
 
   metrics:
     # -- Whether to enable sending metrics
@@ -97,21 +91,21 @@ resources:
     cpu: "50m"
     memory: "1Gi"
 
-# -- Number of seconds for k8s to send SIGKILL after sending SIGTERM
-# @default -- See `values.yaml`
-terminationGracePeriodSeconds: null
-
-# -- Annotations for the mobu frontend pod
-podAnnotations: {}
+# -- Affinity rules for the mobu frontend pod
+affinity: {}
 
 # -- Node selector rules for the mobu frontend pod
 nodeSelector: {}
 
+# -- Annotations for the mobu frontend pod
+podAnnotations: {}
+
+# -- Number of seconds for Kubernetes to send SIGKILL after sending SIGTERM
+# @default -- Use the Kubernetes default
+terminationGracePeriodSeconds: null
+
 # -- Tolerations for the mobu frontend pod
 tolerations: []
-
-# -- Affinity rules for the mobu frontend pod
-affinity: {}
 
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.


### PR DESCRIPTION
Remove the name overrides for the mobu chart, which we no longer use. Rename the `Secret` resource to `mobu` from `mobu-secret`, matching our current style. Alphabetically sort settings in `values.yaml`.