### PR TITLE
DM-49125: Switch idfint to USDF DP02 datastore

### DIFF
--- a/applications/butler/values-idfint.yaml
+++ b/applications/butler/values-idfint.yaml
@@ -2,6 +2,7 @@ autoscaling:
   minReplicas: 3
 config:
   dp02ClientServerIsDefault: true
+  dp02UseSlacDatastore: true
   dp02PostgresUri: postgresql://butler@dp02.rsp-sql-int.internal:5432/dp02
   dp1PostgresUri: postgresql://butler@dp1.rsp-sql-int.internal:5432/dp1
   s3EndpointUrl: "https://storage.googleapis.com"
@@ -9,3 +10,5 @@ config:
     dp02: "file:///opt/lsst/butler/public/config/dp02-server.yaml"
     dp1: "file:///opt/lsst/butler/config/dp1.yaml"
   shareNubladoSecrets: false
+  additionalS3EndpointUrls:
+    slac: "https://sdfdatas3.slac.stanford.edu"

--- a/applications/butler/values-idfprod.yaml
+++ b/applications/butler/values-idfprod.yaml
@@ -6,3 +6,5 @@ config:
   s3EndpointUrl: "https://storage.googleapis.com"
   repositories:
     dp02: "file:///opt/lsst/butler/public/config/dp02-server.yaml"
+  additionalS3EndpointUrls:
+    slac: "https://sdfdatas3.slac.stanford.edu"

--- a/applications/nublado/values-idfint.yaml
+++ b/applications/nublado/values-idfint.yaml
@@ -27,7 +27,7 @@ controller:
         PGPASSFILE: "/opt/lsst/software/jupyterlab/secrets/postgres-credentials.txt"
         GOOGLE_APPLICATION_CREDENTIALS: "/opt/lsst/software/jupyterlab/secrets/butler-gcs-idf-creds.json"
         DAF_BUTLER_REPOSITORY_INDEX: "https://data-int.lsst.cloud/api/butler/configs/idf-repositories.yaml"
-        S3_ENDPOINT_URL: "https://storage.googleapis.com"
+        S3_ENDPOINT_URL: "https://sdfdatas3.slac.stanford.edu"
         IDDS_CONFIG: "/opt/lsst/software/jupyterlab/panda/idds.cfg.client.template"
         PANDA_AUTH: "oidc"
         PANDA_VERIFY_HOST: "off"


### PR DESCRIPTION
Configure the Butler on idfint to serve DP02 files from USDF instead of Google Cloud.