### PR TITLE
DM-49125: Separate Butler server secrets from nublado on prod

### DIFF
--- a/applications/butler/values-idfprod.yaml
+++ b/applications/butler/values-idfprod.yaml
@@ -6,5 +6,6 @@ config:
   s3EndpointUrl: "https://storage.googleapis.com"
   repositories:
     dp02: "file:///opt/lsst/butler/public/config/dp02-server.yaml"
+  shareNubladoSecrets: false
   additionalS3EndpointUrls:
     slac: "https://sdfdatas3.slac.stanford.edu"


### PR DESCRIPTION
In preparation for future changes to switch to the SLAC datastore and roll out DP1 to prod, set up secrets for Butler server that are distinct from the ones provided to users in nublado.