### PR TITLE
DM-49493: Update to Gafaelfawr 13.0.0

### DIFF
--- a/applications/gafaelfawr/Chart.yaml
+++ b/applications/gafaelfawr/Chart.yaml
@@ -5,7 +5,7 @@ description: "Authentication and identity system"
 home: "https://gafaelfawr.lsst.io/"
 sources:
   - "https://github.com/lsst-sqre/gafaelfawr"
-appVersion: 12.5.2
+appVersion: 13.0.0
 
 dependencies:
   - name: "redis"

--- a/applications/gafaelfawr/README.md
+++ b/applications/gafaelfawr/README.md
@@ -25,6 +25,7 @@ Authentication and identity system
 | cloudsql.serviceAccount | string | None, must be set if Cloud SQL Auth Proxy is enabled | The Google service account that has an IAM binding to the `gafaelfawr` Kubernetes service account and has the `cloudsql.client` role |
 | cloudsql.tolerations | list | `[]` | Tolerations for the standalone Cloud SQL Proxy pod |
 | config.afterLogoutUrl | string | Top-level page of this Phalanx environment | Where to send the user after they log out |
+| config.allowSubdomains | bool | `false` | Whether to expose cookies to subdomains. DO NOT SET TO TRUE unless all subdomains of the environment base URL are guaranteed to only reference services protected by Gafaelfawr. |
 | config.baseInternalUrl | string | FQDN under `svc.cluster.local` | URL for direct connections to the Gafaelfawr service, bypassing the Ingress. Must use a service name of `gafaelfawr` and port 8080. |
 | config.cilogon.clientId | string | `nil` | CILogon client ID. One and only one of this, `config.github.clientId`, or `config.oidc.clientId` must be set. |
 | config.cilogon.enrollmentUrl | string | Login fails with an error | Where to send the user if their username cannot be found in LDAP |
