### PR TITLE
DM-45988: Support storing init-outputs in Prompt Processing central repo

### DIFF
--- a/applications/prompt-keda-hsc/README.md
+++ b/applications/prompt-keda-hsc/README.md
@@ -30,6 +30,15 @@ KEDA Prompt Processing instance for HSC
 | prompt-keda.imageNotifications.imageTimeout | string | `"20"` | Timeout to wait after expected script completion for raw image arrival (seconds). |
 | prompt-keda.imageNotifications.kafkaClusterAddress | string | None, must be set | Hostname and port of the Kafka provider |
 | prompt-keda.imageNotifications.topic | string | None, must be set | Topic where raw image arrival notifications appear |
+| prompt-keda.initializer.cleanup_delay | int | `3600` | Time after which to remove old initializer pods (seconds). |
+| prompt-keda.initializer.image.repository | string | `"ghcr.io/lsst-dm/prompt-init"` | Image to use for the PP initializer |
+| prompt-keda.initializer.podAnnotations | object | See the `values.yaml` file. | Pod annotations for the init-output Job |
+| prompt-keda.initializer.resources.cpuLimit | int | `1` | The maximum cpu cores for the initializer. |
+| prompt-keda.initializer.resources.cpuRequest | int | `1` | The cpu cores requested for the initializer. |
+| prompt-keda.initializer.resources.memoryLimit | string | `"1Gi"` | The maximum memory limit for the initializer. |
+| prompt-keda.initializer.resources.memoryRequest | string | `"512Mi"` | The minimum memory to request for the initializer. |
+| prompt-keda.initializer.retries | int | `6` | Maximum number of times to attempt initializing the central repo. If the initializer fails, the PP service cannot run! |
+| prompt-keda.initializer.timeout | int | `120` | Maximum time for a single attempt to initialize the central repo (seconds). |
 | prompt-keda.instrument.calibRepo | string | None, must be set | URI to the shared repo used for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself. |
 | prompt-keda.instrument.name | string | `"HSC"` | The "short" name of the instrument |
 | prompt-keda.instrument.pipelines.main | string | None, must be set | YAML-formatted config describing which pipeline(s) should be run for which visits' raws. Fields are still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |

--- a/applications/prompt-keda-hsc/README.md
+++ b/applications/prompt-keda-hsc/README.md
@@ -31,6 +31,8 @@ KEDA Prompt Processing instance for HSC
 | prompt-keda.imageNotifications.kafkaClusterAddress | string | None, must be set | Hostname and port of the Kafka provider |
 | prompt-keda.imageNotifications.topic | string | None, must be set | Topic where raw image arrival notifications appear |
 | prompt-keda.initializer.cleanup_delay | int | `3600` | Time after which to remove old initializer pods (seconds). |
+| prompt-keda.initializer.cron.day_obs_tz | int | `-12` | Time zone in which day_obs is computed. |
+| prompt-keda.initializer.cron.suspend | bool | `false` | Whether or not to pause daily initializer runs. This makes it impossible to run Prompt Processing, but avoids repo clutter if the telescope is offline. |
 | prompt-keda.initializer.image.repository | string | `"ghcr.io/lsst-dm/prompt-init"` | Image to use for the PP initializer |
 | prompt-keda.initializer.podAnnotations | object | See the `values.yaml` file. | Pod annotations for the init-output Job |
 | prompt-keda.initializer.resources.cpuLimit | int | `1` | The maximum cpu cores for the initializer. |

--- a/applications/prompt-keda-hsc/values.yaml
+++ b/applications/prompt-keda-hsc/values.yaml
@@ -145,6 +145,33 @@ prompt-keda:
       # -- Maximum message age to process, in seconds.
       expiration: 3600
 
+  initializer:
+    image:
+      # -- Image to use for the PP initializer
+      repository: ghcr.io/lsst-dm/prompt-init
+      # Initializer and service must be consistent; pull policy and tag can't be set independently
+    resources:
+      # -- The cpu cores requested for the initializer.
+      cpuRequest: 1
+      # -- The maximum cpu cores for the initializer.
+      cpuLimit: 1
+      # -- The minimum memory to request for the initializer.
+      memoryRequest: "512Mi"
+      # -- The maximum memory limit for the initializer.
+      memoryLimit: "1Gi"
+
+    # -- Maximum time for a single attempt to initialize the central repo (seconds).
+    timeout: 120
+    # -- Maximum number of times to attempt initializing the central repo.
+    # If the initializer fails, the PP service cannot run!
+    retries: 6
+
+    # -- Time after which to remove old initializer pods (seconds).
+    cleanup_delay: 3600
+
+    # -- Pod annotations for the init-output Job
+    # @default -- See the `values.yaml` file.
+    podAnnotations: {}
 
   # -- Override the base name for resources
   nameOverride: ""

--- a/applications/prompt-keda-hsc/values.yaml
+++ b/applications/prompt-keda-hsc/values.yaml
@@ -159,6 +159,12 @@ prompt-keda:
       memoryRequest: "512Mi"
       # -- The maximum memory limit for the initializer.
       memoryLimit: "1Gi"
+    cron:
+      # -- Time zone in which day_obs is computed.
+      day_obs_tz: -12
+      # -- Whether or not to pause daily initializer runs.
+      # This makes it impossible to run Prompt Processing, but avoids repo clutter if the telescope is offline.
+      suspend: false
 
     # -- Maximum time for a single attempt to initialize the central repo (seconds).
     timeout: 120

--- a/applications/prompt-keda-latiss/README.md
+++ b/applications/prompt-keda-latiss/README.md
@@ -30,6 +30,15 @@ KEDA Prompt Processing instance for LATISS
 | prompt-keda.imageNotifications.imageTimeout | int | `20` | Timeout to wait after expected script completion for raw image arrival (seconds). |
 | prompt-keda.imageNotifications.kafkaClusterAddress | string | None, must be set | Hostname and port of the Kafka provider |
 | prompt-keda.imageNotifications.topic | string | None, must be set | Topic where raw image arrival notifications appear |
+| prompt-keda.initializer.cleanup_delay | int | `3600` | Time after which to remove old initializer pods (seconds). |
+| prompt-keda.initializer.image.repository | string | `"ghcr.io/lsst-dm/prompt-init"` | Image to use for the PP initializer |
+| prompt-keda.initializer.podAnnotations | object | See the `values.yaml` file. | Pod annotations for the init-output Job |
+| prompt-keda.initializer.resources.cpuLimit | int | `1` | The maximum cpu cores for the initializer. |
+| prompt-keda.initializer.resources.cpuRequest | int | `1` | The cpu cores requested for the initializer. |
+| prompt-keda.initializer.resources.memoryLimit | string | `"1Gi"` | The maximum memory limit for the initializer. |
+| prompt-keda.initializer.resources.memoryRequest | string | `"512Mi"` | The minimum memory to request for the initializer. |
+| prompt-keda.initializer.retries | int | `6` | Maximum number of times to attempt initializing the central repo. If the initializer fails, the PP service cannot run! |
+| prompt-keda.initializer.timeout | int | `120` | Maximum time for a single attempt to initialize the central repo (seconds). |
 | prompt-keda.instrument.calibRepo | string | None, must be set | URI to the shared repo used for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself. |
 | prompt-keda.instrument.name | string | `"LATISS"` | The "short" name of the instrument |
 | prompt-keda.instrument.pipelines.main | string | None, must be set | YAML-formatted config describing which pipeline(s) should be run for which visits' raws. Fields are still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |

--- a/applications/prompt-keda-latiss/README.md
+++ b/applications/prompt-keda-latiss/README.md
@@ -31,6 +31,8 @@ KEDA Prompt Processing instance for LATISS
 | prompt-keda.imageNotifications.kafkaClusterAddress | string | None, must be set | Hostname and port of the Kafka provider |
 | prompt-keda.imageNotifications.topic | string | None, must be set | Topic where raw image arrival notifications appear |
 | prompt-keda.initializer.cleanup_delay | int | `3600` | Time after which to remove old initializer pods (seconds). |
+| prompt-keda.initializer.cron.day_obs_tz | int | `-12` | Time zone in which day_obs is computed. |
+| prompt-keda.initializer.cron.suspend | bool | `false` | Whether or not to pause daily initializer runs. This makes it impossible to run Prompt Processing, but avoids repo clutter if the telescope is offline. |
 | prompt-keda.initializer.image.repository | string | `"ghcr.io/lsst-dm/prompt-init"` | Image to use for the PP initializer |
 | prompt-keda.initializer.podAnnotations | object | See the `values.yaml` file. | Pod annotations for the init-output Job |
 | prompt-keda.initializer.resources.cpuLimit | int | `1` | The maximum cpu cores for the initializer. |

--- a/applications/prompt-keda-latiss/values.yaml
+++ b/applications/prompt-keda-latiss/values.yaml
@@ -143,6 +143,33 @@ prompt-keda:
       # -- Maximum message age to process, in seconds.
       expiration: 3600
 
+  initializer:
+    image:
+      # -- Image to use for the PP initializer
+      repository: ghcr.io/lsst-dm/prompt-init
+      # Initializer and service must be consistent; pull policy and tag can't be set independently
+    resources:
+      # -- The cpu cores requested for the initializer.
+      cpuRequest: 1
+      # -- The maximum cpu cores for the initializer.
+      cpuLimit: 1
+      # -- The minimum memory to request for the initializer.
+      memoryRequest: "512Mi"
+      # -- The maximum memory limit for the initializer.
+      memoryLimit: "1Gi"
+
+    # -- Maximum time for a single attempt to initialize the central repo (seconds).
+    timeout: 120
+    # -- Maximum number of times to attempt initializing the central repo.
+    # If the initializer fails, the PP service cannot run!
+    retries: 6
+
+    # -- Time after which to remove old initializer pods (seconds).
+    cleanup_delay: 3600
+
+    # -- Pod annotations for the init-output Job
+    # @default -- See the `values.yaml` file.
+    podAnnotations: {}
 
   # -- Override the base name for resources
   nameOverride: ""

--- a/applications/prompt-keda-latiss/values.yaml
+++ b/applications/prompt-keda-latiss/values.yaml
@@ -157,6 +157,12 @@ prompt-keda:
       memoryRequest: "512Mi"
       # -- The maximum memory limit for the initializer.
       memoryLimit: "1Gi"
+    cron:
+      # -- Time zone in which day_obs is computed.
+      day_obs_tz: -12
+      # -- Whether or not to pause daily initializer runs.
+      # This makes it impossible to run Prompt Processing, but avoids repo clutter if the telescope is offline.
+      suspend: false
 
     # -- Maximum time for a single attempt to initialize the central repo (seconds).
     timeout: 120

--- a/applications/prompt-keda-lsstcam/README.md
+++ b/applications/prompt-keda-lsstcam/README.md
@@ -30,6 +30,15 @@ KEDA Prompt Processing instance for LSSTCam
 | prompt-keda.imageNotifications.imageTimeout | int | `20` | Timeout to wait after expected script completion for raw image arrival (seconds). |
 | prompt-keda.imageNotifications.kafkaClusterAddress | string | None, must be set | Hostname and port of the Kafka provider |
 | prompt-keda.imageNotifications.topic | string | None, must be set | Topic where raw image arrival notifications appear |
