### PR TITLE
DM-49329: Allow subdomains in Gafaelfawr on idfdev

### DIFF
--- a/applications/gafaelfawr/values-idfdev.yaml
+++ b/applications/gafaelfawr/values-idfdev.yaml
@@ -4,6 +4,7 @@ redis:
     storageClass: "standard-rwo"
 
 config:
+  allowSubdomains: true
   logLevel: "DEBUG"
   slackAlerts: true
 


### PR DESCRIPTION
Set the configuration option that scopes cookies to the domain instead of the host so that Gafaelfawr can authenticate accesses to per-user subdomains for Nublado.