### PR TITLE
DM-49662: Increase memory limits we hit during load testing

### DIFF
--- a/applications/argocd/values.yaml
+++ b/applications/argocd/values.yaml
@@ -39,7 +39,7 @@ argo-cd:
     resources:
       limits:
         cpu: "8"
-        memory: "3Gi"
+        memory: "6Gi"
       requests:
         cpu: "1"
         memory: "1Gi"

--- a/applications/nublado/values.yaml
+++ b/applications/nublado/values.yaml
@@ -36,7 +36,7 @@ controller:
   resources:
     limits:
       cpu: "1"
-      memory: "400Mi"
+      memory: "1Gi"
     requests:
       cpu: "0.05"
       memory: "200Mi"


### PR DESCRIPTION
Increase memory limits for the Argo CD application controller and the Nublado controller, both of which were OOMKilled when testing scaling Nublado to 3,000 pods.