### PR TITLE
DM-49563: Fix secrets sync with modify and delete

### DIFF
--- a/src/phalanx/services/secrets.py
+++ b/src/phalanx/services/secrets.py
@@ -679,7 +679,8 @@ class SecretsService:
         vault_client
             Client for talking to Vault for this environment.
         vault_secrets
-            Current secrets in Vault for this environment.
+            Current secrets in Vault for this environment. This is modified in
+            place as Vault secrets are updated.
         resolved
             Resolved secrets for this environment.
         """
@@ -687,6 +688,7 @@ class SecretsService:
             if application not in vault_secrets:
                 vault_client.store_application_secret(application, values)
                 print("Created Vault secret for", application)
+                vault_secrets[application] = values
                 continue
             vault_app_secrets = vault_secrets[application]
             for key, secret in values.items():
@@ -695,6 +697,7 @@ class SecretsService:
                         application, key, secret
                     )
                     print("Updated Vault secret for", application, key)
+                    vault_secrets[application][key] = secret
 
     def _sync_pull_secret(
         self,

--- a/tests/cli/secrets_test.py
+++ b/tests/cli/secrets_test.py
@@ -484,3 +484,45 @@ def test_sync_exclude(factory: Factory, mock_vault: MockVaultClient) -> None:
         o for o in all_output if "argocd" not in o and "portal" not in o
     )
     assert result.output == expected
+
+
+def test_sync_modify_delete(
+    factory: Factory, mock_vault: MockVaultClient
+) -> None:
+    """Test a sync that modifies and deletes a secret key at the same time."""
+    input_path = phalanx_test_path()
+    secrets_path = input_path / "secrets" / "idfdev.yaml"
+    config_storage = factory.create_config_storage()
+    environment = config_storage.load_environment("idfdev")
+    mock_vault.load_test_data(environment.vault_path_prefix, "idfdev")
+    _, base_vault_path = environment.vault_path_prefix.split("/", 1)
+    before = _get_app_secret(mock_vault, f"{base_vault_path}/gafaelfawr")
+
+    result = run_cli(
+        "secrets",
+        "sync",
+        "--secrets",
+        str(secrets_path),
+        "--exclude",
+        "argocd",
+        "--exclude",
+        "nublado",
+        "--exclude",
+        "portal",
+        "--exclude",
+        "postgres",
+        "--exclude",
+        "unknown",
+        "--delete",
+        "idfdev",
+        env={"VAULT_TOKEN": "sometoken"},
+    )
+    assert result.exit_code == 0
+    expected = read_output_data("idfdev", "sync-gafaelfawr-output")
+    assert result.output == expected
+    after = _get_app_secret(mock_vault, f"{base_vault_path}/gafaelfawr")
+    assert before["database-password"] != after["database-password"]
+    assert after.get("session-secret")
+    assert after.get("signing-key")
+    assert after.get("slack-webhook")
+    assert "cilogon" not in after

--- a/tests/data/output/idfdev/sync-gafaelfawr-output
+++ b/tests/data/output/idfdev/sync-gafaelfawr-output
@@ -1,0 +1,5 @@
+Updated Vault secret for gafaelfawr database-password
+Updated Vault secret for gafaelfawr session-secret
+Updated Vault secret for gafaelfawr signing-key
+Updated Vault secret for gafaelfawr slack-webhook
+Deleted Vault secret for gafaelfawr cilogon


### PR DESCRIPTION
Previously, if `phalanx secrets sync --delete` needed to modify a secret key's value and also delete a different secret key, it would inadvertantly undo the first operation when doing the second due to an out-of-date in-memory data structure. Fix this by updating the in-memory copy of the Vault secret when secrets are added or modified so that a subsequent delete uses the correct values.