### PR TITLE
DM-50027: Change resources and storage for Portal Redis

### DIFF
--- a/applications/portal/values-idfdev.yaml
+++ b/applications/portal/values-idfdev.yaml
@@ -13,6 +13,11 @@ config:
         storageClass: "standard-rwo"
   ssotap: "ssotap"
 
+redis:
+  persistence:
+    enabled: true
+    storageClass: "standard-rwo"
+
 resources:
   limits:
     memory: "2Gi"

--- a/applications/portal/values-idfint.yaml
+++ b/applications/portal/values-idfint.yaml
@@ -13,6 +13,11 @@ config:
         storageClass: "standard-rwo"
   ssotap: "ssotap"
 
+redis:
+  persistence:
+    enabled: true
+    storageClass: "standard-rwo"
+
 resources:
   limits:
     memory: "30Gi"

--- a/applications/portal/values-idfprod.yaml
+++ b/applications/portal/values-idfprod.yaml
@@ -13,6 +13,11 @@ config:
         storageClass: "standard-rwo"
   ssotap: "ssotap"
 
+redis:
+  persistence:
+    enabled: true
+    storageClass: "standard-rwo"
+
 resources:
   limits:
     cpu: "6"

--- a/applications/portal/values.yaml
+++ b/applications/portal/values.yaml
@@ -117,6 +117,9 @@ redis:
   resources:
     limits:
       cpu: "1"
+      memory: "40Mi"
+    requests:
+      cpu: "50m"
       memory: "20Mi"
 
   # -- Pod annotations for the Redis pod


### PR DESCRIPTION
The Portal Redis has been repeatedly OOM killed on idfint. Increase its memory limit to 40Mi and add explicit requests as we do with other Redis pods that are a bit lower. Enable persistent storage on the IDF deployments since notebook integration breaks if the Redis contents are removed.