### PR TITLE
DM-49075: Update vo-cutouts to 4.1.0

### DIFF
--- a/applications/vo-cutouts/Chart.yaml
+++ b/applications/vo-cutouts/Chart.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 description: "Image cutout service complying with IVOA SODA"
 sources:
   - "https://github.com/lsst-sqre/vo-cutouts"
-appVersion: 4.0.0
+appVersion: 4.1.0
 
 dependencies:
   - name: redis


### PR DESCRIPTION
Now uses Butler to parse URIs to support the new URI format and uses a newer image cutout backend incorporated into the stack container.