### PR TITLE
DM-49929: Load OP_CONNECT_TOKEN and VAULT_TOKEN from 1Password via env file

### DIFF
--- a/docs/admin/audit-secrets.rst
+++ b/docs/admin/audit-secrets.rst
@@ -4,15 +4,27 @@ Audit secrets for an environment
 
 To check that all of the necessary secrets for an environment named ``<environment>`` are in Vault and appear to have the proper form, and to see exactly what a :doc:`syncing secrets for that environment <sync-secrets>` would do, run:
 
-.. prompt:: bash
+.. tab-set::
 
-   phalanx secrets audit <environment>
+   .. tab-item:: General
 
-Add the ``--secrets`` command-line option or set ``OP_CONNECT_TOKEN`` if needed for your choice of a :ref:`static secrets source <admin-static-secrets>`.
-For SQuaRE-managed deployments, the 1Password token for ``OP_CONNECT_TOKEN`` comes from the ``Phalanx 1Password tokens`` item in the SQuaRE 1Password vault.
+      .. prompt:: bash
 
-If you did not store the Vault write token for your environment with the static secrets, the ``VAULT_TOKEN`` environment variable must be set to the Vault write token for this environment (or a read token; this command will not make any changes).
-For SQuaRE-managed environments, you can get the write token from the ``Phalanx Vault write tokens`` item in the SQuaRE 1Password vault.
+         phalanx secrets audit <environment>
+
+      Add the ``--secrets`` command-line option or set ``OP_CONNECT_TOKEN`` if needed for your choice of a :ref:`static secrets source <admin-static-secrets>`.
+      For SQuaRE-managed deployments, the 1Password token for ``OP_CONNECT_TOKEN`` comes from the ``Phalanx 1Password tokens`` item in the SQuaRE 1Password vault.
+
+      If you did not store the Vault write token for your environment with the static secrets, the ``VAULT_TOKEN`` environment variable must be set to the Vault write token for this environment (or a read token; this command will not make any changes).
+      For SQuaRE-managed environments, you can get the write token from the ``Phalanx Vault write tokens`` item in the SQuaRE 1Password vault.
+
+   .. tab-item:: SQuaRE-managed environments (1Password)
+
+      .. prompt:: bash
+
+         op run --env-file="op/<environment>.env" -- phalanx secrets audit <environment>
+
+      See :doc:`op-run-phalanx-cli` for details on :command:`op run`.
 
 The output of the command will be a report of any inconsistencies or problems found in the Vault secrets for this environment.
 No output indicates no problems.

--- a/docs/admin/index.rst
+++ b/docs/admin/index.rst
@@ -34,6 +34,7 @@ Administrators operate infrastructure, manage secrets, and are involved in the d
    update-pull-secret
    migrating-secrets
    set-quotas
+   op-run-phalanx-cli
 
 .. toctree::
    :caption: Troubleshooting

--- a/docs/admin/op-run-phalanx-cli.rst
+++ b/docs/admin/op-run-phalanx-cli.rst
@@ -1,0 +1,42 @@
+###############################################
+Run the phalanx CLI with secrets from 1Password
+###############################################
+
+The :command:`phalanx secrets` CLI uses ``OP_CONNECT_TOKEN`` and ``VAULT_TOKEN`` environment variables to access secrets in 1Password and Vault, respectively.
+To conveniently and securely load these secrets, you can use the 1Password CLI in conjunction with ``.env`` files in the :file:`op` directory of the Phalanx repository.
+
+.. note::
+
+   This documentation is relevant to Phalanx environments managed by SQuaRE.
+
+Set up
+======
+
+To use this technique, you need to have the 1Password CLI (:command:`op`) installed.
+See the `1Password CLI documentation <https://developer.1password.com/docs/cli>`__ for installation instructions.
+
+Next, ensure that you're signed into the 1Password Vault containing the Phalanx secrets:
+
+.. prompt:: bash
+
+   op signin --account lsstit
+
+Change the account as needed for non-SQuaRE environments.
+
+Run the phalanx CLI with 1Password secrets
+==========================================
+
+To run the phalanx CLI with secrets from 1Password, you can prefix the :command:`phalanx` command with :command:`op run`, as in:
+
+.. prompt:: bash
+
+   op run --env-file=op/<env>.env -- phalanx <command> <args>
+
+For example:
+
+.. prompt:: bash
+
+   op run --env-file=op/idfprod.env -- phalanx secrets audit idfprod
+
+The :file:`op/` directory contains a set of ``.env`` files, one for each environment.
+Match the environment name in the ``.env`` file with the environment you are working with.