+| prompt-keda.initializer.cleanup_delay | int | `3600` | Time after which to remove old initializer pods (seconds). |
+| prompt-keda.initializer.image.repository | string | `"ghcr.io/lsst-dm/prompt-init"` | Image to use for the PP initializer |
+| prompt-keda.initializer.podAnnotations | object | See the `values.yaml` file. | Pod annotations for the init-output Job |
+| prompt-keda.initializer.resources.cpuLimit | int | `1` | The maximum cpu cores for the initializer. |
+| prompt-keda.initializer.resources.cpuRequest | int | `1` | The cpu cores requested for the initializer. |
+| prompt-keda.initializer.resources.memoryLimit | string | `"1Gi"` | The maximum memory limit for the initializer. |
+| prompt-keda.initializer.resources.memoryRequest | string | `"512Mi"` | The minimum memory to request for the initializer. |
+| prompt-keda.initializer.retries | int | `6` | Maximum number of times to attempt initializing the central repo. If the initializer fails, the PP service cannot run! |
+| prompt-keda.initializer.timeout | int | `120` | Maximum time for a single attempt to initialize the central repo (seconds). |
 | prompt-keda.instrument.calibRepo | string | None, must be set | URI to the shared repo used for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself. |
 | prompt-keda.instrument.name | string | `"LSSTCam"` | The "short" name of the instrument |
 | prompt-keda.instrument.pipelines.main | string | None, must be set | YAML-formatted config describing which pipeline(s) should be run for which visits' raws. Fields are still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |

--- a/applications/prompt-keda-lsstcam/values.yaml
+++ b/applications/prompt-keda-lsstcam/values.yaml
@@ -150,6 +150,34 @@ prompt-keda:
       # -- Maximum message age to process, in seconds.
       expiration: 3600
 
+  initializer:
+    image:
+      # -- Image to use for the PP initializer
+      repository: ghcr.io/lsst-dm/prompt-init
+      # Initializer and service must be consistent; pull policy and tag can't be set independently
+    resources:
+      # -- The cpu cores requested for the initializer.
+      cpuRequest: 1
+      # -- The maximum cpu cores for the initializer.
+      cpuLimit: 1
+      # -- The minimum memory to request for the initializer.
+      memoryRequest: "512Mi"
+      # -- The maximum memory limit for the initializer.
+      memoryLimit: "1Gi"
+
+    # -- Maximum time for a single attempt to initialize the central repo (seconds).
+    timeout: 120
+    # -- Maximum number of times to attempt initializing the central repo.
+    # If the initializer fails, the PP service cannot run!
+    retries: 6
+
+    # -- Time after which to remove old initializer pods (seconds).
+    cleanup_delay: 3600
+
+    # -- Pod annotations for the init-output Job
+    # @default -- See the `values.yaml` file.
+    podAnnotations: {}
+
 
   # -- Override the base name for resources
   nameOverride: ""

--- a/applications/prompt-keda-lsstcamimsim/README.md
+++ b/applications/prompt-keda-lsstcamimsim/README.md
@@ -30,6 +30,15 @@ KEDA Prompt Processing instance for LSSTCam-imSim.
 | prompt-keda.imageNotifications.imageTimeout | int | `20` | Timeout to wait after expected script completion for raw image arrival (seconds). |
 | prompt-keda.imageNotifications.kafkaClusterAddress | string | None, must be set | Hostname and port of the Kafka provider |
 | prompt-keda.imageNotifications.topic | string | None, must be set | Topic where raw image arrival notifications appear |
+| prompt-keda.initializer.cleanup_delay | int | `3600` | Time after which to remove old initializer pods (seconds). |
+| prompt-keda.initializer.image.repository | string | `"ghcr.io/lsst-dm/prompt-init"` | Image to use for the PP initializer |
+| prompt-keda.initializer.podAnnotations | object | See the `values.yaml` file. | Pod annotations for the init-output Job |
+| prompt-keda.initializer.resources.cpuLimit | int | `1` | The maximum cpu cores for the initializer. |
+| prompt-keda.initializer.resources.cpuRequest | int | `1` | The cpu cores requested for the initializer. |
+| prompt-keda.initializer.resources.memoryLimit | string | `"1Gi"` | The maximum memory limit for the initializer. |
+| prompt-keda.initializer.resources.memoryRequest | string | `"512Mi"` | The minimum memory to request for the initializer. |
+| prompt-keda.initializer.retries | int | `6` | Maximum number of times to attempt initializing the central repo. If the initializer fails, the PP service cannot run! |
+| prompt-keda.initializer.timeout | int | `120` | Maximum time for a single attempt to initialize the central repo (seconds). |
 | prompt-keda.instrument.calibRepo | string | None, must be set | URI to the shared repo used for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself. |
 | prompt-keda.instrument.name | string | `"LSSTCam-imSim"` | The "short" name of the instrument |
 | prompt-keda.instrument.pipelines.main | string | None, must be set | YAML-formatted config describing which pipeline(s) should be run for which visits' raws. Fields are still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |

--- a/applications/prompt-keda-lsstcamimsim/README.md
+++ b/applications/prompt-keda-lsstcamimsim/README.md
@@ -31,6 +31,8 @@ KEDA Prompt Processing instance for LSSTCam-imSim.
 | prompt-keda.imageNotifications.kafkaClusterAddress | string | None, must be set | Hostname and port of the Kafka provider |
 | prompt-keda.imageNotifications.topic | string | None, must be set | Topic where raw image arrival notifications appear |
 | prompt-keda.initializer.cleanup_delay | int | `3600` | Time after which to remove old initializer pods (seconds). |
+| prompt-keda.initializer.cron.day_obs_tz | int | `-12` | Time zone in which day_obs is computed. |
+| prompt-keda.initializer.cron.suspend | bool | `false` | Whether or not to pause daily initializer runs. This makes it impossible to run Prompt Processing, but avoids repo clutter if the telescope is offline. |
 | prompt-keda.initializer.image.repository | string | `"ghcr.io/lsst-dm/prompt-init"` | Image to use for the PP initializer |
 | prompt-keda.initializer.podAnnotations | object | See the `values.yaml` file. | Pod annotations for the init-output Job |
 | prompt-keda.initializer.resources.cpuLimit | int | `1` | The maximum cpu cores for the initializer. |

--- a/applications/prompt-keda-lsstcamimsim/values.yaml
+++ b/applications/prompt-keda-lsstcamimsim/values.yaml
@@ -152,6 +152,34 @@ prompt-keda:
       # -- Maximum message age to process, in seconds.
       expiration: 3600
 
+  initializer:
+    image:
+      # -- Image to use for the PP initializer
+      repository: ghcr.io/lsst-dm/prompt-init
+      # Initializer and service must be consistent; pull policy and tag can't be set independently
+    resources:
+      # -- The cpu cores requested for the initializer.
+      cpuRequest: 1
+      # -- The maximum cpu cores for the initializer.
+      cpuLimit: 1
+      # -- The minimum memory to request for the initializer.
+      memoryRequest: "512Mi"
+      # -- The maximum memory limit for the initializer.
+      memoryLimit: "1Gi"
+
+    # -- Maximum time for a single attempt to initialize the central repo (seconds).
+    timeout: 120
+    # -- Maximum number of times to attempt initializing the central repo.
+    # If the initializer fails, the PP service cannot run!
+    retries: 6
+
+    # -- Time after which to remove old initializer pods (seconds).
+    cleanup_delay: 3600
+
+    # -- Pod annotations for the init-output Job
+    # @default -- See the `values.yaml` file.
+    podAnnotations: {}
+
   # -- Override the base name for resources
   nameOverride: ""
 

--- a/applications/prompt-keda-lsstcamimsim/values.yaml
+++ b/applications/prompt-keda-lsstcamimsim/values.yaml
@@ -166,6 +166,12 @@ prompt-keda:
       memoryRequest: "512Mi"
       # -- The maximum memory limit for the initializer.
       memoryLimit: "1Gi"
+    cron:
+      # -- Time zone in which day_obs is computed.
+      day_obs_tz: -12
+      # -- Whether or not to pause daily initializer runs.
+      # This makes it impossible to run Prompt Processing, but avoids repo clutter if the telescope is offline.
+      suspend: false
 
     # -- Maximum time for a single attempt to initialize the central repo (seconds).
     timeout: 120

--- a/applications/prompt-keda-lsstcomcam/README.md
+++ b/applications/prompt-keda-lsstcomcam/README.md
@@ -29,6 +29,15 @@ KEDA Prompt Processing instance for LSSTComCam.
 | prompt-keda.imageNotifications.imageTimeout | int | `20` | Timeout to wait after expected script completion for raw image arrival (seconds). |
 | prompt-keda.imageNotifications.kafkaClusterAddress | string | None, must be set | Hostname and port of the Kafka provider |
 | prompt-keda.imageNotifications.topic | string | None, must be set | Topic where raw image arrival notifications appear |
+| prompt-keda.initializer.cleanup_delay | int | `3600` | Time after which to remove old initializer pods (seconds). |
+| prompt-keda.initializer.image.repository | string | `"ghcr.io/lsst-dm/prompt-init"` | Image to use for the PP initializer |
+| prompt-keda.initializer.podAnnotations | object | See the `values.yaml` file. | Pod annotations for the init-output Job |
+| prompt-keda.initializer.resources.cpuLimit | int | `1` | The maximum cpu cores for the initializer. |
+| prompt-keda.initializer.resources.cpuRequest | int | `1` | The cpu cores requested for the initializer. |
+| prompt-keda.initializer.resources.memoryLimit | string | `"1Gi"` | The maximum memory limit for the initializer. |
+| prompt-keda.initializer.resources.memoryRequest | string | `"512Mi"` | The minimum memory to request for the initializer. |
+| prompt-keda.initializer.retries | int | `6` | Maximum number of times to attempt initializing the central repo. If the initializer fails, the PP service cannot run! |
+| prompt-keda.initializer.timeout | int | `120` | Maximum time for a single attempt to initialize the central repo (seconds). |
 | prompt-keda.instrument.calibRepo | string | None, must be set | URI to the shared repo used for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself. |
 | prompt-keda.instrument.name | string | `"LSSTComCam"` | The "short" name of the instrument |
 | prompt-keda.instrument.pipelines.main | string | None, must be set | YAML-formatted config describing which pipeline(s) should be run for which visits' raws. Fields are still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |

--- a/applications/prompt-keda-lsstcomcam/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-keda-lsstcomcam/values-usdfdev-prompt-processing.yaml
@@ -43,4 +43,8 @@ prompt-keda:
       # Dev processes very old images, set to ~20 years
       expiration: 600_000_000.0
 
+  initializer:
+    cron:
+      suspend: true
+
   fullnameOverride: "prompt-keda-lsstcomcam"

--- a/applications/prompt-keda-lsstcomcam/values.yaml
+++ b/applications/prompt-keda-lsstcomcam/values.yaml
@@ -142,6 +142,34 @@ prompt-keda:
       # -- Maximum message age to process, in seconds.
       expiration: 3600
 
+  initializer:
+    image:
+      # -- Image to use for the PP initializer
+      repository: ghcr.io/lsst-dm/prompt-init
+      # Initializer and service must be consistent; pull policy and tag can't be set independently
+    resources:
+      # -- The cpu cores requested for the initializer.
+      cpuRequest: 1
+      # -- The maximum cpu cores for the initializer.
+      cpuLimit: 1
+      # -- The minimum memory to request for the initializer.
+      memoryRequest: "512Mi"
+      # -- The maximum memory limit for the initializer.
+      memoryLimit: "1Gi"
+
+    # -- Maximum time for a single attempt to initialize the central repo (seconds).
+    timeout: 120
+    # -- Maximum number of times to attempt initializing the central repo.
+    # If the initializer fails, the PP service cannot run!
+    retries: 6
+
+    # -- Time after which to remove old initializer pods (seconds).
+    cleanup_delay: 3600
+
+    # -- Pod annotations for the init-output Job
+    # @default -- See the `values.yaml` file.
+    podAnnotations: {}
+
   # -- Override the base name for resources
   nameOverride: ""
 

