### PR TITLE
nvr-control: add proxy header for HA auth

### DIFF
--- a/applications/nvr-control/templates/ingress.yaml
+++ b/applications/nvr-control/templates/ingress.yaml
@@ -14,10 +14,12 @@ config:
 template:
   metadata:
     name: nvr-control
-    {{- with .Values.ingress.annotations }}
     annotations:
+      nginx.ingress.kubernetes.io/configuration-snippet: |
+        proxy_set_header X-Rubin-NVR-Proxied-User operator;
+      {{- with .Values.ingress.annotations }}
       {{- toYaml . | nindent 6 }}
-    {{- end }}
+      {{- end }}
   spec:
     rules:
       - host: {{ required "global.host must be set" .Values.global.host }}

--- a/applications/nvr-control/templates/networkpolicy.yaml
+++ b/applications/nvr-control/templates/networkpolicy.yaml
@@ -2,6 +2,8 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: nvr-control
+  labels:
+    {{- include "nvr-control.labels" . | nindent 4 }}
 spec:
   podSelector:
     matchLabels:


### PR DESCRIPTION
We need a fixed header added inbound from the ingress proxy, which the HA header auth provider can use to select a shared account (after upstream authentication with gafaelfawr).