### PR TITLE
DM-50391: Update Qserv Kafka bridge, add shutdown timeout

### DIFF
--- a/applications/qserv-kafka/README.md
+++ b/applications/qserv-kafka/README.md
@@ -19,6 +19,7 @@ Qserv Kafka bridge
 | config.qservDatabaseUrl | string | None, must be set | URL to the Qserv MySQL interface (must use a scheme of `mysql+asyncmy`) |
 | config.qservPollInterval | string | `"1s"` | Interval at which Qserv is polled for query status in Safir `parse_timedelta` format |
 | config.qservRestUrl | string | None, must be set | URL to the Qserv REST API |
+| config.shutdownTimeout | int | 60 (1 minute) | How long to wait for result processing to finish during shutdown before forcibly terminating the pod, in seconds |
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |

--- a/applications/qserv-kafka/templates/deployment.yaml
+++ b/applications/qserv-kafka/templates/deployment.yaml
@@ -94,6 +94,7 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      terminationGracePeriodSeconds: {{ add .Values.config.shutdownTimeout  5 }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/applications/qserv-kafka/values-idfdev.yaml
+++ b/applications/qserv-kafka/values-idfdev.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: "tickets-DM-50253"
+  tag: "tickets-DM-50391"
   pullPolicy: "Always"
 config:
   logLevel: "DEBUG"

--- a/applications/qserv-kafka/values-idfint.yaml
+++ b/applications/qserv-kafka/values-idfint.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: "tickets-DM-50253"
+  tag: "tickets-DM-50391"
   pullPolicy: "Always"
 config:
   logLevel: "DEBUG"

--- a/applications/qserv-kafka/values.yaml
+++ b/applications/qserv-kafka/values.yaml
@@ -31,6 +31,11 @@ config:
   # @default -- None, must be set
   qservRestUrl: null
 
+  # -- How long to wait for result processing to finish during shutdown before
+  # forcibly terminating the pod, in seconds
+  # @default -- 60 (1 minute)
+  shutdownTimeout: 60
+
 image:
   # -- Image to use in the qserv-kafka deployment
   repository: "ghcr.io/lsst-sqre/qserv-kafka"


### PR DESCRIPTION
Update to a new development branch of the Qserv Kafka bridge and add a shutdown timeout for graceful shutdown of result processing. Set the Kubernetes pod termination grace period to five seconds more than the internal timeout for shutdown processing.