### PR TITLE
Fix conditional for telegraf-password

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
           - --template-files=../helm-docs.md.gotmpl
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.6
+    rev: v0.11.7
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/applications/sasquatch/secrets.yaml
+++ b/applications/sasquatch/secrets.yaml
@@ -66,7 +66,7 @@ telegraf-password:
     Telegraf KafkaUser password. Used by the telegraf
     application to connect to the Kafka broker.
     Both telegraf and app-metrics sub-charts use this password.
-  if: strimzi-kafka-users.telegraf.enabled
+  if: strimzi-kafka.users.telegraf.enabled
 ts-salkafka-password:
   description: >-
     ts-salkafka KafkaUser password.


### PR DESCRIPTION
There was a typo in the secret conditional for the `telegraf-password`  as revealed by `phalanx secrets audit`.
Now `phalanx secrets audit` looks correct for both IDF dev and int.
I also removed the unused static secrets from 1password for those environments.
