### PR TITLE
Change consdbtap to use sdm_schemas w.2025.16

### DIFF
--- a/applications/consdbtap/values-usdfdev.yaml
+++ b/applications/consdbtap/values-usdfdev.yaml
@@ -2,4 +2,7 @@ cadc-tap:
   tapSchema:
     image:
       repository: "lsstsqre/tap-schema-usdf-dev-cdb"
-      tag: "main"
+      tag: "w.2025.16"
+
+  config:
+    datalinkPayloadUrl: "https://github.com/lsst/sdm_schemas/releases/download/w.2025.16/datalink-snippets.zip"

--- a/applications/consdbtap/values-usdfint.yaml
+++ b/applications/consdbtap/values-usdfint.yaml
@@ -2,4 +2,7 @@ cadc-tap:
   tapSchema:
     image:
       repository: "lsstsqre/tap-schema-usdf-prod-cdb"
-      tag: "main"
+      tag: "w.2025.16"
+
+  config:
+    datalinkPayloadUrl: "https://github.com/lsst/sdm_schemas/releases/download/w.2025.16/datalink-snippets.zip"

--- a/applications/consdbtap/values-usdfprod.yaml
+++ b/applications/consdbtap/values-usdfprod.yaml
@@ -2,4 +2,7 @@ cadc-tap:
   tapSchema:
     image:
       repository: "lsstsqre/tap-schema-usdf-prod-cdb"
-      tag: "main"
+      tag: "w.2025.16"
+
+  config:
+    datalinkPayloadUrl: "https://github.com/lsst/sdm_schemas/releases/download/w.2025.16/datalink-snippets.zip"


### PR DESCRIPTION
We want `consdbtap` to be versioned independently from the other TAP services. This pins all USDF environments to a known-good tag.