### PR TITLE
Update Prompt Processing to 6.4.2.

### DIFF
--- a/applications/prompt-keda-lsstcam/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-keda-lsstcam/values-usdfprod-prompt-processing.yaml
@@ -1,7 +1,7 @@
 prompt-keda:
   image:
     pullPolicy: IfNotPresent
-    tag: 6.4.1
+    tag: 6.4.2
 
   worker:
     # TODO: need to adjust this once we know how leaky the LSSTCam pipeline is


### PR DESCRIPTION
This version handles nextVisits with no filter spec correctly.