--- a/applications/prompt-keda-lsstcomcamsim/README.md
+++ b/applications/prompt-keda-lsstcomcamsim/README.md
@@ -30,6 +30,15 @@ KEDA Prompt Processing instance for LSSTComCamSim
 | prompt-keda.imageNotifications.imageTimeout | int | `120` | Timeout to wait after expected script completion for raw image arrival (seconds). |
 | prompt-keda.imageNotifications.kafkaClusterAddress | string | None, must be set | Hostname and port of the Kafka provider |
 | prompt-keda.imageNotifications.topic | string | None, must be set | Topic where raw image arrival notifications appear |
+| prompt-keda.initializer.cleanup_delay | int | `3600` | Time after which to remove old initializer pods (seconds). |
+| prompt-keda.initializer.image.repository | string | `"ghcr.io/lsst-dm/prompt-init"` | Image to use for the PP initializer |
+| prompt-keda.initializer.podAnnotations | object | See the `values.yaml` file. | Pod annotations for the init-output Job |
+| prompt-keda.initializer.resources.cpuLimit | int | `1` | The maximum cpu cores for the initializer. |
+| prompt-keda.initializer.resources.cpuRequest | int | `1` | The cpu cores requested for the initializer. |
+| prompt-keda.initializer.resources.memoryLimit | string | `"1Gi"` | The maximum memory limit for the initializer. |
+| prompt-keda.initializer.resources.memoryRequest | string | `"512Mi"` | The minimum memory to request for the initializer. |
+| prompt-keda.initializer.retries | int | `6` | Maximum number of times to attempt initializing the central repo. If the initializer fails, the PP service cannot run! |
+| prompt-keda.initializer.timeout | int | `120` | Maximum time for a single attempt to initialize the central repo (seconds). |
 | prompt-keda.instrument.calibRepo | string | None, must be set | URI to the shared repo used for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself. |
 | prompt-keda.instrument.name | string | None, must be set | The "short" name of the instrument |
 | prompt-keda.instrument.pipelines.main | string | None, must be set | YAML-formatted config describing which pipeline(s) should be run for which visits' raws. Fields are still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |

--- a/applications/prompt-keda-lsstcomcamsim/README.md
+++ b/applications/prompt-keda-lsstcomcamsim/README.md
@@ -31,6 +31,8 @@ KEDA Prompt Processing instance for LSSTComCamSim
 | prompt-keda.imageNotifications.kafkaClusterAddress | string | None, must be set | Hostname and port of the Kafka provider |
 | prompt-keda.imageNotifications.topic | string | None, must be set | Topic where raw image arrival notifications appear |
 | prompt-keda.initializer.cleanup_delay | int | `3600` | Time after which to remove old initializer pods (seconds). |
+| prompt-keda.initializer.cron.day_obs_tz | int | `-12` | Time zone in which day_obs is computed. |
+| prompt-keda.initializer.cron.suspend | bool | `false` | Whether or not to pause daily initializer runs. This makes it impossible to run Prompt Processing, but avoids repo clutter if the telescope is offline. |
 | prompt-keda.initializer.image.repository | string | `"ghcr.io/lsst-dm/prompt-init"` | Image to use for the PP initializer |
 | prompt-keda.initializer.podAnnotations | object | See the `values.yaml` file. | Pod annotations for the init-output Job |
 | prompt-keda.initializer.resources.cpuLimit | int | `1` | The maximum cpu cores for the initializer. |

--- a/applications/prompt-keda-lsstcomcamsim/values.yaml
+++ b/applications/prompt-keda-lsstcomcamsim/values.yaml
@@ -160,6 +160,12 @@ prompt-keda:
       memoryRequest: "512Mi"
       # -- The maximum memory limit for the initializer.
       memoryLimit: "1Gi"
+    cron:
+      # -- Time zone in which day_obs is computed.
+      day_obs_tz: -12
+      # -- Whether or not to pause daily initializer runs.
+      # This makes it impossible to run Prompt Processing, but avoids repo clutter if the telescope is offline.
+      suspend: false
 
     # -- Maximum time for a single attempt to initialize the central repo (seconds).
     timeout: 120

--- a/applications/prompt-keda-lsstcomcamsim/values.yaml
+++ b/applications/prompt-keda-lsstcomcamsim/values.yaml
@@ -146,6 +146,34 @@ prompt-keda:
       # -- Maximum message age to process, in seconds.
       expiration: 3600
 
+  initializer:
+    image:
+      # -- Image to use for the PP initializer
+      repository: ghcr.io/lsst-dm/prompt-init
+      # Initializer and service must be consistent; pull policy and tag can't be set independently
+    resources:
+      # -- The cpu cores requested for the initializer.
+      cpuRequest: 1
+      # -- The maximum cpu cores for the initializer.
+      cpuLimit: 1
+      # -- The minimum memory to request for the initializer.
+      memoryRequest: "512Mi"
+      # -- The maximum memory limit for the initializer.
+      memoryLimit: "1Gi"
+
+    # -- Maximum time for a single attempt to initialize the central repo (seconds).
+    timeout: 120
+    # -- Maximum number of times to attempt initializing the central repo.
+    # If the initializer fails, the PP service cannot run!
+    retries: 6
+
+    # -- Time after which to remove old initializer pods (seconds).
+    cleanup_delay: 3600
+
+    # -- Pod annotations for the init-output Job
+    # @default -- See the `values.yaml` file.
+    podAnnotations: {}
+
   # -- Override the base name for resources
   nameOverride: ""
 

--- a/applications/prompt-proto-service-hsc-gpu/README.md
+++ b/applications/prompt-proto-service-hsc-gpu/README.md
@@ -29,6 +29,15 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.imageNotifications.imageTimeout | int | `20` | Timeout to wait after expected script completion for raw image arrival (seconds). |
 | prompt-proto-service.imageNotifications.kafkaClusterAddress | string | None, must be set | Hostname and port of the Kafka provider |
 | prompt-proto-service.imageNotifications.topic | string | None, must be set | Topic where raw image arrival notifications appear |
+| prompt-proto-service.initializer.cleanup_delay | int | `3600` | Time after which to remove old initializer pods (seconds). |
+| prompt-proto-service.initializer.image.repository | string | `"ghcr.io/lsst-dm/prompt-init"` | Image to use for the PP initializer |
+| prompt-proto-service.initializer.podAnnotations | object | See the `values.yaml` file. | Pod annotations for the init-output Job |
+| prompt-proto-service.initializer.resources.cpuLimit | int | `1` | The maximum cpu cores for the initializer. |
+| prompt-proto-service.initializer.resources.cpuRequest | int | `1` | The cpu cores requested for the initializer. |
+| prompt-proto-service.initializer.resources.memoryLimit | string | `"1Gi"` | The maximum memory limit for the initializer. |
+| prompt-proto-service.initializer.resources.memoryRequest | string | `"512Mi"` | The minimum memory to request for the initializer. |
+| prompt-proto-service.initializer.retries | int | `6` | Maximum number of times to attempt initializing the central repo. If the initializer fails, the PP service cannot run! |
+| prompt-proto-service.initializer.timeout | int | `120` | Maximum time for a single attempt to initialize the central repo (seconds). |
 | prompt-proto-service.instrument.calibRepo | string | None, must be set | URI to the shared repo used for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself. |
 | prompt-proto-service.instrument.name | string | `"HSC"` | The "short" name of the instrument |
 | prompt-proto-service.instrument.pipelines.main | string | None, must be set | YAML-formatted config describing which pipeline(s) should be run for which visits' raws. Fields are still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |

--- a/applications/prompt-proto-service-hsc-gpu/README.md
+++ b/applications/prompt-proto-service-hsc-gpu/README.md
@@ -30,6 +30,8 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.imageNotifications.kafkaClusterAddress | string | None, must be set | Hostname and port of the Kafka provider |
 | prompt-proto-service.imageNotifications.topic | string | None, must be set | Topic where raw image arrival notifications appear |
 | prompt-proto-service.initializer.cleanup_delay | int | `3600` | Time after which to remove old initializer pods (seconds). |
+| prompt-proto-service.initializer.cron.day_obs_tz | int | `-12` | Time zone in which day_obs is computed. |
+| prompt-proto-service.initializer.cron.suspend | bool | `false` | Whether or not to pause daily initializer runs. This makes it impossible to run Prompt Processing, but avoids repo clutter if the telescope is offline. |
 | prompt-proto-service.initializer.image.repository | string | `"ghcr.io/lsst-dm/prompt-init"` | Image to use for the PP initializer |
 | prompt-proto-service.initializer.podAnnotations | object | See the `values.yaml` file. | Pod annotations for the init-output Job |
 | prompt-proto-service.initializer.resources.cpuLimit | int | `1` | The maximum cpu cores for the initializer. |

--- a/applications/prompt-proto-service-hsc-gpu/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-hsc-gpu/values-usdfdev-prompt-processing.yaml
@@ -46,4 +46,8 @@ prompt-proto-service:
     # Dev processes very old images, set to ~20 years
     expiration: 600_000_000.0
 
+  initializer:
+    cron:
+      suspend: true
+
   fullnameOverride: "prompt-proto-service-hsc-gpu"

--- a/applications/prompt-proto-service-hsc-gpu/values.yaml
+++ b/applications/prompt-proto-service-hsc-gpu/values.yaml
@@ -178,6 +178,12 @@ prompt-proto-service:
       memoryRequest: "512Mi"
       # -- The maximum memory limit for the initializer.
       memoryLimit: "1Gi"
+    cron:
+      # -- Time zone in which day_obs is computed.
+      day_obs_tz: -12
+      # -- Whether or not to pause daily initializer runs.
+      # This makes it impossible to run Prompt Processing, but avoids repo clutter if the telescope is offline.
+      suspend: false
 
     # -- Maximum time for a single attempt to initialize the central repo (seconds).
     timeout: 120

--- a/applications/prompt-proto-service-hsc-gpu/values.yaml
+++ b/applications/prompt-proto-service-hsc-gpu/values.yaml
@@ -164,6 +164,34 @@ prompt-proto-service:
     # -- Maximum message age to process, in seconds.
     expiration: 3600
 
+  initializer:
+    image:
+      # -- Image to use for the PP initializer
+      repository: ghcr.io/lsst-dm/prompt-init
+      # Initializer and service must be consistent; pull policy and tag can't be set independently
+    resources:
+      # -- The cpu cores requested for the initializer.
+      cpuRequest: 1
+      # -- The maximum cpu cores for the initializer.
+      cpuLimit: 1
+      # -- The minimum memory to request for the initializer.
+      memoryRequest: "512Mi"
+      # -- The maximum memory limit for the initializer.
+      memoryLimit: "1Gi"
+
+    # -- Maximum time for a single attempt to initialize the central repo (seconds).
+    timeout: 120
+    # -- Maximum number of times to attempt initializing the central repo.
+    # If the initializer fails, the PP service cannot run!
+    retries: 6
+
+    # -- Time after which to remove old initializer pods (seconds).
+    cleanup_delay: 3600
+
+    # -- Pod annotations for the init-output Job
+    # @default -- See the `values.yaml` file.
+    podAnnotations: {}
+
   # -- The number of Knative requests that can be handled simultaneously by one container
   containerConcurrency: 1
 

--- a/applications/prompt-proto-service-hsc/README.md
+++ b/applications/prompt-proto-service-hsc/README.md
@@ -29,6 +29,15 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.imageNotifications.imageTimeout | string | `"20"` | Timeout to wait after expected script completion for raw image arrival (seconds). |
 | prompt-proto-service.imageNotifications.kafkaClusterAddress | string | None, must be set | Hostname and port of the Kafka provider |
 | prompt-proto-service.imageNotifications.topic | string | None, must be set | Topic where raw image arrival notifications appear |
