### PR TITLE
DM-50462: Add MPSky to Prompt Processing configs

### DIFF
--- a/applications/prompt-keda-hsc/README.md
+++ b/applications/prompt-keda-hsc/README.md
@@ -62,6 +62,7 @@ KEDA Prompt Processing instance for HSC
 | prompt-keda.keda.scalingStrategy | string | `"eager"` |  |
 | prompt-keda.keda.successfulJobsHistoryLimit | int | `5` |  |
 | prompt-keda.logLevel | string | log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
+| prompt-keda.mpSky_service | string | `""` | The URI to the MPSky ephemerides service. Empty value is allowed, but its handling is undefined. |
 | prompt-keda.nameOverride | string | `""` | Override the base name for resources |
 | prompt-keda.nodeSelector | object | `{}` | Node selection rules for the Prompt Processing pod |
 | prompt-keda.podAnnotations | object | `{}` | Pod annotations for the Prompt Processing Pod |

--- a/applications/prompt-keda-hsc/values.yaml
+++ b/applications/prompt-keda-hsc/values.yaml
@@ -67,6 +67,10 @@ prompt-keda:
   # If empty, Prompt Processing does not use a microservice.
   raw_microservice: ""
 
+  # -- The URI to the MPSky ephemerides service.
+  # Empty value is allowed, but its handling is undefined.
+  mpSky_service: ""
+
   imageNotifications:
     # -- Hostname and port of the Kafka provider
     # @default -- None, must be set

--- a/applications/prompt-keda-latiss/README.md
+++ b/applications/prompt-keda-latiss/README.md
@@ -62,6 +62,7 @@ KEDA Prompt Processing instance for LATISS
 | prompt-keda.keda.scalingStrategy | string | `"eager"` |  |
 | prompt-keda.keda.successfulJobsHistoryLimit | int | `5` |  |
 | prompt-keda.logLevel | string | log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
+| prompt-keda.mpSky_service | string | `""` | The URI to the MPSky ephemerides service. Empty value is allowed, but its handling is undefined. |
 | prompt-keda.nameOverride | string | `""` | Override the base name for resources |
 | prompt-keda.nodeSelector | object | `{}` | Node selection rules for the Prompt Processing pod |
 | prompt-keda.podAnnotations | object | `{}` | Pod annotations for the Prompt Processing Pod |

--- a/applications/prompt-keda-latiss/values.yaml
+++ b/applications/prompt-keda-latiss/values.yaml
@@ -66,6 +66,10 @@ prompt-keda:
   # If empty, Prompt Processing does not use a microservice.
   raw_microservice: ""
 
+  # -- The URI to the MPSky ephemerides service.
+  # Empty value is allowed, but its handling is undefined.
+  mpSky_service: ""
+
   imageNotifications:
     # -- Hostname and port of the Kafka provider
     # @default -- None, must be set

--- a/applications/prompt-keda-lsstcam/README.md
+++ b/applications/prompt-keda-lsstcam/README.md
@@ -60,6 +60,7 @@ KEDA Prompt Processing instance for LSSTCam
 | prompt-keda.keda.scalingStrategy | string | `"eager"` |  |
 | prompt-keda.keda.successfulJobsHistoryLimit | int | `5` |  |
 | prompt-keda.logLevel | string | log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
+| prompt-keda.mpSky_service | string | `""` | The URI to the MPSky ephemerides service. Empty value is allowed, but its handling is undefined. |
 | prompt-keda.nameOverride | string | `""` | Override the base name for resources |
 | prompt-keda.nodeSelector | object | `{}` | Node selection rules for the Prompt Processing pod |
 | prompt-keda.podAnnotations | object | `{}` | Pod annotations for the Prompt Processing Pod |

--- a/applications/prompt-keda-lsstcam/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-keda-lsstcam/values-usdfprod-prompt-processing.yaml
@@ -106,6 +106,9 @@ prompt-keda:
 
   raw_microservice: http://172.24.5.158:8080/presence
 
+  # TODO: replace with permanent service once it's up
+  mpSky_service: http://sdfiana014.sdf.slac.stanford.edu:3666/ephemerides/
+
   imageNotifications:
     kafkaClusterAddress: prompt-processing-2-kafka-bootstrap.kafka:9092
     topic: rubin-summit-notification

