### PR TITLE
DM-49078: Add support for worker restarts to Keda

### DIFF
--- a/applications/prompt-keda-hsc/README.md
+++ b/applications/prompt-keda-hsc/README.md
@@ -65,3 +65,5 @@ KEDA Prompt Processing instance for HSC
 | prompt-keda.sasquatch.endpointUrl | string | `""` | Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload. This is a preliminary implementation of Sasquatch support, and this parameter may be deprecated if we instead support `SasquatchDatastore` in the future. |
 | prompt-keda.sasquatch.namespace | string | `"lsst.prompt"` | Namespace in the Sasquatch system with which to associate metrics. |
 | prompt-keda.tolerations | list | `[]` | Tolerations for the Prompt Processing pod |
+| prompt-keda.worker.grace_period | int | `45` | When Kubernetes shuts down a pod, the time its workers have to abort processing and save intermediate results (seconds). |
+| prompt-keda.worker.restart | int | `0` | The number of requests to process before rebooting a worker. If 0, workers process requests indefinitely. |

--- a/applications/prompt-keda-hsc/values.yaml
+++ b/applications/prompt-keda-hsc/values.yaml
@@ -8,6 +8,13 @@ prompt-keda:
     # -- Overrides the image tag whose default is the chart appVersion.
     tag: latest
 
+  worker:
+    # -- The number of requests to process before rebooting a worker.
+    # If 0, workers process requests indefinitely.
+    restart: 0
+    # -- When Kubernetes shuts down a pod, the time its workers have to abort processing and save intermediate results (seconds).
+    grace_period: 45
+
   instrument:
     # -- The "short" name of the instrument
     name: HSC

--- a/applications/prompt-keda-latiss/README.md
+++ b/applications/prompt-keda-latiss/README.md
@@ -65,3 +65,5 @@ KEDA Prompt Processing instance for LATISS
 | prompt-keda.sasquatch.endpointUrl | string | `""` | Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload. This is a preliminary implementation of Sasquatch support, and this parameter may be deprecated if we instead support `SasquatchDatastore` in the future. |
 | prompt-keda.sasquatch.namespace | string | `"lsst.prompt"` | Namespace in the Sasquatch system with which to associate metrics. |
 | prompt-keda.tolerations | list | `[]` | Tolerations for the Prompt Processing pod |
+| prompt-keda.worker.grace_period | int | `45` | When Kubernetes shuts down a pod, the time its workers have to abort processing and save intermediate results (seconds). |
+| prompt-keda.worker.restart | int | `0` | The number of requests to process before rebooting a worker. If 0, workers process requests indefinitely. |

--- a/applications/prompt-keda-latiss/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-keda-latiss/values-usdfprod-prompt-processing.yaml
@@ -5,6 +5,9 @@ prompt-keda:
     # Overrides the image tag whose default is the chart appVersion.
     tag: 5.1.0
 
+  worker:
+    restart: 15
+
   instrument:
     pipelines:
       # IMPORTANT: don't use flow-style mappings (i.e., {}) in pipelines specs

--- a/applications/prompt-keda-latiss/values.yaml
+++ b/applications/prompt-keda-latiss/values.yaml
@@ -8,6 +8,13 @@ prompt-keda:
     # -- Overrides the image tag whose default is the chart appVersion.
     tag: latest
 
+  worker:
+    # -- The number of requests to process before rebooting a worker.
+    # If 0, workers process requests indefinitely.
+    restart: 0
+    # -- When Kubernetes shuts down a pod, the time its workers have to abort processing and save intermediate results (seconds).
+    grace_period: 45
+
   instrument:
     # -- The "short" name of the instrument
     name: LATISS

--- a/applications/prompt-keda-lsstcamimsim/README.md
+++ b/applications/prompt-keda-lsstcamimsim/README.md
@@ -65,3 +65,5 @@ KEDA Prompt Processing instance for LSSTCam-imSim.
 | prompt-keda.sasquatch.endpointUrl | string | `""` | Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload. This is a preliminary implementation of Sasquatch support, and this parameter may be deprecated if we instead support `SasquatchDatastore` in the future. |
 | prompt-keda.sasquatch.namespace | string | `"lsst.prompt"` | Namespace in the Sasquatch system with which to associate metrics. |
 | prompt-keda.tolerations | list | `[]` | Tolerations for the Prompt Processing pod |
+| prompt-keda.worker.grace_period | int | `45` | When Kubernetes shuts down a pod, the time its workers have to abort processing and save intermediate results (seconds). |
+| prompt-keda.worker.restart | int | `0` | The number of requests to process before rebooting a worker. If 0, workers process requests indefinitely. |

