### PR TITLE
DM-50253: Add Redis support to Qserv Kafka bridge

### DIFF
--- a/applications/qserv-kafka/Chart.yaml
+++ b/applications/qserv-kafka/Chart.yaml
@@ -1,8 +1,19 @@
 apiVersion: v2
-appVersion: 0.1.0
-description: Qserv Kafka bridge
 name: qserv-kafka
-sources:
-- https://github.com/lsst-sqre/qserv-kafka
 type: application
 version: 1.0.0
+description: "Qserv Kafka bridge"
+sources:
+  - "https://github.com/lsst-sqre/qserv-kafka"
+appVersion: 0.1.0
+
+dependencies:
+  - name: "redis"
+    version: 1.0.15
+    repository: "https://lsst-sqre.github.io/charts/"
+
+annotations:
+  phalanx.lsst.io/docs: |
+    - id: "SQR-097"
+      title: "TAP over QServ using an event-based architecture"
+      url: "https://sqr-097.lsst.io/"

--- a/applications/qserv-kafka/README.md
+++ b/applications/qserv-kafka/README.md
@@ -28,5 +28,13 @@ Qserv Kafka bridge
 | ingress.annotations | object | `{}` | Additional annotations for the ingress rule |
 | nodeSelector | object | `{}` | Node selection rules for the qserv-kafka deployment pod |
 | podAnnotations | object | `{}` | Annotations for the qserv-kafka deployment pod |
+| redis.config.secretKey | string | `"redis-password"` | Key inside secret from which to get the Redis password (do not change) |
+| redis.config.secretName | string | `"qserv-kafka"` | Name of secret containing Redis password |
+| redis.persistence.accessMode | string | `"ReadWriteOnce"` | Access mode of storage to request |
+| redis.persistence.enabled | bool | `true` | Whether to persist Redis storage. Setting this to false will use `emptyDir` and lose track of all queries on restart. Only use this for a test deployment. |
+| redis.persistence.size | string | `"100Mi"` | Amount of persistent storage to request |
+| redis.persistence.storageClass | string | `nil` | Class of storage to request |
+| redis.persistence.volumeClaimName | string | `nil` | Use an existing PVC, not dynamic provisioning. If this is set, the size, storageClass, and accessMode settings are ignored. |
+| redis.resources | object | See `values.yaml` | Resource limits and requests for the Redis pod |
 | resources | object | See `values.yaml` | Resource limits and requests for the qserv-kafka deployment pod |
 | tolerations | list | `[]` | Tolerations for the qserv-kafka deployment pod |

--- a/applications/qserv-kafka/secrets.yaml
+++ b/applications/qserv-kafka/secrets.yaml
@@ -1,3 +1,12 @@
 qserv-password:
   description: >-
-    Password for the MySQL interface to Qserv.
+    Password for the MySQL interface to Qserv. Changes must be coordinated
+    with the corresponding Qserv deployment.
+redis-password:
+  description: >-
+    Password used to authenticate the Qserv Kafka bridge to its internal Redis
+    server, deployed as part of the same Argo CD application. This secret can
+    be changed at any time, but both the Redis server and the Qserv Kafka
+    bridge will then have to be restarted to pick up the new value.
+  generate:
+    type: password

--- a/applications/qserv-kafka/templates/configmap.yaml
+++ b/applications/qserv-kafka/templates/configmap.yaml
@@ -13,4 +13,5 @@ data:
   QSERV_KAFKA_QSERV_DATABASE_URL: {{ .Values.config.qservDatabaseUrl | quote }}
   QSERV_KAFKA_QSERV_POLL_INTERVAL: {{ .Values.config.qservPollInterval | quote }}
   QSERV_KAFKA_QSERV_REST_URL: {{ .Values.config.qservRestUrl | quote }}
+  QSERV_KAFKA_REDIS_URL: "redis://qserv-kafka-redis.{{ .Release.Namespace }}:6379/0"
   QSERV_KAFKA_REWRITE_BASE_URL: {{ .Values.global.baseUrl | quote }}

