### PR TITLE
DM-49125: Use USDF for serving DP02 Butler files

### DIFF
--- a/applications/butler/README.md
+++ b/applications/butler/README.md
@@ -18,6 +18,7 @@ Server for Butler data abstraction service
 | config.additionalS3EndpointUrls | object | No additional URLs | Endpoint URLs for additional S3 services used by the Butler, as a mapping from profile name to URL. |
 | config.dp02ClientServerIsDefault | bool | `false` | True if the 'dp02' Butler repository alias should use client/server Butler.  False if it should use DirectButler. |
 | config.dp02PostgresUri | string | No configuration file for DP02 will be generated. | Postgres connection string pointing to the registry database hosting Data Preview 0.2 data. |
+| config.dp02UseSlacDatastore | bool | `false` | True if the 'dp02' datastore files should be served from SLAC, false if they should be served from Google. |
 | config.dp1PostgresUri | string | No configuration file for DP1 will be generated. | Postgres connection string pointing to the registry database hosting Data Preview 1 data. |
 | config.pathPrefix | string | `"/api/butler"` | The prefix of the path portion of the URL where the Butler service will be exposed.  For example, if the service should be exposed at `https://data.lsst.cloud/api/butler`, this should be set to `/api/butler` |
 | config.pguser | string | Use values specified in per-repository Butler config files. | Postgres username used to connect to the Butler DB |

--- a/applications/butler/templates/configmap-public.yaml
+++ b/applications/butler/templates/configmap-public.yaml
@@ -29,13 +29,21 @@ data:
         - datastore:
             name: FileDatastore@s3://butler-us-central1-panda-dev/dc2
             cls: lsst.daf.butler.datastores.fileDatastore.FileDatastore
-            root: s3://butler-us-central1-panda-dev/dc2
+            {{ if .Values.config.dp02UseSlacDatastore }}
+            root: s3://slac@rubin-dp02-products/dc2/
+            {{ else }}
+            root: s3://butler-us-central1-panda-dev/dc2/
+            {{ end }}
         - datastore:
             # Datasets of type 'raw' are stored in a separate bucket for
             # historical reasons.
             name: FileDatastore@s3://curation-us-central1-desc-dc2-run22i
             cls: lsst.daf.butler.datastores.fileDatastore.FileDatastore
+            {{ if .Values.config.dp02UseSlacDatastore }}
+            root: s3://slac@rubin-dp02-raw/
+            {{ else }}
             root: s3://curation-us-central1-desc-dc2-run22i/
+            {{ end }}
             records:
               table: raw_datastore_records
         - datastore:
@@ -43,7 +51,11 @@ data:
             # are kept in a separate bucket.
             name: FileDatastore@s3://butler-us-central1-dp01-desc-dr6
             cls: lsst.daf.butler.datastores.fileDatastore.FileDatastore
+            {{ if .Values.config.dp02UseSlacDatastore }}
+            root: s3://slac@rubin-dp02-dp01/
+            {{ else }}
             root: s3://butler-us-central1-dp01-desc-dr6/
+            {{ end }}
             records:
               table: dp01_datastore_records
         - datastore:

--- a/applications/butler/templates/configmap-public.yaml
+++ b/applications/butler/templates/configmap-public.yaml
@@ -1,13 +1,4 @@
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: butler-public
-data:
-# WARNING! The files in this configmap are served publicly on the internet via unauthenticated HTTP.
-# DO NOT PUT ANY SENSITIVE INFORMATION IN THESE FILES.
-{{- if .Values.config.dp02PostgresUri }}
-  dp02.yaml: |
+{{- define "butler.dp02_config" }}
     datastore:
       cls: lsst.daf.butler.datastores.chainedDatastore.ChainedDatastore
       datastore_constraints:
@@ -29,21 +20,13 @@ data:
         - datastore:
             name: FileDatastore@s3://butler-us-central1-panda-dev/dc2
             cls: lsst.daf.butler.datastores.fileDatastore.FileDatastore
-            {{ if .Values.config.dp02UseSlacDatastore }}
-            root: s3://slac@rubin-dp02-products/dc2/
-            {{ else }}
-            root: s3://butler-us-central1-panda-dev/dc2/
-            {{ end }}
+            root: {{ .fileDatastoreRoot }}
         - datastore:
             # Datasets of type 'raw' are stored in a separate bucket for
             # historical reasons.
             name: FileDatastore@s3://curation-us-central1-desc-dc2-run22i
             cls: lsst.daf.butler.datastores.fileDatastore.FileDatastore
