### PR TITLE
DM-49036: Avoid using current_datetime

### DIFF
--- a/src/phalanx/services/vault.py
+++ b/src/phalanx/services/vault.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 import json
 from contextlib import suppress
-from datetime import timedelta
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import jinja2
 from hvac.exceptions import Forbidden
-from safir.datetime import current_datetime, format_datetime_for_logging
+from safir.datetime import format_datetime_for_logging
 
 from ..constants import VAULT_WRITE_TOKEN_WARNING_LIFETIME
 from ..exceptions import VaultPathConflictError
@@ -283,7 +283,7 @@ class VaultService:
         expected = template.render({"path": config.vault_path})
         policy = vault_client.get_policy(config.vault_write_policy)
 
-        now = current_datetime()
+        now = datetime.now(tz=UTC)
         policies = {config.vault_write_policy}
         for token in tokens:
             errors = []

--- a/tests/cli/secrets_test.py
+++ b/tests/cli/secrets_test.py
@@ -5,14 +5,13 @@ from __future__ import annotations
 import os
 import re
 from base64 import b64decode, b64encode
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import bcrypt
 import click
 import yaml
 from cryptography.fernet import Fernet
-from safir.datetime import current_datetime
 
 from phalanx.factory import Factory
 from phalanx.models.gafaelfawr import Token
@@ -456,7 +455,7 @@ def test_sync_regenerate(
 
     # Check whether mtime secrets are generated properly.
     mtime = datetime.fromisoformat(argocd["admin.passwordMtime"])
-    now = current_datetime()
+    now = datetime.now(tz=UTC)
     assert now - timedelta(seconds=5) <= mtime <= now
 
 

--- a/tests/cli/vault_test.py
+++ b/tests/cli/vault_test.py
@@ -4,12 +4,11 @@ from __future__ import annotations
 
 import re
 from base64 import b64encode
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import jinja2
 import yaml
-from safir.datetime import current_datetime
 
 from phalanx.constants import (
     VAULT_APPROLE_SECRET_TEMPLATE,
@@ -253,7 +252,7 @@ def test_create_write_token(
     assert result.exit_code == 0
     token = VaultToken.model_validate(yaml.safe_load(result.output))
     assert token.display_name == display_name
-    expires = current_datetime() + lifetime
+    expires = datetime.now(tz=UTC) + lifetime
     assert token.expires
     assert expires - timedelta(seconds=5) <= token.expires <= expires
     assert token.policies == [f"{vault_path}/write"]

--- a/tests/support/vault.py
+++ b/tests/support/vault.py
@@ -6,14 +6,14 @@ import json
 import os
 from collections import defaultdict
 from collections.abc import Iterator
-from datetime import timedelta
+from datetime import UTC, datetime, timedelta
 from typing import Any
 from unittest.mock import patch
 from uuid import uuid4
 
 import hvac
 from hvac.exceptions import InvalidPath
-from safir.datetime import current_datetime, isodatetime
+from safir.datetime import isodatetime
 
 from phalanx.models.vault import VaultAppRoleMetadata, VaultToken
 
@@ -94,15 +94,15 @@ class MockVaultClient:
         """
         assert ttl[-1] == "d"
         if create_expired_token:
-            expires = current_datetime() - timedelta(days=1)
+            expires = datetime.now(tz=UTC) - timedelta(days=1)
         else:
-            expires = current_datetime() + timedelta(days=int(ttl[:-1]))
+            expires = datetime.now(tz=UTC) + timedelta(days=int(ttl[:-1]))
         token = VaultToken(
             display_name=f"token-{display_name}",
             token=f"s.{os.urandom(16).hex()}",
             accessor=os.urandom(16).hex(),
             policies=policies,
-            expires=expires,
+            expires=expires.replace(microsecond=0),
         )
         self._tokens.append(token)
         return {


### PR DESCRIPTION
Python now provides `datetime.now(tz=UTC)`, so use that instead of `current_datetime` from Safir since it's more familiar to the average Python programmer.