### PR TITLE
DM-49036: Use StrEnum where appropriate

### DIFF
--- a/docs/documenteer.toml
+++ b/docs/documenteer.toml
@@ -37,7 +37,6 @@ nitpick_ignore = [
 ]
 nitpick_ignore_regex = [
     # Bug in Sphinx
-    ["py:obj", "SecretGenerateType\\..*"],
     ["py:obj", ".*all fields"],
 ]
 python_api_dir = "internals/api"

--- a/src/phalanx/models/secrets.py
+++ b/src/phalanx/models/secrets.py
@@ -6,7 +6,7 @@ import json
 import secrets
 from base64 import b64encode
 from datetime import UTC, datetime
-from enum import Enum
+from enum import StrEnum
 from pathlib import Path
 from typing import Any, Literal, Self
 
@@ -81,7 +81,7 @@ class ConditionalSecretCopyRules(SecretCopyRules, ConditionalMixin):
     """Possibly conditional rules for copying a secret value from another."""
 
 
-class SecretGenerateType(str, Enum):
+class SecretGenerateType(StrEnum):
     """Type of secret for generated secrets."""
 
     password = "password"


### PR DESCRIPTION
Use `StrEnum` rather than inheriting from both `str` and `Enum`.