### PR TITLE
DM-50058: Upgrade lsst-tap-service to 2.13.1 and tap-postgres to 1.21.1

### DIFF
--- a/charts/cadc-tap/README.md
+++ b/charts/cadc-tap/README.md
@@ -31,12 +31,12 @@ IVOA TAP service
 | config.pg.host | string | None, must be set if backend is `pg` | Host to connect to |
 | config.pg.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the TAP image |
 | config.pg.image.repository | string | `"ghcr.io/lsst-sqre/tap-postgres-service"` | TAP image to use |
-| config.pg.image.tag | string | `"1.20.0"` | Tag of TAP image to use |
+| config.pg.image.tag | string | `"1.21.1"` | Tag of TAP image to use |
 | config.pg.username | string | None, must be set if backend is `pg` | Username to connect with |
 | config.qserv.host | string | `"mock-db:3306"` (the mock QServ) | QServ hostname:port to connect to |
 | config.qserv.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the TAP image |
 | config.qserv.image.repository | string | `"ghcr.io/lsst-sqre/lsst-tap-service"` | TAP image to use |
-| config.qserv.image.tag | string | `"2.12.0"` | Tag of TAP image to use |
+| config.qserv.image.tag | string | `"2.13.1"` | Tag of TAP image to use |
 | config.qserv.jdbcParams | string | `""` | Extra JDBC connection parameters |
 | config.qserv.passwordEnabled | bool | false | Whether the Qserv database is password protected |
 | config.sentryEnabled | bool | `false` | Whether Sentry is enabled in this environment |
@@ -80,7 +80,7 @@ IVOA TAP service
 | uws.affinity | object | `{}` | Affinity rules for the UWS database pod |
 | uws.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the UWS database image |
 | uws.image.repository | string | `"ghcr.io/lsst-sqre/lsst-tap-uws-db"` | UWS database image to use |
-| uws.image.tag | string | `"2.12.0"` | Tag of UWS database image to use |
+| uws.image.tag | string | `"2.13.1"` | Tag of UWS database image to use |
 | uws.nodeSelector | object | `{}` | Node selection rules for the UWS database pod |
 | uws.podAnnotations | object | `{}` | Annotations for the UWS databse pod |
 | uws.resources | object | See `values.yaml` | Resource limits and requests for the UWS database pod |

--- a/charts/cadc-tap/templates/configmap.yaml
+++ b/charts/cadc-tap/templates/configmap.yaml
@@ -7,8 +7,6 @@ metadata:
 data:
   cadc-registry.properties: |
     ivo://ivoa.net/sso#OpenID = {{ .Values.global.baseUrl }}
-    ca.nrc.cadc.reg.client.RegistryClient.baseURL = {{ .Values.global.baseUrl }}/api/{{ .Values.ingress.path }}/reg
-
     # Ignore this, it's only here to satisfy the availability check.
     ivo://ivoa.net/std/CDP#proxy-1.0 = ivo://cadc.nrc.ca/cred
     ivo://ivoa.net/sso#tls-with-password = {{ .Values.global.baseUrl }}

--- a/charts/cadc-tap/values.yaml
+++ b/charts/cadc-tap/values.yaml
@@ -71,7 +71,7 @@ config:
       pullPolicy: "IfNotPresent"
 
       # -- Tag of TAP image to use
-      tag: "1.20.0"
+      tag: "1.21.1"
 
   qserv:
     # -- QServ hostname:port to connect to
@@ -89,7 +89,7 @@ config:
       pullPolicy: "IfNotPresent"
 
       # -- Tag of TAP image to use
-      tag: "2.12.0"
+      tag: "2.13.1"
 
     # -- Whether the Qserv database is password protected
     # @default -- false
@@ -203,7 +203,7 @@ uws:
     pullPolicy: "IfNotPresent"
 
     # -- Tag of UWS database image to use
-    tag: "2.12.0"
+    tag: "2.13.1"
 
   # -- Resource limits and requests for the UWS database pod
   # @default -- See `values.yaml`


### PR DESCRIPTION
## What's new in lsst-tap-service version 2.13.1

- Change TableServlet to use RestServlet similar to what is done in other upstream packages
- Remove unneeded implementations (Registry implementation, now fixed in cadc-reg 1.4.3). (To address bug where we send out requests to the cadc reg)
- Remove JobDAO and CachingFile implementations (JobDAO bug has been fixed, and these were retained here because of the log4j checkpoint bug, i.e. getting checkpoint logs due to log4j conflicts)
- Fix log4j / log4j2 issues (cadc-util imports the log4j2 apis so we don't need to add the dependency). We just include the log4j2 configuration here

## What's new in tap-postgres 1.21.1 version

- Change TableServlet to use RestServlet similar to what is done in other upstream packages
- Upgraded cadc dependencies, java to 11 and remove unneeded implementations of Registry, MaxRec 
- The upgrades include tap-schema upgrades (added column_id field and api_created field)
