### PR TITLE
DM-50027: Add persistent volumes for Portal Redis on USDF

### DIFF
--- a/applications/portal/values-usdfdev.yaml
+++ b/applications/portal/values-usdfdev.yaml
@@ -1,2 +1,7 @@
 config:
   livetap: "live"
+
+redis:
+  persistence:
+    enabled: true
+    storageClass: "wekafs--sdf-k8s01"

--- a/applications/portal/values-usdfint.yaml
+++ b/applications/portal/values-usdfint.yaml
@@ -1,0 +1,4 @@
+redis:
+  persistence:
+    enabled: true
+    storageClass: "wekafs--sdf-k8s01"

--- a/applications/portal/values-usdfprod.yaml
+++ b/applications/portal/values-usdfprod.yaml
@@ -1,2 +1,7 @@
 config:
   livetap: "live"
+
+redis:
+  persistence:
+    enabled: true
+    storageClass: "wekafs--sdf-k8s01"


### PR DESCRIPTION
Following the configuration change for the IDF deployments, also use a persistent volume for the Portal Redis on USDF environments.