### PR TITLE
Increase liveness probe initialDelaySeconds to 90s

### DIFF
--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -63,7 +63,7 @@ Rubin Observatory's telemetry service
 | influxdb.ingress.path | string | `"/influxdb(/\|$)(.*)"` | Path for the ingress |
 | influxdb.ingress.tls | bool | `false` | Whether to obtain TLS certificates for the ingress hostname |
 | influxdb.initScripts.enabled | bool | `false` | Whether to enable the InfluxDB custom initialization script |
-| influxdb.livenessProbe.initialDelaySeconds | int | `60` | Liveness probe initial delay in seconds |
+| influxdb.livenessProbe.initialDelaySeconds | int | `90` | Liveness probe initial delay in seconds |
 | influxdb.persistence.enabled | bool | `true` | Whether to use persistent volume claims. By default, `storageClass` is undefined, choosing the default provisioner (standard on GKE). |
 | influxdb.persistence.size | string | 1TiB for teststand deployments | Persistent volume size |
 | influxdb.resources | object | See `values.yaml` | Kubernetes resource requests and limits |

--- a/applications/sasquatch/values.yaml
+++ b/applications/sasquatch/values.yaml
@@ -40,7 +40,7 @@ influxdb:
 
   livenessProbe:
     # -- Liveness probe initial delay in seconds
-    initialDelaySeconds: 60
+    initialDelaySeconds: 90
 
   persistence:
     # -- Whether to use persistent volume claims. By default, `storageClass`


### PR DESCRIPTION
- The InfluxDB OSS liveness probe is restarting the InfluxDB OSS Pod at USDF dev before it initializes.