### PR TITLE
DM-49624: Update to Nublado 8.8.0

### DIFF
--- a/applications/nublado/Chart.yaml
+++ b/applications/nublado/Chart.yaml
@@ -5,7 +5,7 @@ description: JupyterHub and custom spawner for the Rubin Science Platform
 sources:
   - https://github.com/lsst-sqre/nublado
 home: https://nublado.lsst.io/
-appVersion: 8.7.1
+appVersion: 8.8.0
 
 dependencies:
   - name: jupyterhub

--- a/applications/nublado/README.md
+++ b/applications/nublado/README.md
@@ -116,7 +116,7 @@ JupyterHub and custom spawner for the Rubin Science Platform
 | jupyterhub.hub.extraVolumeMounts | list | `hub-config` and the Gafaelfawr token | Additional volume mounts for JupyterHub |
 | jupyterhub.hub.extraVolumes | list | The `hub-config` `ConfigMap` and the Gafaelfawr token | Additional volumes to make available to JupyterHub |
 | jupyterhub.hub.image.name | string | `"ghcr.io/lsst-sqre/nublado-jupyterhub"` | Image to use for JupyterHub |
-| jupyterhub.hub.image.tag | string | `"8.7.1"` | Tag of image to use for JupyterHub |
+| jupyterhub.hub.image.tag | string | `"8.8.0"` | Tag of image to use for JupyterHub |
 | jupyterhub.hub.loadRoles.server.scopes | list | See `values.yaml` | Default scopes for the user's lab, overridden to allow the lab to delete itself (which we use for our added menu items) |
 | jupyterhub.hub.networkPolicy.enabled | bool | `false` | Whether to enable the default `NetworkPolicy` (currently, the upstream one does not work correctly) |
 | jupyterhub.hub.resources | object | See `values.yaml` | Resource limits and requests |

--- a/applications/nublado/README.md
+++ b/applications/nublado/README.md
@@ -48,6 +48,7 @@ JupyterHub and custom spawner for the Rubin Science Platform
 | controller.config.images.pin | list | `[]` | List of additional image tags to prepull. Listing the image tagged as recommended here is recommended when using a Docker image source to ensure its name can be expanded properly in the menu. |
 | controller.config.images.recommendedTag | string | `"recommended"` | Tag marking the recommended image (shown first in the menu) |
 | controller.config.images.source | object | None, must be specified | Source for prepulled images. For Docker, set `type` to `docker`, `registry` to the hostname and `repository` to the name of the repository. For Google Artifact Repository, set `type` to `google`, `location` to the region, `projectId` to the Google project, `repository` to the name of the repository, and `image` to the name of the image. |
+| controller.config.lab.activityInterval | string | `"1h"` | How frequently the lab should report activity to JupyterHub in Safir `parse_timedelta` format |
 | controller.config.lab.affinity | object | `{}` | Affinity rules for user lab pods |
 | controller.config.lab.application | string | `"nublado-users"` | Argo CD application in which to collect user lab objects |
 | controller.config.lab.deleteTimeout | string | `"1m"` | Timeout for deleting a user's lab resources from Kubernetes in Safir `parse_timedelta` format |

--- a/applications/nublado/templates/hub-configmap.yaml
+++ b/applications/nublado/templates/hub-configmap.yaml
@@ -41,6 +41,9 @@ data:
     # Enable stored auth state.
     c.Authenticator.enable_auth_state = True
 
+    # Redirect to the Gafaelfawr logout handler after logout.
+    c.GafaelfawrAuthenticator.after_logout_redirect = "{{ .Values.global.baseUrl }}/logout"
+
     # Turn off restart after n consecutive failures.
     c.Spawner.consecutive_failure_limit = 0
 

--- a/applications/nublado/values-base.yaml
+++ b/applications/nublado/values-base.yaml
@@ -29,7 +29,7 @@ controller:
         - name: "inithome"
           image:
             repository: "ghcr.io/lsst-sqre/nublado-inithome"
