### PR TITLE
[DM-49812] FIx lsstcam connector configuration

### DIFF
--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -249,6 +249,8 @@ telegraf-kafka-consumer:
     lsstcam:
       enabled: true
       repair: false
+      metric_batch_size: 250
+      max_undelivered_messages: 5000
       database: "efd"
       timestamp_field: "private_efdStamp"
       topicRegexps: |


### PR DESCRIPTION
The lsstcam connector in Sasquatch at USDF is showing this error:

```
E! [agent] Error writing to outputs.influxdb: could not write any address
``` 

Looking at the connector dashboard it is exceeding its buffer limit and using way too much memory.
We spot a difference in the Telegraf config at the Summit and USDF, USDF is missing the following:

```
metric_batch_size: 250
max_undelivered_messages: 5000
```

After fixing the configuration the error is gone and we are operating within the buffer limits.