+| prompt-proto-service.initializer.cleanup_delay | int | `3600` | Time after which to remove old initializer pods (seconds). |
+| prompt-proto-service.initializer.image.repository | string | `"ghcr.io/lsst-dm/prompt-init"` | Image to use for the PP initializer |
+| prompt-proto-service.initializer.podAnnotations | object | See the `values.yaml` file. | Pod annotations for the init-output Job |
+| prompt-proto-service.initializer.resources.cpuLimit | int | `1` | The maximum cpu cores for the initializer. |
+| prompt-proto-service.initializer.resources.cpuRequest | int | `1` | The cpu cores requested for the initializer. |
+| prompt-proto-service.initializer.resources.memoryLimit | string | `"1Gi"` | The maximum memory limit for the initializer. |
+| prompt-proto-service.initializer.resources.memoryRequest | string | `"512Mi"` | The minimum memory to request for the initializer. |
+| prompt-proto-service.initializer.retries | int | `6` | Maximum number of times to attempt initializing the central repo. If the initializer fails, the PP service cannot run! |
+| prompt-proto-service.initializer.timeout | int | `120` | Maximum time for a single attempt to initialize the central repo (seconds). |
 | prompt-proto-service.instrument.calibRepo | string | None, must be set | URI to the shared repo used for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself. |
 | prompt-proto-service.instrument.name | string | `"HSC"` | The "short" name of the instrument |
 | prompt-proto-service.instrument.pipelines.main | string | None, must be set | YAML-formatted config describing which pipeline(s) should be run for which visits' raws. Fields are still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |

--- a/applications/prompt-proto-service-hsc/README.md
+++ b/applications/prompt-proto-service-hsc/README.md
@@ -30,6 +30,8 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.imageNotifications.kafkaClusterAddress | string | None, must be set | Hostname and port of the Kafka provider |
 | prompt-proto-service.imageNotifications.topic | string | None, must be set | Topic where raw image arrival notifications appear |
 | prompt-proto-service.initializer.cleanup_delay | int | `3600` | Time after which to remove old initializer pods (seconds). |
+| prompt-proto-service.initializer.cron.day_obs_tz | int | `-12` | Time zone in which day_obs is computed. |
+| prompt-proto-service.initializer.cron.suspend | bool | `false` | Whether or not to pause daily initializer runs. This makes it impossible to run Prompt Processing, but avoids repo clutter if the telescope is offline. |
 | prompt-proto-service.initializer.image.repository | string | `"ghcr.io/lsst-dm/prompt-init"` | Image to use for the PP initializer |
 | prompt-proto-service.initializer.podAnnotations | object | See the `values.yaml` file. | Pod annotations for the init-output Job |
 | prompt-proto-service.initializer.resources.cpuLimit | int | `1` | The maximum cpu cores for the initializer. |

--- a/applications/prompt-proto-service-hsc/values.yaml
+++ b/applications/prompt-proto-service-hsc/values.yaml
@@ -165,6 +165,34 @@ prompt-proto-service:
     # -- Maximum message age to process, in seconds.
     expiration: 3600
 
+  initializer:
+    image:
+      # -- Image to use for the PP initializer
+      repository: ghcr.io/lsst-dm/prompt-init
+      # Initializer and service must be consistent; pull policy and tag can't be set independently
+    resources:
+      # -- The cpu cores requested for the initializer.
+      cpuRequest: 1
+      # -- The maximum cpu cores for the initializer.
+      cpuLimit: 1
+      # -- The minimum memory to request for the initializer.
+      memoryRequest: "512Mi"
+      # -- The maximum memory limit for the initializer.
+      memoryLimit: "1Gi"
+
+    # -- Maximum time for a single attempt to initialize the central repo (seconds).
+    timeout: 120
+    # -- Maximum number of times to attempt initializing the central repo.
+    # If the initializer fails, the PP service cannot run!
+    retries: 6
+
+    # -- Time after which to remove old initializer pods (seconds).
+    cleanup_delay: 3600
+
+    # -- Pod annotations for the init-output Job
+    # @default -- See the `values.yaml` file.
+    podAnnotations: {}
+
   # -- The number of Knative requests that can be handled simultaneously by one container
   containerConcurrency: 1
 

--- a/applications/prompt-proto-service-hsc/values.yaml
+++ b/applications/prompt-proto-service-hsc/values.yaml
@@ -179,6 +179,12 @@ prompt-proto-service:
       memoryRequest: "512Mi"
       # -- The maximum memory limit for the initializer.
       memoryLimit: "1Gi"
+    cron:
+      # -- Time zone in which day_obs is computed.
+      day_obs_tz: -12
+      # -- Whether or not to pause daily initializer runs.
+      # This makes it impossible to run Prompt Processing, but avoids repo clutter if the telescope is offline.
+      suspend: false
 
     # -- Maximum time for a single attempt to initialize the central repo (seconds).
     timeout: 120

--- a/applications/prompt-proto-service-latiss/README.md
+++ b/applications/prompt-proto-service-latiss/README.md
@@ -30,6 +30,8 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.imageNotifications.kafkaClusterAddress | string | None, must be set | Hostname and port of the Kafka provider |
 | prompt-proto-service.imageNotifications.topic | string | None, must be set | Topic where raw image arrival notifications appear |
 | prompt-proto-service.initializer.cleanup_delay | int | `3600` | Time after which to remove old initializer pods (seconds). |
+| prompt-proto-service.initializer.cron.day_obs_tz | int | `-12` | Time zone in which day_obs is computed. |
+| prompt-proto-service.initializer.cron.suspend | bool | `false` | Whether or not to pause daily initializer runs. This makes it impossible to run Prompt Processing, but avoids repo clutter if the telescope is offline. |
 | prompt-proto-service.initializer.image.repository | string | `"ghcr.io/lsst-dm/prompt-init"` | Image to use for the PP initializer |
 | prompt-proto-service.initializer.podAnnotations | object | See the `values.yaml` file. | Pod annotations for the init-output Job |
 | prompt-proto-service.initializer.resources.cpuLimit | int | `1` | The maximum cpu cores for the initializer. |

--- a/applications/prompt-proto-service-latiss/README.md
+++ b/applications/prompt-proto-service-latiss/README.md
@@ -29,6 +29,15 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.imageNotifications.imageTimeout | int | `20` | Timeout to wait after expected script completion for raw image arrival (seconds). |
 | prompt-proto-service.imageNotifications.kafkaClusterAddress | string | None, must be set | Hostname and port of the Kafka provider |
 | prompt-proto-service.imageNotifications.topic | string | None, must be set | Topic where raw image arrival notifications appear |
+| prompt-proto-service.initializer.cleanup_delay | int | `3600` | Time after which to remove old initializer pods (seconds). |
+| prompt-proto-service.initializer.image.repository | string | `"ghcr.io/lsst-dm/prompt-init"` | Image to use for the PP initializer |
+| prompt-proto-service.initializer.podAnnotations | object | See the `values.yaml` file. | Pod annotations for the init-output Job |
+| prompt-proto-service.initializer.resources.cpuLimit | int | `1` | The maximum cpu cores for the initializer. |
+| prompt-proto-service.initializer.resources.cpuRequest | int | `1` | The cpu cores requested for the initializer. |
+| prompt-proto-service.initializer.resources.memoryLimit | string | `"1Gi"` | The maximum memory limit for the initializer. |
+| prompt-proto-service.initializer.resources.memoryRequest | string | `"512Mi"` | The minimum memory to request for the initializer. |
+| prompt-proto-service.initializer.retries | int | `6` | Maximum number of times to attempt initializing the central repo. If the initializer fails, the PP service cannot run! |
+| prompt-proto-service.initializer.timeout | int | `120` | Maximum time for a single attempt to initialize the central repo (seconds). |
 | prompt-proto-service.instrument.calibRepo | string | None, must be set | URI to the shared repo used for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself. |
 | prompt-proto-service.instrument.name | string | `"LATISS"` | The "short" name of the instrument |
 | prompt-proto-service.instrument.pipelines.main | string | None, must be set | YAML-formatted config describing which pipeline(s) should be run for which visits' raws. Fields are still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |

--- a/applications/prompt-proto-service-latiss/values.yaml
+++ b/applications/prompt-proto-service-latiss/values.yaml
@@ -178,6 +178,12 @@ prompt-proto-service:
       memoryRequest: "512Mi"
       # -- The maximum memory limit for the initializer.
       memoryLimit: "1Gi"
+    cron:
+      # -- Time zone in which day_obs is computed.
+      day_obs_tz: -12
+      # -- Whether or not to pause daily initializer runs.
+      # This makes it impossible to run Prompt Processing, but avoids repo clutter if the telescope is offline.
+      suspend: false
 
     # -- Maximum time for a single attempt to initialize the central repo (seconds).
     timeout: 120

--- a/applications/prompt-proto-service-latiss/values.yaml
+++ b/applications/prompt-proto-service-latiss/values.yaml
@@ -164,6 +164,34 @@ prompt-proto-service:
     # -- Maximum message age to process, in seconds.
     expiration: 3600
 
+  initializer:
+    image:
+      # -- Image to use for the PP initializer
+      repository: ghcr.io/lsst-dm/prompt-init
+      # Initializer and service must be consistent; pull policy and tag can't be set independently
+    resources:
+      # -- The cpu cores requested for the initializer.
+      cpuRequest: 1
+      # -- The maximum cpu cores for the initializer.
+      cpuLimit: 1
+      # -- The minimum memory to request for the initializer.
+      memoryRequest: "512Mi"
+      # -- The maximum memory limit for the initializer.
+      memoryLimit: "1Gi"
+
+    # -- Maximum time for a single attempt to initialize the central repo (seconds).
+    timeout: 120
+    # -- Maximum number of times to attempt initializing the central repo.
+    # If the initializer fails, the PP service cannot run!
+    retries: 6
+
+    # -- Time after which to remove old initializer pods (seconds).
+    cleanup_delay: 3600
+
+    # -- Pod annotations for the init-output Job
+    # @default -- See the `values.yaml` file.
+    podAnnotations: {}
+
   # -- The number of Knative requests that can be handled simultaneously by one container
   containerConcurrency: 1
 

--- a/applications/prompt-proto-service-lsstcam/README.md
+++ b/applications/prompt-proto-service-lsstcam/README.md
@@ -29,6 +29,15 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.imageNotifications.imageTimeout | int | `20` | Timeout to wait after expected script completion for raw image arrival (seconds). |
 | prompt-proto-service.imageNotifications.kafkaClusterAddress | string | None, must be set | Hostname and port of the Kafka provider |
 | prompt-proto-service.imageNotifications.topic | string | None, must be set | Topic where raw image arrival notifications appear |
+| prompt-proto-service.initializer.cleanup_delay | int | `3600` | Time after which to remove old initializer pods (seconds). |
+| prompt-proto-service.initializer.image.repository | string | `"ghcr.io/lsst-dm/prompt-init"` | Image to use for the PP initializer |
+| prompt-proto-service.initializer.podAnnotations | object | See the `values.yaml` file. | Pod annotations for the init-output Job |
+| prompt-proto-service.initializer.resources.cpuLimit | int | `1` | The maximum cpu cores for the initializer. |
+| prompt-proto-service.initializer.resources.cpuRequest | int | `1` | The cpu cores requested for the initializer. |
+| prompt-proto-service.initializer.resources.memoryLimit | string | `"1Gi"` | The maximum memory limit for the initializer. |
+| prompt-proto-service.initializer.resources.memoryRequest | string | `"512Mi"` | The minimum memory to request for the initializer. |
+| prompt-proto-service.initializer.retries | int | `6` | Maximum number of times to attempt initializing the central repo. If the initializer fails, the PP service cannot run! |
+| prompt-proto-service.initializer.timeout | int | `120` | Maximum time for a single attempt to initialize the central repo (seconds). |
 | prompt-proto-service.instrument.calibRepo | string | None, must be set | URI to the shared repo used for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself. |
 | prompt-proto-service.instrument.name | string | `"LSSTCam"` | The "short" name of the instrument |
 | prompt-proto-service.instrument.pipelines.main | string | None, must be set | YAML-formatted config describing which pipeline(s) should be run for which visits' raws. Fields are still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |

--- a/applications/prompt-proto-service-lsstcam/README.md
+++ b/applications/prompt-proto-service-lsstcam/README.md
@@ -30,6 +30,8 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.imageNotifications.kafkaClusterAddress | string | None, must be set | Hostname and port of the Kafka provider |
 | prompt-proto-service.imageNotifications.topic | string | None, must be set | Topic where raw image arrival notifications appear |
 | prompt-proto-service.initializer.cleanup_delay | int | `3600` | Time after which to remove old initializer pods (seconds). |
+| prompt-proto-service.initializer.cron.day_obs_tz | int | `-12` | Time zone in which day_obs is computed. |
+| prompt-proto-service.initializer.cron.suspend | bool | `false` | Whether or not to pause daily initializer runs. This makes it impossible to run Prompt Processing, but avoids repo clutter if the telescope is offline. |
 | prompt-proto-service.initializer.image.repository | string | `"ghcr.io/lsst-dm/prompt-init"` | Image to use for the PP initializer |
 | prompt-proto-service.initializer.podAnnotations | object | See the `values.yaml` file. | Pod annotations for the init-output Job |
 | prompt-proto-service.initializer.resources.cpuLimit | int | `1` | The maximum cpu cores for the initializer. |

--- a/applications/prompt-proto-service-lsstcam/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcam/values-usdfdev-prompt-processing.yaml
@@ -47,4 +47,8 @@ prompt-proto-service:
     # Dev processes very old images, set to ~20 years
     expiration: 600_000_000.0
 
+  initializer:
+    cron:
+      suspend: true
+
   fullnameOverride: "prompt-proto-service-lsstcam"

--- a/applications/prompt-proto-service-lsstcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcam/values.yaml
@@ -165,6 +165,34 @@ prompt-proto-service:
     # -- Maximum message age to process, in seconds.
     expiration: 3600
 
+  initializer:
+    image:
+      # -- Image to use for the PP initializer
+      repository: ghcr.io/lsst-dm/prompt-init
+      # Initializer and service must be consistent; pull policy and tag can't be set independently
+    resources:
+      # -- The cpu cores requested for the initializer.
+      cpuRequest: 1
+      # -- The maximum cpu cores for the initializer.
+      cpuLimit: 1
+      # -- The minimum memory to request for the initializer.
+      memoryRequest: "512Mi"
+      # -- The maximum memory limit for the initializer.
+      memoryLimit: "1Gi"
+
+    # -- Maximum time for a single attempt to initialize the central repo (seconds).
+    timeout: 120
+    # -- Maximum number of times to attempt initializing the central repo.
+    # If the initializer fails, the PP service cannot run!
+    retries: 6
+
+    # -- Time after which to remove old initializer pods (seconds).
+    cleanup_delay: 3600
+
+    # -- Pod annotations for the init-output Job
+    # @default -- See the `values.yaml` file.
+    podAnnotations: {}
+
   # -- The number of Knative requests that can be handled simultaneously by one container
   containerConcurrency: 1
 

--- a/applications/prompt-proto-service-lsstcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcam/values.yaml
@@ -179,6 +179,12 @@ prompt-proto-service:
       memoryRequest: "512Mi"
       # -- The maximum memory limit for the initializer.
       memoryLimit: "1Gi"
+    cron:
+      # -- Time zone in which day_obs is computed.
+      day_obs_tz: -12
+      # -- Whether or not to pause daily initializer runs.
+      # This makes it impossible to run Prompt Processing, but avoids repo clutter if the telescope is offline.
+      suspend: false
 
     # -- Maximum time for a single attempt to initialize the central repo (seconds).
     timeout: 120

--- a/applications/prompt-proto-service-lsstcamimsim/README.md
+++ b/applications/prompt-proto-service-lsstcamimsim/README.md
@@ -30,6 +30,8 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.imageNotifications.kafkaClusterAddress | string | None, must be set | Hostname and port of the Kafka provider |
 | prompt-proto-service.imageNotifications.topic | string | None, must be set | Topic where raw image arrival notifications appear |
 | prompt-proto-service.initializer.cleanup_delay | int | `3600` | Time after which to remove old initializer pods (seconds). |
+| prompt-proto-service.initializer.cron.day_obs_tz | int | `-12` | Time zone in which day_obs is computed. |
+| prompt-proto-service.initializer.cron.suspend | bool | `false` | Whether or not to pause daily initializer runs. This makes it impossible to run Prompt Processing, but avoids repo clutter if the telescope is offline. |
 | prompt-proto-service.initializer.image.repository | string | `"ghcr.io/lsst-dm/prompt-init"` | Image to use for the PP initializer |
 | prompt-proto-service.initializer.podAnnotations | object | See the `values.yaml` file. | Pod annotations for the init-output Job |
 | prompt-proto-service.initializer.resources.cpuLimit | int | `1` | The maximum cpu cores for the initializer. |

--- a/applications/prompt-proto-service-lsstcamimsim/README.md
+++ b/applications/prompt-proto-service-lsstcamimsim/README.md
@@ -29,6 +29,15 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.imageNotifications.imageTimeout | int | `20` | Timeout to wait after expected script completion for raw image arrival (seconds). |
 | prompt-proto-service.imageNotifications.kafkaClusterAddress | string | None, must be set | Hostname and port of the Kafka provider |
 | prompt-proto-service.imageNotifications.topic | string | None, must be set | Topic where raw image arrival notifications appear |
+| prompt-proto-service.initializer.cleanup_delay | int | `3600` | Time after which to remove old initializer pods (seconds). |
+| prompt-proto-service.initializer.image.repository | string | `"ghcr.io/lsst-dm/prompt-init"` | Image to use for the PP initializer |
+| prompt-proto-service.initializer.podAnnotations | object | See the `values.yaml` file. | Pod annotations for the init-output Job |
+| prompt-proto-service.initializer.resources.cpuLimit | int | `1` | The maximum cpu cores for the initializer. |
+| prompt-proto-service.initializer.resources.cpuRequest | int | `1` | The cpu cores requested for the initializer. |
+| prompt-proto-service.initializer.resources.memoryLimit | string | `"1Gi"` | The maximum memory limit for the initializer. |
+| prompt-proto-service.initializer.resources.memoryRequest | string | `"512Mi"` | The minimum memory to request for the initializer. |
+| prompt-proto-service.initializer.retries | int | `6` | Maximum number of times to attempt initializing the central repo. If the initializer fails, the PP service cannot run! |
+| prompt-proto-service.initializer.timeout | int | `120` | Maximum time for a single attempt to initialize the central repo (seconds). |
 | prompt-proto-service.instrument.calibRepo | string | None, must be set | URI to the shared repo used for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself. |
 | prompt-proto-service.instrument.name | string | `"LSSTCam-imSim"` | The "short" name of the instrument |
 | prompt-proto-service.instrument.pipelines.main | string | None, must be set | YAML-formatted config describing which pipeline(s) should be run for which visits' raws. Fields are still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |

--- a/applications/prompt-proto-service-lsstcamimsim/values.yaml
+++ b/applications/prompt-proto-service-lsstcamimsim/values.yaml
@@ -181,6 +181,12 @@ prompt-proto-service:
       memoryRequest: "512Mi"
       # -- The maximum memory limit for the initializer.
       memoryLimit: "1Gi"
+    cron:
+      # -- Time zone in which day_obs is computed.
+      day_obs_tz: -12
+      # -- Whether or not to pause daily initializer runs.
+      # This makes it impossible to run Prompt Processing, but avoids repo clutter if the telescope is offline.
+      suspend: false
 
     # -- Maximum time for a single attempt to initialize the central repo (seconds).
     timeout: 120

--- a/applications/prompt-proto-service-lsstcamimsim/values.yaml
+++ b/applications/prompt-proto-service-lsstcamimsim/values.yaml
@@ -167,6 +167,34 @@ prompt-proto-service:
     # -- Maximum message age to process, in seconds.
     expiration: 3600
 
+  initializer:
+    image:
+      # -- Image to use for the PP initializer
+      repository: ghcr.io/lsst-dm/prompt-init
+      # Initializer and service must be consistent; pull policy and tag can't be set independently
+    resources:
+      # -- The cpu cores requested for the initializer.
+      cpuRequest: 1
+      # -- The maximum cpu cores for the initializer.
+      cpuLimit: 1
+      # -- The minimum memory to request for the initializer.
+      memoryRequest: "512Mi"
+      # -- The maximum memory limit for the initializer.
+      memoryLimit: "1Gi"
+
+    # -- Maximum time for a single attempt to initialize the central repo (seconds).
+    timeout: 120
+    # -- Maximum number of times to attempt initializing the central repo.
+    # If the initializer fails, the PP service cannot run!
+    retries: 6
+
+    # -- Time after which to remove old initializer pods (seconds).
+    cleanup_delay: 3600
+
+    # -- Pod annotations for the init-output Job
+    # @default -- See the `values.yaml` file.
+    podAnnotations: {}
+
   # -- The number of Knative requests that can be handled simultaneously by one container
   containerConcurrency: 1
 

--- a/applications/prompt-proto-service-lsstcomcam/README.md
+++ b/applications/prompt-proto-service-lsstcomcam/README.md
@@ -29,6 +29,15 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.imageNotifications.imageTimeout | int | `20` | Timeout to wait after expected script completion for raw image arrival (seconds). |
 | prompt-proto-service.imageNotifications.kafkaClusterAddress | string | None, must be set | Hostname and port of the Kafka provider |
 | prompt-proto-service.imageNotifications.topic | string | None, must be set | Topic where raw image arrival notifications appear |
+| prompt-proto-service.initializer.cleanup_delay | int | `3600` | Time after which to remove old initializer pods (seconds). |
+| prompt-proto-service.initializer.image.repository | string | `"ghcr.io/lsst-dm/prompt-init"` | Image to use for the PP initializer |
+| prompt-proto-service.initializer.podAnnotations | object | See the `values.yaml` file. | Pod annotations for the init-output Job |
+| prompt-proto-service.initializer.resources.cpuLimit | int | `1` | The maximum cpu cores for the initializer. |
+| prompt-proto-service.initializer.resources.cpuRequest | int | `1` | The cpu cores requested for the initializer. |
+| prompt-proto-service.initializer.resources.memoryLimit | string | `"1Gi"` | The maximum memory limit for the initializer. |
+| prompt-proto-service.initializer.resources.memoryRequest | string | `"512Mi"` | The minimum memory to request for the initializer. |
+| prompt-proto-service.initializer.retries | int | `6` | Maximum number of times to attempt initializing the central repo. If the initializer fails, the PP service cannot run! |
+| prompt-proto-service.initializer.timeout | int | `120` | Maximum time for a single attempt to initialize the central repo (seconds). |
 | prompt-proto-service.instrument.calibRepo | string | None, must be set | URI to the shared repo used for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself. |
 | prompt-proto-service.instrument.name | string | `"LSSTComCam"` | The "short" name of the instrument |
 | prompt-proto-service.instrument.pipelines.main | string | None, must be set | YAML-formatted config describing which pipeline(s) should be run for which visits' raws. Fields are still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |

--- a/applications/prompt-proto-service-lsstcomcam/README.md
+++ b/applications/prompt-proto-service-lsstcomcam/README.md
@@ -30,6 +30,8 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.imageNotifications.kafkaClusterAddress | string | None, must be set | Hostname and port of the Kafka provider |
 | prompt-proto-service.imageNotifications.topic | string | None, must be set | Topic where raw image arrival notifications appear |
 | prompt-proto-service.initializer.cleanup_delay | int | `3600` | Time after which to remove old initializer pods (seconds). |
