### PR TITLE
Tickets/dm 49869: IDF->pull inithome from GAR

### DIFF
--- a/applications/nublado/values-idfdemo.yaml
+++ b/applications/nublado/values-idfdemo.yaml
@@ -26,8 +26,8 @@ controller:
       initContainers:
         - name: "inithome"
           image:
-            repository: "ghcr.io/lsst-sqre/nublado-inithome"
-            tag: "8.8.0"
+            repository: "us-central1-docker.pkg.dev/rubin-shared-services-71ec/sciplat/inithome"
+            tag: "8.8.2"
           privileged: true
           volumeMounts:
             - containerPath: "/home"

--- a/applications/nublado/values-idfdev.yaml
+++ b/applications/nublado/values-idfdev.yaml
@@ -43,8 +43,8 @@ controller:
       initContainers:
         - name: "inithome"
           image:
-            repository: "ghcr.io/lsst-sqre/nublado-inithome"
-            tag: "8.8.0"
+            repository: "us-central1-docker.pkg.dev/rubin-shared-services-71ec/sciplat/inithome"
+            tag: "tickets/DM-49744"
           privileged: true
           volumeMounts:
             - containerPath: "/home"

--- a/applications/nublado/values-idfdev.yaml
+++ b/applications/nublado/values-idfdev.yaml
@@ -44,7 +44,7 @@ controller:
         - name: "inithome"
           image:
             repository: "us-central1-docker.pkg.dev/rubin-shared-services-71ec/sciplat/inithome"
-            tag: "tickets/DM-49744"
+            tag: "8.8.2"
           privileged: true
           volumeMounts:
             - containerPath: "/home"

--- a/applications/nublado/values-idfint.yaml
+++ b/applications/nublado/values-idfint.yaml
@@ -53,8 +53,8 @@ controller:
       initContainers:
         - name: "inithome"
           image:
-            repository: "ghcr.io/lsst-sqre/nublado-inithome"
-            tag: "8.8.0"
+            repository: "us-central1-docker.pkg.dev/rubin-shared-services-71ec/sciplat/inithome"
+            tag: "tickets-DM-49774"
           privileged: true
           volumeMounts:
             - containerPath: "/home"

--- a/applications/nublado/values-idfint.yaml
+++ b/applications/nublado/values-idfint.yaml
@@ -54,7 +54,7 @@ controller:
         - name: "inithome"
           image:
             repository: "us-central1-docker.pkg.dev/rubin-shared-services-71ec/sciplat/inithome"
-            tag: "tickets-DM-49774"
+            tag: "8.8.2"
           privileged: true
           volumeMounts:
             - containerPath: "/home"

--- a/applications/nublado/values-idfprod.yaml
+++ b/applications/nublado/values-idfprod.yaml
@@ -21,8 +21,8 @@ controller:
       initContainers:
         - name: "inithome"
           image:
-            repository: "ghcr.io/lsst-sqre/nublado-inithome"
-            tag: "8.8.0"
+            repository: "us-central1-docker.pkg.dev/rubin-shared-services-71ec/sciplat/inithome"
+            tag: "8.8.2"
           privileged: true
           volumeMounts:
             - containerPath: "/home"


### PR DESCRIPTION
Pull inithome from Google Artifact Registry at IDF.  Eliminates ghcr.io rate limiting for heavy user load.