### PR TITLE
DM-49993: Add test version of Qserv Kafka bridge

### DIFF
--- a/applications/qserv-kafka/.helmignore
+++ b/applications/qserv-kafka/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/applications/qserv-kafka/Chart.yaml
+++ b/applications/qserv-kafka/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+appVersion: 0.1.0
+description: Qserv Kafka bridge
+name: qserv-kafka
+sources:
+- https://github.com/lsst-sqre/qserv-kafka
+type: application
+version: 1.0.0

--- a/applications/qserv-kafka/README.md
+++ b/applications/qserv-kafka/README.md
@@ -1,0 +1,32 @@
+# qserv-kafka
+
+Qserv Kafka bridge
+
+## Source Code
+
+* <https://github.com/lsst-sqre/qserv-kafka>
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Affinity rules for the qserv-kafka deployment pod |
+| config.consumerGroupId | string | `"qserv"` | Kafka consumer group ID |
+| config.jobRunTopic | string | `"lsst.tap.job-run"` | Kafka topic for query execution requests |
+| config.jobStatusTopic | string | `"lsst.tap.job-status"` | Kafka topic for query status |
+| config.logLevel | string | `"INFO"` | Logging level |
+| config.logProfile | string | `"production"` | Logging profile (`production` for JSON, `development` for human-friendly) |
+| config.qservDatabaseUrl | string | None, must be set | URL to the Qserv MySQL interface (must use a scheme of `mysql+asyncmy`) |
+| config.qservPollInterval | string | `"1s"` | Interval at which Qserv is polled for query status in Safir `parse_timedelta` format |
+| config.qservRestUrl | string | None, must be set | URL to the Qserv REST API |
+| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
+| global.host | string | Set by Argo CD | Host name for ingress |
+| global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
+| image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the qserv-kafka image |
+| image.repository | string | `"ghcr.io/lsst-sqre/qserv-kafka"` | Image to use in the qserv-kafka deployment |
+| image.tag | string | The appVersion of the chart | Tag of image to use |
+| ingress.annotations | object | `{}` | Additional annotations for the ingress rule |
+| nodeSelector | object | `{}` | Node selection rules for the qserv-kafka deployment pod |
+| podAnnotations | object | `{}` | Annotations for the qserv-kafka deployment pod |
+| resources | object | See `values.yaml` | Resource limits and requests for the qserv-kafka deployment pod |
+| tolerations | list | `[]` | Tolerations for the qserv-kafka deployment pod |

--- a/applications/qserv-kafka/secrets.yaml
+++ b/applications/qserv-kafka/secrets.yaml
@@ -1,0 +1,3 @@
+qserv-password:
+  description: >-
+    Password for the MySQL interface to Qserv.

