### PR TITLE
Sasquatch fixes for usdfprod

### DIFF
--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -31,8 +31,6 @@ strimzi-kafka:
       enabled: true
     telegraf:
       enabled: true
-    kafkaConnectManager:
-      enabled: true
     promptProcessing:
       enabled: true
     consdb:

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -369,6 +369,8 @@ app-metrics:
   enabled: true
   apps:
     - noteburst
+  influxdb:
+    url: http://sasquatch-influxdb-enterprise-data.sasquatch:8086
 
 backup:
   enabled: true


### PR DESCRIPTION
Telegraf-app-metrics should write to InfluxDB Enterprise at usdfprod. 
Also remove unused KafkaUser in that environment.
