### PR TITLE
DM-49593: Move to NetApp Cloud volumes

### DIFF
--- a/applications/nublado/README.md
+++ b/applications/nublado/README.md
@@ -102,6 +102,9 @@ JupyterHub and custom spawner for the Rubin Science Platform
 | cronjob.resources | object | See `values.yaml` | Resource limits and requests for the tutorials cronjob |
 | cronjob.schedule | string | `"43 * * * *"` | Schedule for the tutorials cronjob. |
 | cronjob.targetVolume | object | See `values.yaml` | Repository volume definition |
+| cronjob.targetVolume.mountPath | string | `"/project"` | Where volume will be mounted in the container |
+| cronjob.targetVolume.path | string | `"/project-share"` | Path on NetApp server |
+| cronjob.targetVolume.server | string | `"127.0.0.1"` | IP address of NetApp server (different per environment) |
 | cronjob.targetVolumePath | string | `"/project"` | Where repository volume should be mounted |
 | cronjob.tolerations | list | `[]` | Tolerations for the tutorials cronjob. |
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |

--- a/applications/nublado/README.md
+++ b/applications/nublado/README.md
@@ -104,7 +104,7 @@ JupyterHub and custom spawner for the Rubin Science Platform
 | cronjob.targetVolume | object | See `values.yaml` | Repository volume definition |
 | cronjob.targetVolume.mountPath | string | `"/project"` | Where volume will be mounted in the container |
 | cronjob.targetVolume.path | string | `"/project-share"` | Path on NetApp server |
-| cronjob.targetVolume.server | string | `"127.0.0.1"` | IP address of NetApp server (different per environment) |
+| cronjob.targetVolume.server | string | `nil` | IP address of NetApp server (different per environment) |
 | cronjob.targetVolumePath | string | `"/project"` | Where repository volume should be mounted |
 | cronjob.tolerations | list | `[]` | Tolerations for the tutorials cronjob. |
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |

--- a/applications/nublado/values-idfdev.yaml
+++ b/applications/nublado/values-idfdev.yaml
@@ -68,19 +68,19 @@ controller:
       volumes:
         - name: "home"
           source:
-            type: nfs
-            serverPath: "/share1/home"
-            server: "10.87.86.26"
+            serverPath: "/home-share"
+            server: "10.234.16.4"
+            type: "nfs"
         - name: "project"
           source:
-            type: nfs
-            serverPath: "/share1/project"
-            server: "10.87.86.26"
+            serverPath: "/project-share"
+            server: "10.234.16.4"
+            type: "nfs"
         - name: "scratch"
           source:
-            type: nfs
-            serverPath: "/share1/scratch"
-            server: "10.87.86.26"
+            serverPath: "/scratch-share"
+            server: "10.234.16.4"
+            type: "nfs"
       volumeMounts:
         - containerPath: "/home"
           volumeName: "home"

--- a/applications/nublado/values.yaml
+++ b/applications/nublado/values.yaml
@@ -699,7 +699,7 @@ cronjob:
     # -- Where volume will be mounted in the container
     mountPath: "/project"   # Conventional
     # -- IP address of NetApp server (different per environment)
-    server: "127.0.0.1"  # This must be changed
+    server: null            # This must be changed
     # -- Path on NetApp server
     path: "/project-share"  # Assigned by Terraform
 

--- a/applications/nublado/values.yaml
+++ b/applications/nublado/values.yaml
@@ -696,8 +696,11 @@ cronjob:
   # -- Repository volume definition
   # @default -- See `values.yaml`
   targetVolume:
+    # -- Where volume will be mounted in the container
     mountPath: "/project"   # Conventional
-    server: "10.234.16.4"   # NetApp always gets this IP, apparently
+    # -- IP address of NetApp server (different per environment)
+    server: "127.0.0.1"  # This must be changed
+    # -- Path on NetApp server
     path: "/project-share"  # Assigned by Terraform
 
   image:


### PR DESCRIPTION
Drop support for the `config.realm` configuration setting, since Gafaelfawr no longer supports configuring it separately. Update the CRD for `GafaelfawrIngress`. Add the new `config.allowSubdomains` setting.

Disable cookie authentication to giftless since it uses a separate hostname anyway and cookies would never have worked (and otherwise the ingress would now be rejected). Clean up its `values.yaml` file a bit and drop the `config.baseUrl` setting in `GafaelfawrIngress` that is now ignored.

Disable cookie authentication for the service endpoint to Wobbly, since services will never have cookies.