### PR TITLE
DM-49361: mobu - ArgoCD resource consistency issues

### DIFF
--- a/applications/mobu/templates/stateful-set.yaml
+++ b/applications/mobu/templates/stateful-set.yaml
@@ -11,8 +11,6 @@ spec:
   selector:
     matchLabels:
       {{- include "mobu.selectorLabels" . | nindent 6 }}
-  strategy:
-    type: "Recreate"
   template:
     metadata:
       annotations:

--- a/applications/mobu/values.yaml
+++ b/applications/mobu/values.yaml
@@ -95,7 +95,11 @@ config:
 resources:
   limits:
     cpu: "1"
-    memory: "3.5Gi"
+    # This is specified in Mi instead of Gi because ArgoCD will always show
+    # OutOfSync because of a bug in value normalization for certain
+    # combinations of attributes in certain resources:
+    # https://github.com/argoproj/argo-cd/issues/16400
+    memory: "3584Mi"
   requests:
     cpu: "50m"
     memory: "1Gi"


### PR DESCRIPTION
* Specify mobu memory reqs in Mi instead of Gi because ArgoCD will always show OutOfSync because of a bug in value normalization for certain combinations of attributes in certain resources: https://github.com/argoproj/argo-cd/issues/16400
* Remove the `strategy` key from the `StatefulSet` because it only applies to `Deployments`