### PR TITLE
DM-50042: Update Datalinker to 3.2.0

### DIFF
--- a/applications/datalinker/Chart.yaml
+++ b/applications/datalinker/Chart.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 description: IVOA DataLink-based service and data discovery
 sources:
   - https://github.com/lsst-sqre/datalinker
-appVersion: 3.1.0
+appVersion: 3.2.0
 annotations:
   phalanx.lsst.io/docs: |
     - id: "DMTN-238"

--- a/applications/datalinker/README.md
+++ b/applications/datalinker/README.md
@@ -12,12 +12,10 @@ IVOA DataLink-based service and data discovery
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules for the datalinker deployment pod |
 | config.hipsPathPrefix | string | `"/api/hips"` | URL path prefix for the HiPS API (must match the configuration of the hips service) |
+| config.linksLifetime | string | `"1h"` | Lifetime of the `{links}` reply. Should be set to match the lifetime of links returned by the Butler server |
 | config.logLevel | string | `"INFO"` | Logging level |
 | config.pathPrefix | string | `"/api/datalink"` | URL path prefix for DataLink and related APIs |
-| config.pgUser | string | `"rubin"` | User to use from the PGPASSFILE if datalinker is using a direct Butler connection (`useButlerServer` is false) |
-| config.s3EndpointUrl | string | `"https://storage.googleapis.com"` | S3 endpoint URL (must be set if using S3) |
 | config.slackAlerts | bool | `false` | Whether to send certain serious alerts to Slack. If `true`, the `slack-webhook` secret must also be set. |
-| config.storageBackend | string | `"GCS"` | Storage backend to use (either `GCS` or `S3`) |
 | config.tapMetadataUrl | string | `"https://github.com/lsst/sdm_schemas/releases/download/1.2.0/datalink-columns.zip"` | URL containing TAP schema metadata used to construct queries |
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.butlerServerRepositories | string | Set by Argo CD | Butler repositories accessible via Butler server |

--- a/applications/datalinker/templates/deployment.yaml
+++ b/applications/datalinker/templates/deployment.yaml
@@ -25,17 +25,11 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: {{ .Chart.Name }}
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - all
-            readOnlyRootFilesystem: true
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: "DATALINKER_CUTOUT_SYNC_URL"
               value: "{{ .Values.global.baseUrl }}/api/cutout/sync"
+            - name: "DATALINKER_LINKS_LIFETIME"
+              value: {{ .Values.config.linksLifetime | quote }}
             - name: "DATALINKER_HIPS_BASE_URL"
               value: "{{ .Values.global.baseUrl }}/api/hips"
             - name: "DATALINKER_LOG_LEVEL"
@@ -44,10 +38,6 @@ spec:
               value: {{ .Values.config.pathPrefix | quote }}
             - name: "DATALINKER_HIPS_PATH_PREFIX"
               value: {{ .Values.config.hipsPathPrefix | quote }}
-            - name: "DATALINKER_STORAGE_BACKEND"
-              value: {{ .Values.config.storageBackend | quote }}
-            - name: "DATALINKER_S3_ENDPOINT_URL"
-              value: {{ .Values.config.s3EndpointUrl | quote }}
             {{- if .Values.config.slackAlerts }}
             - name: "DATALINKER_SLACK_WEBHOOK"
               valueFrom:
@@ -68,6 +58,8 @@ spec:
                   key: "token"
             - name: "DAF_BUTLER_REPOSITORIES"
               value: {{ .Values.global.butlerServerRepositories | b64dec | quote }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: "http"
               containerPort: 8080
@@ -80,8 +72,12 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - all
+            readOnlyRootFilesystem: true
           volumeMounts:
             - name: "tmp"
               mountPath: "/tmp"

--- a/applications/datalinker/values.yaml
+++ b/applications/datalinker/values.yaml
@@ -20,32 +20,26 @@ ingress:
   annotations: {}
 
 config:
+  # -- URL path prefix for the HiPS API (must match the configuration of the
+  # hips service)
+  hipsPathPrefix: "/api/hips"
+
+  # -- Lifetime of the `{links}` reply. Should be set to match the lifetime of
+  # links returned by the Butler server
+  linksLifetime: "1h"
+
   # -- Logging level
   logLevel: "INFO"
 
   # -- URL path prefix for DataLink and related APIs
   pathPrefix: "/api/datalink"
 
-  # -- URL path prefix for the HiPS API (must match the configuration of the
-  # hips service)
-  hipsPathPrefix: "/api/hips"
-
-  # -- URL containing TAP schema metadata used to construct queries
-  tapMetadataUrl: "https://github.com/lsst/sdm_schemas/releases/download/1.2.0/datalink-columns.zip"
-
-  # -- Storage backend to use (either `GCS` or `S3`)
-  storageBackend: "GCS"
-
-  # -- S3 endpoint URL (must be set if using S3)
-  s3EndpointUrl: "https://storage.googleapis.com"
-
-  # -- User to use from the PGPASSFILE if datalinker is using a direct Butler
-  # connection (`useButlerServer` is false)
-  pgUser: "rubin"
-
   # -- Whether to send certain serious alerts to Slack. If `true`, the
   # `slack-webhook` secret must also be set.
   slackAlerts: false
+
+  # -- URL containing TAP schema metadata used to construct queries
+  tapMetadataUrl: "https://github.com/lsst/sdm_schemas/releases/download/1.2.0/datalink-columns.zip"
 
 # -- Affinity rules for the datalinker deployment pod
 affinity: {}


### PR DESCRIPTION
Adds `Expires` and `Cache-Control` headers to `{links}` responses with a new configuration option to specify the lifetime. Also delete old settings that are no longer used and alphabetize the settings.