### PR TITLE
DM-49030: mobu - sentry release

### DIFF
--- a/applications/mobu/templates/deployment.yaml
+++ b/applications/mobu/templates/deployment.yaml
@@ -50,6 +50,8 @@ spec:
                 secretKeyRef:
                   name: "mobu"
                   key: "sentry-dsn"
+            - name: "SENTRY_RELEASE"
+              value: {{ .Values.image.tag | default .Chart.AppVersion }}
             {{- if .Values.config.githubRefreshApp }}
             - name: "MOBU_GITHUB_REFRESH_APP_WEBHOOK_SECRET"
               valueFrom:


### PR DESCRIPTION
Set a `SENTRY_RELEASE` env var to the mobu deployment which will tag every Sentry event with a release, which will let us see which errors show up in which releases.

We'll set this to the image tag, which is (I think) the best indicator that we have for what a release is available to the template.