-            {{ if .Values.config.dp02UseSlacDatastore }}
-            root: s3://slac@rubin-dp02-raw/
-            {{ else }}
-            root: s3://curation-us-central1-desc-dc2-run22i/
-            {{ end }}
+            root: {{ .rawDatastoreRoot }}
             records:
               table: raw_datastore_records
         - datastore:
@@ -51,21 +34,17 @@ data:
             # are kept in a separate bucket.
             name: FileDatastore@s3://butler-us-central1-dp01-desc-dr6
             cls: lsst.daf.butler.datastores.fileDatastore.FileDatastore
-            {{ if .Values.config.dp02UseSlacDatastore }}
-            root: s3://slac@rubin-dp02-dp01/
-            {{ else }}
-            root: s3://butler-us-central1-dp01-desc-dr6/
-            {{ end }}
+            root: {{ .dp01DatastoreRoot }}
             records:
               table: dp01_datastore_records
         - datastore:
             name: FileDatastore@s3://butler-us-central1-dp02-user
             cls: lsst.daf.butler.datastores.fileDatastore.FileDatastore
-            root: s3://butler-us-central1-dp02-user/
+            root: {{ .userDatastoreRoot }}
             records:
               table: user_datastore_records
     registry:
-      db: {{ .Values.config.dp02PostgresUri }}
+      db: {{ .postgresUri }}
       managers:
         collections: lsst.daf.butler.registry.collections.synthIntKey.SynthIntKeyCollectionManager
         datasets: lsst.daf.butler.registry.datasets.byDimensions.ByDimensionsDatasetRecordStorageManagerUUID
@@ -74,6 +53,54 @@ data:
         dimensions: lsst.daf.butler.registry.dimensions.static.StaticDimensionRecordStorageManager
         opaque: lsst.daf.butler.registry.opaque.ByNameOpaqueTableStorageManager
       namespace: dc2_20210215
