### PR TITLE
DM-49388: Disable logging mobu monkeys to file in idfdev

### DIFF
--- a/applications/mobu/values-idfdev.yaml
+++ b/applications/mobu/values-idfdev.yaml
@@ -1,5 +1,6 @@
 config:
   logLevel: DEBUG
+  logMonkeysToFile: false
   profile: development
   metrics:
     enabled: true


### PR DESCRIPTION
Otherwise, I can't see debug logs from individual monkeys.