### PR TITLE
Don't fan-out Prompt Processing messages for turned-off detectors

### DIFF
--- a/applications/next-visit-fan-out/values-usdfprod-prompt-processing.yaml
+++ b/applications/next-visit-fan-out/values-usdfprod-prompt-processing.yaml
@@ -16,3 +16,13 @@ image:
   tag: 2.8.1
 
 instruments: "LSSTCam"
+
+detectorConfig:
+  LSSTCam:
+    # Detectors turned off in early Commissioning
+    78: False
+    79: False
+    80: False
+    120: False
+    121: False
+    122: False


### PR DESCRIPTION
This PR fixes an issue where the Prompt Processing Next Visit Fan-Out service was requesting processing for detectors that were turned off and always produced blank raws.

Despite having `*LSSTCam`, `LSSTCam-imSim` is *not* affected by this patch.