### PR TITLE
tickets/DM-49007: horizontally scale git-lfs to 5 from 3

### DIFF
--- a/applications/giftless/values-roundtable-prod.yaml
+++ b/applications/giftless/values-roundtable-prod.yaml
@@ -1,6 +1,6 @@
 server:
   readonly:
-    replicas: 3
+    replicas: 5
 ingress:
   hostname:
     readonly: "git-lfs.lsst.cloud"


### PR DESCRIPTION
The hosts, which we are treating as immutable because they're Container OS devices, have `somaxconn` set to 1024, so we can't go higher there.  So the easiest way to get past the "backlog fills up, git-lfs goes unresponsive" problem is to spread the load among more servers.

The crash seems to happen during builds, when presumably we have a lot of git-lfs pulls happening in a short time.  But once the servers check out, they seem to neither recover nor die.

Other things we could in principle do:

1) front uwsgi with some sort of session-aggregating web server.  Not sure this will help since I think that's what our ingress is, and it may be that these are all different sessions, happening from different processes during the build phase.
2) dive into the giftless code and try to make it smarter about retries, killing stuck threads, something like that.  Doable, but nontrivial (and at that point we might just want to write our own git-lfs server that is not 14 bajillion layers of abstraction deep).