### PR TITLE
DM-49676: Upgrade TAP to version 2.11.0

### DIFF
--- a/charts/cadc-tap/README.md
+++ b/charts/cadc-tap/README.md
@@ -36,7 +36,7 @@ IVOA TAP service
 | config.qserv.host | string | `"mock-db:3306"` (the mock QServ) | QServ hostname:port to connect to |
 | config.qserv.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the TAP image |
 | config.qserv.image.repository | string | `"ghcr.io/lsst-sqre/lsst-tap-service"` | TAP image to use |
-| config.qserv.image.tag | string | `"2.10.0"` | Tag of TAP image to use |
+| config.qserv.image.tag | string | `"2.11.0"` | Tag of TAP image to use |
 | config.qserv.jdbcParams | string | `""` | Extra JDBC connection parameters |
 | config.qserv.passwordEnabled | bool | false | Whether the Qserv database is password protected |
 | config.sentryEnabled | bool | `false` | Whether Sentry is enabled in this environment |
@@ -80,7 +80,7 @@ IVOA TAP service
 | uws.affinity | object | `{}` | Affinity rules for the UWS database pod |
 | uws.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the UWS database image |
 | uws.image.repository | string | `"ghcr.io/lsst-sqre/lsst-tap-uws-db"` | UWS database image to use |
-| uws.image.tag | string | `"2.10.0"` | Tag of UWS database image to use |
+| uws.image.tag | string | `"2.11.0"` | Tag of UWS database image to use |
 | uws.nodeSelector | object | `{}` | Node selection rules for the UWS database pod |
 | uws.podAnnotations | object | `{}` | Annotations for the UWS databse pod |
 | uws.resources | object | See `values.yaml` | Resource limits and requests for the UWS database pod |

--- a/charts/cadc-tap/values.yaml
+++ b/charts/cadc-tap/values.yaml
@@ -89,7 +89,7 @@ config:
       pullPolicy: "IfNotPresent"
 
       # -- Tag of TAP image to use
-      tag: "2.10.0"
+      tag: "2.11.0"
 
     # -- Whether the Qserv database is password protected
     # @default -- false
@@ -203,7 +203,7 @@ uws:
     pullPolicy: "IfNotPresent"
 
     # -- Tag of UWS database image to use
-    tag: "2.10.0"
+    tag: "2.11.0"
 
   # -- Resource limits and requests for the UWS database pod
   # @default -- See `values.yaml`


### PR DESCRIPTION
## Summary

Upgrade TAP to version 2.11.0

## What's changed in TAP?
- DM-49350: Re-enable log4j configuration for cadc-log, keep log4j2 for sentry by @stvoutsin in https://github.com/lsst-sqre/lsst-tap-service/pull/135
- DM-49350: Fix version cadc-tap since upstream changes break our build, until we update our tap_schema image by @stvoutsin in https://github.com/lsst-sqre/lsst-tap-service/pull/136
- DM-49676: Change Sentry logging to not capture user syntax issues by @stvoutsin in https://github.com/lsst-sqre/lsst-tap-service/pull/137