--- a/applications/prompt-keda-lsstcam/values.yaml
+++ b/applications/prompt-keda-lsstcam/values.yaml
@@ -67,6 +67,10 @@ prompt-keda:
   # If empty, Prompt Processing does not use a microservice.
   raw_microservice: ""
 
+  # -- The URI to the MPSky ephemerides service.
+  # Empty value is allowed, but its handling is undefined.
+  mpSky_service: ""
+
   imageNotifications:
     # -- Hostname and port of the Kafka provider
     # @default -- None, must be set

--- a/applications/prompt-keda-lsstcamimsim/README.md
+++ b/applications/prompt-keda-lsstcamimsim/README.md
@@ -62,6 +62,7 @@ KEDA Prompt Processing instance for LSSTCam-imSim.
 | prompt-keda.keda.scalingStrategy | string | `"eager"` |  |
 | prompt-keda.keda.successfulJobsHistoryLimit | int | `5` |  |
 | prompt-keda.logLevel | string | log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
+| prompt-keda.mpSky_service | string | `""` | The URI to the MPSky ephemerides service. Empty value is allowed, but its handling is undefined. |
 | prompt-keda.nameOverride | string | `""` | Override the base name for resources |
 | prompt-keda.nodeSelector | object | `{}` | Node selection rules for the Prompt Processing pod |
 | prompt-keda.podAnnotations | object | `{}` | Pod annotations for the Prompt Processing Pod |

--- a/applications/prompt-keda-lsstcamimsim/values.yaml
+++ b/applications/prompt-keda-lsstcamimsim/values.yaml
@@ -67,6 +67,10 @@ prompt-keda:
   # If empty, Prompt Processing does not use a microservice.
   raw_microservice: ""
 
+  # -- The URI to the MPSky ephemerides service.
+  # Empty value is allowed, but its handling is undefined.
+  mpSky_service: ""
+
   imageNotifications:
     # -- Hostname and port of the Kafka provider
     # @default -- None, must be set

--- a/applications/prompt-keda-lsstcomcam/README.md
+++ b/applications/prompt-keda-lsstcomcam/README.md
@@ -59,9 +59,11 @@ KEDA Prompt Processing instance for LSSTComCam.
 | prompt-keda.keda.scalingStrategy | string | `"eager"` |  |
 | prompt-keda.keda.successfulJobsHistoryLimit | int | `5` |  |
 | prompt-keda.logLevel | string | log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
+| prompt-keda.mpSky_service | string | `""` | The URI to the MPSky ephemerides service. Empty value is allowed, but its handling is undefined. |
 | prompt-keda.nameOverride | string | `""` | Override the base name for resources |
 | prompt-keda.nodeSelector | object | `{}` | Node selection rules for the Prompt Processing pod |
 | prompt-keda.podAnnotations | object | `{}` | Pod annotations for the Prompt Processing Pod |
+| prompt-keda.raw_microservice | string | `""` | The URI to a microservice that maps image metadata to a file location. If empty, Prompt Processing does not use a microservice. |
 | prompt-keda.registry.centralRepoFile | bool | `false` | If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted. |
 | prompt-keda.resources | object | See `values.yaml` | Kubernetes resource requests and limits |
 | prompt-keda.s3.auth_env | bool | `true` | If set, get S3 credentials from this application's Vault secret. |

--- a/applications/prompt-keda-lsstcomcam/values.yaml
+++ b/applications/prompt-keda-lsstcomcam/values.yaml
@@ -63,6 +63,14 @@ prompt-keda:
     # -- If set, configure S3 checksum options.
     checksum: WHEN_REQUIRED
 
+  # -- The URI to a microservice that maps image metadata to a file location.
+  # If empty, Prompt Processing does not use a microservice.
+  raw_microservice: ""
+
+  # -- The URI to the MPSky ephemerides service.
+  # Empty value is allowed, but its handling is undefined.
+  mpSky_service: ""
+
   imageNotifications:
     # -- Hostname and port of the Kafka provider
     # @default -- None, must be set

--- a/applications/prompt-keda-lsstcomcamsim/README.md
+++ b/applications/prompt-keda-lsstcomcamsim/README.md
@@ -62,6 +62,7 @@ KEDA Prompt Processing instance for LSSTComCamSim
 | prompt-keda.keda.scalingStrategy | string | `"eager"` |  |
 | prompt-keda.keda.successfulJobsHistoryLimit | int | `25` |  |
 | prompt-keda.logLevel | string | log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