@@ -75,7 +76,6 @@ Authentication and identity system
 | config.oidcServer.keyId | string | `"gafaelfawr"` | Key ID (`kid` claim) of generated ID tokens, and the key ID served with the OAuth key metadata |
 | config.proxies | list | [`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`] | List of netblocks used for internal Kubernetes IP addresses, used to determine the true client IP for logging |
 | config.quota | object | `{}` | Quota settings (see [Quotas](https://gafaelfawr.lsst.io/user-guide/helm.html#quotas)). |
-| config.realm | string | Hostname of this Phalanx environment | Authentication realm for HTTP `WWW-Authenticate` headers. |
 | config.slackAlerts | bool | `false` | Whether to send certain serious alerts to Slack. If `true`, the `slack-webhook` secret must also be set. |
 | config.tokenLifetime | string | `"30d"` | Session lifetime. Use `w`, `d`, `h`, `m`, and `s` for time intervals. For example, `1d6h23m` is one day, six hours, 23 minutes. |
 | config.updateSchema | bool | `false` | Whether to automatically update the Gafaelfawr database schema |

--- a/applications/gafaelfawr/crds/ingress.yaml
+++ b/applications/gafaelfawr/crds/ingress.yaml
@@ -57,6 +57,16 @@ spec:
               type: object
               description: "Configuration for the ingress to create."
               properties:
+                allowCookies:
+                  type: boolean
+                  description: >-
+                    Whether to allow cookie authentication or only token
+                    authentication via the `Authorization` header.
+                allowOptions:
+                  type: boolean
+                  description: >-
+                    Whether to allow non-CORS-preflight OPTIONS requests to
+                    this backend. This must be enabled for WebDAV servers.
                 authCacheDuration:
                   type: string
                   description: >-
@@ -189,6 +199,12 @@ spec:
                     used for metrics reporting. When delegating internal
                     tokens, this must match config.delegate.internal.service.
                     This attribute will be required in the future.
+                userDomain:
+                  type: boolean
+                  description: >-
+                    Expect the last component of the request URL hostname to
+                    be a username and only allow access from matching
+                    usernames. Requires that the ingress host be a wildcard.
                 username:
                   type: string
                   description: >-

--- a/applications/gafaelfawr/templates/_helpers.tpl
+++ b/applications/gafaelfawr/templates/_helpers.tpl
@@ -133,10 +133,6 @@ Common environment variables
       name: "gafaelfawr"
       key: "signing-key"
 {{- end }}
-{{- if (not .Values.config.realm) }}
-- name: "GAFAELFAWR_REALM"
-  value: {{ required "global.host must be set" .Values.global.host | quote }}
-{{- end }}
 - name: "GAFAELFAWR_REDIRECT_URL"
   value: "{{ .Values.global.baseUrl }}/login"
 - name: "GAFAELFAWR_REDIS_PASSWORD"

--- a/applications/gafaelfawr/values.yaml
+++ b/applications/gafaelfawr/values.yaml
@@ -41,6 +41,11 @@ config:
   # @default -- Top-level page of this Phalanx environment
   afterLogoutUrl: null
 
+  # -- Whether to expose cookies to subdomains. DO NOT SET TO TRUE unless all
+  # subdomains of the environment base URL are guaranteed to only reference
+  # services protected by Gafaelfawr.
+  allowSubdomains: false
+
   # -- URL for direct connections to the Gafaelfawr service, bypassing the
   # Ingress. Must use a service name of `gafaelfawr` and port 8080.
   # @default -- FQDN under `svc.cluster.local`
@@ -73,10 +78,6 @@ config:
     - "10.0.0.0/8"
     - "172.16.0.0/12"
     - "192.168.0.0/16"
-
-  # -- Authentication realm for HTTP `WWW-Authenticate` headers.
-  # @default -- Hostname of this Phalanx environment
-  realm: null
 
   # -- Whether to send certain serious alerts to Slack. If `true`, the
   # `slack-webhook` secret must also be set.

--- a/applications/giftless/README.md
+++ b/applications/giftless/README.md
@@ -11,7 +11,6 @@ Git-LFS server with GCS S3 backend, with Rubin-specific auth
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules for the giftless frontend pod |
-| config | object | `{"bucketName":"","serviceAccountReadonly":"","serviceAccountReadwrite":"","storageProjectName":""}` | Configuration for giftless server |
 | config.bucketName | string | Must be overridden in environment-specific values file | Bucket name for GCS LFS Object Storage bucket |
 | config.serviceAccountReadonly | string | Must be overridden in environment-specific values file | Read-only service account name for GCS LFS Object Storage bucket |
 | config.serviceAccountReadwrite | string | Must be overridden in environment-specific values file | Read-write service account name for GCS LFS Object Storage bucket |
@@ -22,7 +21,6 @@ Git-LFS server with GCS S3 backend, with Rubin-specific auth
 | image.repository | string | `"ghcr.io/datopian/giftless"` | Giftless image to use |
 | image.tag | string | The appVersion of the chart | Tag of giftless image to use |
 | ingress.annotations | object | `{}` | Additional annotations to add to the ingress |
-| ingress.hostname | object | Must be overridden in environment-specific values file | FQDNs of giftless ingresses |
 | ingress.hostname.readonly | string | Must be overridden in environment-specific values file | FQDN for the read-only giftless ingress |
 | ingress.hostname.readwrite | string | Must be overridden in environment-specific values file | FQDN for the read-write giftless ingress |
 | nameOverride | string | `""` | Override the base name for resources |

--- a/applications/giftless/templates/ingress.yaml
+++ b/applications/giftless/templates/ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "giftless.labels" . | nindent 4 }}
 config:
-  baseUrl: "https://{{ .Values.ingress.hostname.readonly }}"
+  allowCookies: false
   scopes:
     anonymous: true
 template:
@@ -33,17 +33,16 @@ template:
                   port:
                     number: 5000
 ---
-#
-# We need this one because the default Giftless transfer implementation
-# generates a Bearer token for verification...but since we're going
-# through Gafaelfawr, that gets replaced with the Gafaelfawr token.
-# Then verification fails but the upload succeeds.
-#
-# This just means Gafaelfawr lets any verification request through.
-# That does mean that absolutely anyone can verify stored objects.
-# Since we already provide exactly that service anonymously on the
-# readonly endpoint, I don't think this changes anything.
-#
+{{/*
+We cannot use an authenticated Gafaelfawr ingress here because the default
+Giftless transfer implementation generates a Bearer token for verification
+that is unrelated to the Gafaelfawr token.
+
+Since this is an anonymous ingress, Gafaelfawr lets any verification request
+through. Therefore, anyone can verify stored objects, but this should be
+equivalent to functionality already provided on the read-only endpoint, which
+is also anonymous.
+*/}}
 apiVersion: gafaelfawr.lsst.io/v1alpha1
 kind: GafaelfawrIngress
 metadata:
@@ -51,7 +50,6 @@ metadata:
   labels:
     {{- include "giftless.labels" . | nindent 4 }}
 config:
-  baseUrl: "https://{{ .Values.ingress.hostname.readwrite }}"
   scopes:
     anonymous: true
 template:
