### PR TITLE
DM-49531: Enable dp1 for SIAv2 on idfdev and idfint environments

### DIFF
--- a/applications/sia/Chart.yaml
+++ b/applications/sia/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.1.6
+appVersion: 0.1.7
 description: Simple Image Access (SIA) IVOA Service using Butler
 name: sia
 sources:

--- a/applications/sia/values-idfdev.yaml
+++ b/applications/sia/values-idfdev.yaml
@@ -8,6 +8,12 @@ config:
       butler_type: "REMOTE"
       repository: "https://data-dev.lsst.cloud/api/butler/repo/dp02/butler.yaml"
       datalink_url: "https://data-dev.lsst.cloud/api/datalink/links?ID=butler%3A//dp02/{id}"
+    - config: "https://raw.githubusercontent.com/lsst-dm/dax_obscore/refs/heads/main/configs/dp1.yaml"
+      label: "LSST.DP1"
+      name: "dp1"
+      butler_type: "REMOTE"
+      repository: "https://data-dev.lsst.cloud/api/butler/repo/dp1/butler.yaml"
+      datalink_url: "https://data-dev.lsst.cloud/api/datalink/links?ID=butler%3A//dp1/{id}"
 
   enableSentry: true
   sentryTracesSampleRate: 1

--- a/applications/sia/values-idfdev.yaml
+++ b/applications/sia/values-idfdev.yaml
@@ -7,13 +7,13 @@ config:
       name: "dp02"
       butler_type: "REMOTE"
       repository: "https://data-dev.lsst.cloud/api/butler/repo/dp02/butler.yaml"
-      datalink_url: "https://data-dev.lsst.cloud/api/datalink/links?ID=butler%3A//dp02/{id}"
+      datalink_url: "https://data-dev.lsst.cloud/api/datalink/links?ID=ivo%3A%2F%2Forg.rubinobs%2Fusdac%2Fdp1%3Frepo%3Ddp1%26id%3D{id}"
     - config: "https://raw.githubusercontent.com/lsst-dm/dax_obscore/refs/heads/main/configs/dp1.yaml"
       label: "LSST.DP1"
       name: "dp1"
       butler_type: "REMOTE"
       repository: "https://data-dev.lsst.cloud/api/butler/repo/dp1/butler.yaml"
-      datalink_url: "https://data-dev.lsst.cloud/api/datalink/links?ID=butler%3A//dp1/{id}"
+      datalink_url: "https://data-dev.lsst.cloud/api/datalink/links?ID=ivo%3A%2F%2Forg.rubinobs%2Fusdac%2Fdp1%3Frepo%3Ddp1%26id%3D{id}"
 
   enableSentry: true
   sentryTracesSampleRate: 1

--- a/applications/sia/values-idfint.yaml
+++ b/applications/sia/values-idfint.yaml
@@ -8,6 +8,12 @@ config:
       butler_type: "REMOTE"
       repository: "https://data-int.lsst.cloud/api/butler/repo/dp02/butler.yaml"
       datalink_url: "https://data-int.lsst.cloud/api/datalink/links?ID=butler%3A//dp02/{id}"
+    - config: "https://raw.githubusercontent.com/lsst-dm/dax_obscore/refs/heads/main/configs/dp1.yaml"
+      label: "LSST.DP1"
+      name: "dp1"
+      butler_type: "REMOTE"
+      repository: "https://data-int.lsst.cloud/api/butler/repo/dp1/butler.yaml"
+      datalink_url: "https://data-int.lsst.cloud/api/datalink/links?ID=butler%3A//dp1/{id}"
 
   enableSentry: true
   sentryTracesSampleRate: 1

--- a/applications/sia/values-idfint.yaml
+++ b/applications/sia/values-idfint.yaml
@@ -7,13 +7,13 @@ config:
       name: "dp02"
       butler_type: "REMOTE"
       repository: "https://data-int.lsst.cloud/api/butler/repo/dp02/butler.yaml"
-      datalink_url: "https://data-int.lsst.cloud/api/datalink/links?ID=butler%3A//dp02/{id}"
+      datalink_url: "https://data-int.lsst.cloud/api/datalink/links?ID=ivo%3A%2F%2Forg.rubinobs%2Fusdac%2Fdp1%3Frepo%3Ddp1%26id%3D{id}"
     - config: "https://raw.githubusercontent.com/lsst-dm/dax_obscore/refs/heads/main/configs/dp1.yaml"
       label: "LSST.DP1"
       name: "dp1"
       butler_type: "REMOTE"
       repository: "https://data-int.lsst.cloud/api/butler/repo/dp1/butler.yaml"
-      datalink_url: "https://data-int.lsst.cloud/api/datalink/links?ID=butler%3A//dp1/{id}"
+      datalink_url: "https://data-int.lsst.cloud/api/datalink/links?ID=ivo%3A%2F%2Forg.rubinobs%2Fusdac%2Fdp1%3Frepo%3Ddp1%26id%3D{id}"
 
   enableSentry: true
   sentryTracesSampleRate: 1


### PR DESCRIPTION
## Summary
This PR changes the following:
- Upgrade SIA to 0.1.7 (Mainly to pick up latest changes to dax_obscore)
- Enables DP1 for idfint & idfdev

### What's Changed in SIA 0.1.7:
- DM-48938: Capture sia query in sentry tracing by @stvoutsin in https://github.com/lsst-sqre/sia/pull/29
- DM-49503: Update Python and pre-commit dependencies by @rra in https://github.com/lsst-sqre/sia/pull/31
- DM-49531: Update dependencies by @stvoutsin in https://github.com/lsst-sqre/sia/pull/32