--- a/applications/prompt-keda-lsstcamimsim/values.yaml
+++ b/applications/prompt-keda-lsstcamimsim/values.yaml
@@ -8,6 +8,13 @@ prompt-keda:
     # -- Overrides the image tag whose default is the chart appVersion.
     tag: latest
 
+  worker:
+    # -- The number of requests to process before rebooting a worker.
+    # If 0, workers process requests indefinitely.
+    restart: 0
+    # -- When Kubernetes shuts down a pod, the time its workers have to abort processing and save intermediate results (seconds).
+    grace_period: 45
+
   instrument:
     # -- The "short" name of the instrument
     name: LSSTCam-imSim

--- a/applications/prompt-keda-lsstcomcamsim/README.md
+++ b/applications/prompt-keda-lsstcomcamsim/README.md
@@ -65,3 +65,5 @@ KEDA Prompt Processing instance for LSSTComCamSim
 | prompt-keda.sasquatch.endpointUrl | string | `""` | Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload. This is a preliminary implementation of Sasquatch support, and this parameter may be deprecated if we instead support `SasquatchDatastore` in the future. |
 | prompt-keda.sasquatch.namespace | string | `"lsst.prompt"` | Namespace in the Sasquatch system with which to associate metrics. |
 | prompt-keda.tolerations | list | `[]` | Tolerations for the Prompt Processing pod |
+| prompt-keda.worker.grace_period | int | `45` | When Kubernetes shuts down a pod, the time its workers have to abort processing and save intermediate results (seconds). |
+| prompt-keda.worker.restart | int | `0` | The number of requests to process before rebooting a worker. If 0, workers process requests indefinitely. |

--- a/applications/prompt-keda-lsstcomcamsim/values.yaml
+++ b/applications/prompt-keda-lsstcomcamsim/values.yaml
@@ -8,6 +8,13 @@ prompt-keda:
     # -- Overrides the image tag whose default is the chart appVersion.
     tag: latest
 
+  worker:
+    # -- The number of requests to process before rebooting a worker.
+    # If 0, workers process requests indefinitely.
+    restart: 0
+    # -- When Kubernetes shuts down a pod, the time its workers have to abort processing and save intermediate results (seconds).
+    grace_period: 45
+
   instrument:
     # -- The "short" name of the instrument
     # @default -- None, must be set

--- a/charts/prompt-keda/README.md
+++ b/charts/prompt-keda/README.md
@@ -64,3 +64,5 @@ Event-driven processing of camera images
 | sasquatch.endpointUrl | string | `""` | Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload. This is a preliminary implementation of Sasquatch support, and this parameter may be deprecated if we instead support `SasquatchDatastore` in the future. |
 | sasquatch.namespace | string | `"lsst.prompt"` | Namespace in the Sasquatch system with which to associate metrics. |
 | tolerations | list | `[]` | Tolerations for the Prompt Processing pod |
+| worker.grace_period | int | `45` | When Kubernetes shuts down a pod, the time its workers have to abort processing and save intermediate results (seconds). |
+| worker.restart | int | `0` | The number of requests to process before rebooting a worker. If 0, workers process requests indefinitely. |

--- a/charts/prompt-keda/templates/scaled-job.yaml
+++ b/charts/prompt-keda/templates/scaled-job.yaml
@@ -49,6 +49,8 @@ spec:
             env:
               - name: PLATFORM
                 value: keda
+              - name: WORKER_RESTART_FREQ
+                value: {{ .Values.worker.restart | toString | quote }}
               - name: RUBIN_INSTRUMENT
                 value: {{ .Values.instrument.name }}
               - name: PREPROCESSING_PIPELINES_CONFIG

--- a/charts/prompt-keda/values.yaml
+++ b/charts/prompt-keda/values.yaml
@@ -11,6 +11,13 @@ image:
   # -- Overrides the image tag whose default is the chart appVersion.
   tag: latest
 
+worker:
+  # -- The number of requests to process before rebooting a worker.
+  # If 0, workers process requests indefinitely.
+  restart: 0
+  # -- When Kubernetes shuts down a pod, the time its workers have to abort processing and save intermediate results (seconds).
+  grace_period: 45
+
 instrument:
   # -- The "short" name of the instrument
   # @default -- None, must be set


### PR DESCRIPTION
This PR adds the same worker config hooks to the Keda implementation as already exist for Knative. Only `worker.restart` is actually implemented on this PR; `worker.grace_period` is for future use.