@@ -87,7 +85,7 @@ metadata:
   labels:
     {{- include "giftless.labels" . | nindent 4 }}
 config:
-  baseUrl: "https://{{ .Values.ingress.hostname.readwrite }}"
+  allowCookies: false
   scopes:
     all:
       - "write:git-lfs"

--- a/applications/giftless/values.yaml
+++ b/applications/giftless/values.yaml
@@ -16,79 +16,93 @@ resources:
     cpu: "20m"
     memory: "110Mi"
 
-# -- Annotations for the giftless frontend pod
-podAnnotations: {}
+# -- Affinity rules for the giftless frontend pod
+affinity: {}
 
 # -- Node selector rules for the giftless frontend pod
 nodeSelector: {}
 
+# -- Annotations for the giftless frontend pod
+podAnnotations: {}
+
 # -- Tolerations for the giftless frontend pod
 tolerations: []
-
-# -- Affinity rules for the giftless frontend pod
-affinity: {}
 
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 image:
   # -- Giftless image to use
-  repository: ghcr.io/datopian/giftless
+  repository: "ghcr.io/datopian/giftless"
+
   # -- Pull policy for the giftless image
   pullPolicy: "IfNotPresent"
+
   # -- Tag of giftless image to use
   # @default -- The appVersion of the chart
   tag: ""
 
 ingress:
-  # -- FQDNs of giftless ingresses
-  # @default -- Must be overridden in environment-specific values file
+  # -- Additional annotations to add to the ingress
+  annotations: {}
+
   hostname:
     # -- FQDN for the read-only giftless ingress
     # @default -- Must be overridden in environment-specific values file
     readonly: ""
+
     # -- FQDN for the read-write giftless ingress
     # @default -- Must be overridden in environment-specific values file
     readwrite: ""
-  # -- Additional annotations to add to the ingress
-  annotations: {}
 
 server:
   # -- Turn on debugging mode
   debug: false
+
   readonly:
     # -- Number of replicas for readonly server
     replicas: 1
+
     # -- Number of processes for readonly server
     processes: 4
+
     # -- Number of threads per readonly process
     threads: 2
+
     # -- Socket listen queue depth
     queue: 1024
-    # -- Kill stuck worker after this many seconds
-    timeout: 86400
-  readwrite:
-    # -- Number of replicas for readwrite server
-    replicas: 1
-    # -- Number of processes for readwrite server
-    processes: 4
-    # -- Number of threads per readwrite process
-    threads: 2
-    # -- Socket listen queue depth
-    queue: 1024
+
     # -- Kill stuck worker after this many seconds
     timeout: 86400
 
-# -- Configuration for giftless server
+  readwrite:
+    # -- Number of replicas for readwrite server
+    replicas: 1
+
+    # -- Number of processes for readwrite server
+    processes: 4
+
+    # -- Number of threads per readwrite process
+    threads: 2
+
+    # -- Socket listen queue depth
+    queue: 1024
+
+    # -- Kill stuck worker after this many seconds
+    timeout: 86400
+
 config:
   # -- Project name for GCS LFS Object Storage bucket
   # @default -- Must be overridden in environment-specific values file
   storageProjectName: ""
+
   # -- Bucket name for GCS LFS Object Storage bucket
   # @default -- Must be overridden in environment-specific values file
   bucketName: ""
+
   # -- Read-only service account name for GCS LFS Object Storage bucket
   # @default -- Must be overridden in environment-specific values file
   serviceAccountReadonly: ""
+
   # -- Read-write service account name for GCS LFS Object Storage bucket
   # @default -- Must be overridden in environment-specific values file
   serviceAccountReadwrite: ""

--- a/applications/wobbly/templates/ingress-service.yaml
+++ b/applications/wobbly/templates/ingress-service.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "wobbly.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
+  allowCookies: false
   onlyServices:
     {{- range .Values.config.services }}
     - {{ . | quote }}


### PR DESCRIPTION
Drop support for the `config.realm` configuration setting, since Gafaelfawr no longer supports configuring it separately. Update the CRD for `GafaelfawrIngress`. Add the new `config.allowSubdomains` setting.

Disable cookie authentication to giftless since it uses a separate hostname anyway and cookies would never have worked (and otherwise the ingress would now be rejected). Clean up its `values.yaml` file a bit and drop the `config.baseUrl` setting in `GafaelfawrIngress` that is now ignored.

Disable cookie authentication for the service endpoint to Wobbly, since services will never have cookies.