### PR TITLE
DM-49493: Update Nublado to 8.7.0

### DIFF
--- a/applications/nublado/Chart.yaml
+++ b/applications/nublado/Chart.yaml
@@ -5,7 +5,7 @@ description: JupyterHub and custom spawner for the Rubin Science Platform
 sources:
   - https://github.com/lsst-sqre/nublado
 home: https://nublado.lsst.io/
-appVersion: 8.6.0
+appVersion: 8.7.0
 
 dependencies:
   - name: jupyterhub

--- a/applications/nublado/README.md
+++ b/applications/nublado/README.md
@@ -115,7 +115,7 @@ JupyterHub and custom spawner for the Rubin Science Platform
 | jupyterhub.hub.extraVolumeMounts | list | `hub-config` and the Gafaelfawr token | Additional volume mounts for JupyterHub |
 | jupyterhub.hub.extraVolumes | list | The `hub-config` `ConfigMap` and the Gafaelfawr token | Additional volumes to make available to JupyterHub |
 | jupyterhub.hub.image.name | string | `"ghcr.io/lsst-sqre/nublado-jupyterhub"` | Image to use for JupyterHub |
-| jupyterhub.hub.image.tag | string | `"8.4.1"` | Tag of image to use for JupyterHub |
+| jupyterhub.hub.image.tag | string | `"8.7.0"` | Tag of image to use for JupyterHub |
 | jupyterhub.hub.loadRoles.server.scopes | list | `["self"]` | Default scopes for the user's lab, overridden to allow the lab to delete itself (which we use for our added menu items) |
 | jupyterhub.hub.networkPolicy.enabled | bool | `false` | Whether to enable the default `NetworkPolicy` (currently, the upstream one does not work correctly) |
 | jupyterhub.hub.resources | object | See `values.yaml` | Resource limits and requests |

--- a/applications/nublado/values-base.yaml
+++ b/applications/nublado/values-base.yaml
@@ -29,7 +29,7 @@ controller:
         - name: "inithome"
           image:
             repository: "ghcr.io/lsst-sqre/nublado-inithome"
-            tag: "8.4.1"
+            tag: "8.7.0"
           privileged: true
           volumeMounts:
             - containerPath: "/home"

--- a/applications/nublado/values-idfdemo.yaml
+++ b/applications/nublado/values-idfdemo.yaml
@@ -27,7 +27,7 @@ controller:
         - name: "inithome"
           image:
             repository: "ghcr.io/lsst-sqre/nublado-inithome"
-            tag: "8.4.1"
+            tag: "8.7.0"
           privileged: true
           volumeMounts:
             - containerPath: "/home"

--- a/applications/nublado/values-idfdev.yaml
+++ b/applications/nublado/values-idfdev.yaml
@@ -44,7 +44,7 @@ controller:
         - name: "inithome"
           image:
             repository: "ghcr.io/lsst-sqre/nublado-inithome"
-            tag: "8.4.1"
+            tag: "8.7.0"
           privileged: true
           volumeMounts:
             - containerPath: "/home"

--- a/applications/nublado/values-idfint.yaml
+++ b/applications/nublado/values-idfint.yaml
@@ -54,7 +54,7 @@ controller:
         - name: "inithome"
           image:
             repository: "ghcr.io/lsst-sqre/nublado-inithome"
-            tag: "8.4.1"
+            tag: "8.7.0"
           privileged: true
           volumeMounts:
             - containerPath: "/home"

--- a/applications/nublado/values-idfprod.yaml
+++ b/applications/nublado/values-idfprod.yaml
@@ -22,7 +22,7 @@ controller:
         - name: "inithome"
           image:
             repository: "ghcr.io/lsst-sqre/nublado-inithome"
-            tag: "8.4.1"
+            tag: "8.7.0"
           privileged: true
           volumeMounts:
             - containerPath: "/home"

--- a/applications/nublado/values-roe.yaml
+++ b/applications/nublado/values-roe.yaml
@@ -14,7 +14,7 @@ controller:
         - name: "inithome"
           image:
             repository: "ghcr.io/lsst-sqre/nublado-inithome"
-            tag: "8.4.1"
+            tag: "8.7.0"
           privileged: true
           volumeMounts:
             - containerPath: "/home"

--- a/applications/nublado/values-summit.yaml
+++ b/applications/nublado/values-summit.yaml
@@ -28,7 +28,7 @@ controller:
         - name: "inithome"
           image:
             repository: "ghcr.io/lsst-sqre/nublado-inithome"
-            tag: "8.4.1"
+            tag: "8.7.0"
           privileged: true
           volumeMounts:
             - containerPath: "/home"

--- a/applications/nublado/values-tucson-teststand.yaml
+++ b/applications/nublado/values-tucson-teststand.yaml
@@ -30,7 +30,7 @@ controller:
         - name: "inithome"
           image:
             repository: "ghcr.io/lsst-sqre/nublado-inithome"
-            tag: "8.4.1"
+            tag: "8.7.0"
           privileged: true
           volumeMounts:
             - containerPath: "/home"

--- a/applications/nublado/values.yaml
+++ b/applications/nublado/values.yaml
@@ -459,7 +459,7 @@ jupyterhub:
       name: "ghcr.io/lsst-sqre/nublado-jupyterhub"
 
       # -- Tag of image to use for JupyterHub
-      tag: "8.4.1"
+      tag: "8.7.0"
 
     # -- Resource limits and requests
     # @default -- See `values.yaml`


### PR DESCRIPTION
Upgrade the Nublado application to the 8.7.0 release, which includes an additional `GafaelfawrIngress` setting in file server ingresses that is required to work with Gafaelfawr 13.0.0 and later.