### PR TITLE
DM-50410: Update the test Qserv Kafka bridge

### DIFF
--- a/applications/qserv-kafka/README.md
+++ b/applications/qserv-kafka/README.md
@@ -19,7 +19,7 @@ Qserv Kafka bridge
 | config.qservDatabaseUrl | string | None, must be set | URL to the Qserv MySQL interface (must use a scheme of `mysql+asyncmy`) |
 | config.qservPollInterval | string | `"1s"` | Interval at which Qserv is polled for query status in Safir `parse_timedelta` format |
 | config.qservRestUrl | string | None, must be set | URL to the Qserv REST API |
-| config.shutdownTimeout | int | 60 (1 minute) | How long to wait for result processing to finish during shutdown before forcibly terminating the pod, in seconds |
+| config.resultTimeout | int | 3600 (1 hour) | How long to wait for result processing (retrieval and upload) before timing out, in seconds. This doubles as the timeout forcibly terminating the pod. |
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |

--- a/applications/qserv-kafka/templates/configmap.yaml
+++ b/applications/qserv-kafka/templates/configmap.yaml
@@ -14,4 +14,5 @@ data:
   QSERV_KAFKA_QSERV_POLL_INTERVAL: {{ .Values.config.qservPollInterval | quote }}
   QSERV_KAFKA_QSERV_REST_URL: {{ .Values.config.qservRestUrl | quote }}
   QSERV_KAFKA_REDIS_URL: "redis://qserv-kafka-redis.{{ .Release.Namespace }}:6379/0"
+  QSERV_KAFKA_RESULT_TIMEOUT: {{ .Values.config.resultTimeout | quote }}
   QSERV_KAFKA_REWRITE_BASE_URL: {{ .Values.global.baseUrl | quote }}

--- a/applications/qserv-kafka/templates/deployment.yaml
+++ b/applications/qserv-kafka/templates/deployment.yaml
@@ -94,7 +94,7 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      terminationGracePeriodSeconds: {{ add .Values.config.shutdownTimeout  5 }}
+      terminationGracePeriodSeconds: {{ add .Values.config.resultTimeout 5 }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/applications/qserv-kafka/values-idfdev.yaml
+++ b/applications/qserv-kafka/values-idfdev.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: "tickets-DM-50391"
+  tag: "tickets-DM-50410"
   pullPolicy: "Always"
 config:
   logLevel: "DEBUG"

--- a/applications/qserv-kafka/values-idfint.yaml
+++ b/applications/qserv-kafka/values-idfint.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: "tickets-DM-50391"
+  tag: "tickets-DM-50410"
   pullPolicy: "Always"
 config:
   logLevel: "DEBUG"

--- a/applications/qserv-kafka/values.yaml
+++ b/applications/qserv-kafka/values.yaml
@@ -31,10 +31,11 @@ config:
   # @default -- None, must be set
   qservRestUrl: null
 
-  # -- How long to wait for result processing to finish during shutdown before
-  # forcibly terminating the pod, in seconds
-  # @default -- 60 (1 minute)
-  shutdownTimeout: 60
+  # -- How long to wait for result processing (retrieval and upload) before
+  # timing out, in seconds. This doubles as the timeout forcibly terminating
+  # the pod.
+  # @default -- 3600 (1 hour)
+  resultTimeout: 3600
 
 image:
   # -- Image to use in the qserv-kafka deployment


### PR DESCRIPTION
Rename `shutdownTimeout` to `resultTimeout` to fit the newer version of Qserv Kafka bridge and update to the new test version of the bridge.