--- a/docs/admin/sync-secrets.rst
+++ b/docs/admin/sync-secrets.rst
@@ -20,15 +20,27 @@ Syncing secrets
 
 To populate Vault with all of the necessary secrets for an environment named ``<environment>``, run:
 
-.. prompt:: bash
+.. tab-set::
 
-   phalanx secrets sync <environment>
+   .. tab-item:: General
 
-Add the ``--secrets`` command-line option or set ``OP_CONNECT_TOKEN`` if needed for your choice of a :ref:`static secrets source <admin-static-secrets>`.
-For SQuaRE-managed deployments, the 1Password token for ``OP_CONNECT_TOKEN`` comes from the ``Phalanx 1Password tokens`` item in the SQuaRE 1Password vault.
+      .. prompt:: bash
 
-If you did not store the Vault write token for your environment with the static secrets, the ``VAULT_TOKEN`` environment variable must be set to the Vault write token for this environment.
-For SQuaRE-managed environments, you can get the write token from the ``Phalanx Vault write tokens`` item in the SQuaRE 1Password vault.
+         phalanx secrets sync <environment>
+
+      Add the ``--secrets`` command-line option or set ``OP_CONNECT_TOKEN`` if needed for your choice of a :ref:`static secrets source <admin-static-secrets>`.
+      For SQuaRE-managed deployments, the 1Password token for ``OP_CONNECT_TOKEN`` comes from the ``Phalanx 1Password tokens`` item in the SQuaRE 1Password vault.
+
+      If you did not store the Vault write token for your environment with the static secrets, the ``VAULT_TOKEN`` environment variable must be set to the Vault write token for this environment.
+      For SQuaRE-managed environments, you can get the write token from the ``Phalanx Vault write tokens`` item in the SQuaRE 1Password vault.
+
+   .. tab-item:: SQuaRE-managed environments (1Password)
+
+      .. prompt:: bash
+
+         op run --env-file="op/<environment>.env" -- phalanx secrets sync <environment>
+
+      See :doc:`op-run-phalanx-cli` for details on :command:`op run`.
 
 Only secrets for the named environment will be affected.
 No changes will be made outside of the configured secrets path for that environment.

--- a/docs/admin/update-pull-secret.rst
+++ b/docs/admin/update-pull-secret.rst
@@ -14,11 +14,24 @@ To update the pull secret for an environment, follow these steps:
 
 #. If you are storing static secrets anywhere other than Vault, synchronize secets for your environment.
 
-   .. prompt:: bash
+   .. tab-set::
 
-      phalanx secrets sync <environment>
+      .. tab-item:: General
 
-   Replace ``<environment>`` with the short identifier of your environment.
+         .. prompt:: bash
+
+            phalanx secrets sync <environment>
+
+         Replace ``<environment>`` with the short identifier of your environment.
+
+      .. tab-item:: SQuaRE-managed environments (1Password)
+
+         .. prompt:: bash
+
+            op run --env-file="op/<environment>.env" -- phalanx secrets sync <environment>
+
+         Replace ``<environment>`` with the short identifier of your environment.
+         See :doc:`op-run-phalanx-cli` for details on using the 1Password CLI to run the phalanx CLI with secrets from 1Password.
 
    This should update the ``pull-secret`` secret in Vault.
 

