### PR TITLE
DM-50489: Increase memory for some summit components.

### DIFF
--- a/applications/auxtel/values-summit.yaml
+++ b/applications/auxtel/values-summit.yaml
@@ -64,10 +64,10 @@ atheaderservice:
   resources:
     limits:
       cpu: 800m
-      memory: 700Mi
+      memory: 2000Mi
     requests:
       cpu: 80m
-      memory: 250Mi
+      memory: 700Mi
 
 athexapod:
   enabled: true

--- a/applications/envsys/values-summit.yaml
+++ b/applications/envsys/values-summit.yaml
@@ -155,10 +155,10 @@ dream:
   resources:
     requests:
       cpu: 70m
-      memory: 96Mi
+      memory: 300Mi
     limits:
       cpu: 700m
-      memory: 300Mi
+      memory: 900Mi
 
 earthquake-ess302:
   enabled: true

--- a/applications/simonyitel/values-summit.yaml
+++ b/applications/simonyitel/values-summit.yaml
@@ -139,10 +139,10 @@ gcheaderservice101:
   resources:
     limits:
       cpu: 2000m
-      memory: 700Mi
+      memory: 2100Mi
     requests:
       cpu: 200m
-      memory: 232Mi
+      memory: 700Mi
 
 gcheaderservice102:
   enabled: true
@@ -161,10 +161,10 @@ gcheaderservice102:
   resources:
     limits:
       cpu: 2000m
-      memory: 700Mi
+      memory: 2100Mi
     requests:
       cpu: 200m
-      memory: 236Mi
+      memory: 700Mi
 
 gcheaderservice103:
   enabled: true
@@ -183,10 +183,10 @@ gcheaderservice103:
   resources:
     limits:
       cpu: 2000m
-      memory: 700Mi
+      memory: 2100Mi
     requests:
       cpu: 200m
-      memory: 225Mi
+      memory: 700Mi
 
 lasertracker1:
   enabled: true


### PR DESCRIPTION
The following components were reaching their memory limits:

- atheaderservice-7pk99 = 80.6 %
- dream-dg44z = 81.7 %
- gcheaderservice101-xh5sj = 88.0 %
- gcheaderservice102-25nqq = 91.6 %
- gcheaderservice103-2tn76 = 89.3 %

Their memory requests/limits have been updated accordingly.