### PR TITLE
DM-49993: Switch qserv Sasquatch user to TLS authentication

### DIFF
--- a/applications/sasquatch/charts/tap/templates/kafka-users.yaml
+++ b/applications/sasquatch/charts/tap/templates/kafka-users.yaml
@@ -37,12 +37,7 @@ metadata:
     strimzi.io/cluster: {{ .Values.cluster.name }}
 spec:
   authentication:
-    type: scram-sha-512
-    password:
-      valueFrom:
-        secretKeyRef:
-          name: sasquatch
-          key: qserv-password
+    type: tls
   authorization:
     type: simple
     acls:

--- a/applications/sasquatch/values-idfint.yaml
+++ b/applications/sasquatch/values-idfint.yaml
@@ -155,3 +155,6 @@ backup:
 
 backpack:
   enabled: true
+
+tap:
+  enabled: true


### PR DESCRIPTION
Now that the Qserv Kafka bridge will be running in the same cluster as Sasquatch, we can use TLS for authentication rather than passwords. Switch the corresponding Kafka user resource.