### PR TITLE
DM-50300: Noteburst workers start sequentially

### DIFF
--- a/applications/noteburst/templates/worker-deployment.yaml
+++ b/applications/noteburst/templates/worker-deployment.yaml
@@ -13,6 +13,22 @@ spec:
   selector:
     matchLabels:
       {{- include "noteburst.selectorLabels" . | nindent 6 }}
+  {{- if gt (int .Values.config.worker.workerCount) 1 }}
+  # If we have more than one worker, use a rolling update strategy to
+  # ensure only one worker starts up at a time.
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate
+  {{- else }}
+  # With one worker, start one worker before stopping the old one.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+  {{- end }}
   template:
     metadata:
       annotations:


### PR DESCRIPTION
Ensure that noteburst workers start one-at-a-time to help reduce contention of identities when there's an issue acquiring a jupyterlab pod.