### PR TITLE
Migrate Prompt Processing to YAML APDB configs

### DIFF
--- a/applications/prompt-keda-hsc/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-keda-hsc/values-usdfdev-prompt-processing.yaml
@@ -28,7 +28,7 @@ prompt-keda:
     topic: prompt-processing-dev
 
   apdb:
-    config: s3://rubin-pp-dev-users/apdb_config/sql/pp_apdb_hsc-dev.py
+    config: s3://rubin-pp-dev-users/apdb_config/sql/pp_apdb_hsc-dev.yaml
 
   alerts:
     username: kafka-admin

--- a/applications/prompt-keda-latiss/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-keda-latiss/values-usdfdev-prompt-processing.yaml
@@ -31,7 +31,7 @@ prompt-keda:
     topic: prompt-processing-dev
 
   apdb:
-    config: s3://rubin-pp-dev-users/apdb_config/cassandra/pp_apdb_latiss-dev.py
+    config: s3://rubin-pp-dev-users/apdb_config/cassandra/pp_apdb_latiss-dev.yaml
 
   alerts:
     username: kafka-admin

--- a/applications/prompt-keda-latiss/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-keda-latiss/values-usdfprod-prompt-processing.yaml
@@ -57,7 +57,7 @@ prompt-keda:
     imageTimeout: 110
 
   apdb:
-    config: s3://rubin-summit-users/apdb_config/cassandra/pp_apdb_latiss.py
+    config: s3://rubin-summit-users/apdb_config/cassandra/pp_apdb_latiss.yaml
 
   alerts:
     username: kafka-admin

--- a/applications/prompt-keda-lsstcomcam/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-keda-lsstcomcam/values-usdfdev-prompt-processing.yaml
@@ -29,7 +29,7 @@ prompt-keda:
     topic: prompt-processing-dev
 
   apdb:
-    config: s3://rubin-pp-dev-users/apdb_config/cassandra/pp_apdb_lsstcomcam-dev.py
+    config: s3://rubin-pp-dev-users/apdb_config/cassandra/pp_apdb_lsstcomcam-dev.yaml
 
   alerts:
     topic: "alert-stream-test"

--- a/applications/prompt-keda-lsstcomcamsim/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-keda-lsstcomcamsim/values-usdfdev-prompt-processing.yaml
@@ -31,7 +31,7 @@ prompt-keda:
     topic: prompt-processing-dev
 
   apdb:
-    config: s3://rubin-pp-dev-users/apdb_config/cassandra/pp_apdb_lsstcomcamsim-dev.py
+    config: s3://rubin-pp-dev-users/apdb_config/cassandra/pp_apdb_lsstcomcamsim-dev.yaml
 
   alerts:
     username: kafka-admin

--- a/applications/prompt-proto-service-hsc-gpu/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-hsc-gpu/values-usdfdev-prompt-processing.yaml
@@ -33,7 +33,7 @@ prompt-proto-service:
     topic: prompt-processing-dev
 
   apdb:
-    config: s3://rubin-pp-dev-users/apdb_config/sql/pp_apdb_hsc-dev.py
+    config: s3://rubin-pp-dev-users/apdb_config/sql/pp_apdb_hsc-dev.yaml
 
   alerts:
     topic: "alert-stream-test"

--- a/applications/prompt-proto-service-hsc/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-hsc/values-usdfdev-prompt-processing.yaml
@@ -34,7 +34,7 @@ prompt-proto-service:
     topic: prompt-processing-dev
 
   apdb:
-    config: s3://rubin-pp-dev-users/apdb_config/sql/pp_apdb_hsc-dev.py
+    config: s3://rubin-pp-dev-users/apdb_config/sql/pp_apdb_hsc-dev.yaml
 
   alerts:
     topic: "alert-stream-test"

--- a/applications/prompt-proto-service-latiss/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfdev-prompt-processing.yaml
@@ -35,7 +35,7 @@ prompt-proto-service:
     topic: prompt-processing-dev
 
   apdb:
-    config: s3://rubin-pp-dev-users/apdb_config/cassandra/pp_apdb_latiss-dev.py
+    config: s3://rubin-pp-dev-users/apdb_config/cassandra/pp_apdb_latiss-dev.yaml
 
   alerts:
     topic: "alert-stream-test"

--- a/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfprod-prompt-processing.yaml
@@ -65,7 +65,7 @@ prompt-proto-service:
     imageTimeout: 110
 
   apdb:
-    config: s3://rubin-summit-users/apdb_config/cassandra/pp_apdb_latiss.py
+    config: s3://rubin-summit-users/apdb_config/cassandra/pp_apdb_latiss.yaml
 
   alerts:
     topic: "latiss-alerts"

--- a/applications/prompt-proto-service-lsstcomcam/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/values-usdfdev-prompt-processing.yaml
@@ -34,7 +34,7 @@ prompt-proto-service:
     topic: prompt-processing-dev
 
   apdb:
-    config: s3://rubin-pp-dev-users/apdb_config/cassandra/pp_apdb_lsstcomcam-dev.py
+    config: s3://rubin-pp-dev-users/apdb_config/cassandra/pp_apdb_lsstcomcam-dev.yaml
 
   alerts:
     topic: "alert-stream-test"

--- a/applications/prompt-proto-service-lsstcomcamsim/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcomcamsim/values-usdfdev-prompt-processing.yaml
@@ -35,7 +35,7 @@ prompt-proto-service:
     topic: prompt-processing-dev
 
   apdb:
-    config: s3://rubin-pp-dev-users/apdb_config/cassandra/pp_apdb_lsstcomcamsim-dev.py
+    config: s3://rubin-pp-dev-users/apdb_config/cassandra/pp_apdb_lsstcomcamsim-dev.yaml
 
   alerts:
     topic: alert-stream-test


### PR DESCRIPTION
This PR migrates all active APDB configs from the deprecated pex_config (`.py`) format to YAML. The config files have already been converted.