### PR TITLE
DM-50267: Prompt Processing SSL Kafka Consumer Fix

### DIFF
--- a/applications/next-visit-fan-out/README.md
+++ b/applications/next-visit-fan-out/README.md
@@ -20,7 +20,7 @@ Poll next visit events from Kafka, duplicate them, and send them to all applicat
 | kafka.expiration | float | `3600` | Maximum message age to consider, in seconds. |
 | kafka.offset | string | `"latest"` |  |
 | kafka.saslMechamism | string | `"SCRAM-SHA-512"` |  |
-| kafka.securityProtocol | string | `"SASL_PLAINTEXT"` |  |
+| kafka.securityProtocol | string | `"SASL_SSL"` |  |
 | keda.redisHealthCheckInterval | int | `3` | Redis health check interval in seconds. |
 | keda.redisHost | string | See `values.yaml`. | Redis cluster host. |
 | keda.redisRetryCount | int | `3` | Redis max retry count |

--- a/applications/next-visit-fan-out/values-usdfdev-prompt-processing.yaml
+++ b/applications/next-visit-fan-out/values-usdfdev-prompt-processing.yaml
@@ -6,7 +6,7 @@ knative:
 
 kafka:
   schemaRegistryUrl: http://10.103.126.51:8081
-  sasquatchAddress: 10.100.226.209:9094
+  sasquatchAddress: 172.24.10.24:9094
   consumerGroup: test-group-3
   nextVisitTopic: test.next-visit-job
   # Dev processes very old images, set to ~20 years
@@ -16,6 +16,6 @@ image:
   repository: ghcr.io/lsst-dm/next_visit_fan_out
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 2.7.0
+  tag: 2.7.1
 
 instruments: "LATISS LSSTCam LSSTCam-imSim LSSTComCam LSSTComCamSim HSC"

--- a/applications/next-visit-fan-out/values-usdfprod-prompt-processing.yaml
+++ b/applications/next-visit-fan-out/values-usdfprod-prompt-processing.yaml
@@ -5,7 +5,7 @@ knative:
 
 kafka:
   schemaRegistryUrl: http://10.104.61.102:8081
-  sasquatchAddress: 10.96.121.181:9094
+  sasquatchAddress: 172.24.10.20:9094
   consumerGroup: next-visit-fan-out-1
   nextVisitTopic: lsst.sal.ScriptQueue.logevent_nextVisit
 
@@ -13,6 +13,6 @@ image:
   repository: ghcr.io/lsst-dm/next_visit_fan_out
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 2.7.0
+  tag: 2.7.1
 
 instruments: "LSSTCam"

--- a/applications/next-visit-fan-out/values.yaml
+++ b/applications/next-visit-fan-out/values.yaml
@@ -42,7 +42,7 @@ keda:
 kafka:
   offset: latest
   saslMechamism: SCRAM-SHA-512
-  securityProtocol: SASL_PLAINTEXT
+  securityProtocol: SASL_SSL
   # -- Maximum message age to consider, in seconds.
   expiration: 3600.0
 


### PR DESCRIPTION
Change to `SASL_SSL` and Kafka broker IPs after Sasquatch issues with connectivity to Summit through firewall.