### PR TITLE
DM-49662: Increase Nublado activity reporting interval to 1h

### DIFF
--- a/applications/nublado/README.md
+++ b/applications/nublado/README.md
@@ -99,7 +99,7 @@ JupyterHub and custom spawner for the Rubin Science Platform
 | hub.timeout.startup | int | `90` | Timeout for JupyterLab to start in seconds. Currently this sometimes takes over 60 seconds for reasons we don't understand. |
 | hub.useSubdomains | bool | `false` | Whether to put each user's lab in a separate domain. This is strongly recommended for security, but requires wildcard DNS and cert-manager support and requires subdomain support be enabled in Gafaelfawr. |
 | jupyterhub.cull.enabled | bool | `true` | Enable the lab culler. |
-| jupyterhub.cull.every | int | 300 (5 minutes) | How frequently to check for idle labs in seconds |
+| jupyterhub.cull.every | int | 3600 (1 hour) | How frequently to check for idle labs in seconds |
 | jupyterhub.cull.maxAge | int | 2160000 (25 days) | Maximum age of a lab regardless of activity |
 | jupyterhub.cull.removeNamedServers | bool | `true` | Whether to remove named servers when culling their lab |
 | jupyterhub.cull.timeout | int | 432000 (5 days) | Default idle timeout before the lab is automatically deleted in seconds |

--- a/applications/nublado/templates/hub-configmap.yaml
+++ b/applications/nublado/templates/hub-configmap.yaml
@@ -18,14 +18,19 @@ data:
     )
 
     # JupyterHub uses a single database connection for all database activity
-    # and JupyterLab by default sends activity updates every 30 seconds. By
-    # the time we reach 1,000 active users, this is completely saturating
-    # JupyterHub and it stops being able to do work. This interval controls
-    # how frequently JupyterHub is willing to update activity information in
-    # the database. Increase it to 10 minutes, which is still a very long time
-    # compared to our idle thresholds.
-    c.JupyterHub.activity_resolution = 600
-    c.JupyterHub.last_activity_interval = 600
+    # and JupyterLab by default sends activity updates every five minutes
+    # (each of which turns into a lot of database activity). By the time we
+    # reach 1,000 active users, this is completely saturating JupyterHub and
+    # it stops being able to do work.
+    #
+    # We have reconfigured JupyterLab via the console to only send updates
+    # once an hour to prevent this problem. To protect against labs sending
+    # updates more frequently for some reason, also suppress updates more
+    # frequently than that. However, the lab randomizes the reporting interval
+    # by 10%, so set this limit to once per half-hour so that each update is
+    # recorded.
+    c.JupyterHub.activity_resolution = 1800
+    c.JupyterHub.last_activity_interval = 1800
 
     # Turn off concurrent spawn limit.
     c.JupyterHub.concurrent_spawn_limit = 0

--- a/applications/nublado/values.yaml
+++ b/applications/nublado/values.yaml
@@ -442,8 +442,8 @@ jupyterhub:
     timeout: 432000
 
     # -- How frequently to check for idle labs in seconds
-    # @default -- 300 (5 minutes)
-    every: 300
+    # @default -- 3600 (1 hour)
+    every: 3600
 
     # -- Whether to log out the user (from JupyterHub) when culling their lab
     users: false


### PR DESCRIPTION
Even at once every ten minutes, recording user lab activity is saturating JupyterHub. Increase the storage interval to one hour and also configure JupyterLab to only report activity once an hour. This is still very long compared to our idle cull interval. Also configure the idle culler to only check once every hour for labs to kill.