### PR TITLE
DM-49993: Use hostname for Qserv REST API

### DIFF
--- a/applications/qserv-kafka/values-idfint.yaml
+++ b/applications/qserv-kafka/values-idfint.yaml
@@ -4,4 +4,4 @@ image:
 config:
   logLevel: "DEBUG"
   qservDatabaseUrl: "mysql+asyncmy://qsmaster@qserv-int.slac.stanford.edu:4090/"
-  qservRestUrl: "https://134.79.23.197:4098/"
+  qservRestUrl: "https://qserv-int-https.slac.stanford.edu:4098/"


### PR DESCRIPTION
The idfint Qserv REST API has been assigned a hostname, so use that instead of the IP address.