### PR TITLE
DM-49664: Schedule Prompt Processing on PP nodes, where possible.

### DIFF
--- a/applications/prompt-keda-lsstcam/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-keda-lsstcam/values-usdfprod-prompt-processing.yaml
@@ -118,3 +118,12 @@ prompt-keda:
   podAnnotations: {
     edu.stanford.slac.sdf.project/usdf-embargo: "true"
   }
+
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 10
+        preference:
+          matchExpressions:
+          - key: node-role.kubernetes.io/prompt-processing
+            operator: Exists


### PR DESCRIPTION
This PR fixes an incorrect scheduling configuration that wasn't caught on #4505.