### PR TITLE
Fix EFD replication at USDF

### DIFF
--- a/applications/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
@@ -176,7 +176,10 @@ spec:
             loadBalancerIP: {{ .Values.kafka.externalListener.bootstrap.loadBalancerIP }}
             {{- end }}
             {{- if .Values.kafka.externalListener.bootstrap.annotations }}
-            annotations: {{ .Values.kafka.externalListener.bootstrap.annotations }}
+            annotations:
+              {{- range $key, $value  := .Values.kafka.externalListener.bootstrap.annotations }}
+              {{ $key }}: {{ $value }}
+              {{- end}}
             {{- end }}
           {{- if .Values.kafka.externalListener.brokers }}
           brokers:

--- a/applications/sasquatch/charts/strimzi-kafka/templates/mirrormaker2.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/mirrormaker2.yaml
@@ -77,7 +77,6 @@ spec:
         # Increase request timeout
         producer.request.timeout.ms: 240000
         consumer.request.timeout.ms: 240000
-        admin.timeout.ms: 600000
     heartbeatConnector:
       config:
         heartbeats.topic.replication.factor: 3

--- a/applications/sasquatch/charts/strimzi-kafka/templates/mirrormaker2.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/mirrormaker2.yaml
@@ -50,7 +50,6 @@ spec:
       config:
         replication.factor: 3
         offset-syncs.topic.replication.factor: 3
-        sync.topic.configs.enabled: "false"
         # Dot not replicate topic ACLs configuration.
         sync.topic.acls.enabled: "false"
         # The frequency to check for new topics.

--- a/applications/sasquatch/charts/strimzi-kafka/templates/mirrormaker2.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/mirrormaker2.yaml
@@ -86,7 +86,7 @@ spec:
         # Frequency of checks for new consumer groups.
         refresh.groups.interval.seconds: 300
         # Enables synchronization of consumer group offsets to the target cluster.
-        sync.group.offsets.enabled: true
+        sync.group.offsets.enabled: false
         # The frequency to sync group offsets.
         sync.group.offsets.interval.seconds: 60
         # The frequency of checks for offset tracking.

--- a/applications/sasquatch/charts/strimzi-kafka/templates/mirrormaker2.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/mirrormaker2.yaml
@@ -46,7 +46,7 @@ spec:
   - sourceCluster: "source"
     targetCluster: "target"
     sourceConnector:
-      tasksMax: 10
+      tasksMax: 32
       config:
         replication.factor: 3
         offset-syncs.topic.replication.factor: 3

--- a/applications/sasquatch/charts/strimzi-kafka/templates/mirrormaker2.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/mirrormaker2.yaml
@@ -75,8 +75,8 @@ spec:
         producer.max.request.size: 10485760
         producer.buffer.memory: 10485760
         # Increase request timeout
-        producer.request.timeout.ms: 600000
-        consumer.request.timeout.ms: 600000
+        producer.request.timeout.ms: 240000
+        consumer.request.timeout.ms: 240000
     heartbeatConnector:
       config:
         heartbeats.topic.replication.factor: 3

--- a/applications/sasquatch/charts/strimzi-kafka/templates/mirrormaker2.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/mirrormaker2.yaml
@@ -50,6 +50,7 @@ spec:
       config:
         replication.factor: 3
         offset-syncs.topic.replication.factor: 3
+        sync.topic.configs.enabled: "false"
         # Dot not replicate topic ACLs configuration.
         sync.topic.acls.enabled: "false"
         # The frequency to check for new topics.

--- a/applications/sasquatch/charts/strimzi-kafka/templates/mirrormaker2.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/mirrormaker2.yaml
@@ -77,6 +77,7 @@ spec:
         # Increase request timeout
         producer.request.timeout.ms: 240000
         consumer.request.timeout.ms: 240000
+        admin.timeout.ms: 600000
     heartbeatConnector:
       config:
         heartbeats.topic.replication.factor: 3

--- a/applications/sasquatch/charts/strimzi-kafka/templates/mirrormaker2.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/mirrormaker2.yaml
@@ -76,8 +76,8 @@ spec:
         producer.max.request.size: 10485760
         producer.buffer.memory: 10485760
         # Increase request timeout
-        producer.request.timeout.ms: 240000
-        consumer.request.timeout.ms: 240000
+        producer.request.timeout.ms: 600000
+        consumer.request.timeout.ms: 600000
     heartbeatConnector:
       config:
         heartbeats.topic.replication.factor: 3

--- a/applications/sasquatch/values-usdfdev.yaml
+++ b/applications/sasquatch/values-usdfdev.yaml
@@ -1,4 +1,21 @@
 strimzi-kafka:
+  kafka:
+    externalListener:
+      tls:
+        enabled: true
+      bootstrap:
+        annotations:
+          metallb.universe.tf/address-pool: sdf-rubin-ingest
+      brokers:
+        - broker: 0
+          annotations:
+            metallb.universe.tf/address-pool: sdf-rubin-ingest
+        - broker: 1
+          annotations:
+            metallb.universe.tf/address-pool: sdf-rubin-ingest
+        - broker: 2
+          annotations:
+            metallb.universe.tf/address-pool: sdf-rubin-ingest
   mirrormaker2:
     enabled: false
     source:

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -178,7 +178,7 @@ telegraf:
     m1m3:
       enabled: true
       repair: false
