### PR TITLE
Shift timing of Wobbly maintenance

### DIFF
--- a/applications/wobbly/README.md
+++ b/applications/wobbly/README.md
@@ -39,7 +39,7 @@ IVOA UWS database storage
 | ingress.annotations | object | `{}` | Additional annotations for the ingress rule |
 | maintenance.cleanupSeconds | int | 86400 (1 day) | How long to keep old jobs around before deleting them |
 | maintenance.deadlineSeconds | int | 300 (5 minutes) | How long the job is allowed to run before it will be terminated |
-| maintenance.schedule | string | `"10 * * * *"` | Cron schedule string for Wobbly periodic maintenance (in UTC) |
+| maintenance.schedule | string | `"8 * * * *"` | Cron schedule string for Wobbly periodic maintenance (in UTC) |
 | nodeSelector | object | `{}` | Node selection rules for the wobbly deployment pod |
 | podAnnotations | object | `{}` | Annotations for the wobbly deployment pod |
 | replicaCount | int | `1` | Number of web deployment pods to start |

--- a/applications/wobbly/values.yaml
+++ b/applications/wobbly/values.yaml
@@ -126,7 +126,7 @@ cloudsql:
 
 maintenance:
   # -- Cron schedule string for Wobbly periodic maintenance (in UTC)
-  schedule: "10 * * * *"
+  schedule: "8 * * * *"
 
   # -- How long the job is allowed to run before it will be terminated
   # @default -- 300 (5 minutes)


### PR DESCRIPTION
Try moving the Wobbly maintenance job off of 10 minutes past the hour to see if the timing is why we constantly get alerts about it but not about the Gafaelfawr maintenance jobs that use the same pattern.