### PR TITLE
Prompt Processing:  Disable Prompt Proto Service

### DIFF
--- a/environments/values-usdfdev-prompt-processing.yaml
+++ b/environments/values-usdfdev-prompt-processing.yaml
@@ -17,13 +17,13 @@ applications:
   prompt-keda-lsstcamimsim: true
   prompt-keda-lsstcomcam: true
   prompt-keda-lsstcomcamsim: true
-  prompt-proto-service-hsc: true
-  prompt-proto-service-hsc-gpu: true
-  prompt-proto-service-latiss: true
-  prompt-proto-service-lsstcam: true
-  prompt-proto-service-lsstcamimsim: true
-  prompt-proto-service-lsstcomcam: true
-  prompt-proto-service-lsstcomcamsim: true
+  prompt-proto-service-hsc: false
+  prompt-proto-service-hsc-gpu: false
+  prompt-proto-service-latiss: false
+  prompt-proto-service-lsstcam: false
+  prompt-proto-service-lsstcamimsim: false
+  prompt-proto-service-lsstcomcam: false
+  prompt-proto-service-lsstcomcamsim: false
   prompt-redis: true
   strimzi: true
   vault-secrets-operator: false

--- a/environments/values-usdfprod-prompt-processing.yaml
+++ b/environments/values-usdfprod-prompt-processing.yaml
@@ -12,7 +12,7 @@ applications:
   next-visit-fan-out-keda: false
   prompt-keda-latiss: true
   prompt-proto-service-hsc: false
-  prompt-proto-service-latiss: true
+  prompt-proto-service-latiss: false
   prompt-proto-service-lsstcam: false
   prompt-proto-service-lsstcamimsim: false
   prompt-proto-service-lsstcomcam: false

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -12,7 +12,17 @@ import yaml
 from phalanx.factory import Factory
 from phalanx.models.applications import Project
 
-_ALLOW_DISABLED = {"production-tools", "next-visit-fan-out-keda"}
+_ALLOW_DISABLED = {
+    "production-tools",
+    "next-visit-fan-out-keda",
+    "prompt-proto-service-hsc",
+    "prompt-proto-service-hsc-gpu",
+    "prompt-proto-service-latiss",
+    "prompt-proto-service-lsstcam",
+    "prompt-proto-service-lsstcamimsim",
+    "prompt-proto-service-lsstcomcam",
+    "prompt-proto-service-lsstcomcamsim",
+}
 """Temporary whitelist of applications not enabled anywhere."""
 
 _ALLOW_NO_SECRETS = {"next-visit-fan-out"}


### PR DESCRIPTION
Disable `prompt-proto-service` in dev and prod due to the move the Keda.  The applications are being kept for now as Keda is evaluated in production.