--- a/applications/qserv-kafka/templates/_helpers.tpl
+++ b/applications/qserv-kafka/templates/_helpers.tpl
@@ -1,0 +1,26 @@
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "qserv-kafka.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "qserv-kafka.labels" -}}
+helm.sh/chart: {{ include "qserv-kafka.chart" . }}
+{{ include "qserv-kafka.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "qserv-kafka.selectorLabels" -}}
+app.kubernetes.io/name: "qserv-kafka"
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/applications/qserv-kafka/templates/configmap.yaml
+++ b/applications/qserv-kafka/templates/configmap.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "qserv-kafka"
+  labels:
+    {{- include "qserv-kafka.labels" . | nindent 4 }}
+data:
+  QSERV_KAFKA_CONSUMER_GROUP_ID: {{ .Values.config.consumerGroupId | quote }}
+  QSERV_KAFKA_JOB_RUN_TOPIC: {{ .Values.config.jobRunTopic | quote }}
+  QSERV_KAFKA_JOB_STATUS_TOPIC: {{ .Values.config.jobStatusTopic | quote }}
+  QSERV_KAFKA_LOG_LEVEL: {{ .Values.config.logLevel | quote }}
+  QSERV_KAFKA_PROFILE: {{ .Values.config.logProfile | quote }}
+  QSERV_KAFKA_QSERV_DATABASE_URL: {{ .Values.config.qservDatabaseUrl | quote }}
+  QSERV_KAFKA_QSERV_POLL_INTERVAL: {{ .Values.config.qservPollInterval | quote }}
+  QSERV_KAFKA_QSERV_REST_URL: {{ .Values.config.qservRestUrl | quote }}

--- a/applications/qserv-kafka/templates/deployment.yaml
+++ b/applications/qserv-kafka/templates/deployment.yaml
@@ -1,0 +1,100 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "qserv-kafka"
+  labels:
+    {{- include "qserv-kafka.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "qserv-kafka.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "qserv-kafka.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      automountServiceAccountToken: false
+      containers:
+        - name: {{ .Chart.Name }}
+          env:
+            - name: "QSERV_KAFKA_QSERV_DATABASE_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  name: "qserv-kafka"
+                  key: "qserv-password"
+            - name: "KAFKA_BOOTSTRAP_SERVERS"
+              valueFrom:
+                secretKeyRef:
+                  name: "qserv-kafka-access"
+                  key: "bootstrapServers"
+            - name: "KAFKA_CLIENT_CERT_PATH"
+              value: "/etc/qserv-kafka/user.crt"
+            - name: "KAFKA_CLIENT_KEY_PATH"
+              value: "/etc/qserv-kafka/user.key"
+            - name: "KAFKA_CLUSTER_CA_PATH"
+              value: "/etc/qserv-kafka/ca.crt"
+            - name: "KAFKA_SECURITY_PROTOCOL"
+              valueFrom:
+                secretKeyRef:
+                  name: "qserv-kafka-access"
+                  key: "securityProtocol"
+          envFrom:
+            - configMapRef:
+                name: "qserv-kafka"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: "http"
+              containerPort: 8080
+              protocol: "TCP"
+          readinessProbe:
+            httpGet:
+              path: "/"
+              port: "http"
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: "kafka"
+              mountPath: "/etc/qserv-kafka/ca.crt"
+              readOnly: true
+              subPath: "ssl.truststore.crt"
+            - name: "kafka"
+              mountPath: "/etc/qserv-kafka/user.crt"
+              readOnly: true
+              subPath: "ssl.keystore.crt"
+            - name: "kafka"
+              mountPath: "/etc/qserv-kafka/user.key"
+              readOnly: true
+              subPath: "ssl.keystore.key"
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+      volumes:
+        - name: "kafka"
+          secret:
+            secretName: "qserv-kafka-access"

--- a/applications/qserv-kafka/templates/kafka-access.yaml
+++ b/applications/qserv-kafka/templates/kafka-access.yaml
@@ -1,0 +1,16 @@
+apiVersion: access.strimzi.io/v1alpha1
+kind: KafkaAccess
+metadata:
+  name: "qserv-kafka-access"
+  labels:
+    {{- include "qserv-kafka.labels" . | nindent 4 }}
+spec:
+  kafka:
+    name: "sasquatch"
+    namespace: "sasquatch"
+    listener: "tls"
+  user:
+    kind: "KafkaUser"
+    apiGroup: "kafka.strimzi.io"
+    name: "qserv"
+    namespace: "sasquatch"

--- a/applications/qserv-kafka/templates/networkpolicy.yaml
+++ b/applications/qserv-kafka/templates/networkpolicy.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: "qserv-kafka"
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "qserv-kafka.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - "Ingress"
+  ingress:
+    # Allow inbound access from pods (in any namespace) labeled
+    # gafaelfawr.lsst.io/ingress: true.
+    - from:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              gafaelfawr.lsst.io/ingress: "true"
+      ports:
+        - protocol: "TCP"
+          port: 8080

--- a/applications/qserv-kafka/templates/vault-secrets.yaml
+++ b/applications/qserv-kafka/templates/vault-secrets.yaml
@@ -1,0 +1,9 @@
+apiVersion: ricoberger.de/v1alpha1
+kind: VaultSecret
+metadata:
+  name: "qserv-kafka"
+  labels:
+    {{- include "qserv-kafka.labels" . | nindent 4 }}
+spec:
+  path: "{{ .Values.global.vaultSecretsPath }}/qserv-kafka"
+  type: Opaque

--- a/applications/qserv-kafka/values-idfint.yaml
+++ b/applications/qserv-kafka/values-idfint.yaml
@@ -1,0 +1,7 @@
+image:
+  tag: "tickets-DM-49993"
+  pullPolicy: "Always"
+config:
+  logLevel: "DEBUG"
+  qservDatabaseUrl: "mysql+asyncmy://qsmaster@qserv-int.slac.stanford.edu:4090/"
+  qservRestUrl: "https://134.79.23.197:4098/"

--- a/applications/qserv-kafka/values.yaml
+++ b/applications/qserv-kafka/values.yaml
@@ -1,0 +1,78 @@
+# Default values for qserv-kafka.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  # -- Image to use in the qserv-kafka deployment
+  repository: "ghcr.io/lsst-sqre/qserv-kafka"
+
+  # -- Pull policy for the qserv-kafka image
+  pullPolicy: "IfNotPresent"
+
+  # -- Tag of image to use
+  # @default -- The appVersion of the chart
+  tag: null
+
+config:
+  # -- Kafka consumer group ID
+  consumerGroupId: "qserv"
+
+  # -- Kafka topic for query execution requests
+  jobRunTopic: "lsst.tap.job-run"
+
+  # -- Kafka topic for query status
+  jobStatusTopic: "lsst.tap.job-status"
+
+  # -- Logging level
+  logLevel: "INFO"
+
+  # -- Logging profile (`production` for JSON, `development` for
+  # human-friendly)
+  logProfile: "production"
+
+  # -- URL to the Qserv MySQL interface (must use a scheme of `mysql+asyncmy`)
+  # @default -- None, must be set
+  qservDatabaseUrl: null
+
+  # -- Interval at which Qserv is polled for query status in Safir
+  # `parse_timedelta` format
+  qservPollInterval: "1s"
+
+  # -- URL to the Qserv REST API
+  # @default -- None, must be set
+  qservRestUrl: null
+
+ingress:
+  # -- Additional annotations for the ingress rule
+  annotations: {}
+
+# -- Affinity rules for the qserv-kafka deployment pod
+affinity: {}
+
+# -- Node selection rules for the qserv-kafka deployment pod
+nodeSelector: {}
+
+# -- Annotations for the qserv-kafka deployment pod
+podAnnotations: {}
+
+# -- Resource limits and requests for the qserv-kafka deployment pod
+# @default -- See `values.yaml`
+resources: {}
+
+# -- Tolerations for the qserv-kafka deployment pod
+tolerations: []
+
+# The following will be set by parameters injected by Argo CD and should not
+# be set in the individual environment values files.
+global:
+  # -- Base URL for the environment
+  # @default -- Set by Argo CD
+  baseUrl: null
+
+  # -- Host name for ingress
+  # @default -- Set by Argo CD
+  host: null
+
+  # -- Base path for Vault secrets
+  # @default -- Set by Argo CD
+  vaultSecretsPath: null

--- a/docs/applications/qserv-kafka/index.rst
+++ b/docs/applications/qserv-kafka/index.rst
@@ -1,0 +1,24 @@
+.. px-app:: qserv-kafka
+
+################################
+qserv-kafka — Qserv Kafka bridge
+################################
+
+.. jinja:: qserv-kafka
+   :file: applications/_summary.rst.jinja
+
+Qserv is the backend database used by the Rubin Science Platform for visits and related information.
+To make the link between the TAP server and Qserv less vulnerable to network outages, service restarts, and other transient issues, and to better manage queuing and load, TAP queries are done by putting a request into a Kafka queue and then waiting for the result to be returned in a different Kafka queue.
+
+This service implements the bridge between the Kafka queues and the Qserv database.
+It translates Kafka messages into Qserv's internal APIs, polls Qserv to watch for queries to complete, uploads the resulting VOTable to S3-compatible storage, and sends status messages back to Kafka about the job progress.
+
+For more details on the design, see :sqr:`097`.
+
+Guides
+======
+
+.. toctree::
+   :maxdepth: 1
+
+   values

--- a/docs/applications/qserv-kafka/values.md
+++ b/docs/applications/qserv-kafka/values.md
@@ -1,0 +1,12 @@
+```{px-app-values} qserv-kafka
+```
+
+# qserv-kafka Helm values reference
+
+Helm values reference table for the {px-app}`qserv-kafka` application.
+
+```{include} ../../../applications/qserv-kafka/README.md
+---
+start-after: "## Values"
+---
+```

--- a/docs/applications/rsp.rst
+++ b/docs/applications/rsp.rst
@@ -19,6 +19,7 @@ Argo CD project: ``rsp``
    noteburst/index
    nublado/index
    portal/index
+   qserv-kafka/index
    semaphore/index
    sia/index
    squareone/index

--- a/environments/README.md
+++ b/environments/README.md
@@ -63,6 +63,7 @@
 | applications.prompt-proto-service-lsstcomcam | bool | `false` | Enable the prompt-proto-service-lsstcomcam application |
 | applications.prompt-proto-service-lsstcomcamsim | bool | `false` | Enable the prompt-proto-service-lsstcomcamsim application |
 | applications.prompt-redis | bool | `false` | Enable the prompt-redis application |
+| applications.qserv-kafka | bool | `false` | Enable the qserv-kafka application |
 | applications.rubin-rag | bool | `false` | Enable the rubin-rag application |
 | applications.rubintv | bool | `false` | Enable the rubintv application |
 | applications.rubintv-dev | bool | `false` | Enable the rubintv-dev application |

--- a/environments/templates/applications/rsp/qserv-kafka.yaml
+++ b/environments/templates/applications/rsp/qserv-kafka.yaml
@@ -1,0 +1,34 @@
+{{- if (index .Values "applications" "qserv-kafka") -}}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "qserv-kafka"
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: "qserv-kafka"
+  namespace: "argocd"
+  finalizers:
+    - "resources-finalizer.argocd.argoproj.io"
+spec:
+  destination:
+    namespace: "qserv-kafka"
+    server: "https://kubernetes.default.svc"
+  project: "rsp"
+  source:
+    path: "applications/qserv-kafka"
+    repoURL: {{ .Values.repoUrl | quote }}
+    targetRevision: {{ .Values.targetRevision | quote }}
+    helm:
+      parameters:
+        - name: "global.host"
+          value: {{ .Values.fqdn | quote }}
+        - name: "global.baseUrl"
+          value: "https://{{ .Values.fqdn }}"
+        - name: "global.vaultSecretsPath"
+          value: {{ .Values.vaultPathPrefix | quote }}
+      valueFiles:
+        - "values.yaml"
+        - "values-{{ .Values.name }}.yaml"
+{{- end -}}

--- a/environments/values-idfint.yaml
+++ b/environments/values-idfint.yaml
@@ -23,6 +23,7 @@ applications:
   noteburst: true
   nublado: true
   portal: true
+  qserv-kafka: true
   rubin-rag: true
   sasquatch: true
   sia: true

--- a/environments/values.yaml
+++ b/environments/values.yaml
@@ -88,6 +88,9 @@ applications:
   # most other applications use `GafaelfawrIngress`
   gafaelfawr: true
 
+  # -- Enable the qserv-kafka application
+  qserv-kafka: false
+
   # -- Enable the rubin-rag application
   rubin-rag: false
 


### PR DESCRIPTION
Add new Qserv Kafka bridge application. Deploy a test container for now since there has been no formal release. Configure it on idfint, since that's the environment for which we have information about MySQL and REST connect URLs.