+| prompt-proto-service.initializer.cron.day_obs_tz | int | `-12` | Time zone in which day_obs is computed. |
+| prompt-proto-service.initializer.cron.suspend | bool | `false` | Whether or not to pause daily initializer runs. This makes it impossible to run Prompt Processing, but avoids repo clutter if the telescope is offline. |
 | prompt-proto-service.initializer.image.repository | string | `"ghcr.io/lsst-dm/prompt-init"` | Image to use for the PP initializer |
 | prompt-proto-service.initializer.podAnnotations | object | See the `values.yaml` file. | Pod annotations for the init-output Job |
 | prompt-proto-service.initializer.resources.cpuLimit | int | `1` | The maximum cpu cores for the initializer. |

--- a/applications/prompt-proto-service-lsstcomcam/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/values-usdfdev-prompt-processing.yaml
@@ -47,4 +47,8 @@ prompt-proto-service:
     # Dev processes very old images, set to ~20 years
     expiration: 600_000_000.0
 
+  initializer:
+    cron:
+      suspend: true
+
   fullnameOverride: "prompt-proto-service-lsstcomcam"

--- a/applications/prompt-proto-service-lsstcomcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/values.yaml
@@ -174,6 +174,12 @@ prompt-proto-service:
       memoryRequest: "512Mi"
       # -- The maximum memory limit for the initializer.
       memoryLimit: "1Gi"
+    cron:
+      # -- Time zone in which day_obs is computed.
+      day_obs_tz: -12
+      # -- Whether or not to pause daily initializer runs.
+      # This makes it impossible to run Prompt Processing, but avoids repo clutter if the telescope is offline.
+      suspend: false
 
     # -- Maximum time for a single attempt to initialize the central repo (seconds).
     timeout: 120

--- a/applications/prompt-proto-service-lsstcomcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/values.yaml
@@ -160,6 +160,34 @@ prompt-proto-service:
     # -- Maximum message age to process, in seconds.
     expiration: 3600
 
+  initializer:
+    image:
+      # -- Image to use for the PP initializer
+      repository: ghcr.io/lsst-dm/prompt-init
+      # Initializer and service must be consistent; pull policy and tag can't be set independently
+    resources:
+      # -- The cpu cores requested for the initializer.
+      cpuRequest: 1
+      # -- The maximum cpu cores for the initializer.
+      cpuLimit: 1
+      # -- The minimum memory to request for the initializer.
+      memoryRequest: "512Mi"
+      # -- The maximum memory limit for the initializer.
+      memoryLimit: "1Gi"
+
+    # -- Maximum time for a single attempt to initialize the central repo (seconds).
+    timeout: 120
+    # -- Maximum number of times to attempt initializing the central repo.
+    # If the initializer fails, the PP service cannot run!
+    retries: 6
+
+    # -- Time after which to remove old initializer pods (seconds).
+    cleanup_delay: 3600
+
+    # -- Pod annotations for the init-output Job
+    # @default -- See the `values.yaml` file.
+    podAnnotations: {}
+
   # -- The number of Knative requests that can be handled simultaneously by one container
   containerConcurrency: 1
 

--- a/applications/prompt-proto-service-lsstcomcamsim/README.md
+++ b/applications/prompt-proto-service-lsstcomcamsim/README.md
@@ -29,6 +29,15 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.imageNotifications.imageTimeout | int | `120` | Timeout to wait after expected script completion for raw image arrival (seconds). |
 | prompt-proto-service.imageNotifications.kafkaClusterAddress | string | None, must be set | Hostname and port of the Kafka provider |
 | prompt-proto-service.imageNotifications.topic | string | None, must be set | Topic where raw image arrival notifications appear |
+| prompt-proto-service.initializer.cleanup_delay | int | `3600` | Time after which to remove old initializer pods (seconds). |
+| prompt-proto-service.initializer.image.repository | string | `"ghcr.io/lsst-dm/prompt-init"` | Image to use for the PP initializer |
+| prompt-proto-service.initializer.podAnnotations | object | See the `values.yaml` file. | Pod annotations for the init-output Job |
+| prompt-proto-service.initializer.resources.cpuLimit | int | `1` | The maximum cpu cores for the initializer. |
+| prompt-proto-service.initializer.resources.cpuRequest | int | `1` | The cpu cores requested for the initializer. |
+| prompt-proto-service.initializer.resources.memoryLimit | string | `"1Gi"` | The maximum memory limit for the initializer. |
+| prompt-proto-service.initializer.resources.memoryRequest | string | `"512Mi"` | The minimum memory to request for the initializer. |
+| prompt-proto-service.initializer.retries | int | `6` | Maximum number of times to attempt initializing the central repo. If the initializer fails, the PP service cannot run! |
+| prompt-proto-service.initializer.timeout | int | `120` | Maximum time for a single attempt to initialize the central repo (seconds). |
 | prompt-proto-service.instrument.calibRepo | string | None, must be set | URI to the shared repo used for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself. |
 | prompt-proto-service.instrument.name | string | `"LSSTComCamSim"` | The "short" name of the instrument |
 | prompt-proto-service.instrument.pipelines.main | string | None, must be set | YAML-formatted config describing which pipeline(s) should be run for which visits' raws. Fields are still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |

--- a/applications/prompt-proto-service-lsstcomcamsim/README.md
+++ b/applications/prompt-proto-service-lsstcomcamsim/README.md
@@ -30,6 +30,8 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.imageNotifications.kafkaClusterAddress | string | None, must be set | Hostname and port of the Kafka provider |
 | prompt-proto-service.imageNotifications.topic | string | None, must be set | Topic where raw image arrival notifications appear |
 | prompt-proto-service.initializer.cleanup_delay | int | `3600` | Time after which to remove old initializer pods (seconds). |
+| prompt-proto-service.initializer.cron.day_obs_tz | int | `-12` | Time zone in which day_obs is computed. |
+| prompt-proto-service.initializer.cron.suspend | bool | `false` | Whether or not to pause daily initializer runs. This makes it impossible to run Prompt Processing, but avoids repo clutter if the telescope is offline. |
 | prompt-proto-service.initializer.image.repository | string | `"ghcr.io/lsst-dm/prompt-init"` | Image to use for the PP initializer |
 | prompt-proto-service.initializer.podAnnotations | object | See the `values.yaml` file. | Pod annotations for the init-output Job |
 | prompt-proto-service.initializer.resources.cpuLimit | int | `1` | The maximum cpu cores for the initializer. |

--- a/applications/prompt-proto-service-lsstcomcamsim/values.yaml
+++ b/applications/prompt-proto-service-lsstcomcamsim/values.yaml
@@ -166,6 +166,34 @@ prompt-proto-service:
     # -- Maximum message age to process, in seconds.
     expiration: 3600
 
+  initializer:
+    image:
+      # -- Image to use for the PP initializer
+      repository: ghcr.io/lsst-dm/prompt-init
+      # Initializer and service must be consistent; pull policy and tag can't be set independently
+    resources:
+      # -- The cpu cores requested for the initializer.
+      cpuRequest: 1
+      # -- The maximum cpu cores for the initializer.
+      cpuLimit: 1
+      # -- The minimum memory to request for the initializer.
+      memoryRequest: "512Mi"
+      # -- The maximum memory limit for the initializer.
+      memoryLimit: "1Gi"
+
+    # -- Maximum time for a single attempt to initialize the central repo (seconds).
+    timeout: 120
+    # -- Maximum number of times to attempt initializing the central repo.
+    # If the initializer fails, the PP service cannot run!
+    retries: 6
+
+    # -- Time after which to remove old initializer pods (seconds).
+    cleanup_delay: 3600
+
+    # -- Pod annotations for the init-output Job
+    # @default -- See the `values.yaml` file.
+    podAnnotations: {}
+
   # -- The number of Knative requests that can be handled simultaneously by one container
   containerConcurrency: 1
 

--- a/applications/prompt-proto-service-lsstcomcamsim/values.yaml
+++ b/applications/prompt-proto-service-lsstcomcamsim/values.yaml
@@ -180,6 +180,12 @@ prompt-proto-service:
       memoryRequest: "512Mi"
       # -- The maximum memory limit for the initializer.
       memoryLimit: "1Gi"
+    cron:
+      # -- Time zone in which day_obs is computed.
+      day_obs_tz: -12
+      # -- Whether or not to pause daily initializer runs.
+      # This makes it impossible to run Prompt Processing, but avoids repo clutter if the telescope is offline.
+      suspend: false
 
     # -- Maximum time for a single attempt to initialize the central repo (seconds).
     timeout: 120

--- a/charts/prompt-keda/README.md
+++ b/charts/prompt-keda/README.md
@@ -31,6 +31,8 @@ Event-driven processing of camera images
 | imageNotifications.kafkaClusterAddress | string | None, must be set | Hostname and port of the Kafka provider |
 | imageNotifications.topic | string | None, must be set | Topic where raw image arrival notifications appear |
 | initializer.cleanup_delay | int | `3600` | Time after which to remove old initializer pods (seconds). |
+| initializer.cron.day_obs_tz | int | `-12` | Time zone in which day_obs is computed. |
+| initializer.cron.suspend | bool | `false` | Whether or not to pause daily initializer runs. This makes it impossible to run Prompt Processing, but avoids repo clutter if the telescope is offline. |
 | initializer.image.repository | string | `"ghcr.io/lsst-dm/prompt-init"` | Image to use for the PP initializer |
 | initializer.podAnnotations | object | See the `values.yaml` file. | Pod annotations for the init-output Job |
 | initializer.resources.cpuLimit | int | `1` | The maximum cpu cores for the initializer. |

--- a/charts/prompt-keda/README.md
+++ b/charts/prompt-keda/README.md
@@ -30,6 +30,15 @@ Event-driven processing of camera images
 | imageNotifications.imageTimeout | int | `20` | Timeout to wait after expected script completion for raw image arrival (seconds). |
 | imageNotifications.kafkaClusterAddress | string | None, must be set | Hostname and port of the Kafka provider |
 | imageNotifications.topic | string | None, must be set | Topic where raw image arrival notifications appear |
+| initializer.cleanup_delay | int | `3600` | Time after which to remove old initializer pods (seconds). |
+| initializer.image.repository | string | `"ghcr.io/lsst-dm/prompt-init"` | Image to use for the PP initializer |
+| initializer.podAnnotations | object | See the `values.yaml` file. | Pod annotations for the init-output Job |
+| initializer.resources.cpuLimit | int | `1` | The maximum cpu cores for the initializer. |
+| initializer.resources.cpuRequest | int | `1` | The cpu cores requested for the initializer. |
+| initializer.resources.memoryLimit | string | `"1Gi"` | The maximum memory limit for the initializer. |
+| initializer.resources.memoryRequest | string | `"512Mi"` | The minimum memory to request for the initializer. |
+| initializer.retries | int | `6` | Maximum number of times to attempt initializing the central repo. If the initializer fails, the PP service cannot run! |
+| initializer.timeout | int | `120` | Maximum time for a single attempt to initialize the central repo (seconds). |
 | instrument.calibRepo | string | None, must be set | URI to the shared repo used for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself. |
 | instrument.name | string | None, must be set | The "short" name of the instrument |
 | instrument.pipelines.main | string | None, must be set | YAML-formatted config describing which pipeline(s) should be run for which visits' raws. Fields are still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |

--- a/charts/prompt-keda/templates/_service-init.tpl
+++ b/charts/prompt-keda/templates/_service-init.tpl
@@ -41,6 +41,17 @@ spec:
           value: {{ .Values.s3.disableBucketValidation | toString | quote }}
         - name: CONFIG_APDB
           value: {{ .Values.apdb.config }}
+        - name: SASQUATCH_URL
+          value: {{ .Values.sasquatch.endpointUrl }}
+        {{- if and .Values.sasquatch.endpointUrl .Values.sasquatch.auth_env }}
+        - name: SASQUATCH_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "prompt-keda.fullname" . }}-secret
+              key: sasquatch_token
+        {{- end }}
+        - name: DAF_BUTLER_SASQUATCH_NAMESPACE
+          value: {{ .Values.sasquatch.namespace }}
         - name: S3_ENDPOINT_URL
           value: {{ .Values.s3.endpointUrl }}
         {{- if .Values.s3.auth_env }}

