### PR TITLE
DM-49388: Update mobu to version 15.0.0

### DIFF
--- a/applications/mobu/Chart.yaml
+++ b/applications/mobu/Chart.yaml
@@ -5,4 +5,4 @@ description: "Continuous integration testing"
 home: https://mobu.lsst.io/
 sources:
   - "https://github.com/lsst-sqre/mobu"
-appVersion: 14.2.1
+appVersion: 15.0.0

--- a/applications/mobu/README.md
+++ b/applications/mobu/README.md
@@ -15,6 +15,7 @@ Continuous integration testing
 | affinity | object | `{}` | Affinity rules for the mobu frontend pod |
 | config.autostart | list | `[]` | Autostart specification. Must be a list of mobu flock specifications. Each flock listed will be automatically started when mobu is started. |
 | config.availableServices | list | `[]` | Which applications (tap, butler, etc.) are available in this environment. Notebooks can specify a `mobu.required_services` list in their metadata, and mobu will only run them if all services in that list are in this `availableServices` list. See [the Mobu documentation](https://mobu.lsst.io/user_guide/in_repo_config.html#service-specific-notebooks) |
+| config.gafaelfawrTimeout | string | Use the default timeout for the Safir connection pool | Timeout for Gafaelfawr token creation requests during flock startup |
 | config.githubCiApp | string | disabled. | Configuration for the GitHub CI app integration. See [the Mobu documentation](https://mobu.lsst.io/operations/github_ci_app.html#add-phalanx-configuration) |
 | config.githubRefreshApp | string | disabled. | Configuration for the GitHub refresh app integration. See [the Mobu documentation](https://mobu.lsst.io/operations/github_refresh_app.html#add-phalanx-configuration) |
 | config.logLevel | string | `"INFO"` | Log level. Set to 'DEBUG' to include the output from all flocks in the main mobu log. |

--- a/applications/mobu/secrets.yaml
+++ b/applications/mobu/secrets.yaml
@@ -39,7 +39,7 @@ github-ci-app-webhook-secret:
     one for every mobu environment that supports this functionality.
 
     Mobu has a GitHub app integration in certain environments that creates
-    GitHub actions checks that run a solitary NotebookRunner business when
+    GitHub actions checks that run a solitary NotebookRunnerList business when
     changes are pushed to a notebook repo. This integration works by GitHub
     sending webhook requests to Mobu. GitHub hashes these requests with the
     value in this secret, and Mobu does the same and checks that the hashes
@@ -58,12 +58,12 @@ github-refresh-app-webhook-secret:
     one for every mobu environment that supports this functionality.
 
     Mobu has a GitHub app integration in certain environments that enables
-    NotebookRunner flocks to refresh their notebooks when changes get pushed to
-    their repo and branch in GitHub. This integration works by GitHub sending
-    webhook requests to Mobu. GitHub hashes these requests with the value in
-    this secret, and Mobu does the same and checks that the hashes match, in
-    order to verify that the request actually came from the expected GitHub app
-    integration.
+    NotebookRunnerList flocks to refresh their notebooks when changes get
+    pushed to their repo and branch in GitHub. This integration works by
+    GitHub sending webhook requests to Mobu. GitHub hashes these requests with
+    the value in this secret, and Mobu does the same and checks that the
+    hashes match, in order to verify that the request actually came from the
+    expected GitHub app integration.
 
     This value is also configured in the GitHub UI for the matching GitHub
     application. If we need to change this value, the Phalanx secret must be

--- a/applications/mobu/tests/github_ci_app_enabled_test.yaml
+++ b/applications/mobu/tests/github_ci_app_enabled_test.yaml
@@ -53,6 +53,7 @@ tests:
           value: |
             autostart: []
             availableServices: []
+            gafaelfawrTimeout: null
             githubCiApp:
               acceptedGithubOrgs:
               - org1

--- a/applications/mobu/tests/github_disabled_test.yaml
+++ b/applications/mobu/tests/github_disabled_test.yaml
@@ -15,6 +15,7 @@ tests:
           value: |
             autostart: []
             availableServices: []
+            gafaelfawrTimeout: null
             githubCiApp: null
             githubRefreshApp: null
             logLevel: INFO

--- a/applications/mobu/tests/github_refresh_app_enabled_test.yaml
+++ b/applications/mobu/tests/github_refresh_app_enabled_test.yaml
@@ -37,6 +37,7 @@ tests:
           value: |
             autostart: []
             availableServices: []
+            gafaelfawrTimeout: null
             githubCiApp: null
             githubRefreshApp:
               acceptedGithubOrgs:

--- a/applications/mobu/values-ccin2p3.yaml
+++ b/applications/mobu/values-ccin2p3.yaml
@@ -9,7 +9,7 @@ config:
           gidnumber: 1021
       scopes: ["exec:notebook", "exec:portal", "read:image", "read:tap"]
       business:
-        type: "NotebookRunner"
+        type: "NotebookRunnerCounting"
         options:
           repo_url: "https://github.com/lsst-sqre/system-test.git"
           repo_branch: "prod"
@@ -23,7 +23,7 @@ config:
           gidnumber: 1021
       scopes: ["exec:notebook", "exec:portal", "read:image", "read:tap"]
       business:
-        type: "NotebookRunner"
+        type: "NotebookRunnerCounting"
         options:
           image:
             image_class: "latest-weekly"

--- a/applications/mobu/values-idfdev.yaml
+++ b/applications/mobu/values-idfdev.yaml
@@ -29,7 +29,7 @@ config:
       scopes:
         - "exec:notebook"
       business:
-        type: "NotebookRunner"
+        type: "NotebookRunnerCounting"
         options:
           repo_url: "https://github.com/lsst-sqre/dfuchs-test-mobu.git"
           repo_ref: "main"
@@ -44,7 +44,7 @@ config:
         - "read:image"
         - "read:tap"
       business:
-        type: "NotebookRunner"
+        type: "NotebookRunnerCounting"
         options:
           repo_url: "https://github.com/lsst-sqre/system-test.git"
           repo_ref: "prod"
@@ -59,7 +59,7 @@ config:
         - "read:image"
         - "read:tap"
       business:
-        type: "NotebookRunner"
+        type: "NotebookRunnerCounting"
         options:
           repo_url: "https://github.com/lsst/tutorial-notebooks.git"
           repo_ref: "main"

--- a/applications/mobu/values-idfint.yaml
+++ b/applications/mobu/values-idfint.yaml
@@ -30,7 +30,7 @@ config:
         - "read:image"
         - "read:tap"
       business:
-        type: "NotebookRunner"
+        type: "NotebookRunnerCounting"
         options:
           repo_url: "https://github.com/lsst-sqre/system-test.git"
           repo_ref: "prod"
@@ -45,7 +45,7 @@ config:
         - "read:image"
         - "read:tap"
       business:
-        type: "NotebookRunner"
+        type: "NotebookRunnerCounting"
         options:
           image:
             image_class: "latest-weekly"
@@ -62,7 +62,7 @@ config:
         - "read:image"
         - "read:tap"
       business:
-        type: "NotebookRunner"
+        type: "NotebookRunnerCounting"
         options:
           repo_url: "https://github.com/lsst/tutorial-notebooks.git"
           repo_ref: "main"
@@ -78,7 +78,7 @@ config:
         - "read:image"
         - "read:tap"
       business:
-        type: "NotebookRunner"
+        type: "NotebookRunnerCounting"
         options:
           image:
             image_class: "latest-weekly"

--- a/applications/mobu/values-idfprod.yaml
+++ b/applications/mobu/values-idfprod.yaml
@@ -30,7 +30,7 @@ config:
         - "read:image"
         - "read:tap"
       business:
-        type: "NotebookRunner"
+        type: "NotebookRunnerCounting"
         options:
           repo_url: "https://github.com/lsst-sqre/system-test.git"
           repo_ref: "prod"
@@ -46,7 +46,7 @@ config:
         - "read:image"
         - "read:tap"
       business:
-        type: "NotebookRunner"
+        type: "NotebookRunnerCounting"
         options:
           repo_url: "https://github.com/lsst-sqre/system-test.git"
           repo_ref: "prod"
@@ -63,7 +63,7 @@ config:
         - "read:image"
         - "read:tap"
       business:
-        type: "NotebookRunner"
+        type: "NotebookRunnerCounting"
         options:
           repo_url: "https://github.com/lsst/tutorial-notebooks.git"
           repo_ref: "main"

--- a/applications/mobu/values-usdfdev.yaml
+++ b/applications/mobu/values-usdfdev.yaml
@@ -16,7 +16,7 @@ config:
         - "read:image"
         - "read:tap"
       business:
-        type: "NotebookRunner"
+        type: "NotebookRunnerCounting"
         options:
           image:
             image_class: "latest-weekly"

--- a/applications/mobu/values-usdfint.yaml
+++ b/applications/mobu/values-usdfint.yaml
@@ -16,7 +16,7 @@ config:
         - "read:image"
         - "read:tap"
       business:
-        type: "NotebookRunner"
+        type: "NotebookRunnerCounting"
         options:
           image:
             image_class: "latest-weekly"

--- a/applications/mobu/values-usdfprod.yaml
+++ b/applications/mobu/values-usdfprod.yaml
@@ -13,7 +13,7 @@ config:
         - "read:image"
         - "read:tap"
       business:
-        type: "NotebookRunner"
+        type: "NotebookRunnerCounting"
         options:
           repo_url: "https://github.com/lsst-sqre/system-test.git"
           repo_ref: "prod"

--- a/applications/mobu/values.yaml
+++ b/applications/mobu/values.yaml
@@ -27,6 +27,10 @@ config:
   # Each flock listed will be automatically started when mobu is started.
   autostart: []
 
+  # -- Timeout for Gafaelfawr token creation requests during flock startup
+  # @default -- Use the default timeout for the Safir connection pool
+  gafaelfawrTimeout: null
+
   # -- Configuration for the GitHub refresh app integration.
   # See [the Mobu documentation](https://mobu.lsst.io/operations/github_refresh_app.html#add-phalanx-configuration)
   # @default -- disabled.


### PR DESCRIPTION
This release retires the `NotebookRunner` business name in favor of `NotebookRunnerCounting` and `NotebookRunnerList` and adds support for per-user subdomains in Nublado. It also adds a new configuration option, `gafaelfawrTimeout`, to change the timeout for Gafealfawr requests during flock startup.