### PR TITLE
DM-49610: Get back on upstream telegraf

### DIFF
--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -105,9 +105,9 @@ Rubin Observatory's telemetry service
 | app-metrics.envFromSecret | string | `""` | Name of the secret with values to be added to the environment |
 | app-metrics.globalAppConfig | object | See `values.yaml` | app-metrics configuration in any environment in which the subchart is enabled. This should stay globally specified here, and it shouldn't be overridden.  See [here](https://sasquatch.lsst.io/user-guide/app-metrics.html#configuration) for the structure of this value. |
 | app-metrics.globalInfluxTags | list | `["application"]` | Keys in an every event sent by any app that should be recorded in InfluxDB as "tags" (vs. "fields"). These will be concatenated with the `influxTags` from `globalAppConfig` |
-| app-metrics.image.pullPolicy | string | `"Always"` | Image pull policy |
-| app-metrics.image.repo | string | `"ghcr.io/lsst-sqre/telegraf"` | Telegraf image repository |
-| app-metrics.image.tag | string | `"nightly-alpine-2025-01-09"` | Telegraf image tag |
+| app-metrics.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
+| app-metrics.image.repo | string | `"docker.io/library/telegraf"` | Telegraf image repository |
+| app-metrics.image.tag | string | `"1.34.0-alpine"` | Telegraf image tag |
 | app-metrics.imagePullSecrets | list | `[]` | Secret names to use for Docker pulls |
 | app-metrics.influxdb.url | string | `"http://sasquatch-influxdb.sasquatch:8086"` | URL of the InfluxDB v1 instance to write to |
 | app-metrics.nodeSelector | object | `{}` | Node labels for pod assignment |

--- a/applications/sasquatch/charts/app-metrics/README.md
+++ b/applications/sasquatch/charts/app-metrics/README.md
@@ -15,9 +15,9 @@ Kafka topics, users, and a telegraf connector for metrics events.
 | envFromSecret | string | `""` | Name of the secret with values to be added to the environment |
 | globalAppConfig | object | See `values.yaml` | app-metrics configuration in any environment in which the subchart is enabled. This should stay globally specified here, and it shouldn't be overridden.  See [here](https://sasquatch.lsst.io/user-guide/app-metrics.html#configuration) for the structure of this value. |
 | globalInfluxTags | list | `["application"]` | Keys in an every event sent by any app that should be recorded in InfluxDB as "tags" (vs. "fields"). These will be concatenated with the `influxTags` from `globalAppConfig` |
-| image.pullPolicy | string | `"Always"` | Image pull policy |
-| image.repo | string | `"ghcr.io/lsst-sqre/telegraf"` | Telegraf image repository |
-| image.tag | string | `"nightly-alpine-2025-01-09"` | Telegraf image tag |
+| image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
+| image.repo | string | `"docker.io/library/telegraf"` | Telegraf image repository |
+| image.tag | string | `"1.34.0-alpine"` | Telegraf image tag |
 | imagePullSecrets | list | `[]` | Secret names to use for Docker pulls |
 | influxdb.url | string | `"http://sasquatch-influxdb.sasquatch:8086"` | URL of the InfluxDB v1 instance to write to |
 | nodeSelector | object | `{}` | Node labels for pod assignment |

--- a/applications/sasquatch/charts/app-metrics/values.yaml
+++ b/applications/sasquatch/charts/app-metrics/values.yaml
@@ -46,21 +46,15 @@ cluster:
   # the parent Sasquatch chart.
   name: sasquatch
 
-# These values refer to the Telegraf deployment and config
-# We are currently using a nightly build to get functionality that will be
-# released in 1.34, in March 2025. Once 1.34 has been released, we should
-# stop using this nightly build.
 image:
   # -- Telegraf image repository
-  repo: "ghcr.io/lsst-sqre/telegraf"
-  #repo: "docker.io/library/telegraf"
+  repo: "docker.io/library/telegraf"
 
   # -- Telegraf image tag
-  tag: "nightly-alpine-2025-01-09"
-  # tag: "1.30.2-alpine"
+  tag: "1.34.0-alpine"
 
   # -- Image pull policy
-  pullPolicy: "Always"
+  pullPolicy: "IfNotPresent"
 
 # -- Annotations for telegraf-kafka-consumers pods
 podAnnotations: {}


### PR DESCRIPTION
We are using a specific nightly build of telegraf for app metrics collection because it has our added support for Avro unions.

[1.34](https://github.com/influxdata/telegraf/releases/tag/v1.34.0) finally has [our Avro union support](https://github.com/influxdata/telegraf/pull/16272).