--- a/charts/prompt-keda/templates/_service-init.tpl
+++ b/charts/prompt-keda/templates/_service-init.tpl
@@ -1,0 +1,144 @@
+{{/* Shared spec for init-output Job and CronJob. */}}
+{{- define "prompt-keda.service-init" -}}
+spec:
+  template:
+    metadata:
+      {{- with .Values.initializer.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      initContainers:
+      - name: init-db-auth
+        # Make a copy of the read-only secret that's owned by lsst
+        # lsst account is created by main image with id 1000
+        image: busybox
+        command: ["sh", "-c", "cp -L /app/db-auth-mount/db-auth.yaml /app/dbauth/ && chown 1000:1000 /app/dbauth/db-auth.yaml && chmod u=r,go-rwx /app/dbauth/db-auth.yaml"]
+        volumeMounts:
+        - mountPath: /app/db-auth-mount
+          name: db-auth-mount
+          readOnly: true
+        - mountPath: /app/dbauth
+          name: db-auth-credentials-file
+      containers:
+      - image: "{{ .Values.initializer.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+        name: user-container
+        env:
+        - name: RUBIN_INSTRUMENT
+          value: {{ .Values.instrument.name }}
+        - name: PREPROCESSING_PIPELINES_CONFIG
+          value: |-
+            {{- .Values.instrument.pipelines.preprocessing | nindent 12 }}
+        - name: MAIN_PIPELINES_CONFIG
+          value: |-
+            {{- .Values.instrument.pipelines.main | nindent 12 }}
+        - name: SKYMAP
+          value: {{ .Values.instrument.skymap }}
+        - name: CALIB_REPO
+          value: {{ .Values.instrument.calibRepo }}
+        - name: LSST_DISABLE_BUCKET_VALIDATION
+          value: {{ .Values.s3.disableBucketValidation | toString | quote }}
+        - name: CONFIG_APDB
+          value: {{ .Values.apdb.config }}
+        - name: S3_ENDPOINT_URL
+          value: {{ .Values.s3.endpointUrl }}
+        {{- if .Values.s3.auth_env }}
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "prompt-keda.fullname" . }}-secret
+              key: s3_access_key
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "prompt-keda.fullname" . }}-secret
+              key: s3_secret_key
+        {{- end }}
+        {{- if .Values.s3.cred_file_auth }}
+        - name: AWS_SHARED_CREDENTIALS_FILE
+          value: /app/s3/credentials
+        {{- end }}
+        {{- with .Values.s3.aws_profile }}
+        - name: AWS_PROFILE
+          value: {{ . }}
+        {{- end }}
+        {{- with .Values.s3.checksum }}
+        - name: AWS_REQUEST_CHECKSUM_CALCULATION
+          value: {{ . }}
+        {{- end }}
+        - name: LSST_DB_AUTH
+          value: /app/lsst-credentials/db-auth.yaml
+        - name: SERVICE_LOG_LEVELS
+          value: {{ .Values.logLevel }}
+        volumeMounts:
+        - mountPath: /app/lsst-credentials
+          name: db-auth-credentials-file
+          readOnly: true
+        {{- if .Values.s3.cred_file_auth }}
+        - mountPath: /app/s3/
+          name: s3-credentials-file
+        {{- end }}
+        {{- if .Values.registry.centralRepoFile }}
+        - mountPath: {{ .Values.instrument.calibRepo }}
+          name: central-repo-file
+        {{- end }}
+        {{- with .Values.additionalVolumeMounts }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        resources:
+          requests:
+            cpu: {{ .Values.initializer.resources.cpuRequest | toString | quote}}
+            memory: {{ .Values.initializer.resources.memoryRequest }}
+          limits:
+            cpu: {{ .Values.initializer.resources.cpuLimit | toString | quote}}
+            memory: {{ .Values.initializer.resources.memoryLimit }}
+      volumes:
+      - name: db-auth-mount
+        # Temporary mount for db-auth.yaml; cannot be read directly because it's owned by root
+        secret:
+          secretName: {{ template "prompt-keda.fullname" . }}-secret
+          defaultMode: 256
+          items:
+            - key: db-auth_file
+              path: db-auth.yaml
+      - name: db-auth-credentials-file
+        emptyDir:
+          sizeLimit: 10Ki  # Just a text file!
+      {{- if .Values.s3.cred_file_auth }}
+      - name: s3-credentials-file
+        secret:
+          secretName: {{ template "prompt-keda.fullname" . }}-secret
+          items:
+           - key: s3_credentials_file
+             path: credentials
+      {{- end }}
+      {{- if .Values.registry.centralRepoFile }}
+      - name: central-repo-file
+        secret:
+          secretName: {{ template "prompt-keda.fullname" . }}-secret
+          items:
+          - key: central_repo_file
+            path: butler.yaml
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      enableServiceLinks: true
+      restartPolicy: Never
+      activeDeadlineSeconds: {{ .Values.initializer.timeout }}
+  backoffLimit: {{ .Values.initializer.retries }}
+  ttlSecondsAfterFinished: {{ .Values.initializer.cleanup_delay }}
+  podFailurePolicy:
+    rules:
+    # Successful init is essential for other components, don't fail on external shutdowns
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+        status: "True"
+{{- end }}

--- a/charts/prompt-keda/templates/_service-init.tpl
+++ b/charts/prompt-keda/templates/_service-init.tpl
@@ -80,6 +80,18 @@ spec:
         {{- end }}
         - name: LSST_DB_AUTH
           value: /app/lsst-credentials/db-auth.yaml
+        {{- /* Job does not produce alerts, but PackageAlertsTask may ping the server. */}}
+        - name: AP_KAFKA_PRODUCER_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "prompt-keda.fullname" . }}-secret
+              key: alert_stream_pass
+        - name: AP_KAFKA_PRODUCER_USERNAME
+          value: {{ .Values.alerts.username}}
+        - name: AP_KAFKA_SERVER
+          value: {{ .Values.alerts.server}}
+        - name: AP_KAFKA_TOPIC
+          value: {{ .Values.alerts.topic}}
         - name: SERVICE_LOG_LEVELS
           value: {{ .Values.logLevel }}
         volumeMounts:

--- a/charts/prompt-keda/templates/scaled-job.yaml
+++ b/charts/prompt-keda/templates/scaled-job.yaml
@@ -2,6 +2,8 @@ apiVersion: keda.sh/v1alpha1
 kind: ScaledJob
 metadata:
   name: {{ include "prompt-keda.fullname" . }}
+  annotations:
+    argocd.argoproj.io/hook: PostSync
   labels:
     instrument: {{ .Values.instrument.name | lower }}
 spec:

--- a/charts/prompt-keda/templates/service-init-cron.yaml
+++ b/charts/prompt-keda/templates/service-init-cron.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cron-{{ include "prompt-keda.fullname" . }}
+spec:
+  # Ten minutes after change of day_obs
+  schedule: "10 0 * * *"
+  timeZone: Etc/{{ .Values.initializer.cron.day_obs_tz | int | mul -1 | printf "GMT%+d" }}
+  concurrencyPolicy: Replace
+  suspend: {{ .Values.initializer.cron.suspend }}
+  # Ensure suspended jobs don't create a backlog
+  startingDeadlineSeconds: 82800  # 23h
+  jobTemplate:
+{{ include "prompt-keda.service-init" . | indent 4 }}

--- a/charts/prompt-keda/templates/service-init.yaml
+++ b/charts/prompt-keda/templates/service-init.yaml
@@ -3,4 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: init-{{ include "prompt-keda.fullname" . }}
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
 {{ include "prompt-keda.service-init" . }}

--- a/charts/prompt-keda/templates/service-init.yaml
+++ b/charts/prompt-keda/templates/service-init.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: init-{{ include "prompt-keda.fullname" . }}
+{{ include "prompt-keda.service-init" . }}

--- a/charts/prompt-keda/values.yaml
+++ b/charts/prompt-keda/values.yaml
@@ -160,6 +160,12 @@ initializer:
     memoryRequest: "512Mi"
     # -- The maximum memory limit for the initializer.
     memoryLimit: "1Gi"
+  cron:
+    # -- Time zone in which day_obs is computed.
+    day_obs_tz: -12
+    # -- Whether or not to pause daily initializer runs.
+    # This makes it impossible to run Prompt Processing, but avoids repo clutter if the telescope is offline.
+    suspend: false
 
   # -- Maximum time for a single attempt to initialize the central repo (seconds).
   timeout: 120

--- a/charts/prompt-keda/values.yaml
+++ b/charts/prompt-keda/values.yaml
@@ -146,6 +146,33 @@ keda:
     # -- Maximum message age to process, in seconds.
     expiration: 3600
 
+initializer:
+  image:
+    # -- Image to use for the PP initializer
+    repository: ghcr.io/lsst-dm/prompt-init
+    # Initializer and service must be consistent; pull policy and tag can't be set independently
+  resources:
+    # -- The cpu cores requested for the initializer.
+    cpuRequest: 1
+    # -- The maximum cpu cores for the initializer.
+    cpuLimit: 1
+    # -- The minimum memory to request for the initializer.
+    memoryRequest: "512Mi"
+    # -- The maximum memory limit for the initializer.
+    memoryLimit: "1Gi"
+
+  # -- Maximum time for a single attempt to initialize the central repo (seconds).
+  timeout: 120
+  # -- Maximum number of times to attempt initializing the central repo.
+  # If the initializer fails, the PP service cannot run!
+  retries: 6
+
+  # -- Time after which to remove old initializer pods (seconds).
+  cleanup_delay: 3600
+
+  # -- Pod annotations for the init-output Job
+  # @default -- See the `values.yaml` file.
+  podAnnotations: {}
 
 # -- Override the base name for resources
 nameOverride: ""

--- a/charts/prompt-proto-service/README.md
+++ b/charts/prompt-proto-service/README.md
@@ -32,6 +32,15 @@ Event-driven processing of camera images
 | imageNotifications.kafkaClusterAddress | string | None, must be set | Hostname and port of the Kafka provider |
 | imageNotifications.topic | string | None, must be set | Topic where raw image arrival notifications appear |
 | imagePullSecrets | list | `[]` |  |
+| initializer.cleanup_delay | int | `3600` | Time after which to remove old initializer pods (seconds). |
+| initializer.image.repository | string | `"ghcr.io/lsst-dm/prompt-init"` | Image to use for the PP initializer |
+| initializer.podAnnotations | object | See the `values.yaml` file. | Pod annotations for the init-output Job |
+| initializer.resources.cpuLimit | int | `1` | The maximum cpu cores for the initializer. |
+| initializer.resources.cpuRequest | int | `1` | The cpu cores requested for the initializer. |
+| initializer.resources.memoryLimit | string | `"1Gi"` | The maximum memory limit for the initializer. |
+| initializer.resources.memoryRequest | string | `"512Mi"` | The minimum memory to request for the initializer. |
+| initializer.retries | int | `6` | Maximum number of times to attempt initializing the central repo. If the initializer fails, the PP service cannot run! |
+| initializer.timeout | int | `120` | Maximum time for a single attempt to initialize the central repo (seconds). |
 | instrument.calibRepo | string | None, must be set | URI to the shared repo used for calibrations, templates, and pipeline outputs. If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself. |
 | instrument.name | string | None, must be set | The "short" name of the instrument |
 | instrument.pipelines.main | string | None, must be set | YAML-formatted config describing which pipeline(s) should be run for which visits' raws. Fields are still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |

