### PR TITLE
DM-48977: Fix labels for mobu

### DIFF
--- a/applications/mobu/templates/_helpers.tpl
+++ b/applications/mobu/templates/_helpers.tpl
@@ -11,6 +11,7 @@ Common labels
 */}}
 {{- define "mobu.labels" -}}
 helm.sh/chart: {{ include "mobu.chart" . }}
+{{ include "mobu.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}


### PR DESCRIPTION
The `mobu.labels` macro needs to include `mobu.selectorLabels`.