--- a/op/README.md
+++ b/op/README.md
@@ -1,0 +1,15 @@
+# 1Password secrets bootstrap for the Phalanx CLI
+
+The `.env` files in this directory provide a convenient and secure mechanism for accessing the `$OP_CONNECT_TOKEN` and `$VAULT_TOKEN` environment variables from 1Password for Phalanx environments managed by SQuaRE.
+These secrets are required to use the `phalanx secrets` CLI.
+
+To use these `.env` files, you need to have the [1Password CLI](https://developer.1password.com/docs/cli/) installed and signed into the correct 1Password Vault (LSST IT) with `op signin`.
+
+Example usage:
+
+```bash
+op run --env-file="op/idfprod.env" -- phalanx secrets audit idfprod
+```
+
+Match the environment name in the `.env` file with the environment you are working with.
+The `--` separates the command to be run from the options for `op run`.

--- a/op/README.md
+++ b/op/README.md
@@ -13,3 +13,5 @@ op run --env-file="op/idfprod.env" -- phalanx secrets audit idfprod
 
 Match the environment name in the `.env` file with the environment you are working with.
 The `--` separates the command to be run from the options for `op run`.
+
+See also: https://phalanx.lsst.io/admin/op-run-phalanx-cli.html

--- a/op/base.env
+++ b/op/base.env
@@ -1,0 +1,2 @@
+OP_CONNECT_TOKEN="op://SQuaRE/Phalanx 1Password tokens/base"
+VAULT_TOKEN="op://SQuaRE/Phalanx Vault write tokens/base"

--- a/op/idfdemo.env
+++ b/op/idfdemo.env
@@ -1,0 +1,2 @@
+OP_CONNECT_TOKEN="op://SQuaRE/Phalanx 1Password tokens/idfdemo"
+VAULT_TOKEN="op://SQuaRE/Phalanx Vault write tokens/idfdemo"

--- a/op/idfdev.env
+++ b/op/idfdev.env
@@ -1,0 +1,2 @@
+OP_CONNECT_TOKEN="op://SQuaRE/Phalanx 1Password tokens/idfdev"
+VAULT_TOKEN="op://SQuaRE/Phalanx Vault write tokens/idfdev"

--- a/op/idfint.env
+++ b/op/idfint.env
@@ -1,0 +1,2 @@
+OP_CONNECT_TOKEN="op://SQuaRE/Phalanx 1Password tokens/idfint"
+VAULT_TOKEN="op://SQuaRE/Phalanx Vault write tokens/idfint"

--- a/op/idfprod.env
+++ b/op/idfprod.env
@@ -1,0 +1,2 @@
+OP_CONNECT_TOKEN="op://SQuaRE/Phalanx 1Password tokens/idfprod"
+VAULT_TOKEN="op://SQuaRE/Phalanx Vault write tokens/idfprod"

--- a/op/minikube.env
+++ b/op/minikube.env
@@ -1,0 +1,2 @@
+OP_CONNECT_TOKEN="op://SQuaRE/Phalanx 1Password tokens/minikube"
+VAULT_TOKEN="op://SQuaRE/Phalanx Vault write tokens/minikube"

--- a/op/roundtable-dev.env
+++ b/op/roundtable-dev.env
@@ -1,0 +1,2 @@
+OP_CONNECT_TOKEN="op://SQuaRE/Phalanx 1Password tokens/roundtable-dev"
+VAULT_TOKEN="op://SQuaRE/Phalanx Vault write tokens/roundtable-dev"

--- a/op/roundtable-prod.env
+++ b/op/roundtable-prod.env
@@ -1,0 +1,2 @@
+OP_CONNECT_TOKEN="op://SQuaRE/Phalanx 1Password tokens/roundtable-prod"
+VAULT_TOKEN="op://SQuaRE/Phalanx Vault write tokens/roundtable-prod"

--- a/op/summit.env
+++ b/op/summit.env
@@ -1,0 +1,2 @@
+OP_CONNECT_TOKEN="op://SQuaRE/Phalanx 1Password tokens/summit"
+VAULT_TOKEN="op://SQuaRE/Phalanx Vault write tokens/summit"

--- a/op/tucston-teststand.env
+++ b/op/tucston-teststand.env
@@ -1,0 +1,2 @@
+OP_CONNECT_TOKEN="op://SQuaRE/Phalanx 1Password tokens/tucson-teststand"
+VAULT_TOKEN="op://SQuaRE/Phalanx Vault write tokens/tucson-teststand"


### PR DESCRIPTION
This PR takes advantage of the 1Password CLI's ability to load secrets referenced by their path in a .env file. With this change, admins no longer need to manually load the VAULT_TOKEN and OP_CONNECT_TOKEN into their shell environments to run phalanx commands like `phalanx secrets sync`. An example usage is:

```sh
PHALANX_ENV="idfprod" op run --env-file="op/square.env" -- phalanx secrets audit
```

Note that I've had the user set PHALANX_ENV, which is used to specify secret paths in `square.env` specific to that Phalanx environment. I've also modified the Phalanx CLI to accept `PHALANX_ENV` as an environment variable instead of as a command-line argument.

Note an alternative approach could be to have a separate `.env` file for each Phalanx environment. This would let us set `PHALANX_ENV` in that file, and make the resulting CL invocations shorter, at the small cost fo maintaining more `.env` files. E.g.

```sh
op run --env-file="op/idfprod.env" -- phalanx secrets audit
```

What do you think? Perhaps this second approach would provide a better user experience.