+| prompt-keda.mpSky_service | string | `""` | The URI to the MPSky ephemerides service. Empty value is allowed, but its handling is undefined. |
 | prompt-keda.nameOverride | string | `""` | Override the base name for resources |
 | prompt-keda.nodeSelector | object | `{}` | Node selection rules for the Prompt Processing pod |
 | prompt-keda.podAnnotations | object | `{}` | Pod annotations for the Prompt Processing Pod |

--- a/applications/prompt-keda-lsstcomcamsim/values.yaml
+++ b/applications/prompt-keda-lsstcomcamsim/values.yaml
@@ -68,6 +68,10 @@ prompt-keda:
   # If empty, Prompt Processing does not use a microservice.
   raw_microservice: ""
 
+  # -- The URI to the MPSky ephemerides service.
+  # Empty value is allowed, but its handling is undefined.
+  mpSky_service: ""
+
   imageNotifications:
     # -- Hostname and port of the Kafka provider
     # @default -- None, must be set

--- a/applications/prompt-proto-service-hsc-gpu/README.md
+++ b/applications/prompt-proto-service-hsc-gpu/README.md
@@ -59,6 +59,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.knative.memoryRequest | string | `"2Gi"` | The minimum memory to request for the full pod (see `containerConcurrency`). |
 | prompt-proto-service.knative.responseStartTimeout | int | `0` | Maximum time that a container can send nothing to Knative after initial submission (seconds). This is only useful if the container runs async workers. If 0, idle timeout is ignored. |
 | prompt-proto-service.logLevel | string | log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
+| prompt-proto-service.mpSky_service | string | `""` | The URI to the MPSky ephemerides service. Empty value is allowed, but its handling is undefined. |
 | prompt-proto-service.podAnnotations | object | See the `values.yaml` file. | Annotations for the prompt-proto-service pod |
 | prompt-proto-service.raw_microservice | string | `""` | The URI to a microservice that maps image metadata to a file location. If empty, Prompt Processing does not use a microservice. |
 | prompt-proto-service.registry.centralRepoFile | bool | `false` | If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted. |

--- a/applications/prompt-proto-service-hsc-gpu/values.yaml
+++ b/applications/prompt-proto-service-hsc-gpu/values.yaml
@@ -85,6 +85,10 @@ prompt-proto-service:
   # If empty, Prompt Processing does not use a microservice.
   raw_microservice: ""
 
+  # -- The URI to the MPSky ephemerides service.
+  # Empty value is allowed, but its handling is undefined.
+  mpSky_service: ""
+
   imageNotifications:
     # -- Hostname and port of the Kafka provider
     # @default -- None, must be set

--- a/applications/prompt-proto-service-hsc/README.md
+++ b/applications/prompt-proto-service-hsc/README.md
@@ -59,6 +59,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.knative.memoryRequest | string | `"2Gi"` | The minimum memory to request for the full pod (see `containerConcurrency`). |
 | prompt-proto-service.knative.responseStartTimeout | int | `0` | Maximum time that a container can send nothing to Knative after initial submission (seconds). This is only useful if the container runs async workers. If 0, idle timeout is ignored. |
 | prompt-proto-service.logLevel | string | log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
+| prompt-proto-service.mpSky_service | string | `""` | The URI to the MPSky ephemerides service. Empty value is allowed, but its handling is undefined. |
 | prompt-proto-service.podAnnotations | object | See the `values.yaml` file. | Annotations for the prompt-proto-service pod |
 | prompt-proto-service.raw_microservice | string | `""` | The URI to a microservice that maps image metadata to a file location. If empty, Prompt Processing does not use a microservice. |
 | prompt-proto-service.registry.centralRepoFile | bool | `false` | If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted. |

--- a/applications/prompt-proto-service-hsc/values.yaml
+++ b/applications/prompt-proto-service-hsc/values.yaml
@@ -86,6 +86,10 @@ prompt-proto-service:
   # If empty, Prompt Processing does not use a microservice.
   raw_microservice: ""
 
+  # -- The URI to the MPSky ephemerides service.
+  # Empty value is allowed, but its handling is undefined.
+  mpSky_service: ""
+
   imageNotifications:
     # -- Hostname and port of the Kafka provider
     # @default -- None, must be set