--- a/charts/prompt-proto-service/README.md
+++ b/charts/prompt-proto-service/README.md
@@ -33,6 +33,8 @@ Event-driven processing of camera images
 | imageNotifications.topic | string | None, must be set | Topic where raw image arrival notifications appear |
 | imagePullSecrets | list | `[]` |  |
 | initializer.cleanup_delay | int | `3600` | Time after which to remove old initializer pods (seconds). |
+| initializer.cron.day_obs_tz | int | `-12` | Time zone in which day_obs is computed. |
+| initializer.cron.suspend | bool | `false` | Whether or not to pause daily initializer runs. This makes it impossible to run Prompt Processing, but avoids repo clutter if the telescope is offline. |
 | initializer.image.repository | string | `"ghcr.io/lsst-dm/prompt-init"` | Image to use for the PP initializer |
 | initializer.podAnnotations | object | See the `values.yaml` file. | Pod annotations for the init-output Job |
 | initializer.resources.cpuLimit | int | `1` | The maximum cpu cores for the initializer. |

--- a/charts/prompt-proto-service/templates/_service-init.tpl
+++ b/charts/prompt-proto-service/templates/_service-init.tpl
@@ -41,6 +41,17 @@ spec:
           value: {{ .Values.s3.disableBucketValidation | toString | quote }}
         - name: CONFIG_APDB
           value: {{ .Values.apdb.config }}
+        - name: SASQUATCH_URL
+          value: {{ .Values.sasquatch.endpointUrl }}
+        {{- if and .Values.sasquatch.endpointUrl .Values.sasquatch.auth_env }}
+        - name: SASQUATCH_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "prompt-proto-service.fullname" . }}-secret
+              key: sasquatch_token
+        {{- end }}
+        - name: DAF_BUTLER_SASQUATCH_NAMESPACE
+          value: {{ .Values.sasquatch.namespace }}
         - name: S3_ENDPOINT_URL
           value: {{ .Values.s3.endpointUrl }}
         {{- if .Values.s3.auth_env }}

--- a/charts/prompt-proto-service/templates/_service-init.tpl
+++ b/charts/prompt-proto-service/templates/_service-init.tpl
@@ -80,6 +80,18 @@ spec:
         {{- end }}
         - name: LSST_DB_AUTH
           value: /app/lsst-credentials/db-auth.yaml
+        {{- /* Job does not produce alerts, but PackageAlertsTask may ping the server. */}}
+        - name: AP_KAFKA_PRODUCER_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "prompt-proto-service.fullname" . }}-secret
+              key: alert_stream_pass
+        - name: AP_KAFKA_PRODUCER_USERNAME
+          value: {{ .Values.alerts.username}}
+        - name: AP_KAFKA_SERVER
+          value: {{ .Values.alerts.server}}
+        - name: AP_KAFKA_TOPIC
+          value: {{ .Values.alerts.topic}}
         - name: SERVICE_LOG_LEVELS
           value: {{ .Values.logLevel }}
         volumeMounts:

--- a/charts/prompt-proto-service/templates/_service-init.tpl
+++ b/charts/prompt-proto-service/templates/_service-init.tpl
@@ -1,0 +1,144 @@
+{{/* Shared spec for init-output Job and CronJob. */}}
+{{- define "prompt-proto-service.service-init" -}}
+spec:
+  template:
+    metadata:
+      {{- with .Values.initializer.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      initContainers:
+      - name: init-db-auth
+        # Make a copy of the read-only secret that's owned by lsst
+        # lsst account is created by main image with id 1000
+        image: busybox
+        command: ["sh", "-c", "cp -L /app/db-auth-mount/db-auth.yaml /app/dbauth/ && chown 1000:1000 /app/dbauth/db-auth.yaml && chmod u=r,go-rwx /app/dbauth/db-auth.yaml"]
+        volumeMounts:
+        - mountPath: /app/db-auth-mount
+          name: db-auth-mount
+          readOnly: true
+        - mountPath: /app/dbauth
+          name: db-auth-credentials-file
+      containers:
+      - image: "{{ .Values.initializer.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+        name: user-container
+        env:
+        - name: RUBIN_INSTRUMENT
+          value: {{ .Values.instrument.name }}
+        - name: PREPROCESSING_PIPELINES_CONFIG
+          value: |-
+            {{- .Values.instrument.pipelines.preprocessing | nindent 12 }}
+        - name: MAIN_PIPELINES_CONFIG
+          value: |-
+            {{- .Values.instrument.pipelines.main | nindent 12 }}
+        - name: SKYMAP
+          value: {{ .Values.instrument.skymap }}
+        - name: CALIB_REPO
+          value: {{ .Values.instrument.calibRepo }}
+        - name: LSST_DISABLE_BUCKET_VALIDATION
+          value: {{ .Values.s3.disableBucketValidation | toString | quote }}
+        - name: CONFIG_APDB
+          value: {{ .Values.apdb.config }}
+        - name: S3_ENDPOINT_URL
+          value: {{ .Values.s3.endpointUrl }}
+        {{- if .Values.s3.auth_env }}
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "prompt-proto-service.fullname" . }}-secret
+              key: s3_access_key
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "prompt-proto-service.fullname" . }}-secret
+              key: s3_secret_key
+        {{- end }}
+        {{- if .Values.s3.cred_file_auth }}
+        - name: AWS_SHARED_CREDENTIALS_FILE
+          value: /app/s3/credentials
+        {{- end }}
+        {{- with .Values.s3.aws_profile }}
+        - name: AWS_PROFILE
+          value: {{ . }}
+        {{- end }}
+        {{- with .Values.s3.checksum }}
+        - name: AWS_REQUEST_CHECKSUM_CALCULATION
+          value: {{ . }}
+        {{- end }}
+        - name: LSST_DB_AUTH
+          value: /app/lsst-credentials/db-auth.yaml
+        - name: SERVICE_LOG_LEVELS
+          value: {{ .Values.logLevel }}
+        volumeMounts:
+        - mountPath: /app/lsst-credentials
+          name: db-auth-credentials-file
+          readOnly: true
+        {{- if .Values.s3.cred_file_auth }}
+        - mountPath: /app/s3/
+          name: s3-credentials-file
+        {{- end }}
+        {{- if .Values.registry.centralRepoFile }}
+        - mountPath: {{ .Values.instrument.calibRepo }}
+          name: central-repo-file
+        {{- end }}
+        {{- with .Values.additionalVolumeMounts }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        resources:
+          requests:
+            cpu: {{ .Values.initializer.resources.cpuRequest | toString | quote}}
+            memory: {{ .Values.initializer.resources.memoryRequest }}
+          limits:
+            cpu: {{ .Values.initializer.resources.cpuLimit | toString | quote}}
+            memory: {{ .Values.initializer.resources.memoryLimit }}
+      volumes:
+      - name: db-auth-mount
+        # Temporary mount for db-auth.yaml; cannot be read directly because it's owned by root
+        secret:
+          secretName: {{ template "prompt-proto-service.fullname" . }}-secret
+          defaultMode: 256
+          items:
+            - key: db-auth_file
+              path: db-auth.yaml
+      - name: db-auth-credentials-file
+        emptyDir:
+          sizeLimit: 10Ki  # Just a text file!
+      {{- if .Values.s3.cred_file_auth }}
+      - name: s3-credentials-file
+        secret:
+          secretName: {{ template "prompt-proto-service.fullname" . }}-secret
+          items:
+           - key: s3_credentials_file
+             path: credentials
+      {{- end }}
+      {{- if .Values.registry.centralRepoFile }}
+      - name: central-repo-file
+        secret:
+          secretName: {{ template "prompt-proto-service.fullname" . }}-secret
+          items:
+          - key: central_repo_file
+            path: butler.yaml
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      enableServiceLinks: true
+      restartPolicy: Never
+      activeDeadlineSeconds: {{ .Values.initializer.timeout }}
+  backoffLimit: {{ .Values.initializer.retries }}
+  ttlSecondsAfterFinished: {{ .Values.initializer.cleanup_delay }}
+  podFailurePolicy:
+    rules:
+    # Successful init is essential for other components, don't fail on external shutdowns
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+        status: "True"
+{{- end }}

--- a/charts/prompt-proto-service/templates/prompt-proto-service.yaml
+++ b/charts/prompt-proto-service/templates/prompt-proto-service.yaml
@@ -3,6 +3,8 @@ apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
   name: {{ include "prompt-proto-service.fullname" . }}
+  annotations:
+    argocd.argoproj.io/hook: PostSync
 spec:
   template:
     metadata:

--- a/charts/prompt-proto-service/templates/service-init-cron.yaml
+++ b/charts/prompt-proto-service/templates/service-init-cron.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cron-{{ include "prompt-proto-service.fullname" . }}
+spec:
+  # Ten minutes after change of day_obs
+  schedule: "10 0 * * *"
+  timeZone: Etc/{{ .Values.initializer.cron.day_obs_tz | int | mul -1 | printf "GMT%+d" }}
+  concurrencyPolicy: Replace
+  suspend: {{ .Values.initializer.cron.suspend }}
+  # Ensure suspended jobs don't create a backlog
+  startingDeadlineSeconds: 82800  # 23h
+  jobTemplate:
+{{ include "prompt-proto-service.service-init" . | indent 4 }}

--- a/charts/prompt-proto-service/templates/service-init.yaml
+++ b/charts/prompt-proto-service/templates/service-init.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: init-{{ include "prompt-proto-service.fullname" . }}
+{{ include "prompt-proto-service.service-init" . }}

--- a/charts/prompt-proto-service/templates/service-init.yaml
+++ b/charts/prompt-proto-service/templates/service-init.yaml
@@ -3,4 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: init-{{ include "prompt-proto-service.fullname" . }}
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
 {{ include "prompt-proto-service.service-init" . }}

--- a/charts/prompt-proto-service/values.yaml
+++ b/charts/prompt-proto-service/values.yaml
@@ -165,6 +165,34 @@ knative:
   # -- Maximum message age to process, in seconds.
   expiration: 3600
 
+initializer:
+  image:
+    # -- Image to use for the PP initializer
+    repository: ghcr.io/lsst-dm/prompt-init
+    # Initializer and service must be consistent; pull policy and tag can't be set independently
+  resources:
+    # -- The cpu cores requested for the initializer.
+    cpuRequest: 1
+    # -- The maximum cpu cores for the initializer.
+    cpuLimit: 1
+    # -- The minimum memory to request for the initializer.
+    memoryRequest: "512Mi"
+    # -- The maximum memory limit for the initializer.
+    memoryLimit: "1Gi"
+
+  # -- Maximum time for a single attempt to initialize the central repo (seconds).
+  timeout: 120
+  # -- Maximum number of times to attempt initializing the central repo.
+  # If the initializer fails, the PP service cannot run!
+  retries: 6
+
+  # -- Time after which to remove old initializer pods (seconds).
+  cleanup_delay: 3600
+
+  # -- Pod annotations for the init-output Job
+  # @default -- See the `values.yaml` file.
+  podAnnotations: {}
+
 # -- Override the base name for resources
 nameOverride: ""
 

--- a/charts/prompt-proto-service/values.yaml
+++ b/charts/prompt-proto-service/values.yaml
@@ -179,6 +179,12 @@ initializer:
     memoryRequest: "512Mi"
     # -- The maximum memory limit for the initializer.
     memoryLimit: "1Gi"
+  cron:
+    # -- Time zone in which day_obs is computed.
+    day_obs_tz: -12
+    # -- Whether or not to pause daily initializer runs.
+    # This makes it impossible to run Prompt Processing, but avoids repo clutter if the telescope is offline.
+    suspend: false
 
   # -- Maximum time for a single attempt to initialize the central repo (seconds).
   timeout: 120


### PR DESCRIPTION
This PR adds a Job and CronJob that create init-outputs and output collections for the Prompt Processing service. By design, these jobs share much of their config with the primary service and **must** be updated together in order to work correctly.