### PR TITLE
DM-49026: Upgrade ssotap & tap versions and remove dependency on external cadc registry service

### DIFF
--- a/charts/cadc-tap/README.md
+++ b/charts/cadc-tap/README.md
@@ -31,12 +31,12 @@ IVOA TAP service
 | config.pg.host | string | None, must be set if backend is `pg` | Host to connect to |
 | config.pg.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the TAP image |
 | config.pg.image.repository | string | `"ghcr.io/lsst-sqre/tap-postgres-service"` | TAP image to use |
-| config.pg.image.tag | string | `"1.19.0"` | Tag of TAP image to use |
+| config.pg.image.tag | string | `"1.20.0"` | Tag of TAP image to use |
 | config.pg.username | string | None, must be set if backend is `pg` | Username to connect with |
 | config.qserv.host | string | `"mock-db:3306"` (the mock QServ) | QServ hostname:port to connect to |
 | config.qserv.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the TAP image |
 | config.qserv.image.repository | string | `"ghcr.io/lsst-sqre/lsst-tap-service"` | TAP image to use |
-| config.qserv.image.tag | string | `"2.7.0"` | Tag of TAP image to use |
+| config.qserv.image.tag | string | `"2.8.0"` | Tag of TAP image to use |
 | config.qserv.jdbcParams | string | `""` | Extra JDBC connection parameters |
 | config.qserv.passwordEnabled | bool | false | Whether the Qserv database is password protected |
 | config.serviceName | string | None, must be set | Name of the service from Gafaelfawr's perspective, used for metrics reporting |
@@ -79,7 +79,7 @@ IVOA TAP service
 | uws.affinity | object | `{}` | Affinity rules for the UWS database pod |
 | uws.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the UWS database image |
 | uws.image.repository | string | `"ghcr.io/lsst-sqre/lsst-tap-uws-db"` | UWS database image to use |
-| uws.image.tag | string | `"2.7.0"` | Tag of UWS database image to use |
+| uws.image.tag | string | `"2.8.0"` | Tag of UWS database image to use |
 | uws.nodeSelector | object | `{}` | Node selection rules for the UWS database pod |
 | uws.podAnnotations | object | `{}` | Annotations for the UWS databse pod |
 | uws.resources | object | See `values.yaml` | Resource limits and requests for the UWS database pod |

--- a/charts/cadc-tap/templates/configmap.yaml
+++ b/charts/cadc-tap/templates/configmap.yaml
@@ -7,6 +7,7 @@ metadata:
 data:
   cadc-registry.properties: |
     ivo://ivoa.net/sso#OpenID = {{ .Values.global.baseUrl }}
+    ca.nrc.cadc.reg.client.RegistryClient.baseURL = {{ .Values.global.baseUrl }}/api/{{ .Values.ingress.path }}/reg
 
     # Ignore this, it's only here to satisfy the availability check.
     ivo://ivoa.net/std/CDP#proxy-1.0 = ivo://cadc.nrc.ca/cred

--- a/charts/cadc-tap/templates/tap-ingress-anonymous.yaml
+++ b/charts/cadc-tap/templates/tap-ingress-anonymous.yaml
@@ -30,7 +30,7 @@ template:
       - host: {{ required "global.host must be set" .Values.global.host | quote }}
         http:
           paths:
-            - path: "/api/{{ .Values.ingress.path }}/(availability|capabilities|swagger-ui.*)"
+            - path: "/api/{{ .Values.ingress.path }}/(availability|capabilities|reg|swagger-ui.*)"
               pathType: "ImplementationSpecific"
               backend:
                 service:

--- a/charts/cadc-tap/values.yaml
+++ b/charts/cadc-tap/values.yaml
@@ -71,7 +71,7 @@ config:
       pullPolicy: "IfNotPresent"
 
       # -- Tag of TAP image to use
-      tag: "1.19.0"
+      tag: "1.20.0"
 
   qserv:
     # -- QServ hostname:port to connect to
@@ -89,7 +89,7 @@ config:
       pullPolicy: "IfNotPresent"
 
       # -- Tag of TAP image to use
-      tag: "2.7.0"
+      tag: "2.8.0"
 
     # -- Whether the Qserv database is password protected
     # @default -- false
@@ -200,7 +200,7 @@ uws:
     pullPolicy: "IfNotPresent"
 
     # -- Tag of UWS database image to use
-    tag: "2.7.0"
+    tag: "2.8.0"
 
   # -- Resource limits and requests for the UWS database pod
   # @default -- See `values.yaml`


### PR DESCRIPTION
## Summary

We recently noticed an issue where all TAP services were misbehaving with what turned out to be a broken web service at cadc: https://ws.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/reg/resource-caps. This gets queried by the `RegistryClient` class in the reg package of cadc, which occurs when `/capabilities` is checked. In this case this request was timing out due to an outage at CADC.

To address this we introduce a new '/reg' endpoint which is can be queried and returns an empty file for the `/reg/resource-caps`'endpoint which is what is queried by the `RegistryClient` to collect additional metadata for capabilities. This does not have to contain any content in our case as our capabilities endpoints don't depend on any extra resource-caps.

The changes above required building a new version & image for the lsst-tap-service & tap-postgres applications, so we also upgrade to those versions. The new versions also include upgrade dependencies for the cadc libs, a short summary of the changes is:

**lsst-tap-service:**

- DM-48908: Fix Rubin Table writes to work with newer version of cadc-dali by @stvoutsin in https://github.com/lsst-sqre/lsst-tap-service/pull/128
- DM-49026: Add new /reg endpoint to remove dependency on external cadc web-service by @stvoutsin in https://github.com/lsst-sqre/lsst-tap-service/pull/129

**tap-postgres**
- Upgrade a subset of the cadc dependencies in https://github.com/lsst-sqre/tap-postgres/commit/fa11f649f4997fa9081f7869913b4399a1bef4aa
- DM-49026: Add new /reg endpoint to remove dependency on external cadc web-service in https://github.com/lsst-sqre/tap-postgres/pull/51/commits/732c16ab43abefb29ff35691b6d6a20e93802b5c