### PR TITLE
Configure Prompt Processing for early Science Verification

### DIFF
--- a/applications/prompt-keda-lsstcam/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-keda-lsstcam/values-usdfprod-prompt-processing.yaml
@@ -71,9 +71,29 @@ prompt-keda:
         # Ignore unknown events during Commissioning
         - {pipelines: []}
       preprocessing: |-
-        # TODO: run if and only if ApPipe is a possibility
-        # - survey: BLOCK-365
-        #   pipelines: ['${PROMPT_PROCESSING_DIR}/pipelines/LSSTCam/Preprocessing.yaml']
+        # Run to enable solar system processing in SingleFrame
+        - survey: BLOCK-365
+          pipelines: ['${PROMPT_PROCESSING_DIR}/pipelines/LSSTCam/Preprocessing.yaml']
+        - survey: BLOCK-T407
+          pipelines: ['${PROMPT_PROCESSING_DIR}/pipelines/LSSTCam/Preprocessing.yaml']
+        - survey: BLOCK-T364
+          pipelines: ['${PROMPT_PROCESSING_DIR}/pipelines/LSSTCam/Preprocessing.yaml']
+        - survey: BLOCK-T365
+          pipelines: ['${PROMPT_PROCESSING_DIR}/pipelines/LSSTCam/Preprocessing.yaml']
+        - survey: BLOCK-T366
+          pipelines: ['${PROMPT_PROCESSING_DIR}/pipelines/LSSTCam/Preprocessing.yaml']
+        - survey: BLOCK-T367
+          pipelines: ['${PROMPT_PROCESSING_DIR}/pipelines/LSSTCam/Preprocessing.yaml']
+        - survey: BLOCK-T368
+          pipelines: ['${PROMPT_PROCESSING_DIR}/pipelines/LSSTCam/Preprocessing.yaml']
+        - survey: BLOCK-T369
+          pipelines: ['${PROMPT_PROCESSING_DIR}/pipelines/LSSTCam/Preprocessing.yaml']
+        - survey: BLOCK-T373
+          pipelines: ['${PROMPT_PROCESSING_DIR}/pipelines/LSSTCam/Preprocessing.yaml']
+        - survey: BLOCK-T460
+          pipelines: ['${PROMPT_PROCESSING_DIR}/pipelines/LSSTCam/Preprocessing.yaml']
+        - survey: BLOCK-T461
+          pipelines: ['${PROMPT_PROCESSING_DIR}/pipelines/LSSTCam/Preprocessing.yaml']
         - {survey: "", pipelines: []}
         # Don't preprocess anything unknown
         - {pipelines: []}

--- a/applications/prompt-keda-lsstcam/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-keda-lsstcam/values-usdfprod-prompt-processing.yaml
@@ -23,32 +23,52 @@ prompt-keda:
           - ${PROMPT_PROCESSING_DIR}/pipelines/LSSTCam/Isr.yaml
         - survey: BLOCK-T427  # Daytime checkout
           pipelines: ['${PROMPT_PROCESSING_DIR}/pipelines/LSSTCam/Isr-cal.yaml']
-        # Manual observations during SV blocks?
+        # SV blocks *not* marked BLOCK-365
         - survey: BLOCK-T407
-          pipelines: []
+          pipelines:
+          - ${PROMPT_PROCESSING_DIR}/pipelines/LSSTCam/SingleFrame.yaml
+          - ${PROMPT_PROCESSING_DIR}/pipelines/LSSTCam/Isr.yaml
         - survey: BLOCK-T364
-          pipelines: []
+          pipelines:
+          - ${PROMPT_PROCESSING_DIR}/pipelines/LSSTCam/SingleFrame.yaml
+          - ${PROMPT_PROCESSING_DIR}/pipelines/LSSTCam/Isr.yaml
         - survey: BLOCK-T365
-          pipelines: []
+          pipelines:
+          - ${PROMPT_PROCESSING_DIR}/pipelines/LSSTCam/SingleFrame.yaml
+          - ${PROMPT_PROCESSING_DIR}/pipelines/LSSTCam/Isr.yaml
         - survey: BLOCK-T366
-          pipelines: []
+          pipelines:
+          - ${PROMPT_PROCESSING_DIR}/pipelines/LSSTCam/SingleFrame.yaml
+          - ${PROMPT_PROCESSING_DIR}/pipelines/LSSTCam/Isr.yaml
         - survey: BLOCK-T367
-          pipelines: []
+          pipelines:
+          - ${PROMPT_PROCESSING_DIR}/pipelines/LSSTCam/SingleFrame.yaml
+          - ${PROMPT_PROCESSING_DIR}/pipelines/LSSTCam/Isr.yaml
         - survey: BLOCK-T368
-          pipelines: []
+          pipelines:
+          - ${PROMPT_PROCESSING_DIR}/pipelines/LSSTCam/SingleFrame.yaml
+          - ${PROMPT_PROCESSING_DIR}/pipelines/LSSTCam/Isr.yaml
         - survey: BLOCK-T369
-          pipelines: []
+          pipelines:
+          - ${PROMPT_PROCESSING_DIR}/pipelines/LSSTCam/SingleFrame.yaml
+          - ${PROMPT_PROCESSING_DIR}/pipelines/LSSTCam/Isr.yaml
         - survey: BLOCK-T373
-          pipelines: []
+          pipelines:
+          - ${PROMPT_PROCESSING_DIR}/pipelines/LSSTCam/SingleFrame.yaml
+          - ${PROMPT_PROCESSING_DIR}/pipelines/LSSTCam/Isr.yaml
         - survey: BLOCK-T460
-          pipelines: []
+          pipelines:
+          - ${PROMPT_PROCESSING_DIR}/pipelines/LSSTCam/SingleFrame.yaml
+          - ${PROMPT_PROCESSING_DIR}/pipelines/LSSTCam/Isr.yaml
         - survey: BLOCK-T461
-          pipelines: []
+          pipelines:
+          - ${PROMPT_PROCESSING_DIR}/pipelines/LSSTCam/SingleFrame.yaml
+          - ${PROMPT_PROCESSING_DIR}/pipelines/LSSTCam/Isr.yaml
         # Produces nextVisits but not images
         - {survey: "BLOCK-T454", pipelines: []}
         # Miscellaneous scripts, not always images
         - {survey: "", pipelines: []}
-        # Ignore unknown events
+        # Ignore unknown events during Commissioning
         - {pipelines: []}
       preprocessing: |-
         # TODO: run if and only if ApPipe is a possibility

--- a/applications/prompt-keda-lsstcam/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-keda-lsstcam/values-usdfprod-prompt-processing.yaml
@@ -144,8 +144,6 @@ prompt-keda:
   initializer:
     # 6 retries is not enough time to fix, e.g., DB permissions problems
     retries: 15
-    # Keep around for first few days so we can check in the morning PDT
-    cleanup_delay: 21600  # 6 hours
 
     podAnnotations: {
       edu.stanford.slac.sdf.project/usdf-embargo: "true"

--- a/applications/prompt-keda-lsstcam/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-keda-lsstcam/values-usdfprod-prompt-processing.yaml
@@ -97,8 +97,7 @@ prompt-keda:
         - {survey: "", pipelines: []}
         # Don't preprocess anything unknown
         - {pipelines: []}
-    # TODO: need to adjust this based on observed slew accuracy
-    preloadPadding: 50
+    preloadPadding: 50.1
     calibRepo: s3://rubin-summit-users
 
   s3:


### PR DESCRIPTION
This PR reorients the Prompt Processing config towards SV visits and fixes some minor issues.