### PR TITLE
Update Prompt Processing alert stream.

### DIFF
--- a/applications/prompt-keda-lsstcam/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-keda-lsstcam/values-usdfprod-prompt-processing.yaml
@@ -3,6 +3,11 @@ prompt-keda:
     pullPolicy: IfNotPresent
     tag: 6.7.0
 
+  alerts:
+    username: kafka-admin
+    server: usdf-alert-stream-dev.lsst.cloud:9094
+    topic: lsst-alerts-v7.4
+
   worker:
     # TODO: need to adjust this once we know how leaky the LSSTCam pipeline is
     # restart: 7
@@ -118,11 +123,6 @@ prompt-keda:
 
   apdb:
     config: s3://rubin-summit-users/apdb_config/cassandra/pp_apdb_lsstcam.yaml
-
-  alerts:
-    username: kafka-admin
-    server: usdf-alert-stream-dev.lsst.cloud:9094
-    topic: lsst-alerts-v7.4
 
   # TODO: may need to override for debugging
   logLevel: timer.lsst.activator=DEBUG timer.lsst.daf.butler=DEBUG lsst.diaPipe=VERBOSE lsst.rbClassify=VERBOSE lsst.daf.butler=VERBOSE

--- a/applications/prompt-keda-lsstcam/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-keda-lsstcam/values-usdfprod-prompt-processing.yaml
@@ -122,7 +122,7 @@ prompt-keda:
   alerts:
     username: kafka-admin
     server: usdf-alert-stream-dev.lsst.cloud:9094
-    topic: lsst-alerts
+    topic: lsst-alerts-v7.4
 
   # TODO: may need to override for debugging
   logLevel: timer.lsst.activator=DEBUG timer.lsst.daf.butler=DEBUG lsst.diaPipe=VERBOSE lsst.rbClassify=VERBOSE lsst.daf.butler=VERBOSE


### PR DESCRIPTION
This PR updates the Prompt Processing alert topic from `lsst-alerts` to `lsst-alerts-v7.4`. This is for forward-compatibility only; we are not yet running any pipelines that send alerts to this topic.

It also reorganizes the LSSTCam-prod config file so that the Prompt Processing version and alert stream version are easier to update together.