### PR TITLE
DM-50481: Use the released version of qserv-kafka

### DIFF
--- a/applications/qserv-kafka/values-idfdev.yaml
+++ b/applications/qserv-kafka/values-idfdev.yaml
@@ -1,6 +1,3 @@
-image:
-  tag: "tickets-DM-50410"
-  pullPolicy: "Always"
 config:
   logLevel: "DEBUG"
   qservDatabaseUrl: "mysql+asyncmy://qsmaster@qserv-int.slac.stanford.edu:4090/"

--- a/applications/qserv-kafka/values-idfint.yaml
+++ b/applications/qserv-kafka/values-idfint.yaml
@@ -1,6 +1,3 @@
-image:
-  tag: "tickets-DM-50410"
-  pullPolicy: "Always"
 config:
   logLevel: "DEBUG"
   qservDatabaseUrl: "mysql+asyncmy://qsmaster@qserv-int.slac.stanford.edu:4090/"


### PR DESCRIPTION
There is now a 0.1.0 release. Use that version on idfdev and idfint instead of using a ticket branch build.