### PR TITLE
DM-48978: Keda Support on Next Visit Fan Out

### DIFF
--- a/applications/next-visit-fan-out-keda/README.md
+++ b/applications/next-visit-fan-out-keda/README.md
@@ -21,13 +21,18 @@ Temporary application for processing next visit events with keda.
 | kafka.offset | string | `"latest"` |  |
 | kafka.saslMechamism | string | `"SCRAM-SHA-512"` |  |
 | kafka.securityProtocol | string | `"SASL_PLAINTEXT"` |  |
+| keda.redisHealthCheckInterval | int | `3` | Redis health check interval in seconds. |
 | keda.redisHost | string | See `values.yaml`. | Redis cluster host. |
+| keda.redisRetryCount | int | `3` | Redis max retry count |
+| keda.redisRetryDelayCap | int | `5` | Maximum delay time for Redis retries in seconds. |
+| keda.redisRetryInitialDelay | int | `1` | Initial delay for first Redis retry in seconds. |
 | keda.redisStreams | object | See `values.yaml`. | A mapping of instrument to that instrument's Keda Scaled Job. |
 | knative.maxMessages | string | None, must be set. | The maximum number of messages that can be forwarded to all Knative instances combined. |
 | knative.retryRequests | bool | `true` | Whether or not to retry requests that returned a suitable response. |
 | knative.urls | object | See `values.yaml`. | A mapping of instrument to that instrument's Knative service. |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` | Node selection rules for the next-visit-fan-out deployment pod |
+| platform | string | `"keda"` | Platform to submit events to.  Either knative or keda. |
 | podAnnotations."prometheus.io/port" | string | `"8000"` |  |
 | podAnnotations."prometheus.io/scrape" | string | `"true"` |  |
 | replicaCount | int | `1` |  |

--- a/applications/next-visit-fan-out-keda/templates/deployment.yaml
+++ b/applications/next-visit-fan-out-keda/templates/deployment.yaml
@@ -23,6 +23,8 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
+            - name: PLATFORM
+              value: {{ .Values.platform }}
             - name: KAFKA_SCHEMA_REGISTRY_URL
               value: {{ .Values.kafka.schemaRegistryUrl }}
             - name: KAFKA_CLUSTER
@@ -61,6 +63,14 @@ spec:
               value: /etc/config/instrument.yaml
             - name: REDIS_HOST
               value: {{ .Values.keda.redisHost }}
