### PR TITLE
DM-49546: Bump limits for JupyterHub proxy

### DIFF
--- a/applications/nublado/values.yaml
+++ b/applications/nublado/values.yaml
@@ -579,8 +579,8 @@ jupyterhub:
       # @default -- See `values.yaml`
       resources:
         limits:
-          cpu: "150m"
-          memory: "200Mi"
+          cpu: "1"
+          memory: "400Mi"
         requests:
           cpu: "5m"
           memory: "30Mi"


### PR DESCRIPTION
Increase the limit for the JupyterHub proxy to a full CPU and double the memory limit. The current requests are accurate for normal usage right now, but under load testing the JupyterHub proxy ran out of memory and was OOM-killed, and we're seeing warnings about it hitting its CPU limits.