### PR TITLE
DM-49546: Fix default scopes for user servers

### DIFF
--- a/applications/nublado/README.md
+++ b/applications/nublado/README.md
@@ -117,7 +117,7 @@ JupyterHub and custom spawner for the Rubin Science Platform
 | jupyterhub.hub.extraVolumes | list | The `hub-config` `ConfigMap` and the Gafaelfawr token | Additional volumes to make available to JupyterHub |
 | jupyterhub.hub.image.name | string | `"ghcr.io/lsst-sqre/nublado-jupyterhub"` | Image to use for JupyterHub |
 | jupyterhub.hub.image.tag | string | `"8.7.0"` | Tag of image to use for JupyterHub |
-| jupyterhub.hub.loadRoles.server.scopes | list | `["self"]` | Default scopes for the user's lab, overridden to allow the lab to delete itself (which we use for our added menu items) |
+| jupyterhub.hub.loadRoles.server.scopes | list | See `values.yaml` | Default scopes for the user's lab, overridden to allow the lab to delete itself (which we use for our added menu items) |
 | jupyterhub.hub.networkPolicy.enabled | bool | `false` | Whether to enable the default `NetworkPolicy` (currently, the upstream one does not work correctly) |
 | jupyterhub.hub.resources | object | See `values.yaml` | Resource limits and requests |
 | jupyterhub.ingress.enabled | bool | `false` | Whether to enable the default ingress. Should always be disabled since we install our own `GafaelfawrIngress` to avoid repeating the global hostname and manually configuring authentication |

--- a/applications/nublado/values.yaml
+++ b/applications/nublado/values.yaml
@@ -540,7 +540,11 @@ jupyterhub:
       server:
         # -- Default scopes for the user's lab, overridden to allow the lab to
         # delete itself (which we use for our added menu items)
-        scopes: ["self"]
+        # @default -- See `values.yaml`
+        scopes:
+          - "access:servers!user"
+          - "delete:servers!user"
+          - "users:activity!user"
 
   ingress:
     # -- Whether to enable the default ingress. Should always be disabled


### PR DESCRIPTION
We want to grant servers the ability to delete themselves since that's how the logout menu works. This previously was done by giving the server full `self` access, but that provides access to all sorts of other things we don't want the server to be doing, such as creating tokens for the user. Restrict that to only the permissions normally given to servers, plus the ability to delete servers.