--- a/applications/prompt-proto-service-latiss/README.md
+++ b/applications/prompt-proto-service-latiss/README.md
@@ -59,6 +59,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.knative.memoryRequest | string | `"2Gi"` | The minimum memory to request for the full pod (see `containerConcurrency`). |
 | prompt-proto-service.knative.responseStartTimeout | int | `0` | Maximum time that a container can send nothing to Knative after initial submission (seconds). This is only useful if the container runs async workers. If 0, idle timeout is ignored. |
 | prompt-proto-service.logLevel | string | log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
+| prompt-proto-service.mpSky_service | string | `""` | The URI to the MPSky ephemerides service. Empty value is allowed, but its handling is undefined. |
 | prompt-proto-service.podAnnotations | object | See the `values.yaml` file. | Annotations for the prompt-proto-service pod |
 | prompt-proto-service.raw_microservice | string | `""` | The URI to a microservice that maps image metadata to a file location. If empty, Prompt Processing does not use a microservice. |
 | prompt-proto-service.registry.centralRepoFile | bool | `false` | If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted. |

--- a/applications/prompt-proto-service-latiss/values.yaml
+++ b/applications/prompt-proto-service-latiss/values.yaml
@@ -85,6 +85,10 @@ prompt-proto-service:
   # If empty, Prompt Processing does not use a microservice.
   raw_microservice: ""
 
+  # -- The URI to the MPSky ephemerides service.
+  # Empty value is allowed, but its handling is undefined.
+  mpSky_service: ""
+
   imageNotifications:
     # -- Hostname and port of the Kafka provider
     # @default -- None, must be set

--- a/applications/prompt-proto-service-lsstcam/README.md
+++ b/applications/prompt-proto-service-lsstcam/README.md
@@ -59,6 +59,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.knative.memoryRequest | string | `"2Gi"` | The minimum memory to request for the full pod (see `containerConcurrency`). |
 | prompt-proto-service.knative.responseStartTimeout | int | `0` | Maximum time that a container can send nothing to Knative after initial submission (seconds). This is only useful if the container runs async workers. If 0, idle timeout is ignored. |
 | prompt-proto-service.logLevel | string | log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
+| prompt-proto-service.mpSky_service | string | `""` | The URI to the MPSky ephemerides service. Empty value is allowed, but its handling is undefined. |
 | prompt-proto-service.podAnnotations | object | See the `values.yaml` file. | Annotations for the prompt-proto-service pod |
 | prompt-proto-service.raw_microservice | string | `""` | The URI to a microservice that maps image metadata to a file location. If empty, Prompt Processing does not use a microservice. |
 | prompt-proto-service.registry.centralRepoFile | bool | `false` | If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted. |

--- a/applications/prompt-proto-service-lsstcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcam/values.yaml
@@ -86,6 +86,10 @@ prompt-proto-service:
   # If empty, Prompt Processing does not use a microservice.
   raw_microservice: ""
 
+  # -- The URI to the MPSky ephemerides service.
+  # Empty value is allowed, but its handling is undefined.
+  mpSky_service: ""
+
   imageNotifications:
     # -- Hostname and port of the Kafka provider
     # @default -- None, must be set

--- a/applications/prompt-proto-service-lsstcamimsim/README.md
+++ b/applications/prompt-proto-service-lsstcamimsim/README.md
@@ -59,6 +59,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.knative.memoryRequest | string | `"2Gi"` | The minimum memory to request for the full pod (see `containerConcurrency`). |
 | prompt-proto-service.knative.responseStartTimeout | int | `0` | Maximum time that a container can send nothing to Knative after initial submission (seconds). This is only useful if the container runs async workers. If 0, idle timeout is ignored. |
 | prompt-proto-service.logLevel | string | log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
+| prompt-proto-service.mpSky_service | string | `""` | The URI to the MPSky ephemerides service. Empty value is allowed, but its handling is undefined. |
 | prompt-proto-service.podAnnotations | object | See the `values.yaml` file. | Annotations for the prompt-proto-service pod |
 | prompt-proto-service.raw_microservice | string | `""` | The URI to a microservice that maps image metadata to a file location. If empty, Prompt Processing does not use a microservice. |
 | prompt-proto-service.registry.centralRepoFile | bool | `false` | If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted. |

