### PR TITLE
DM-50225: Add URL rewriting to the Qserv Kafka bridge

### DIFF
--- a/applications/qserv-kafka/templates/configmap.yaml
+++ b/applications/qserv-kafka/templates/configmap.yaml
@@ -13,3 +13,4 @@ data:
   QSERV_KAFKA_QSERV_DATABASE_URL: {{ .Values.config.qservDatabaseUrl | quote }}
   QSERV_KAFKA_QSERV_POLL_INTERVAL: {{ .Values.config.qservPollInterval | quote }}
   QSERV_KAFKA_QSERV_REST_URL: {{ .Values.config.qservRestUrl | quote }}
+  QSERV_KAFKA_REWRITE_BASE_URL: {{ .Values.global.baseUrl | quote }}

--- a/applications/qserv-kafka/values-idfdev.yaml
+++ b/applications/qserv-kafka/values-idfdev.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: "tickets-DM-49993"
+  tag: "tickets-DM-50225"
   pullPolicy: "Always"
 config:
   logLevel: "DEBUG"

--- a/applications/qserv-kafka/values-idfint.yaml
+++ b/applications/qserv-kafka/values-idfint.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: "tickets-DM-49993"
+  tag: "tickets-DM-50225"
   pullPolicy: "Always"
 config:
   logLevel: "DEBUG"


### PR DESCRIPTION
Update the test version of the Qserv Kafka bridge to a version that supports URL rewriting of access URLs.