### PR TITLE
DM-49329: Enable user subdomains for Nublado on idfdev

### DIFF
--- a/applications/nublado/README.md
+++ b/applications/nublado/README.md
@@ -97,6 +97,7 @@ JupyterHub and custom spawner for the Rubin Science Platform
 | hub.minimumTokenLifetime | string | `jupyterhub.cull.maxAge` if lab culling is enabled, else none | Minimum remaining token lifetime when spawning a lab. The token cannot be renewed, so it should ideally live as long as the lab does. If the token has less remaining lifetime, the user will be redirected to reauthenticate before spawning a lab. |
 | hub.resources | object | See `values.yaml` | Resource limits and requests for the Hub |
 | hub.timeout.startup | int | `90` | Timeout for JupyterLab to start in seconds. Currently this sometimes takes over 60 seconds for reasons we don't understand. |
+| hub.useSubdomains | bool | `false` | Whether to put each user's lab in a separate domain. This is strongly recommended for security, but requires wildcard DNS and cert-manager support and requires subdomain support be enabled in Gafaelfawr. |
 | jupyterhub.cull.enabled | bool | `true` | Enable the lab culler. |
 | jupyterhub.cull.every | int | 300 (5 minutes) | How frequently to check for idle labs in seconds |
 | jupyterhub.cull.maxAge | int | 2160000 (25 days) | Maximum age of a lab regardless of activity |

--- a/applications/nublado/templates/hub-configmap.yaml
+++ b/applications/nublado/templates/hub-configmap.yaml
@@ -25,7 +25,7 @@ data:
     {{- if .Values.hub.useSubdomains }}
 
     # Use separate hostnames for each user lab.
-    c.JupyterHub.subdomain_host = "nb.{{ .Values.global.host }}"
+    c.JupyterHub.subdomain_host = "https://nb.{{ .Values.global.host }}"
     {{- end }}
 
     # Enable stored auth state.

--- a/applications/nublado/templates/hub-configmap.yaml
+++ b/applications/nublado/templates/hub-configmap.yaml
@@ -22,6 +22,11 @@ data:
 
     # Add custom templates.
     c.JupyterHub.template_paths = [ "/usr/local/etc/jupyterhub/templates" ]
+    {{- if .Values.hub.useSubdomains }}
+
+    # Use separate hostnames for each user lab.
+    c.JupyterHub.subdomain_host = "nb.{{ .Values.global.host }}"
+    {{- end }}
 
     # Enable stored auth state.
     c.Authenticator.enable_auth_state = True

--- a/applications/nublado/templates/proxy-ingress.yaml
+++ b/applications/nublado/templates/proxy-ingress.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "nublado.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   authCacheDuration: "5m"
   loginRedirect: true
   scopes:
@@ -17,9 +16,14 @@ config:
 template:
   metadata:
     name: "proxy"
-    {{- with .Values.proxy.ingress.annotations }}
+    {{- if (or .Values.hub.useSubdomains .Values.proxy.ingress.annotations) }}
     annotations:
+      {{- if .Values.hub.useSubdomains }}
+      cert-manager.io/cluster-issuer: "letsencrypt-dns"
+      {{- end }}
+      {{- with .Values.proxy.ingress.annotations }}
       {{- toYaml . | nindent 6 }}
+      {{- end }}
     {{- end }}
   spec:
     rules:
@@ -33,3 +37,62 @@ template:
                   name: "proxy-public"
                   port:
                     name: "http"
+      {{- if .Values.hub.useSubdomains }}
+      - host: "nb.{{ .Values.global.host }}"
+        http:
+          paths:
+            - path: "/"
+              pathType: "Prefix"
+              backend:
+                service:
+                  name: "proxy-public"
+                  port:
+                    name: "http"
+      {{- end }}
+    {{- if .Values.hub.useSubdomains }}
+    tls:
+      - hosts:
+          - "nb.{{ .Values.global.host }}"
+        secretName: "nublado-tls"
+    {{- end }}
+{{- if .Values.hub.useSubdomains }}
+---
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
+metadata:
+  name: "proxy-labs"
+  labels:
+    {{- include "nublado.labels" . | nindent 4 }}
+config:
+  authCacheDuration: "5m"
+  loginRedirect: true
+  scopes:
+    all:
+      - "exec:notebook"
+  service: "nublado"
+  userDomain: true
+template:
+  metadata:
+    name: "proxy-labs"
+    annotations:
+      cert-manager.io/cluster-issuer: "letsencrypt-dns"
+      {{- with .Values.proxy.ingress.annotations }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+  spec:
+    rules:
+      - host: "*.nb.{{ .Values.global.host }}"
+        http:
+          paths:
+            - path: "/"
+              pathType: "Prefix"
+              backend:
+                service:
+                  name: "proxy-public"
+                  port:
+                    name: "http"
+    tls:
+      - hosts:
+          - "*.nb.{{ .Values.global.host }}"
+        secretName: "nublado-lab-tls"
+{{- end }}

--- a/applications/nublado/values-idfdev.yaml
+++ b/applications/nublado/values-idfdev.yaml
@@ -89,8 +89,15 @@ controller:
           volumeName: "scratch"
     metrics:
       enabled: true
+hub:
+  useSubdomains: true
 jupyterhub:
   hub:
+    config:
+      JupyterHub:
+        # This has to exist for Zero to JupyterHub to configure the proxy
+        # correctly.
+        subdomain_host: "nb.data-dev.lsst.cloud"
     db:
       upgrade: true
       url: "postgresql://nublado@cloud-sql-proxy.nublado/nublado"

--- a/applications/nublado/values.yaml
+++ b/applications/nublado/values.yaml
@@ -425,6 +425,11 @@ hub:
     # takes over 60 seconds for reasons we don't understand.
     startup: 90
 
+  # -- Whether to put each user's lab in a separate domain. This is strongly
+  # recommended for security, but requires wildcard DNS and cert-manager
+  # support and requires subdomain support be enabled in Gafaelfawr.
+  useSubdomains: false
+
 # Configuration for the Zero to JupyterHub subchart.
 jupyterhub:
   cull:


### PR DESCRIPTION
Add a new optional ingress that handles the subdomain routing if user subdomains are enabled, and enable user subdomains on data-dev.lsst.cloud. For now, do this with two settings because the proxy configuration requires setting a Zero to JupyterHub configuration setting that we otherwise ignore.