### PR TITLE
Revert "Switch idfprod to USDF DP02 datastore"

### DIFF
--- a/applications/butler/values-idfprod.yaml
+++ b/applications/butler/values-idfprod.yaml
@@ -2,7 +2,6 @@ autoscaling:
   minReplicas: 3
 config:
   dp02ClientServerIsDefault: true
-  dp02UseSlacDatastore: true
   dp02PostgresUri: postgresql://butler@dp02.rsp-sql-stable.internal:5432/dp02
   s3EndpointUrl: "https://storage.googleapis.com"
   repositories:

--- a/applications/nublado/values-idfprod.yaml
+++ b/applications/nublado/values-idfprod.yaml
@@ -15,7 +15,7 @@ controller:
         PGPASSFILE: "/opt/lsst/software/jupyterlab/secrets/postgres-credentials.txt"
         GOOGLE_APPLICATION_CREDENTIALS: "/opt/lsst/software/jupyterlab/secrets/butler-gcs-idf-creds.json"
         DAF_BUTLER_REPOSITORY_INDEX: "https://data.lsst.cloud/api/butler/configs/idf-repositories.yaml"
-        S3_ENDPOINT_URL: "https://sdfdatas3.slac.stanford.edu"
+        S3_ENDPOINT_URL: "https://storage.googleapis.com"
         CULL_TERMINAL_INACTIVE_TIMEOUT: "432000"  # 5 days
         TMPDIR: "/tmp"
       initContainers:


### PR DESCRIPTION
This switches back to Google Cloud for hosting DP0.2 files on IDF prod.

This reverts commit e25e88fda76e3e18205ff8850a6309674a5b6e9f.