### PR TITLE
DM-49125: Move DP02 data product Butler root

### DIFF
--- a/applications/butler/templates/configmap-public.yaml
+++ b/applications/butler/templates/configmap-public.yaml
@@ -80,7 +80,7 @@ data:
     # Cloud Storage, and s3:// to access Weka S3 at USDF.
     {{ include "butler.dp02_config" (dict
        "postgresUri" .Values.config.dp02PostgresUri
-       "fileDatastoreRoot" "s3://rubin-dp02-products/dc2/"
+       "fileDatastoreRoot" "s3://rubin-dp02-products/"
        "rawDatastoreRoot" "s3://rubin-dp02-raw/"
        "dp01DatastoreRoot" "s3://rubin-dp02-dp01/"
        "userDatastoreRoot" "gs://butler-us-central1-dp02-user/"
@@ -93,7 +93,7 @@ data:
     {{ if .Values.config.dp02UseSlacDatastore }}
     {{ include "butler.dp02_config" (dict
        "postgresUri" .Values.config.dp02PostgresUri
-       "fileDatastoreRoot" "s3://slac@rubin-dp02-products/dc2/"
+       "fileDatastoreRoot" "s3://slac@rubin-dp02-products/"
        "rawDatastoreRoot" "s3://slac@rubin-dp02-raw/"
        "dp01DatastoreRoot" "s3://slac@rubin-dp02-dp01/"
        "userDatastoreRoot" "s3://butler-us-central1-dp02-user/"


### PR DESCRIPTION
The weekly 2022_40 stack version used for some tutorials does not accept a trailing directory name in a datastore root with Weka S3, because it enforces that the root `exists()` which it does not in S3 because it is a directory.

We are moving the directory on the filesystem so the needed files live at the root.