### PR TITLE
DM-49067: Re-add datalinker Butler configuration

### DIFF
--- a/applications/datalinker/templates/deployment.yaml
+++ b/applications/datalinker/templates/deployment.yaml
@@ -66,6 +66,8 @@ spec:
                 secretKeyRef:
                   name: "datalinker-gafaelfawr-token"
                   key: "token"
+            - name: "DAF_BUTLER_REPOSITORIES"
+              value: {{ .Values.global.butlerServerRepositories | b64dec | quote }}
           ports:
             - name: "http"
               containerPort: 8080


### PR DESCRIPTION
Removal of direct Butler support was too aggressive and removed the remote Butler configuration. Add it back.