### PR TITLE
DM-49388: Update Ghostwriter to 0.2.0

### DIFF
--- a/applications/ghostwriter/Chart.yaml
+++ b/applications/ghostwriter/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.1.2
+appVersion: 0.2.0
 description: URL rewriter/personalizer
 name: ghostwriter
 sources:


### PR DESCRIPTION
This version adds support for per-user subdomains in Nublado.