### PR TITLE
Increase initial delay in InfluxDB OSS liveness probe

### DIFF
--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -63,6 +63,7 @@ Rubin Observatory's telemetry service
 | influxdb.ingress.path | string | `"/influxdb(/\|$)(.*)"` | Path for the ingress |
 | influxdb.ingress.tls | bool | `false` | Whether to obtain TLS certificates for the ingress hostname |
 | influxdb.initScripts.enabled | bool | `false` | Whether to enable the InfluxDB custom initialization script |
+| influxdb.livenessProbe.initialDelaySeconds | int | `60` | Liveness probe initial delay in seconds |
 | influxdb.persistence.enabled | bool | `true` | Whether to use persistent volume claims. By default, `storageClass` is undefined, choosing the default provisioner (standard on GKE). |
 | influxdb.persistence.size | string | 1TiB for teststand deployments | Persistent volume size |
 | influxdb.resources | object | See `values.yaml` | Kubernetes resource requests and limits |

--- a/applications/sasquatch/values.yaml
+++ b/applications/sasquatch/values.yaml
@@ -38,6 +38,10 @@ influxdb:
     # -- InfluxDB image tag
     tag: "1.11.8"
 
+  livenessProbe:
+    # -- Liveness probe initial delay in seconds
+    initialDelaySeconds: 60
+
   persistence:
     # -- Whether to use persistent volume claims. By default, `storageClass`
     # is undefined, choosing the default provisioner (standard on GKE).


### PR DESCRIPTION
It is taking longer for the database to read the indexes from disk during initialization. This was noticed at USDF but set an initial delay of 60s by default.