### PR TITLE
Fix acls for tab an qserv users

### DIFF
--- a/applications/sasquatch/charts/strimzi-kafka/templates/users.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/users.yaml
@@ -357,6 +357,11 @@ spec:
         type: allow
         host: "*"
         operation: All
+      - resource:
+          type: cluster
+        operations:
+          - Describe
+          - DescribeConfigs
 {{- end }}
 {{- if .Values.users.qserv.enabled }}
 ---
@@ -389,4 +394,9 @@ spec:
         type: allow
         host: "*"
         operation: All
+      - resource:
+          type: cluster
+        operations:
+          - Describe
+          - DescribeConfigs
 {{- end }}


### PR DESCRIPTION
- Add permission to retrieve cluster metadata, this is required for producers