### PR TITLE
DM-49036: Update model configuration to current style

### DIFF
--- a/docs/extras/schemas/environment.json
+++ b/docs/extras/schemas/environment.json
@@ -1,6 +1,7 @@
 {
   "$defs": {
     "ControlSystemConfig": {
+      "additionalProperties": false,
       "description": "Configuration for the Control System.",
       "properties": {
         "appNamespace": {
@@ -112,6 +113,7 @@
       "type": "object"
     },
     "GCPMetadata": {
+      "additionalProperties": false,
       "description": "Google Cloud Platform hosting metadata.\n\nHolds information about where in Google Cloud Platform this Phalanx\nenvironment is hosted. This supports generating documentation that\nincludes this metadata, making it easier for administrators to know what\noptions to pass to :command:`gcloud` to do things such as get Kubernetes\ncredentials.",
       "properties": {
         "projectId": {
@@ -139,6 +141,7 @@
       "type": "object"
     },
     "OnepasswordConfig": {
+      "additionalProperties": false,
       "description": "Configuration for 1Password static secrets source.",
       "properties": {
         "connectUrl": {

--- a/src/phalanx/models/environments.py
+++ b/src/phalanx/models/environments.py
@@ -15,9 +15,9 @@ from pydantic import (
     GetJsonSchemaHandler,
     field_validator,
 )
+from pydantic.alias_generators import to_camel
 from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import CoreSchema
-from safir.pydantic import CamelCaseModel
 
 from .applications import Application, ApplicationInstance
 from .secrets import Secret
@@ -40,7 +40,7 @@ __all__ = [
 ]
 
 
-class GCPMetadata(CamelCaseModel):
+class GCPMetadata(BaseModel):
     """Google Cloud Platform hosting metadata.
 
     Holds information about where in Google Cloud Platform this Phalanx
@@ -49,6 +49,10 @@ class GCPMetadata(CamelCaseModel):
     options to pass to :command:`gcloud` to do things such as get Kubernetes
     credentials.
     """
+
+    model_config = ConfigDict(
+        alias_generator=to_camel, extra="forbid", populate_by_name=True
+    )
 
     project_id: str = Field(
         ...,
@@ -69,8 +73,12 @@ class GCPMetadata(CamelCaseModel):
     )
 
 
-class OnepasswordConfig(CamelCaseModel):
+class OnepasswordConfig(BaseModel):
     """Configuration for 1Password static secrets source."""
+
+    model_config = ConfigDict(
+        alias_generator=to_camel, extra="forbid", populate_by_name=True
+    )
 
     connect_url: AnyHttpUrl = Field(
         ...,
@@ -87,8 +95,12 @@ class OnepasswordConfig(CamelCaseModel):
     )
 
 
-class ControlSystemConfig(CamelCaseModel):
+class ControlSystemConfig(BaseModel):
     """Configuration for the Control System."""
+
+    model_config = ConfigDict(
+        alias_generator=to_camel, extra="forbid", populate_by_name=True
+    )
 
     app_namespace: str | None = Field(
         None,
@@ -152,12 +164,14 @@ class ControlSystemConfig(CamelCaseModel):
     )
 
 
-class EnvironmentBaseConfig(CamelCaseModel):
+class EnvironmentBaseConfig(BaseModel):
     """Environment configuration options.
 
     Configuration common to `~phalanx.models.environments.EnvironmentConfig`
     and `~phalanx.models.environments.Environment`.
     """
+
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
     name: str = Field(..., title="Name", description="Name of the environment")
 
@@ -307,6 +321,10 @@ class EnvironmentConfig(EnvironmentBaseConfig):
     `EnvironmentBaseConfig` instead.
     """
 
+    model_config = ConfigDict(
+        alias_generator=to_camel, extra="forbid", populate_by_name=True
+    )
+
     applications: dict[str, bool] = Field(
         ...,
         title="Enabled applications",
@@ -337,8 +355,6 @@ class EnvironmentConfig(EnvironmentBaseConfig):
         ),
     )
 
-    model_config = ConfigDict(extra="forbid")
-
     @classmethod
     def __get_pydantic_json_schema__(
         cls, core_schema: CoreSchema, handler: GetJsonSchemaHandler
@@ -359,8 +375,6 @@ class Environment(EnvironmentBaseConfig):
 
     applications: dict[str, ApplicationInstance]
     """Applications enabled for that environment, by name."""
-
-    model_config = ConfigDict(populate_by_name=True)
 
     def all_applications(self) -> list[ApplicationInstance]:
         """Return all enabled applications in sorted order."""

--- a/src/phalanx/models/secrets.py
+++ b/src/phalanx/models/secrets.py
@@ -62,6 +62,8 @@ class ConditionalMixin(BaseModel):
 class SecretCopyRules(BaseModel):
     """Rules for copying a secret value from another secret."""
 
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
     application: str = Field(
         ...,
         title="Application",
@@ -73,8 +75,6 @@ class SecretCopyRules(BaseModel):
         title="Key",
         description="Secret key from which the secret should be copied",
     )
-
-    model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
 
 class ConditionalSecretCopyRules(SecretCopyRules, ConditionalMixin):
@@ -95,14 +95,14 @@ class SecretGenerateType(StrEnum):
 class SimpleSecretGenerateRules(BaseModel):
     """Rules for generating a secret value with no source information."""
 
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
     type: Literal[
         SecretGenerateType.password,
         SecretGenerateType.gafaelfawr_token,
         SecretGenerateType.fernet_key,
         SecretGenerateType.rsa_private_key,
     ] = Field(..., title="Secret type", description="Type of secret")
-
-    model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
     def generate(self) -> SecretStr:
         """Generate a new secret following these rules."""
@@ -195,6 +195,8 @@ class SecretOnepasswordConfig(BaseModel):
 class SecretConfig(BaseModel):
     """Specification for an application secret."""
 
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
     description: str | None = Field(
         None, title="Description", description="Description of the secret"
     )
@@ -221,8 +223,6 @@ class SecretConfig(BaseModel):
     value: SecretStr | None = Field(
         None, title="Value", description="Fixed value of secret"
     )
-
-    model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
 
 class ConditionalSecretConfig(SecretConfig, ConditionalMixin):
@@ -281,6 +281,8 @@ class Secret(SecretConfig):
 class RegistryPullSecret(BaseModel):
     """Pull secret for a specific Docker Repository."""
 
+    model_config = ConfigDict(extra="forbid")
+
     username: str = Field(
         ..., title="Username", description="HTTP Basic Auth username"
     )
@@ -289,11 +291,11 @@ class RegistryPullSecret(BaseModel):
         ..., title="Password", description="HTTP Basic Auth password"
     )
 
-    model_config = ConfigDict(extra="forbid")
-
 
 class PullSecret(BaseModel):
     """Specification for a Docker pull secret."""
+
+    model_config = ConfigDict(extra="forbid")
 
     description: YAMLFoldedString = Field(
         YAMLFoldedString(PULL_SECRET_DESCRIPTION),
@@ -308,8 +310,6 @@ class PullSecret(BaseModel):
         title="Pull secret by registry",
         description="Pull secrets for each registry that needs one",
     )
-
-    model_config = ConfigDict(extra="forbid")
 
     def to_dockerconfigjson(self) -> str:
         """Convert to the serialized format used by Docker."""
@@ -350,6 +350,8 @@ class ResolvedSecrets(BaseModel):
 class StaticSecret(BaseModel):
     """Value of a static secret provided in a YAML file."""
 
+    model_config = ConfigDict(extra="forbid")
+
     description: YAMLFoldedString | None = Field(
         None,
         title="Description of secret",
@@ -371,8 +373,6 @@ class StaticSecret(BaseModel):
         description="Value of the secret, or `None` if it's not known",
     )
 
-    model_config = ConfigDict(extra="forbid")
-
 
 class StaticSecrets(BaseModel):
     """Model for the YAML file containing static secrets.
@@ -381,6 +381,8 @@ class StaticSecrets(BaseModel):
     in which case the description fields of the `StaticSecret` members are
     ignored.
     """
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
     applications: dict[str, dict[str, StaticSecret]] = Field(
         {},
@@ -403,8 +405,6 @@ class StaticSecrets(BaseModel):
         description="Vault write token for this environment",
         alias="vault-write-token",
     )
-
-    model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
     @classmethod
     def from_path(cls, path: Path) -> Self:


### PR DESCRIPTION
Move `model_config` settings to the top of the class instead of after the attributes so that they're more apparent. Use the native Pydantic way of supporting camel-case attributes instead of using Safir's `CamelCaseModel`.