+            - name: REDIS_RETRY_DELAY_CAP
+              value: {{ .Values.keda.redisRetryDelayCap | toString | quote }}
+            - name: REDIS_RETRY_INITIAL_DELAY
+              value: {{ .Values.keda.redisRetryInitialDelay | toString | quote }}
+            - name: REDIS_RETRY_COUNT
+              value: {{ .Values.keda.redisRetryCount | toString | quote }}
+            - name: REDIS_HEALTH_CHECK_INTERVAL
+              value: {{ .Values.keda.redisHealthCheckInterval | toString | quote }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/applications/next-visit-fan-out-keda/values.yaml
+++ b/applications/next-visit-fan-out-keda/values.yaml
@@ -1,3 +1,6 @@
+# -- Platform to submit events to.  Either knative or keda.
+platform: "keda"
+
 knative:
   # -- A mapping of instrument to that instrument's Knative service.
   # @default -- See `values.yaml`.
@@ -18,6 +21,14 @@ keda:
   # -- Redis cluster host.
   # @default -- See `values.yaml`.
   redisHost: prompt-redis.prompt-redis
+  # -- Maximum delay time for Redis retries in seconds.
+  redisRetryDelayCap: 5
+  # -- Initial delay for first Redis retry in seconds.
+  redisRetryInitialDelay: 1
+  # -- Redis max retry count
+  redisRetryCount: 3
+  # -- Redis health check interval in seconds.
+  redisHealthCheckInterval: 3
   # -- A mapping of instrument to that instrument's Keda Scaled Job.
   # @default -- See `values.yaml`.
   redisStreams:

--- a/applications/next-visit-fan-out/README.md
+++ b/applications/next-visit-fan-out/README.md
@@ -21,11 +21,18 @@ Poll next visit events from Kafka, duplicate them, and send them to all applicat
 | kafka.offset | string | `"latest"` |  |
 | kafka.saslMechamism | string | `"SCRAM-SHA-512"` |  |
 | kafka.securityProtocol | string | `"SASL_PLAINTEXT"` |  |
+| keda.redisHealthCheckInterval | int | `3` | Redis health check interval in seconds. |
+| keda.redisHost | string | See `values.yaml`. | Redis cluster host. |
+| keda.redisRetryCount | int | `3` | Redis max retry count |
+| keda.redisRetryDelayCap | int | `5` | Maximum delay time for Redis retries in seconds. |
+| keda.redisRetryInitialDelay | int | `1` | Initial delay for first Redis retry in seconds. |
+| keda.redisStreams | object | See `values.yaml`. | A mapping of instrument to that instrument's Keda Scaled Job. |
 | knative.maxMessages | string | None, must be set. | The maximum number of messages that can be forwarded to all Knative instances combined. |
 | knative.retryRequests | bool | `true` | Whether or not to retry requests that returned a suitable response. |
 | knative.urls | object | See `values.yaml`. | A mapping of instrument to that instrument's Knative service. |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` | Node selection rules for the next-visit-fan-out deployment pod |
+| platform | string | `""` | Platform to submit events to.  Either knative or keda. |
 | podAnnotations."prometheus.io/port" | string | `"8000"` |  |
 | podAnnotations."prometheus.io/scrape" | string | `"true"` |  |
 | replicaCount | int | `1` |  |

--- a/applications/next-visit-fan-out/templates/deployment.yaml
+++ b/applications/next-visit-fan-out/templates/deployment.yaml
@@ -23,6 +23,8 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
+            - name: PLATFORM
+              value: {{ .Values.platform }}
             - name: KAFKA_SCHEMA_REGISTRY_URL
               value: {{ .Values.kafka.schemaRegistryUrl }}
             - name: KAFKA_CLUSTER
@@ -59,6 +61,16 @@ spec:
               value: {{ .Values.instruments }}
             - name: INSTRUMENT_CONFIG_FILE
               value: /etc/config/instrument.yaml
+            - name: REDIS_HOST
+              value: {{ .Values.keda.redisHost }}
+            - name: REDIS_RETRY_DELAY_CAP
+              value: {{ .Values.keda.redisRetryDelayCap | toString | quote }}
+            - name: REDIS_RETRY_INITIAL_DELAY
+              value: {{ .Values.keda.redisRetryInitialDelay | toString | quote }}
+            - name: REDIS_RETRY_COUNT
+              value: {{ .Values.keda.redisRetryCount | toString | quote }}
+            - name: REDIS_HEALTH_CHECK_INTERVAL
+              value: {{ .Values.keda.redisHealthCheckInterval | toString | quote }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/applications/next-visit-fan-out/templates/instruments.yaml
+++ b/applications/next-visit-fan-out/templates/instruments.yaml
@@ -7,5 +7,7 @@ data:
   instruments: |
     knative-urls:
       {{- .Values.knative.urls | toYaml | nindent 6 }}
+    redis-streams:
+      {{- .Values.keda.redisStreams | toYaml | nindent 6 }}
     detectors:
       {{- .Values.detectorConfig | toYaml | nindent 6 }}

--- a/applications/next-visit-fan-out/values-usdfdev-prompt-processing.yaml
+++ b/applications/next-visit-fan-out/values-usdfdev-prompt-processing.yaml
@@ -1,4 +1,4 @@
-platform: knative
+platform: keda
 
 knative:
   maxMessages: 2000
@@ -8,7 +8,7 @@ kafka:
   schemaRegistryUrl: http://10.103.126.51:8081
   sasquatchAddress: 10.100.226.209:9094
   consumerGroup: test-group-3
-  nextVisitTopic: test.next-visit
+  nextVisitTopic: test.next-visit-job
   # Dev processes very old images, set to ~20 years
   expiration: 600_000_000.0
 

--- a/applications/next-visit-fan-out/values-usdfdev-prompt-processing.yaml
+++ b/applications/next-visit-fan-out/values-usdfdev-prompt-processing.yaml
@@ -1,3 +1,5 @@
+platform: knative
+
 knative:
   maxMessages: 2000
   retryRequests: false

--- a/applications/next-visit-fan-out/values-usdfdev-prompt-processing.yaml
+++ b/applications/next-visit-fan-out/values-usdfdev-prompt-processing.yaml
@@ -16,6 +16,6 @@ image:
   repository: ghcr.io/lsst-dm/next_visit_fan_out
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 2.6.0
+  tag: 2.7.0
 
 instruments: "LATISS LSSTCam LSSTCam-imSim LSSTComCam LSSTComCamSim HSC"

--- a/applications/next-visit-fan-out/values-usdfprod-prompt-processing.yaml
+++ b/applications/next-visit-fan-out/values-usdfprod-prompt-processing.yaml
@@ -1,3 +1,5 @@
+platform: knative
+
 knative:
   maxMessages: 2000
 

--- a/applications/next-visit-fan-out/values-usdfprod-prompt-processing.yaml
+++ b/applications/next-visit-fan-out/values-usdfprod-prompt-processing.yaml
@@ -1,4 +1,4 @@
-platform: knative
+platform: keda
 
 knative:
   maxMessages: 2000

--- a/applications/next-visit-fan-out/values-usdfprod-prompt-processing.yaml
+++ b/applications/next-visit-fan-out/values-usdfprod-prompt-processing.yaml
@@ -13,6 +13,6 @@ image:
   repository: ghcr.io/lsst-dm/next_visit_fan_out
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 2.5.0
+  tag: 2.7.0
 
 instruments: "LATISS"

--- a/applications/next-visit-fan-out/values.yaml
+++ b/applications/next-visit-fan-out/values.yaml
@@ -1,3 +1,6 @@
+# -- Platform to submit events to.  Either knative or keda.
+platform: ""
+
 knative:
   # -- A mapping of instrument to that instrument's Knative service.
   # @default -- See `values.yaml`.
@@ -13,6 +16,28 @@ knative:
   maxMessages: ""
   # -- Whether or not to retry requests that returned a suitable response.
   retryRequests: true
+
+keda:
+  # -- Redis cluster host.
+  # @default -- See `values.yaml`.
+  redisHost: prompt-redis.prompt-redis
+  # -- Maximum delay time for Redis retries in seconds.
+  redisRetryDelayCap: 5
+  # -- Initial delay for first Redis retry in seconds.
+  redisRetryInitialDelay: 1
+  # -- Redis max retry count
+  redisRetryCount: 3
+  # -- Redis health check interval in seconds.
+  redisHealthCheckInterval: 3
+  # -- A mapping of instrument to that instrument's Keda Scaled Job.
+  # @default -- See `values.yaml`.
+  redisStreams:
+    HSC: instrument:hsc
+    LATISS: instrument:latiss
+    LSSTComCam: instrument:lsstcomcam
+    LSSTComCamSim: instrument:lsstcomcamsim
+    LSSTCam: instrument:lsstcam
+    LSSTCam-imSim: instrument:lsstcamimsim
 
 kafka:
   offset: latest

--- a/environments/values-usdfdev-prompt-processing.yaml
+++ b/environments/values-usdfdev-prompt-processing.yaml
@@ -9,7 +9,7 @@ applications:
   ingress-nginx: false
   keda: true
   next-visit-fan-out: true
-  next-visit-fan-out-keda: true
+  next-visit-fan-out-keda: false
   prompt-kafka: true
   prompt-keda-hsc: true
   prompt-keda-latiss: true

--- a/environments/values-usdfprod-prompt-processing.yaml
+++ b/environments/values-usdfprod-prompt-processing.yaml
@@ -9,7 +9,7 @@ applications:
   ingress-nginx: false
   keda: true
   next-visit-fan-out: true
-  next-visit-fan-out-keda: true
+  next-visit-fan-out-keda: false
   prompt-keda-latiss: true
   prompt-proto-service-hsc: false
   prompt-proto-service-latiss: true

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -12,7 +12,7 @@ import yaml
 from phalanx.factory import Factory
 from phalanx.models.applications import Project
 
-_ALLOW_DISABLED = {"production-tools"}
+_ALLOW_DISABLED = {"production-tools", "next-visit-fan-out-keda"}
 """Temporary whitelist of applications not enabled anywhere."""
 
 _ALLOW_NO_SECRETS = {"next-visit-fan-out"}


### PR DESCRIPTION
Adds env variables and instrument config for Redis Steams to `next-visit-fan-out` and `next-visit-fan-out-keda` applications for co-existence.