### PR TITLE
Disable InfluxDB Enterprise at the Summit

### DIFF
--- a/applications/sasquatch/values-summit.yaml
+++ b/applications/sasquatch/values-summit.yaml
@@ -133,7 +133,7 @@ customInfluxDBIngress:
   hostname: summit-lsp.lsst.codes
 
 influxdb-enterprise:
-  enabled: true
+  enabled: false
   license:
     secret:
       name: sasquatch
@@ -370,7 +370,7 @@ telegraf-kafka-consumer-oss:
 
 # This set of connectors is used to write to the InfluxDB Enterprise instance
 telegraf-kafka-consumer:
-  enabled: true
+  enabled: false
   influxdb:
     url: "http://sasquatch-influxdb-enterprise-data.sasquatch:8086"
   kafkaConsumers:


### PR DESCRIPTION
- Disable InfluxDB Enterprise and Telegraf connectors at the Summit to reduce load
- We are waiting on the second InfluxDB Enterprise node to migrate to InfluxDB Enterprise