--- a/applications/prompt-proto-service-lsstcamimsim/values.yaml
+++ b/applications/prompt-proto-service-lsstcamimsim/values.yaml
@@ -88,6 +88,10 @@ prompt-proto-service:
   # If empty, Prompt Processing does not use a microservice.
   raw_microservice: ""
 
+  # -- The URI to the MPSky ephemerides service.
+  # Empty value is allowed, but its handling is undefined.
+  mpSky_service: ""
+
   imageNotifications:
     # -- Hostname and port of the Kafka provider
     # @default -- None, must be set

--- a/applications/prompt-proto-service-lsstcomcam/README.md
+++ b/applications/prompt-proto-service-lsstcomcam/README.md
@@ -58,7 +58,9 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.knative.memoryRequest | string | `"2Gi"` | The minimum memory to request for the full pod (see `containerConcurrency`). |
 | prompt-proto-service.knative.responseStartTimeout | int | `900` | Maximum time that a container can send nothing to Knative after initial submission (seconds). This is only useful if the container runs async workers. If 0, idle timeout is ignored. |
 | prompt-proto-service.logLevel | string | log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
+| prompt-proto-service.mpSky_service | string | `""` | The URI to the MPSky ephemerides service. Empty value is allowed, but its handling is undefined. |
 | prompt-proto-service.podAnnotations | object | See the `values.yaml` file. | Annotations for the prompt-proto-service pod |
+| prompt-proto-service.raw_microservice | string | `""` | The URI to a microservice that maps image metadata to a file location. If empty, Prompt Processing does not use a microservice. |
 | prompt-proto-service.registry.centralRepoFile | bool | `false` | If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted. |
 | prompt-proto-service.s3.auth_env | bool | `true` | If set, get S3 credentials from this application's Vault secret. |
 | prompt-proto-service.s3.checksum | string | `"WHEN_REQUIRED"` | If set, configure S3 checksum options. |

--- a/applications/prompt-proto-service-lsstcomcam/values.yaml
+++ b/applications/prompt-proto-service-lsstcomcam/values.yaml
@@ -85,6 +85,14 @@ prompt-proto-service:
     # -- If set, configure S3 checksum options.
     checksum: WHEN_REQUIRED
 
+  # -- The URI to a microservice that maps image metadata to a file location.
+  # If empty, Prompt Processing does not use a microservice.
+  raw_microservice: ""
+
+  # -- The URI to the MPSky ephemerides service.
+  # Empty value is allowed, but its handling is undefined.
+  mpSky_service: ""
+
   imageNotifications:
     # -- Hostname and port of the Kafka provider
     # @default -- None, must be set

--- a/applications/prompt-proto-service-lsstcomcamsim/README.md
+++ b/applications/prompt-proto-service-lsstcomcamsim/README.md
@@ -59,6 +59,7 @@ Prompt Proto Service is an event driven service for processing camera images. Th
 | prompt-proto-service.knative.memoryRequest | string | `"2Gi"` | The minimum memory to request for the full pod (see `containerConcurrency`). |
 | prompt-proto-service.knative.responseStartTimeout | int | `0` | Maximum time that a container can send nothing to Knative after initial submission (seconds). This is only useful if the container runs async workers. If 0, idle timeout is ignored. |
 | prompt-proto-service.logLevel | string | log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
+| prompt-proto-service.mpSky_service | string | `""` | The URI to the MPSky ephemerides service. Empty value is allowed, but its handling is undefined. |
 | prompt-proto-service.podAnnotations | object | See the `values.yaml` file. | Annotations for the prompt-proto-service pod |
 | prompt-proto-service.raw_microservice | string | `""` | The URI to a microservice that maps image metadata to a file location. If empty, Prompt Processing does not use a microservice. |
 | prompt-proto-service.registry.centralRepoFile | bool | `false` | If set, this application's Vault secret must contain a `central_repo_file` key containing a remote Butler configuration, and `instrument.calibRepo` is the local path where this file is mounted. |

--- a/applications/prompt-proto-service-lsstcomcamsim/values.yaml
+++ b/applications/prompt-proto-service-lsstcomcamsim/values.yaml
@@ -87,6 +87,10 @@ prompt-proto-service:
   # If empty, Prompt Processing does not use a microservice.
   raw_microservice: ""
 
+  # -- The URI to the MPSky ephemerides service.
+  # Empty value is allowed, but its handling is undefined.
+  mpSky_service: ""
+
   imageNotifications:
     # -- Hostname and port of the Kafka provider
     # @default -- None, must be set

