### PR TITLE
Transition consdb to the logical replica at USDF

### DIFF
--- a/applications/consdb/values-usdfdev.yaml
+++ b/applications/consdb/values-usdfdev.yaml
@@ -1,7 +1,7 @@
 db:
   user: "usdf"
   passwordkey: "oods-password"
-  host: "usdf-summitdb.slac.stanford.edu"
+  host: "usdf-summitdb-replica.slac.stanford.edu"
   database: "exposurelog"
 hinfo:
   latiss:

--- a/applications/consdb/values-usdfprod.yaml
+++ b/applications/consdb/values-usdfprod.yaml
@@ -1,7 +1,7 @@
 db:
   user: "usdf"
   passwordkey: "oods-password"
-  host: "usdf-summitdb.slac.stanford.edu"
+  host: "usdf-summitdb-replica.slac.stanford.edu"
   database: "exposurelog"
 hinfo:
   latiss:


### PR DESCRIPTION
In consdb, the the database should be changed to point to the logical replica instead of the new physical replica.