### PR TITLE
DM-49125: Switch idfprod to USDF DP02 datastore

### DIFF
--- a/applications/butler/values-idfprod.yaml
+++ b/applications/butler/values-idfprod.yaml
@@ -2,6 +2,7 @@ autoscaling:
   minReplicas: 3
 config:
   dp02ClientServerIsDefault: true
+  dp02UseSlacDatastore: true
   dp02PostgresUri: postgresql://butler@dp02.rsp-sql-stable.internal:5432/dp02
   s3EndpointUrl: "https://storage.googleapis.com"
   repositories:

--- a/applications/nublado/values-idfprod.yaml
+++ b/applications/nublado/values-idfprod.yaml
@@ -16,7 +16,7 @@ controller:
         PGPASSFILE: "/opt/lsst/software/jupyterlab/secrets/postgres-credentials.txt"
         GOOGLE_APPLICATION_CREDENTIALS: "/opt/lsst/software/jupyterlab/secrets/butler-gcs-idf-creds.json"
         DAF_BUTLER_REPOSITORY_INDEX: "https://data.lsst.cloud/api/butler/configs/idf-repositories.yaml"
-        S3_ENDPOINT_URL: "https://storage.googleapis.com"
+        S3_ENDPOINT_URL: "https://sdfdatas3.slac.stanford.edu"
         CULL_TERMINAL_INACTIVE_TIMEOUT: "432000"  # 5 days
         TMPDIR: "/tmp"
       initContainers:


### PR DESCRIPTION
Configure the Butler on idfprod to serve DP02 files from USDF instead of Google Cloud.