### PR TITLE
DM-49427: Filter out old fanned-out messages in Keda

### DIFF
--- a/applications/prompt-keda-hsc/README.md
+++ b/applications/prompt-keda-hsc/README.md
@@ -42,6 +42,7 @@ KEDA Prompt Processing instance for HSC
 | prompt-keda.keda.pollingInterval | int | `2` |  |
 | prompt-keda.keda.redisStreams.activationLagCount | string | `"1"` |  |
 | prompt-keda.keda.redisStreams.consumerGroup | string | `"hsc_consumer_group"` |  |
+| prompt-keda.keda.redisStreams.expiration | int | `3600` | Maximum message age to process, in seconds. |
 | prompt-keda.keda.redisStreams.host | string | `"prompt-redis.prompt-redis"` |  |
 | prompt-keda.keda.redisStreams.lagCount | string | `"1"` |  |
 | prompt-keda.keda.redisStreams.msgListenTimeout | int | `900` |  |

--- a/applications/prompt-keda-hsc/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-keda-hsc/values-usdfdev-prompt-processing.yaml
@@ -41,6 +41,9 @@ prompt-keda:
 
   keda:
     maxReplicaCount: 400
+    redisStreams:
+      # Dev processes very old images, set to ~20 years
+      expiration: 600_000_000.0
 
   podAnnotations: {
     edu.stanford.slac.sdf.project/usdf-embargo: "true"

--- a/applications/prompt-keda-hsc/values.yaml
+++ b/applications/prompt-keda-hsc/values.yaml
@@ -142,6 +142,8 @@ prompt-keda:
       lagCount: "1"
       # Number of entries in the Pending Entries List for the specified consumer group in the Redis Stream
       pendingEntriesCount: "1"
+      # -- Maximum message age to process, in seconds.
+      expiration: 3600
 
 
   # -- Override the base name for resources

--- a/applications/prompt-keda-latiss/README.md
+++ b/applications/prompt-keda-latiss/README.md
@@ -42,6 +42,7 @@ KEDA Prompt Processing instance for LATISS
 | prompt-keda.keda.pollingInterval | int | `2` |  |
 | prompt-keda.keda.redisStreams.activationLagCount | string | `"1"` |  |
 | prompt-keda.keda.redisStreams.consumerGroup | string | `"latiss_consumer_group"` |  |
+| prompt-keda.keda.redisStreams.expiration | int | `3600` | Maximum message age to process, in seconds. |
 | prompt-keda.keda.redisStreams.host | string | `"prompt-redis.prompt-redis"` |  |
 | prompt-keda.keda.redisStreams.lagCount | string | `"1"` |  |
 | prompt-keda.keda.redisStreams.msgListenTimeout | int | `900` |  |

--- a/applications/prompt-keda-latiss/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-keda-latiss/values-usdfdev-prompt-processing.yaml
@@ -42,6 +42,11 @@ prompt-keda:
     endpointUrl: https://usdf-rsp-dev.slac.stanford.edu/sasquatch-rest-proxy
     auth_env: false
 
+  keda:
+    redisStreams:
+      # Dev processes very old images, set to ~20 years
+      expiration: 600_000_000.0
+
   podAnnotations: {
     edu.stanford.slac.sdf.project/usdf-embargo: "true"
   }

--- a/applications/prompt-keda-latiss/values.yaml
+++ b/applications/prompt-keda-latiss/values.yaml
@@ -140,6 +140,8 @@ prompt-keda:
       lagCount: "1"
       # Number of entries in the Pending Entries List for the specified consumer group in the Redis Stream
       pendingEntriesCount: "1"
+      # -- Maximum message age to process, in seconds.
+      expiration: 3600
 
 
   # -- Override the base name for resources

--- a/applications/prompt-keda-lsstcam/README.md
+++ b/applications/prompt-keda-lsstcam/README.md
@@ -42,6 +42,7 @@ KEDA Prompt Processing instance for LSSTCam
 | prompt-keda.keda.pollingInterval | int | `2` |  |
 | prompt-keda.keda.redisStreams.activationLagCount | string | `"1"` |  |
 | prompt-keda.keda.redisStreams.consumerGroup | string | `"lsstcam_consumer_group"` |  |
+| prompt-keda.keda.redisStreams.expiration | int | `3600` | Maximum message age to process, in seconds. |
 | prompt-keda.keda.redisStreams.host | string | `"prompt-redis.prompt-redis"` |  |
 | prompt-keda.keda.redisStreams.lagCount | string | `"1"` |  |
 | prompt-keda.keda.redisStreams.msgListenTimeout | int | `900` |  |

--- a/applications/prompt-keda-lsstcam/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-keda-lsstcam/values-usdfdev-prompt-processing.yaml
@@ -40,3 +40,8 @@ prompt-keda:
   sasquatch:
     endpointUrl: https://usdf-rsp-dev.slac.stanford.edu/sasquatch-rest-proxy
     auth_env: false
+
+  keda:
+    redisStreams:
+      # Dev processes very old images, set to ~20 years
+      expiration: 600_000_000.0

--- a/applications/prompt-keda-lsstcam/values.yaml
+++ b/applications/prompt-keda-lsstcam/values.yaml
@@ -147,6 +147,8 @@ prompt-keda:
       lagCount: "1"
       # Number of entries in the Pending Entries List for the specified consumer group in the Redis Stream
       pendingEntriesCount: "1"
+      # -- Maximum message age to process, in seconds.
+      expiration: 3600
 
 
   # -- Override the base name for resources

--- a/applications/prompt-keda-lsstcamimsim/README.md
+++ b/applications/prompt-keda-lsstcamimsim/README.md
@@ -42,6 +42,7 @@ KEDA Prompt Processing instance for LSSTCam-imSim.
 | prompt-keda.keda.pollingInterval | int | `2` |  |
 | prompt-keda.keda.redisStreams.activationLagCount | string | `"1"` |  |
 | prompt-keda.keda.redisStreams.consumerGroup | string | `"lsstcamimsim_consumer_group"` |  |
+| prompt-keda.keda.redisStreams.expiration | int | `3600` | Maximum message age to process, in seconds. |
 | prompt-keda.keda.redisStreams.host | string | `"prompt-redis.prompt-redis"` |  |
 | prompt-keda.keda.redisStreams.lagCount | string | `"1"` |  |
 | prompt-keda.keda.redisStreams.msgListenTimeout | int | `900` |  |

--- a/applications/prompt-keda-lsstcamimsim/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-keda-lsstcamimsim/values-usdfdev-prompt-processing.yaml
@@ -43,3 +43,6 @@ prompt-keda:
 
   keda:
     maxReplicaCount: 100 # TODO.  Increase after testing.
+    redisStreams:
+      # Dev processes very old images, set to ~20 years
+      expiration: 600_000_000.0

--- a/applications/prompt-keda-lsstcamimsim/values.yaml
+++ b/applications/prompt-keda-lsstcamimsim/values.yaml
@@ -149,6 +149,8 @@ prompt-keda:
       lagCount: "1"
       # Number of entries in the Pending Entries List for the specified consumer group in the Redis Stream
       pendingEntriesCount: "1"
+      # -- Maximum message age to process, in seconds.
+      expiration: 3600
 
   # -- Override the base name for resources
   nameOverride: ""

--- a/applications/prompt-keda-lsstcomcam/README.md
+++ b/applications/prompt-keda-lsstcomcam/README.md
@@ -41,6 +41,7 @@ KEDA Prompt Processing instance for LSSTComCam.
 | prompt-keda.keda.pollingInterval | int | `2` |  |
 | prompt-keda.keda.redisStreams.activationLagCount | string | `"1"` |  |
 | prompt-keda.keda.redisStreams.consumerGroup | string | `"lsstcomcam_consumer_group"` |  |
+| prompt-keda.keda.redisStreams.expiration | int | `3600` | Maximum message age to process, in seconds. |
 | prompt-keda.keda.redisStreams.host | string | `"prompt-redis.prompt-redis"` |  |
 | prompt-keda.keda.redisStreams.lagCount | string | `"1"` |  |
 | prompt-keda.keda.redisStreams.msgListenTimeout | int | `900` |  |

--- a/applications/prompt-keda-lsstcomcam/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-keda-lsstcomcam/values-usdfdev-prompt-processing.yaml
@@ -38,4 +38,9 @@ prompt-keda:
     endpointUrl: https://usdf-rsp-dev.slac.stanford.edu/sasquatch-rest-proxy
     auth_env: false
 
+  keda:
+    redisStreams:
+      # Dev processes very old images, set to ~20 years
+      expiration: 600_000_000.0
+
   fullnameOverride: "prompt-keda-lsstcomcam"

--- a/applications/prompt-keda-lsstcomcam/values.yaml
+++ b/applications/prompt-keda-lsstcomcam/values.yaml
@@ -139,6 +139,8 @@ prompt-keda:
       lagCount: "1"
       # Number of entries in the Pending Entries List for the specified consumer group in the Redis Stream
       pendingEntriesCount: "1"
+      # -- Maximum message age to process, in seconds.
+      expiration: 3600
 
   # -- Override the base name for resources
   nameOverride: ""

--- a/applications/prompt-keda-lsstcomcamsim/README.md
+++ b/applications/prompt-keda-lsstcomcamsim/README.md
@@ -42,6 +42,7 @@ KEDA Prompt Processing instance for LSSTComCamSim
 | prompt-keda.keda.pollingInterval | int | `2` |  |
 | prompt-keda.keda.redisStreams.activationLagCount | string | `"1"` |  |
 | prompt-keda.keda.redisStreams.consumerGroup | string | `"lsstcomcamsim_consumer_group"` |  |
+| prompt-keda.keda.redisStreams.expiration | int | `3600` | Maximum message age to process, in seconds. |
 | prompt-keda.keda.redisStreams.host | string | `"prompt-redis.prompt-redis"` |  |
 | prompt-keda.keda.redisStreams.lagCount | string | `"1"` |  |
 | prompt-keda.keda.redisStreams.msgListenTimeout | int | `900` |  |

--- a/applications/prompt-keda-lsstcomcamsim/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-keda-lsstcomcamsim/values-usdfdev-prompt-processing.yaml
@@ -42,6 +42,11 @@ prompt-keda:
     endpointUrl: https://usdf-rsp-dev.slac.stanford.edu/sasquatch-rest-proxy
     auth_env: false
 
+  keda:
+    redisStreams:
+      # Dev processes very old images, set to ~20 years
+      expiration: 600_000_000.0
+
   podAnnotations: {
     edu.stanford.slac.sdf.project/usdf-embargo: "true"
   }

--- a/applications/prompt-keda-lsstcomcamsim/values.yaml
+++ b/applications/prompt-keda-lsstcomcamsim/values.yaml
@@ -143,6 +143,8 @@ prompt-keda:
       lagCount: "1"
       # Number of entries in the Pending Entries List for the specified consumer group in the Redis Stream
       pendingEntriesCount: "1"
+      # -- Maximum message age to process, in seconds.
+      expiration: 3600
 
   # -- Override the base name for resources
   nameOverride: ""

--- a/applications/prompt-proto-service-hsc-gpu/README.md
+++ b/applications/prompt-proto-service-hsc-gpu/README.md
@@ -39,6 +39,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.knative.cpuRequest | int | `1` | The cpu cores requested for the full pod (see `containerConcurrency`). |
 | prompt-proto-service.knative.ephemeralStorageLimit | string | `"5Gi"` | The maximum storage space allowed for each container (mostly local Butler). This allocation is for the full pod (see `containerConcurrency`) |
 | prompt-proto-service.knative.ephemeralStorageRequest | string | `"5Gi"` | The storage space reserved for each container (mostly local Butler). This allocation is for the full pod (see `containerConcurrency`) |
+| prompt-proto-service.knative.expiration | int | `3600` | Maximum message age to process, in seconds. |
 | prompt-proto-service.knative.extraTimeout | int | `10` | To acommodate scheduling problems, Knative waits for a request for twice `worker.timeout`. This parameter adds extra time to that minimum (seconds). |
 | prompt-proto-service.knative.gpu | bool | `true` | GPUs enabled. |
 | prompt-proto-service.knative.gpuRequest | int | `1` | The number of GPUs to request for the full pod (see `containerConcurrency`). |

--- a/applications/prompt-proto-service-hsc-gpu/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-hsc-gpu/values-usdfdev-prompt-processing.yaml
@@ -42,4 +42,8 @@ prompt-proto-service:
     endpointUrl: https://usdf-rsp-dev.slac.stanford.edu/sasquatch-rest-proxy
     auth_env: false
 
+  knative:
+    # Dev processes very old images, set to ~20 years
+    expiration: 600_000_000.0
+
   fullnameOverride: "prompt-proto-service-hsc-gpu"

--- a/applications/prompt-proto-service-hsc-gpu/values.yaml
+++ b/applications/prompt-proto-service-hsc-gpu/values.yaml
@@ -161,6 +161,8 @@ prompt-proto-service:
     # This is only useful if the container runs async workers.
     # If 0, idle timeout is ignored.
     responseStartTimeout: 0
+    # -- Maximum message age to process, in seconds.
+    expiration: 3600
 
   # -- The number of Knative requests that can be handled simultaneously by one container
   containerConcurrency: 1

--- a/applications/prompt-proto-service-hsc/README.md
+++ b/applications/prompt-proto-service-hsc/README.md
@@ -39,6 +39,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.knative.cpuRequest | int | `1` | The cpu cores requested for the full pod (see `containerConcurrency`). |
 | prompt-proto-service.knative.ephemeralStorageLimit | string | `"5Gi"` | The maximum storage space allowed for each container (mostly local Butler). This allocation is for the full pod (see `containerConcurrency`) |
 | prompt-proto-service.knative.ephemeralStorageRequest | string | `"5Gi"` | The storage space reserved for each container (mostly local Butler). This allocation is for the full pod (see `containerConcurrency`) |
+| prompt-proto-service.knative.expiration | int | `3600` | Maximum message age to process, in seconds. |
 | prompt-proto-service.knative.extraTimeout | int | `10` | To acommodate scheduling problems, Knative waits for a request for twice `worker.timeout`. This parameter adds extra time to that minimum (seconds). |
 | prompt-proto-service.knative.gpu | bool | `false` | GPUs enabled. |
 | prompt-proto-service.knative.gpuRequest | int | `0` | The number of GPUs to request for the full pod (see `containerConcurrency`). |

--- a/applications/prompt-proto-service-hsc/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-hsc/values-usdfdev-prompt-processing.yaml
@@ -43,4 +43,8 @@ prompt-proto-service:
     endpointUrl: https://usdf-rsp-dev.slac.stanford.edu/sasquatch-rest-proxy
     auth_env: false
 
+  knative:
+    # Dev processes very old images, set to ~20 years
+    expiration: 600_000_000.0
+
   fullnameOverride: "prompt-proto-service-hsc"

--- a/applications/prompt-proto-service-hsc/values.yaml
+++ b/applications/prompt-proto-service-hsc/values.yaml
@@ -162,6 +162,8 @@ prompt-proto-service:
     # This is only useful if the container runs async workers.
     # If 0, idle timeout is ignored.
     responseStartTimeout: 0
+    # -- Maximum message age to process, in seconds.
+    expiration: 3600
 
   # -- The number of Knative requests that can be handled simultaneously by one container
   containerConcurrency: 1

--- a/applications/prompt-proto-service-latiss/README.md
+++ b/applications/prompt-proto-service-latiss/README.md
@@ -39,6 +39,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.knative.cpuRequest | int | `1` | The cpu cores requested for the full pod (see `containerConcurrency`). |
 | prompt-proto-service.knative.ephemeralStorageLimit | string | `"5Gi"` | The maximum storage space allowed for each container (mostly local Butler). This allocation is for the full pod (see `containerConcurrency`) |
 | prompt-proto-service.knative.ephemeralStorageRequest | string | `"5Gi"` | The storage space reserved for each container (mostly local Butler). This allocation is for the full pod (see `containerConcurrency`) |
+| prompt-proto-service.knative.expiration | int | `3600` | Maximum message age to process, in seconds. |
 | prompt-proto-service.knative.extraTimeout | int | `10` | To acommodate scheduling problems, Knative waits for a request for twice `worker.timeout`. This parameter adds extra time to that minimum (seconds). |
 | prompt-proto-service.knative.gpu | bool | `false` | GPUs enabled. |
 | prompt-proto-service.knative.gpuRequest | int | `0` | The number of GPUs to request for the full pod (see `containerConcurrency`). |

--- a/applications/prompt-proto-service-latiss/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-latiss/values-usdfdev-prompt-processing.yaml
@@ -44,4 +44,8 @@ prompt-proto-service:
     endpointUrl: https://usdf-rsp-dev.slac.stanford.edu/sasquatch-rest-proxy
     auth_env: false
 
+  knative:
+    # Dev processes very old images, set to ~20 years
+    expiration: 600_000_000.0
+
   fullnameOverride: "prompt-proto-service-latiss"

--- a/applications/prompt-proto-service-latiss/values.yaml
+++ b/applications/prompt-proto-service-latiss/values.yaml
@@ -161,6 +161,8 @@ prompt-proto-service:
     # This is only useful if the container runs async workers.
     # If 0, idle timeout is ignored.
     responseStartTimeout: 0
+    # -- Maximum message age to process, in seconds.
+    expiration: 3600
 
   # -- The number of Knative requests that can be handled simultaneously by one container
   containerConcurrency: 1

--- a/applications/prompt-proto-service-lsstcam/README.md
+++ b/applications/prompt-proto-service-lsstcam/README.md
@@ -39,6 +39,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.knative.cpuRequest | int | `1` | The cpu cores requested for the full pod (see `containerConcurrency`). |
 | prompt-proto-service.knative.ephemeralStorageLimit | string | `"5Gi"` | The maximum storage space allowed for each container (mostly local Butler). This allocation is for the full pod (see `containerConcurrency`) |
 | prompt-proto-service.knative.ephemeralStorageRequest | string | `"5Gi"` | The storage space reserved for each container (mostly local Butler). This allocation is for the full pod (see `containerConcurrency`) |
+| prompt-proto-service.knative.expiration | int | `3600` | Maximum message age to process, in seconds. |
 | prompt-proto-service.knative.extraTimeout | int | `10` | To acommodate scheduling problems, Knative waits for a request for twice `worker.timeout`. This parameter adds extra time to that minimum (seconds). |
 | prompt-proto-service.knative.gpu | bool | `false` | GPUs enabled. |
 | prompt-proto-service.knative.gpuRequest | int | `0` | The number of GPUs to request for the full pod (see `containerConcurrency`). |

--- a/applications/prompt-proto-service-lsstcam/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcam/values-usdfdev-prompt-processing.yaml
@@ -43,4 +43,8 @@ prompt-proto-service:
     endpointUrl: https://usdf-rsp-dev.slac.stanford.edu/sasquatch-rest-proxy
     auth_env: false
 
+  knative:
+    # Dev processes very old images, set to ~20 years
+    expiration: 600_000_000.0
+
   fullnameOverride: "prompt-proto-service-lsstcam"

--- a/applications/prompt-proto-service-lsstcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcam/values.yaml
@@ -162,6 +162,8 @@ prompt-proto-service:
     # This is only useful if the container runs async workers.
     # If 0, idle timeout is ignored.
     responseStartTimeout: 0
+    # -- Maximum message age to process, in seconds.
+    expiration: 3600
 
   # -- The number of Knative requests that can be handled simultaneously by one container
   containerConcurrency: 1

--- a/applications/prompt-proto-service-lsstcamimsim/README.md
+++ b/applications/prompt-proto-service-lsstcamimsim/README.md
@@ -39,6 +39,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.knative.cpuRequest | int | `1` | The cpu cores requested for the full pod (see `containerConcurrency`). |
 | prompt-proto-service.knative.ephemeralStorageLimit | string | `"8Gi"` | The maximum storage space allowed for each container (mostly local Butler). This allocation is for the full pod (see `containerConcurrency`) |
 | prompt-proto-service.knative.ephemeralStorageRequest | string | `"8Gi"` | The storage space reserved for each container (mostly local Butler). This allocation is for the full pod (see `containerConcurrency`) |
+| prompt-proto-service.knative.expiration | int | `3600` | Maximum message age to process, in seconds. |
 | prompt-proto-service.knative.extraTimeout | int | `10` | To acommodate scheduling problems, Knative waits for a request for twice `worker.timeout`. This parameter adds extra time to that minimum (seconds). |
 | prompt-proto-service.knative.gpu | bool | `false` | GPUs enabled. |
 | prompt-proto-service.knative.gpuRequest | int | `0` | The number of GPUs to request for the full pod (see `containerConcurrency`). |

--- a/applications/prompt-proto-service-lsstcamimsim/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcamimsim/values-usdfdev-prompt-processing.yaml
@@ -44,4 +44,8 @@ prompt-proto-service:
     endpointUrl: https://usdf-rsp-dev.slac.stanford.edu/sasquatch-rest-proxy
     auth_env: false
 
+  knative:
+    # Dev processes very old images, set to ~20 years
+    expiration: 600_000_000.0
+
   fullnameOverride: "prompt-proto-service-lsstcamimsim"

--- a/applications/prompt-proto-service-lsstcamimsim/values.yaml
+++ b/applications/prompt-proto-service-lsstcamimsim/values.yaml
@@ -164,6 +164,8 @@ prompt-proto-service:
     # This is only useful if the container runs async workers.
     # If 0, idle timeout is ignored.
     responseStartTimeout: 0
+    # -- Maximum message age to process, in seconds.
+    expiration: 3600
 
   # -- The number of Knative requests that can be handled simultaneously by one container
   containerConcurrency: 1

--- a/applications/prompt-proto-service-lsstcomcam/README.md
+++ b/applications/prompt-proto-service-lsstcomcam/README.md
@@ -39,6 +39,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.knative.cpuRequest | int | `1` | The cpu cores requested for the full pod (see `containerConcurrency`). |
 | prompt-proto-service.knative.ephemeralStorageLimit | string | `"8Gi"` | The maximum storage space allowed for each container (mostly local Butler). This allocation is for the full pod (see `containerConcurrency`) |
 | prompt-proto-service.knative.ephemeralStorageRequest | string | `"8Gi"` | The storage space reserved for each container (mostly local Butler). This allocation is for the full pod (see `containerConcurrency`) |
+| prompt-proto-service.knative.expiration | int | `3600` | Maximum message age to process, in seconds. |
 | prompt-proto-service.knative.gpu | bool | `false` | GPUs enabled. |
 | prompt-proto-service.knative.gpuRequest | int | `0` | The number of GPUs to request for the full pod (see `containerConcurrency`). |
 | prompt-proto-service.knative.idleTimeout | int | `900` | Maximum time that a container can send nothing to Knative (seconds). This is only useful if the container runs async workers. If 0, idle timeout is ignored. |

--- a/applications/prompt-proto-service-lsstcomcam/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/values-usdfdev-prompt-processing.yaml
@@ -43,4 +43,8 @@ prompt-proto-service:
     endpointUrl: https://usdf-rsp-dev.slac.stanford.edu/sasquatch-rest-proxy
     auth_env: false
 
+  knative:
+    # Dev processes very old images, set to ~20 years
+    expiration: 600_000_000.0
+
   fullnameOverride: "prompt-proto-service-lsstcomcam"

--- a/applications/prompt-proto-service-lsstcomcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/values.yaml
@@ -157,6 +157,8 @@ prompt-proto-service:
     # This is only useful if the container runs async workers.
     # If 0, idle timeout is ignored.
     responseStartTimeout: 900
+    # -- Maximum message age to process, in seconds.
+    expiration: 3600
 
   # -- The number of Knative requests that can be handled simultaneously by one container
   containerConcurrency: 1

--- a/applications/prompt-proto-service-lsstcomcamsim/README.md
+++ b/applications/prompt-proto-service-lsstcomcamsim/README.md
@@ -39,6 +39,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.knative.cpuRequest | int | `1` | The cpu cores requested for the full pod (see `containerConcurrency`). |
 | prompt-proto-service.knative.ephemeralStorageLimit | string | `"5Gi"` | The maximum storage space allowed for each container (mostly local Butler). This allocation is for the full pod (see `containerConcurrency`) |
 | prompt-proto-service.knative.ephemeralStorageRequest | string | `"5Gi"` | The storage space reserved for each container (mostly local Butler). This allocation is for the full pod (see `containerConcurrency`) |
+| prompt-proto-service.knative.expiration | int | `3600` | Maximum message age to process, in seconds. |
 | prompt-proto-service.knative.extraTimeout | int | `10` | To acommodate scheduling problems, Knative waits for a request for twice `worker.timeout`. This parameter adds extra time to that minimum (seconds). |
 | prompt-proto-service.knative.gpu | bool | `false` | GPUs enabled. |
 | prompt-proto-service.knative.gpuRequest | int | `0` | The number of GPUs to request for the full pod (see `containerConcurrency`). |

--- a/applications/prompt-proto-service-lsstcomcamsim/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-proto-service-lsstcomcamsim/values-usdfdev-prompt-processing.yaml
@@ -44,4 +44,8 @@ prompt-proto-service:
     endpointUrl: https://usdf-rsp-dev.slac.stanford.edu/sasquatch-rest-proxy
     auth_env: false
 
+  knative:
+    # Dev processes very old images, set to ~20 years
+    expiration: 600_000_000.0
+
   fullnameOverride: "prompt-proto-service-lsstcomcamsim"

--- a/applications/prompt-proto-service-lsstcomcamsim/values.yaml
+++ b/applications/prompt-proto-service-lsstcomcamsim/values.yaml
@@ -163,6 +163,8 @@ prompt-proto-service:
     # This is only useful if the container runs async workers.
     # If 0, idle timeout is ignored.
     responseStartTimeout: 0
+    # -- Maximum message age to process, in seconds.
+    expiration: 3600
 
   # -- The number of Knative requests that can be handled simultaneously by one container
   containerConcurrency: 1

--- a/charts/prompt-keda/README.md
+++ b/charts/prompt-keda/README.md
@@ -42,6 +42,7 @@ Event-driven processing of camera images
 | keda.pollingInterval | int | `2` |  |
 | keda.redisStreams.activationLagCount | string | `"1"` |  |
 | keda.redisStreams.consumerGroup | string | `""` |  |
+| keda.redisStreams.expiration | int | `3600` | Maximum message age to process, in seconds. |
 | keda.redisStreams.host | string | `""` |  |
 | keda.redisStreams.lagCount | string | `"1"` |  |
 | keda.redisStreams.msgListenTimeout | int | `900` |  |

--- a/charts/prompt-keda/templates/scaled-job.yaml
+++ b/charts/prompt-keda/templates/scaled-job.yaml
@@ -61,6 +61,8 @@ spec:
                   {{- .Values.instrument.pipelines.main | nindent 18 }}
               - name: SKYMAP
                 value: {{ .Values.instrument.skymap }}
+              - name: MESSAGE_EXPIRATION
+                value: {{ .Values.keda.redisStreams.expiration | toString | quote }}
               - name: PRELOAD_PADDING
                 value: {{ .Values.instrument.preloadPadding | toString | quote }}
               - name: IMAGE_BUCKET

--- a/charts/prompt-keda/values.yaml
+++ b/charts/prompt-keda/values.yaml
@@ -143,6 +143,8 @@ keda:
     lagCount: "1"
     # Number of entries in the Pending Entries List for the specified consumer group in the Redis Stream
     pendingEntriesCount: "1"
+    # -- Maximum message age to process, in seconds.
+    expiration: 3600
 
 
 # -- Override the base name for resources

--- a/charts/prompt-proto-service/README.md
+++ b/charts/prompt-proto-service/README.md
@@ -42,6 +42,7 @@ Event-driven processing of camera images
 | knative.cpuRequest | int | `1` | The cpu cores requested for the full pod (see `containerConcurrency`). |
 | knative.ephemeralStorageLimit | string | `"5Gi"` | The maximum storage space allowed for each container (mostly local Butler). This allocation is for the full pod (see `containerConcurrency`) |
 | knative.ephemeralStorageRequest | string | `"5Gi"` | The storage space reserved for each container (mostly local Butler). This allocation is for the full pod (see `containerConcurrency`) |
+| knative.expiration | int | `3600` | Maximum message age to process, in seconds. |
 | knative.extraTimeout | int | `10` | To acommodate scheduling problems, Knative waits for a request for twice `worker.timeout`. This parameter adds extra time to that minimum (seconds). |
 | knative.gpu | bool | `false` | GPUs enabled. |
 | knative.gpuRequest | int | `0` | The number of GPUs to request for the full pod (see `containerConcurrency`). |

--- a/charts/prompt-proto-service/templates/prompt-proto-service.yaml
+++ b/charts/prompt-proto-service/templates/prompt-proto-service.yaml
@@ -51,6 +51,8 @@ spec:
             {{- .Values.instrument.pipelines.main | nindent 12 }}
         - name: SKYMAP
           value: {{ .Values.instrument.skymap }}
+        - name: MESSAGE_EXPIRATION
+          value: {{ .Values.knative.expiration | toString | quote }}
         - name: PRELOAD_PADDING
           value: {{ .Values.instrument.preloadPadding | toString | quote }}
         - name: IMAGE_BUCKET

--- a/charts/prompt-proto-service/values.yaml
+++ b/charts/prompt-proto-service/values.yaml
@@ -162,6 +162,8 @@ knative:
   # This is only useful if the container runs async workers.
   # If 0, startup timeout is ignored.
   responseStartTimeout: 0
+  # -- Maximum message age to process, in seconds.
+  expiration: 3600
 
 # -- Override the base name for resources
 nameOverride: ""


### PR DESCRIPTION
This PR adds a message expiration config parameter to Prompt Processing. This parameter allows rejection of old nextVisit messages independently of the fan-out service, but the latter's functionality is not being deprecated at this time.