### PR TITLE
DM-48792: Enable SIA mobu runner on idfdev

### DIFF
--- a/applications/mobu/values-idfdev.yaml
+++ b/applications/mobu/values-idfdev.yaml
@@ -76,3 +76,13 @@ config:
         options:
           query_set: "dp0.2"
         restart: true
+    - name: "sia"
+      count: 1
+      users:
+        - username: "bot-mobu-sia"
+      scopes: ["read:image"]
+      business:
+        type: "SIAQuerySetRunner"
+        options:
+          query_set: "dp02"
+        restart: true

--- a/applications/mobu/values-idfint.yaml
+++ b/applications/mobu/values-idfint.yaml
@@ -98,3 +98,13 @@ config:
         options:
           query_set: "dp0.2"
         restart: true
+    - name: "sia"
+      count: 1
+      users:
+        - username: "bot-mobu-sia"
+      scopes: ["read:image"]
+      business:
+        type: "SIAQuerySetRunner"
+        options:
+          query_set: "dp02"
+        restart: true


### PR DESCRIPTION
Use new SIAQuerySetRunner in mobu to run SIAv2 queries on idfdev & idfint