### PR TITLE
DM-49665: Adjust resource limits for consdb tapSchema container

### DIFF
--- a/applications/consdbtap/README.md
+++ b/applications/consdbtap/README.md
@@ -20,6 +20,8 @@ IVOA TAP service for the Consolidated Database (ConsDB)
 | cadc-tap.config.vaultSecretName | string | `"consdbtap"` | Vault secret name: the final key in the vault path |
 | cadc-tap.ingress.path | string | `"consdbtap"` | Ingress path that should be routed to this service |
 | cadc-tap.serviceAccount.name | string | `"consdbtap"` | Name of the Kubernetes `ServiceAccount`, used for CloudSQL access |
+| cadc-tap.tapSchema.resources.limits.memory | string | `"2Gi"` |  |
+| cadc-tap.tapSchema.resources.requests.memory | string | `"600Mi"` |  |
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |

--- a/applications/consdbtap/values.yaml
+++ b/applications/consdbtap/values.yaml
@@ -29,6 +29,12 @@ cadc-tap:
   serviceAccount:
     # -- Name of the Kubernetes `ServiceAccount`, used for CloudSQL access
     name: "consdbtap"
+  tapSchema:
+    resources:
+      limits:
+        memory: "2Gi"
+      requests:
+        memory: "600Mi"
 
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.


### PR DESCRIPTION
The consdb container wants to allocate 600 MB initially, reflected in the new request limit, and it seems to intermittently
 exceed the 1Gi limit when starting up, so this was increased to 2Gi. 

New settings were tested and confirmed to work on `usdf-rsp-dev`.