### PR TITLE
DM-49602: Convert idfint to per-user notebook domains

### DIFF
--- a/applications/gafaelfawr/values-idfint.yaml
+++ b/applications/gafaelfawr/values-idfint.yaml
@@ -6,6 +6,7 @@ redis:
     storageClass: "standard-rwo"
 
 config:
+  allowSubdomains: true
   slackAlerts: true
 
   cilogon:

--- a/applications/nublado/values-idfint.yaml
+++ b/applications/nublado/values-idfint.yaml
@@ -113,8 +113,16 @@ controller:
     metrics:
       enabled: true
 
+hub:
+  useSubdomains: true
+
 jupyterhub:
   hub:
+    config:
+      JupyterHub:
+        # This has to exist for Zero to JupyterHub to configure the proxy
+        # correctly.
+        subdomain_host: "nb.data-int.lsst.cloud"
     db:
       url: "postgresql://nublado@cloud-sql-proxy.nublado/nublado"
       upgrade: true


### PR DESCRIPTION
Enable subdomain support in Gafaelfawr for idfint and switch to per-user subdomains for Nublado in idfint.