+{{- end }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: butler-public
+data:
+# WARNING! The files in this configmap are served publicly on the internet via unauthenticated HTTP.
+# DO NOT PUT ANY SENSITIVE INFORMATION IN THESE FILES.
+{{- if .Values.config.dp02PostgresUri }}
+   # Datastore configuration for the old setup where all files were stored in
+   # Google Cloud Storage buckets, accessed as S3.
+   {{- $dp02GcsRoots := (dict
+       "postgresUri" .Values.config.dp02PostgresUri
+       "fileDatastoreRoot" "s3://butler-us-central1-panda-dev/dc2/"
+       "rawDatastoreRoot" "s3://curation-us-central1-desc-dc2-run22i/"
+       "dp01DatastoreRoot" "s3://butler-us-central1-dp01-desc-dr6/"
+       "userDatastoreRoot" "s3://butler-us-central1-dp02-user/"
+    ) -}}
+  # End-user-facing DirectButler configuration for DP02.
+  dp02.yaml: |
+    {{ if .Values.config.dp02UseSlacDatastore }}
+    # Because this has to work with an ancient version of the Butler library from
+    # 2022, S3 profiles are not supported.  So we use a gs:// URI to access Google
+    # Cloud Storage, and s3:// to access Weka S3 at USDF.
+    {{ include "butler.dp02_config" (dict
+       "postgresUri" .Values.config.dp02PostgresUri
+       "fileDatastoreRoot" "s3://rubin-dp02-products/dc2/"
+       "rawDatastoreRoot" "s3://rubin-dp02-raw/"
+       "dp01DatastoreRoot" "s3://rubin-dp02-dp01/"
+       "userDatastoreRoot" "gs://butler-us-central1-dp02-user/"
+    )}}
+    {{ else }}
+    {{ include "butler.dp02_config" $dp02GcsRoots }}
+    {{ end }}
+  # Internal Butler server configuration for DP02.
+  dp02-server.yaml: |
+    {{ if .Values.config.dp02UseSlacDatastore }}
+    {{ include "butler.dp02_config" (dict
+       "postgresUri" .Values.config.dp02PostgresUri
+       "fileDatastoreRoot" "s3://slac@rubin-dp02-products/dc2/"
+       "rawDatastoreRoot" "s3://slac@rubin-dp02-raw/"
+       "dp01DatastoreRoot" "s3://slac@rubin-dp02-dp01/"
+       "userDatastoreRoot" "s3://butler-us-central1-dp02-user/"
+    )}}
+    {{ else }}
+    {{ include "butler.dp02_config" $dp02GcsRoots }}
+    {{ end }}
   # Repository index for END USERS defining aliases for Butler configurations.
   # This is NOT the configuration used internally for Butler server itself.
   # It is also NOT the configuration that should be used by Phalanx services

--- a/applications/butler/values-idfdev.yaml
+++ b/applications/butler/values-idfdev.yaml
@@ -5,9 +5,12 @@ config:
   dp02ClientServerIsDefault: true
   # butler-registry-dp02-dev Google Cloud SQL instance in science-platform-dev
   dp02PostgresUri: postgresql://butler@dp02.rsp-sql-dev.internal:5432/dp02
+  dp02UseSlacDatastore: true
   dp1PostgresUri: postgresql://butler@dp1.rsp-sql-dev.internal:5432/dp1
   s3EndpointUrl: "https://storage.googleapis.com"
   repositories:
     dp02: "file:///opt/lsst/butler/public/config/dp02.yaml"
     dp1: "file:///opt/lsst/butler/config/dp1.yaml"
   shareNubladoSecrets: false
+  additionalS3EndpointUrls:
+    slac: "https://sdfdatas3.slac.stanford.edu"

--- a/applications/butler/values-idfdev.yaml
+++ b/applications/butler/values-idfdev.yaml
@@ -9,7 +9,7 @@ config:
   dp1PostgresUri: postgresql://butler@dp1.rsp-sql-dev.internal:5432/dp1
   s3EndpointUrl: "https://storage.googleapis.com"
   repositories:
-    dp02: "file:///opt/lsst/butler/public/config/dp02.yaml"
+    dp02: "file:///opt/lsst/butler/public/config/dp02-server.yaml"
     dp1: "file:///opt/lsst/butler/config/dp1.yaml"
   shareNubladoSecrets: false
   additionalS3EndpointUrls:

--- a/applications/butler/values-idfint.yaml
+++ b/applications/butler/values-idfint.yaml
@@ -6,6 +6,6 @@ config:
   dp1PostgresUri: postgresql://butler@dp1.rsp-sql-int.internal:5432/dp1
   s3EndpointUrl: "https://storage.googleapis.com"
   repositories:
-    dp02: "file:///opt/lsst/butler/public/config/dp02.yaml"
+    dp02: "file:///opt/lsst/butler/public/config/dp02-server.yaml"
     dp1: "file:///opt/lsst/butler/config/dp1.yaml"
   shareNubladoSecrets: false

--- a/applications/butler/values-idfprod.yaml
+++ b/applications/butler/values-idfprod.yaml
@@ -5,4 +5,4 @@ config:
   dp02PostgresUri: postgresql://butler@dp02.rsp-sql-stable.internal:5432/dp02
   s3EndpointUrl: "https://storage.googleapis.com"
   repositories:
-    dp02: "file:///opt/lsst/butler/public/config/dp02.yaml"
+    dp02: "file:///opt/lsst/butler/public/config/dp02-server.yaml"

--- a/applications/butler/values.yaml
+++ b/applications/butler/values.yaml
@@ -105,6 +105,10 @@ config:
   # Butler.  False if it should use DirectButler.
   dp02ClientServerIsDefault: false
 
+  # -- True if the 'dp02' datastore files should be served from SLAC, false
+  # if they should be served from Google.
+  dp02UseSlacDatastore: false
+
   # -- Postgres username used to connect to the Butler DB
   # @default -- Use values specified in per-repository Butler config files.
   pguser: ""

--- a/applications/nublado/values-idfdev.yaml
+++ b/applications/nublado/values-idfdev.yaml
@@ -28,7 +28,7 @@ controller:
         PGPASSFILE: "/opt/lsst/software/jupyterlab/secrets/postgres-credentials.txt"
         DAF_BUTLER_REPOSITORY_INDEX: "https://data-dev.lsst.cloud/api/butler/configs/idf-repositories.yaml"
         GOOGLE_APPLICATION_CREDENTIALS: "/opt/lsst/software/jupyterlab/secrets/butler-gcs-idf-creds.json"
-        S3_ENDPOINT_URL: "https://storage.googleapis.com"
+        S3_ENDPOINT_URL: "https://sdfdatas3.slac.stanford.edu"
         TMPDIR: "/tmp"
       initContainers:
         - name: "inithome"


### PR DESCRIPTION
Configure the `idfdev` Butler server to use Weka S3 at USDF for serving Data Preview 0.2 files.