--- a/charts/prompt-keda/README.md
+++ b/charts/prompt-keda/README.md
@@ -62,6 +62,7 @@ Event-driven processing of camera images
 | keda.scalingStrategy | string | `"eager"` |  |
 | keda.successfulJobsHistoryLimit | int | `25` |  |
 | logLevel | string | log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
+| mpSky_service | string | `""` | The URI to the MPSky ephemerides service. Empty value is allowed, but its handling is undefined. |
 | nameOverride | string | `""` | Override the base name for resources |
 | nodeSelector | object | `{}` | Node selection rules for the Prompt Porcessing pod |
 | podAnnotations | object | `{"prometheus.io/port":"8000","prometheus.io/scrape":"true"}` | Pod annotations for the Prompt Processing Pod |

--- a/charts/prompt-keda/templates/scaled-job.yaml
+++ b/charts/prompt-keda/templates/scaled-job.yaml
@@ -85,6 +85,11 @@ spec:
                 value: {{ .Values.imageNotifications.kafkaClusterAddress }}
               - name: RAW_MICROSERVICE
                 value: {{ .Values.raw_microservice }}
+              # MpSkyEphemerisQuery handles MP_SKY_URL being unset, but not empty
+              {{- with .Values.mpSky_service }}
+              - name: MP_SKY_URL
+                value: {{ . }}
+              {{- end }}
               - name: SASQUATCH_URL
                 value: {{ .Values.sasquatch.endpointUrl }}
               {{- if and .Values.sasquatch.endpointUrl .Values.sasquatch.auth_env }}

--- a/charts/prompt-keda/values.yaml
+++ b/charts/prompt-keda/values.yaml
@@ -69,6 +69,10 @@ s3:
 # If empty, Prompt Processing does not use a microservice.
 raw_microservice: ""
 
+# -- The URI to the MPSky ephemerides service.
+# Empty value is allowed, but its handling is undefined.
+mpSky_service: ""
+
 imageNotifications:
   # -- Hostname and port of the Kafka provider
   # @default -- None, must be set

--- a/charts/prompt-proto-service/README.md
+++ b/charts/prompt-proto-service/README.md
@@ -62,6 +62,7 @@ Event-driven processing of camera images
 | knative.memoryRequest | string | `"2Gi"` | The minimum memory to request for the full pod (see `containerConcurrency`). |
 | knative.responseStartTimeout | int | `0` | Maximum time that a container can send nothing to Knative after initial submission (seconds). This is only useful if the container runs async workers. If 0, startup timeout is ignored. |
 | logLevel | string | log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
+| mpSky_service | string | `""` | The URI to the MPSky ephemerides service. Empty value is allowed, but its handling is undefined. |
 | nameOverride | string | `""` | Override the base name for resources |
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | See the `values.yaml` file. | Annotations for the prompt-proto-service pod |

--- a/charts/prompt-proto-service/templates/prompt-proto-service.yaml
+++ b/charts/prompt-proto-service/templates/prompt-proto-service.yaml
@@ -75,6 +75,11 @@ spec:
           value: {{ .Values.imageNotifications.kafkaClusterAddress }}
         - name: RAW_MICROSERVICE
           value: {{ .Values.raw_microservice }}
+        # MpSkyEphemerisQuery handles MP_SKY_URL being unset, but not empty
+        {{- with .Values.mpSky_service }}
+        - name: MP_SKY_URL
+          value: {{ . }}
+        {{- end }}
         - name: SASQUATCH_URL
           value: {{ .Values.sasquatch.endpointUrl }}
         {{- if and .Values.sasquatch.endpointUrl .Values.sasquatch.auth_env }}

--- a/charts/prompt-proto-service/values.yaml
+++ b/charts/prompt-proto-service/values.yaml
@@ -86,6 +86,10 @@ s3:
 # If empty, Prompt Processing does not use a microservice.
 raw_microservice: ""
 
+# -- The URI to the MPSky ephemerides service.
+# Empty value is allowed, but its handling is undefined.
+mpSky_service: ""
+
 imageNotifications:
   # -- Hostname and port of the Kafka provider
   # @default -- None, must be set


### PR DESCRIPTION
This PR adds configuration hooks for `MP_SKY_URL` to Prompt Processing. However, it leaves the variable undefined for everything except LSSTCam-prod.