### PR TITLE
DM-49361: mobu - multi-instance

### DIFF
--- a/applications/mobu/Chart.yaml
+++ b/applications/mobu/Chart.yaml
@@ -5,4 +5,4 @@ description: "Continuous integration testing"
 home: https://mobu.lsst.io/
 sources:
   - "https://github.com/lsst-sqre/mobu"
-appVersion: 15.0.0
+appVersion: 15.1.0

--- a/applications/mobu/README.md
+++ b/applications/mobu/README.md
@@ -38,6 +38,7 @@ Continuous integration testing
 | ingress.annotations | object | `{}` | Additional annotations to add to the ingress |
 | nodeSelector | object | `{}` | Node selector rules for the mobu frontend pod |
 | podAnnotations | object | `{}` | Annotations for the mobu frontend pod |
+| replicaCount | int | `1` | Number of mobu instances to start. Starting more than one should only be used temporarily in specific circumstances. See [the Mobu documentation](https://mobu.lsst.io/user-guide/multiple-replicas.html) |
 | resources | object | See `values.yaml` | Resource limits and requests for the mobu frontend pod |
 | terminationGracePeriodSeconds | string | Use the Kubernetes default | Number of seconds for Kubernetes to send SIGKILL after sending SIGTERM |
 | tolerations | list | `[]` | Tolerations for the mobu frontend pod |

--- a/applications/mobu/templates/stateful-set.yaml
+++ b/applications/mobu/templates/stateful-set.yaml
@@ -1,11 +1,13 @@
+# See the docs for why this is a StatefulSet and not a Deployment:
+# https://mobu.lsst.io/user-guide/multiple-replicas.html
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: "mobu"
   labels:
     {{- include "mobu.labels" . | nindent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
       {{- include "mobu.selectorLabels" . | nindent 6 }}
@@ -38,6 +40,12 @@ spec:
             {{- end }}
             - name: "MOBU_ENVIRONMENT_URL"
               value: {{ .Values.global.baseUrl }}
+            - name: "MOBU_REPLICA_COUNT"
+              value: {{ .Values.replicaCount | quote }}
+            - name: "MOBU_REPLICA_INDEX"
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['apps.kubernetes.io/pod-index']
             - name: "MOBU_GAFAELFAWR_TOKEN"
               valueFrom:
                 secretKeyRef:

--- a/applications/mobu/tests/github_ci_app_enabled_test.yaml
+++ b/applications/mobu/tests/github_ci_app_enabled_test.yaml
@@ -24,8 +24,8 @@ tests:
           path: "config.scopes.anonymous"
           value: true
 
-  - it: "Should inject secrets into the Deployment env"
-    template: "deployment.yaml"
+  - it: "Should inject secrets into the StatefulSet env"
+    template: "stateful-set.yaml"
     asserts:
       - contains:
           path: "spec.template.spec.containers[0].env"

--- a/applications/mobu/tests/github_disabled_test.yaml
+++ b/applications/mobu/tests/github_disabled_test.yaml
@@ -32,8 +32,8 @@ tests:
             sentryEnvironment: null
             sentryTracesSampleConfig: 0
             slackAlerts: true
-  - it: "Should not inject GitHub CI app secrets into the Deployment env"
-    template: "deployment.yaml"
+  - it: "Should not inject GitHub CI app secrets into the StatefulSet env"
+    template: "stateful-set.yaml"
     asserts:
       - notContains:
           path: "spec.template.spec.containers[0].env"
@@ -50,8 +50,8 @@ tests:
           any: true
           content:
             name: "MOBU_GITHUB_CI_APP_WEBHOOK_SECRET"
-  - it: "Should not inject GitHub refresh app secrets into the Deployment env"
-    template: "deployment.yaml"
+  - it: "Should not inject GitHub refresh app secrets into the StatefulSet env"
+    template: "stateful-set.yaml"
     asserts:
       - notContains:
           path: "spec.template.spec.containers[0].env"

--- a/applications/mobu/tests/github_refresh_app_enabled_test.yaml
+++ b/applications/mobu/tests/github_refresh_app_enabled_test.yaml
@@ -18,8 +18,8 @@ tests:
           path: "config.scopes.anonymous"
           value: true
 
-  - it: "Should inject secrets into the Deployment env"
-    template: "deployment.yaml"
+  - it: "Should inject secrets into the StatefulSet env"
+    template: "stateful-set.yaml"
     asserts:
       - contains:
           path: "spec.template.spec.containers[0].env"

--- a/applications/mobu/tests/termination_grace_period_test.yaml
+++ b/applications/mobu/tests/termination_grace_period_test.yaml
@@ -1,7 +1,7 @@
 suite: terminationGracePeriod set
 tests:
-  - it: "Should set terminationGracePeriod in the deployment pod spec"
-    template: "deployment.yaml"
+  - it: "Should set terminationGracePeriod in the StaefulSet pod spec"
+    template: "stateful-set.yaml"
     set:
       terminationGracePeriodSeconds: 500
       global:
@@ -10,8 +10,8 @@ tests:
       - equal:
           path: "spec.template.spec.terminationGracePeriodSeconds"
           value: 500
-  - it: "Should set terminationGracePeriod in the deployment pod spec"
-    template: "deployment.yaml"
+  - it: "Should set terminationGracePeriod in the StatefulSet pod spec"
+    template: "stateful-set.yaml"
     set:
       terminationGracePeriodSeconds: null
       global:

--- a/applications/mobu/values.yaml
+++ b/applications/mobu/values.yaml
@@ -1,5 +1,10 @@
 # Default values for mobu.
 
+# -- Number of mobu instances to start. Starting more than one should only be
+# used temporarily in specific circumstances. See [the Mobu
+# documentation](https://mobu.lsst.io/user-guide/multiple-replicas.html)
+replicaCount: 1
+
 image:
   # -- mobu image to use
   repository: "ghcr.io/lsst-sqre/mobu"


### PR DESCRIPTION
* The replica count from the helm chart values is templated into the `replicas` value of the Mobu workload, and the `MOBU_REPLICA_COUNT` environment variable.

* The Mobu workload is a `StatefulSet` instead of a `Deployment` so that the [pod index label](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-index-label) can be passed as the value to the `MOBU_REPLICA_INDEX` env var via the Kubernetes [Downward API](https://kubernetes.io/docs/concepts/workloads/pods/downward-api/). This ensures that monkeys can be distributed as evenly as possible among all of the replicas in the `StatefulSet`.

Goes with [this Mobu PR](https://github.com/lsst-sqre/mobu/pull/448).