--- a/applications/qserv-kafka/templates/deployment.yaml
+++ b/applications/qserv-kafka/templates/deployment.yaml
@@ -5,10 +5,12 @@ metadata:
   labels:
     {{- include "qserv-kafka.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: 1
   selector:
     matchLabels:
       {{- include "qserv-kafka.selectorLabels" . | nindent 6 }}
+  strategy:
+    type: "Recreate"
   template:
     metadata:
       annotations:
@@ -18,6 +20,7 @@ spec:
         {{- end }}
       labels:
         {{- include "qserv-kafka.selectorLabels" . | nindent 8 }}
+        qserv-kafka-redis-client: "true"
     spec:
       {{- with .Values.affinity }}
       affinity:
@@ -32,6 +35,11 @@ spec:
                 secretKeyRef:
                   name: "qserv-kafka"
                   key: "qserv-password"
+            - name: "QSERV_KAFKA_REDIS_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  name: "qserv-kafka"
+                  key: "redis-password"
             - name: "KAFKA_BOOTSTRAP_SERVERS"
               valueFrom:
                 secretKeyRef:

--- a/applications/qserv-kafka/values-idfdev.yaml
+++ b/applications/qserv-kafka/values-idfdev.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: "tickets-DM-50225"
+  tag: "tickets-DM-50253"
   pullPolicy: "Always"
 config:
   logLevel: "DEBUG"

--- a/applications/qserv-kafka/values-idfint.yaml
+++ b/applications/qserv-kafka/values-idfint.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: "tickets-DM-50225"
+  tag: "tickets-DM-50253"
   pullPolicy: "Always"
 config:
   logLevel: "DEBUG"

--- a/applications/qserv-kafka/values.yaml
+++ b/applications/qserv-kafka/values.yaml
@@ -2,17 +2,6 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-image:
-  # -- Image to use in the qserv-kafka deployment
-  repository: "ghcr.io/lsst-sqre/qserv-kafka"
-
-  # -- Pull policy for the qserv-kafka image
-  pullPolicy: "IfNotPresent"
-
-  # -- Tag of image to use
-  # @default -- The appVersion of the chart
-  tag: null
-
 config:
   # -- Kafka consumer group ID
   consumerGroupId: "qserv"
@@ -42,6 +31,17 @@ config:
   # @default -- None, must be set
   qservRestUrl: null
 
+image:
+  # -- Image to use in the qserv-kafka deployment
+  repository: "ghcr.io/lsst-sqre/qserv-kafka"
+
+  # -- Pull policy for the qserv-kafka image
+  pullPolicy: "IfNotPresent"
+
+  # -- Tag of image to use
+  # @default -- The appVersion of the chart
+  tag: null
+
 ingress:
   # -- Additional annotations for the ingress rule
   annotations: {}
@@ -61,6 +61,44 @@ resources: {}
 
 # -- Tolerations for the qserv-kafka deployment pod
 tolerations: []
+
+redis:
+  config:
+    # -- Name of secret containing Redis password
+    secretName: "qserv-kafka"
+
+    # -- Key inside secret from which to get the Redis password (do not
+    # change)
+    secretKey: "redis-password"
+
+  persistence:
+    # -- Whether to persist Redis storage. Setting this to false will use
+    # `emptyDir` and lose track of all queries on restart. Only use this for a
+    # test deployment.
+    enabled: true
+
+    # -- Access mode of storage to request
+    accessMode: "ReadWriteOnce"
+
+    # -- Amount of persistent storage to request
+    size: "100Mi"
+
+    # -- Class of storage to request
+    storageClass: null
+
+    # -- Use an existing PVC, not dynamic provisioning. If this is set, the
+    # size, storageClass, and accessMode settings are ignored.
+    volumeClaimName: null
+
+  # -- Resource limits and requests for the Redis pod
+  # @default -- See `values.yaml`
+  resources:
+    limits:
+      cpu: "0.5"
+      memory: "10Mi"
+    requests:
+      cpu: "10m"
+      memory: "5Mi"
 
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.


### PR DESCRIPTION
Set up an internal Redis to store query state, allowing the bridge to be restarted without losing track of what queries are running. Ensure only one copy of the bridge is running at a time, since we don't currently have a locking mechanism to prevent multiple copies of the bridge from processing the same Qserv query.