### PR TITLE
DM-49388: Update noteburst to 0.16.0

### DIFF
--- a/applications/noteburst/Chart.yaml
+++ b/applications/noteburst/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: noteburst
 version: 1.0.0
-appVersion: "0.15.1"
+appVersion: "0.16.0"
 description: Noteburst is a notebook execution service for the Rubin Science Platform.
 type: application
 home: https://noteburst.lsst.io/


### PR DESCRIPTION
Adds support for per-user subdomains for Nublado-managed JupyterLab instances.