### PR TITLE
Use BLOCK-365 for Prompt Processing SV survey.

### DIFF
--- a/applications/prompt-keda-lsstcam/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-keda-lsstcam/values-usdfprod-prompt-processing.yaml
@@ -55,7 +55,7 @@ prompt-keda:
         - {pipelines: []}
       preprocessing: |-
         # TODO: run if and only if ApPipe is a possibility
-        # - survey: BLOCK-T407
+        # - survey: BLOCK-365
         #   pipelines: ['${PROMPT_PROCESSING_DIR}/pipelines/LSSTCam/Preprocessing.yaml']
         - {survey: "", pipelines: []}
         # Don't preprocess anything unknown


### PR DESCRIPTION
The Prompt Processing configuration replaced BLOCK-T407 with BLOCK-365 in the main pipeline but not the preprocessing pipeline. This would have made it impossible to run ApPipe has the config been activated.