### PR TITLE
Increase wobbly CPU limit to 1

### DIFF
--- a/applications/wobbly/values.yaml
+++ b/applications/wobbly/values.yaml
@@ -118,7 +118,7 @@ cloudsql:
   # @default -- See `values.yaml`
   resources:
     limits:
-      cpu: "100m"
+      cpu: "1"
       memory: "20Mi"
     requests:
       cpu: "5m"


### PR DESCRIPTION
CPU limits lower than 1 have not proven to be that useful compared to allowing burst usage when needed, and this seems to be the cause of spurious monitoring warnings for the maintenance job.