-            tag: "8.7.1"
+            tag: "8.8.0"
           privileged: true
           volumeMounts:
             - containerPath: "/home"

--- a/applications/nublado/values-idfdemo.yaml
+++ b/applications/nublado/values-idfdemo.yaml
@@ -27,7 +27,7 @@ controller:
         - name: "inithome"
           image:
             repository: "ghcr.io/lsst-sqre/nublado-inithome"
-            tag: "8.7.1"
+            tag: "8.8.0"
           privileged: true
           volumeMounts:
             - containerPath: "/home"

--- a/applications/nublado/values-idfdev.yaml
+++ b/applications/nublado/values-idfdev.yaml
@@ -44,7 +44,7 @@ controller:
         - name: "inithome"
           image:
             repository: "ghcr.io/lsst-sqre/nublado-inithome"
-            tag: "8.7.1"
+            tag: "8.8.0"
           privileged: true
           volumeMounts:
             - containerPath: "/home"

--- a/applications/nublado/values-idfint.yaml
+++ b/applications/nublado/values-idfint.yaml
@@ -54,7 +54,7 @@ controller:
         - name: "inithome"
           image:
             repository: "ghcr.io/lsst-sqre/nublado-inithome"
-            tag: "8.7.1"
+            tag: "8.8.0"
           privileged: true
           volumeMounts:
             - containerPath: "/home"

--- a/applications/nublado/values-idfprod.yaml
+++ b/applications/nublado/values-idfprod.yaml
@@ -22,7 +22,7 @@ controller:
         - name: "inithome"
           image:
             repository: "ghcr.io/lsst-sqre/nublado-inithome"
-            tag: "8.7.1"
+            tag: "8.8.0"
           privileged: true
           volumeMounts:
             - containerPath: "/home"

--- a/applications/nublado/values-roe.yaml
+++ b/applications/nublado/values-roe.yaml
@@ -14,7 +14,7 @@ controller:
         - name: "inithome"
           image:
             repository: "ghcr.io/lsst-sqre/nublado-inithome"
-            tag: "8.7.1"
+            tag: "8.8.0"
           privileged: true
           volumeMounts:
             - containerPath: "/home"

--- a/applications/nublado/values-summit.yaml
+++ b/applications/nublado/values-summit.yaml
@@ -28,7 +28,7 @@ controller:
         - name: "inithome"
           image:
             repository: "ghcr.io/lsst-sqre/nublado-inithome"
-            tag: "8.7.1"
+            tag: "8.8.0"
           privileged: true
           volumeMounts:
             - containerPath: "/home"

--- a/applications/nublado/values-tucson-teststand.yaml
+++ b/applications/nublado/values-tucson-teststand.yaml
@@ -30,7 +30,7 @@ controller:
         - name: "inithome"
           image:
             repository: "ghcr.io/lsst-sqre/nublado-inithome"
-            tag: "8.7.1"
+            tag: "8.8.0"
           privileged: true
           volumeMounts:
             - containerPath: "/home"

--- a/applications/nublado/values.yaml
+++ b/applications/nublado/values.yaml
@@ -152,6 +152,10 @@ controller:
       aliasTags: []
 
     lab:
+      # -- How frequently the lab should report activity to JupyterHub in
+      # Safir `parse_timedelta` format
+      activityInterval: 1h
+
       # -- Affinity rules for user lab pods
       affinity: {}
 

--- a/applications/nublado/values.yaml
+++ b/applications/nublado/values.yaml
@@ -464,7 +464,7 @@ jupyterhub:
       name: "ghcr.io/lsst-sqre/nublado-jupyterhub"
 
       # -- Tag of image to use for JupyterHub
-      tag: "8.7.1"
+      tag: "8.8.0"
 
     # -- Resource limits and requests
     # @default -- See `values.yaml`


### PR DESCRIPTION
Add configuration for where to redirect the user after a JupyterHub logout so that we send the user to the Gafaelfawr logout handler instead of creating a redirect loop inside JupyterHub.