### PR TITLE
DM-49545: Change vault policies to read mount point from configuration

### DIFF
--- a/src/phalanx/data/vault-read-policy.hcl.jinja
+++ b/src/phalanx/data/vault-read-policy.hcl.jinja
@@ -1,6 +1,6 @@
-path "secret/data/{{ path }}/+" {
+path "{{ mount_point }}/data/{{ path }}/+" {
   capabilities = ["read"]
 }
-path "secret/metadata/{{ path }}/+" {
+path "{{ mount_point }}/metadata/{{ path }}/+" {
   capabilities = ["list", "read"]
 }

--- a/src/phalanx/data/vault-write-policy.hcl.jinja
+++ b/src/phalanx/data/vault-write-policy.hcl.jinja
@@ -1,21 +1,21 @@
-path "secret/data/{{ path }}" {
+path "{{ mount_point }}/data/{{ path }}" {
   capabilities = ["create", "delete", "read", "update"]
 }
-path "secret/data/{{ path }}/+" {
+path "{{ mount_point }}/data/{{ path }}/+" {
   capabilities = ["create", "delete", "read", "update"]
 }
-path "secret/metadata/{{ path }}" {
+path "{{ mount_point }}/metadata/{{ path }}" {
   capabilities = ["delete", "list", "read", "update"]
 }
-path "secret/metadata/{{ path }}/+" {
+path "{{ mount_point }}/metadata/{{ path }}/+" {
   capabilities = ["delete", "list", "read", "update"]
 }
-path "secret/delete/{{ path }}/+" {
+path "{{ mount_point }}/delete/{{ path }}/+" {
   capabilities = ["update"]
 }
-path "secret/destroy/{{ path }}/+" {
+path "{{ mount_point }}/destroy/{{ path }}/+" {
   capabilities = ["update"]
 }
-path "secret/undelete/{{ path }}/+" {
+path "{{ mount_point }}/undelete/{{ path }}/+" {
   capabilities = ["update"]
 }

--- a/src/phalanx/models/environments.py
+++ b/src/phalanx/models/environments.py
@@ -276,6 +276,12 @@ class EnvironmentBaseConfig(BaseModel):
         return path
 
     @property
+    def vault_mount_point(self) -> str:
+        """Vault mount point."""
+        mount_point, _ = self.vault_path_prefix.split("/", 1)
+        return mount_point
+
+    @property
     def vault_read_approle(self) -> str:
         """Name of the Vault read AppRole for this environment."""
         # AppRole names cannot contain /, so we'll use only the final

--- a/src/phalanx/services/vault.py
+++ b/src/phalanx/services/vault.py
@@ -140,7 +140,12 @@ class VaultService:
         config = self._config.load_environment_config(environment)
         vault_client = self._vault.get_vault_client(config)
         template = self._templates.get_template("vault-read-policy.hcl.jinja")
-        policy = template.render({"path": config.vault_path})
+        policy = template.render(
+            {
+                "path": config.vault_path,
+                "mount_point": config.vault_mount_point,
+            }
+        )
         vault_client.create_policy(config.vault_read_policy, policy)
         approle = vault_client.get_approle(config.vault_read_approle)
         if approle:
@@ -181,7 +186,12 @@ class VaultService:
         for token in tokens:
             vault_client.revoke_token(token.accessor)
         template = self._templates.get_template("vault-write-policy.hcl.jinja")
-        policy = template.render({"path": config.vault_path})
+        policy = template.render(
+            {
+                "path": config.vault_path,
+                "mount_point": config.vault_mount_point,
+            }
+        )
         vault_client.create_policy(config.vault_write_policy, policy)
         return vault_client.create_token(
             config.vault_write_token, [config.vault_write_policy], lifetime
@@ -241,7 +251,12 @@ class VaultService:
         expected_policies = {config.vault_read_policy}
         errors = self._audit_policies(approle.policies, expected_policies)
         template = self._templates.get_template("vault-read-policy.hcl.jinja")
-        expected = template.render({"path": config.vault_path})
+        expected = template.render(
+            {
+                "path": config.vault_path,
+                "mount_point": config.vault_mount_point,
+            }
+        )
         policy = vault_client.get_policy(config.vault_read_policy)
         if policy != expected:
             name = config.vault_read_policy
@@ -280,7 +295,12 @@ class VaultService:
             report = "Multiple write tokens found\n"
 
         template = self._templates.get_template("vault-write-policy.hcl.jinja")
-        expected = template.render({"path": config.vault_path})
+        expected = template.render(
+            {
+                "path": config.vault_path,
+                "mount_point": config.vault_mount_point,
+            }
+        )
         policy = vault_client.get_policy(config.vault_write_policy)
 
         now = datetime.now(tz=UTC)

--- a/tests/cli/vault_test.py
+++ b/tests/cli/vault_test.py
@@ -161,7 +161,7 @@ def test_create_read_approle(
 ) -> None:
     config_storage = factory.create_config_storage()
     environment = config_storage.load_environment_config("idfdev")
-    _, vault_path = environment.vault_path_prefix.split("/", 1)
+    mount_point, vault_path = environment.vault_path_prefix.split("/", 1)
 
     result = run_cli(
         "vault",
@@ -184,7 +184,9 @@ def test_create_read_approle(
     r = mock_vault.read_policy(approle.policies[0])
     seen_policy = r["rules"]
     template = templates.get_template("vault-read-policy.hcl.jinja")
-    expected_policy = template.render({"path": vault_path})
+    expected_policy = template.render(
+        {"path": vault_path, "mount_point": mount_point}
+    )
     assert seen_policy == expected_policy
 
     # Check that it has only one SecretID.
@@ -236,7 +238,7 @@ def test_create_write_token(
 ) -> None:
     config_storage = factory.create_config_storage()
     environment = config_storage.load_environment_config("idfdev")
-    _, vault_path = environment.vault_path_prefix.split("/", 1)
+    mount_point, vault_path = environment.vault_path_prefix.split("/", 1)
     if "/" in vault_path:
         display_name = "token-" + vault_path.rsplit("/", 1)[1]
     else:
@@ -265,7 +267,9 @@ def test_create_write_token(
     r = mock_vault.read_policy(token.policies[0])
     seen_policy = r["rules"]
     template = templates.get_template("vault-write-policy.hcl.jinja")
-    expected_policy = template.render({"path": vault_path})
+    expected_policy = template.render(
+        {"path": vault_path, "mount_point": mount_point}
+    )
     assert seen_policy == expected_policy
 
 


### PR DESCRIPTION
This PR modifies how we generate the vault policies, to use the mount point from the vault path in the environment configuration rather than a fixed "/secret" path.