### PR TITLE
DM-49662: Define a separate Nublado controller startup probe

### DIFF
--- a/applications/nublado/templates/controller-deployment.yaml
+++ b/applications/nublado/templates/controller-deployment.yaml
@@ -71,6 +71,12 @@ spec:
             httpGet:
               path: "/"
               port: "http"
+          startupProbe:
+            httpGet:
+              path: "/"
+              port: "http"
+            failureThreshold: 30
+            periodSeconds: 10
           {{- with .Values.controller.resources }}
           resources:
             {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
If the Nublado controller has to recover a lot of state from Kubernetes, it may take some time to start up. Configure a separate startup probe that gives it up to five minutes.