### PR TITLE
Add tutorial notebook pull cronjob/idfdev

### DIFF
--- a/applications/nublado/README.md
+++ b/applications/nublado/README.md
@@ -91,6 +91,19 @@ JupyterHub and custom spawner for the Rubin Science Platform
 | controller.resources | object | See `values.yaml` | Resource limits and requests for the Nublado controller |
 | controller.slackAlerts | bool | `false` | Whether to enable Slack alerts. If set to true, `slack_webhook` must be set in the corresponding Nublado Vault secret. |
 | controller.tolerations | list | `[]` | Tolerations for the Nublado controller |
+| cronjob.affinity | object | `{}` | Affinity rules for the tutorials cronjob. |
+| cronjob.enabled | bool | `false` | Enable tutorials refresh? |
+| cronjob.gitBranch | string | `"main"` | Branch of repository to clone |
+| cronjob.gitSource | string | `"https://github.com/lsst/tutorial-notebooks"` | Source for repository to clone |
+| cronjob.gitTarget | string | `"/project/cst_repos/tutorial-notebooks"` | Target where repository should land |
+| cronjob.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the controller image |
+| cronjob.image.repository | string | `"ghcr.io/lsst-sqre/repo-cloner"` | Repository cloner image to use |
+| cronjob.image.tag | string | The appVersion of the chart | Tag of Nublado controller image to use |
+| cronjob.resources | object | See `values.yaml` | Resource limits and requests for the tutorials cronjob |
+| cronjob.schedule | string | `"43 * * * *"` | Schedule for the tutorials cronjob. |
+| cronjob.targetVolume | object | See `values.yaml` | Repository volume definition |
+| cronjob.targetVolumePath | string | `"/project"` | Where repository volume should be mounted |
+| cronjob.tolerations | list | `[]` | Tolerations for the tutorials cronjob. |
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |

--- a/applications/nublado/templates/tutorial-cronjob.yaml
+++ b/applications/nublado/templates/tutorial-cronjob.yaml
@@ -1,0 +1,56 @@
+{{ if .Values.cronjob.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: tutorials
+spec:
+  schedule: {{ .Values.cronjob.schedule | quote }}
+  successfulJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          automountServiceAccountToken: false
+          {{- with .Values.cronjob.tolerations }}
+          tolerations:
+{{- toYaml . | indent 12 }}
+          {{- end }}
+          {{- with .Values.cronjob.affinity }}
+          affinity:
+{{- toYaml . | indent 12 }}
+          {{- end }}
+          containers:
+          - name: tutorial
+            image: "{{ .Values.cronjob.image.repository }}:{{ .Values.cronjob.image.tag | default .Chart.AppVersion }}"
+            imagePullPolicy: "{{ .Values.cronjob.image.pullPolicy }}"
+            {{- with .Values.cronjob.resources }}
+            resources:
+{{ toYaml . | indent 14 }}
+            {{- end }}
+            command: [ "/entrypoint.sh" ]
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              runAsNonRoot: true
+              runAsUser: 1000
+              runAsGroup: 1000
+              capabilities:
+                drop:
+                - all
+            env:
+            - name: "GIT_SRC"
+              value: {{ .Values.cronjob.gitSource | quote }}
+            - name: "GIT_TARGET"
+              value: {{ .Values.cronjob.gitTarget | quote }}
+            - name: "GIT_BRANCH"
+              value: {{ .Values.cronjob.gitBranch | quote }}
+            volumeMounts:
+            - mountPath: {{ .Values.cronjob.targetVolume.mountPath }}
+              name: target
+          volumes:
+          - name: target
+            nfs:
+              server: {{ .Values.cronjob.targetVolume.server }}
+              path: {{ .Values.cronjob.targetVolume.path }}
+{{- end }}

--- a/applications/nublado/values-idfdev.yaml
+++ b/applications/nublado/values-idfdev.yaml
@@ -40,6 +40,7 @@ controller:
         GOOGLE_APPLICATION_CREDENTIALS: "/opt/lsst/software/jupyterlab/secrets/butler-gcs-idf-creds.json"
         S3_ENDPOINT_URL: "https://sdfdatas3.slac.stanford.edu"
         TMPDIR: "/tmp"
+        TUTORIAL_NOTEBOOKS_CACHE_DIR: "/project/cst_repos/tutorial-notebooks"
       initContainers:
         - name: "inithome"
           image:
@@ -105,3 +106,12 @@ cloudsql:
   enabled: true
   instanceConnectionName: "science-platform-dev-7696:us-central1:science-platform-dev-e9e11de2"
   serviceAccount: "nublado@science-platform-dev-7696.iam.gserviceaccount.com"
+cronjob:
+  enabled: true
+  image:
+    tag: tickets-DM-49131
+    pullPolicy: Always
+  targetVolume:
+    mountPath: "/project"
+    server: "10.234.16.4"
+    path: "/project-share"

--- a/applications/nublado/values.yaml
+++ b/applications/nublado/values.yaml
@@ -696,9 +696,9 @@ cronjob:
   # -- Repository volume definition
   # @default -- See `values.yaml`
   targetVolume:
-    nfs:
-      path: /project-share
-      server: 10.234.16.4  #  NetApp servers always seem to be here.
+    mountPath: "/project"   # Conventional
+    server: "10.234.16.4"   # NetApp always gets this IP, apparently
+    path: "/project-share"  # Assigned by Terraform
 
   image:
     # -- Repository cloner image to use

--- a/applications/nublado/values.yaml
+++ b/applications/nublado/values.yaml
@@ -675,6 +675,60 @@ secrets:
   # user's lab.
   templateSecrets: true
 
+# If we're installing tutorials at a given site, this cronjob controls
+# their refresh.
+cronjob:
+  # -- Enable tutorials refresh?
+  enabled: false
+
+  # -- Source for repository to clone
+  gitSource: "https://github.com/lsst/tutorial-notebooks"
+
+  # -- Target where repository should land
+  gitTarget: "/project/cst_repos/tutorial-notebooks"
+
+  # -- Branch of repository to clone
+  gitBranch: "main"
+
+  # -- Where repository volume should be mounted
+  targetVolumePath: "/project"
+
+  # -- Repository volume definition
+  # @default -- See `values.yaml`
+  targetVolume:
+    nfs:
+      path: /project-share
+      server: 10.234.16.4  #  NetApp servers always seem to be here.
+
+  image:
+    # -- Repository cloner image to use
+    repository: "ghcr.io/lsst-sqre/repo-cloner"
+
+    # -- Pull policy for the controller image
+    pullPolicy: "IfNotPresent"
+
+    # -- Tag of Nublado controller image to use
+    # @default -- The appVersion of the chart
+    tag: null
+
+  # -- Resource limits and requests for the tutorials cronjob
+  # @default -- See `values.yaml`
+  resources:
+    limits:
+      cpu: "1"
+      memory: "1Gi"
+    requests:
+      cpu: "50m"
+      memory: "50Mi"
+
+  # -- Tolerations for the tutorials cronjob.
+  tolerations: []
+  # -- Affinity rules for the tutorials cronjob.
+  affinity: {}
+  # -- Schedule for the tutorials cronjob.
+  schedule: "43 * * * *"
+
+
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:


### PR DESCRIPTION
This will keep our tutorial notebooks fresh, initially on IDF-dev so we don't have to do a clone with each lab start.