-      metric_batch_size: 2500
+      metric_batch_size: 2000
       database: "efd"
       timestamp_field: "private_efdStamp"
       topicRegexps: |

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -32,8 +32,7 @@ strimzi-kafka:
     enabled: true
     source:
       bootstrapServer: sasquatch-summit-kafka-bootstrap.lsst.codes:9094
-      topicsPattern: "registry-schemas, lsst.sal.MTMount.*, lsst.sal.MTCamera.*, lsst.sal.MTHeaderService.*, lsst.sal.MTOODS.*, lsst.sal.DIMM.*, lsst.sal.DREAM.*, lsst.sal.EAS.*, lsst.sal.ESS.*, lsst.sal.DSM.*, lsst.sal.EPM.*, lsst.sal.HVAC.*, lsst.sal.WeatherForecast.*, lsst.sal.AT.*, lsst.sal.GIS.*, lsst.sal.MTM2.*, lsst.sal.MTVMS.*, lsst.sal.ScriptQueue.*"
-      #", lsst.dm.*, lsst.backpack.*, lsst.ATCamera.*, lsst.CCCamera.*, lsst.MTCamera.*, lsst.obsenv.*, lsst.cp.*"
+      topicsPattern: "registry-schemas, lsst.sal.*, lsst.dm.*, lsst.backpack.*, lsst.ATCamera.*, lsst.CCCamera.*, lsst.MTCamera.*, lsst.obsenv.*, lsst.cp.*"
     resources:
       requests:
         cpu: 2

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -32,8 +32,8 @@ strimzi-kafka:
     enabled: true
     source:
       bootstrapServer: sasquatch-summit-kafka-bootstrap.lsst.codes:9094
-      topicsPattern: "registry-schemas, lsst.sal.*"
-      #, lsst.dm.*, lsst.backpack.*, lsst.ATCamera.*, lsst.CCCamera.*, lsst.MTCamera.*, lsst.obsenv.*, lsst.cp.*"
+      topicsPattern: "registry-schemas, lsst.sal.MTMount.*, lsst.sal.MTCamera.*, lsst.sal.MTHeaderService.*, lsst.sal.MTOODS.*, lsst.sal.DIMM.*, lsst.sal.DREAM.*, lsst.sal.EAS.*, lsst.sal.ESS.*, lsst.sal.DSM.*, lsst.sal.EPM.*, lsst.sal.HVAC.*, lsst.sal.WeatherForecast.*, lsst.sal.AT.*, lsst.sal.GIS.*, lsst.sal.MTM2.*, lsst.sal.MTVMS.*, lsst.sal.ScriptQueue.*"
+      #", lsst.dm.*, lsst.backpack.*, lsst.ATCamera.*, lsst.CCCamera.*, lsst.MTCamera.*, lsst.obsenv.*, lsst.cp.*"
     resources:
       requests:
         cpu: 2

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -32,7 +32,8 @@ strimzi-kafka:
     enabled: true
     source:
       bootstrapServer: sasquatch-summit-kafka-bootstrap.lsst.codes:9094
-      topicsPattern: "registry-schemas, lsst.sal.*, lsst.dm.*, lsst.backpack.*, lsst.ATCamera.*, lsst.CCCamera.*, lsst.MTCamera.*, lsst.obsenv.*, lsst.cp.*"
+      topicsPattern: "registry-schemas, lsst.sal.*"
+      #, lsst.dm.*, lsst.backpack.*, lsst.ATCamera.*, lsst.CCCamera.*, lsst.MTCamera.*, lsst.obsenv.*, lsst.cp.*"
     resources:
       requests:
         cpu: 2

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -5,6 +5,22 @@ strimzi-kafka:
       replica.lag.time.max.ms: 120000
       log.retention.minutes: 10080
       offsets.retention.minutes: 10080
+    externalListener:
+      tls:
+        enabled: true
+      bootstrap:
+        annotations:
+          metallb.universe.tf/address-pool: sdf-rubin-ingest
+      brokers:
+        - broker: 6
+          annotations:
+            metallb.universe.tf/address-pool: sdf-rubin-ingest
+        - broker: 7
+          annotations:
+            metallb.universe.tf/address-pool: sdf-rubin-ingest
+        - broker: 8
+          annotations:
+            metallb.universe.tf/address-pool: sdf-rubin-ingest
 
   connect:
     enabled: true


### PR DESCRIPTION
Use the right annotation to allocate Kafka IPs on the Pixel Zone. 
Increase number of MM2 tasks to increate throughput.
Disable replication of Summit consumer group offsets as they are not needed at USDF.
Reduce M1M3 batch size to avoid timeout problems when writing to InfluxDB.

