### PR TITLE
Setup lsst.example connector

### DIFF
--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -407,11 +407,11 @@ Rubin Observatory's telemetry service
 | telegraf.image.repo | string | `"docker.io/library/telegraf"` | Telegraf image repository |
 | telegraf.image.tag | string | `"1.32.1-alpine"` | Telegraf image tag |
 | telegraf.imagePullSecrets | list | `[]` | Secret names to use for Docker pulls |
-| telegraf.influxdb.database | string | `""` | Name of the InfluxDB v1 database to write to (required) |
 | telegraf.influxdb.url | string | `"http://sasquatch-influxdb.sasquatch:8086"` | URL of the InfluxDB v1 instance to write to |
 | telegraf.kafkaConsumers.test.collection_jitter | string | "0s" | Data collection jitter. This is used to jitter the collection by a random amount. Each plugin will sleep for a random time within jitter before collecting. |
 | telegraf.kafkaConsumers.test.compression_codec | int | 3 | Compression codec. 0 : None, 1 : Gzip, 2 : Snappy, 3 : LZ4, 4 : ZSTD |
 | telegraf.kafkaConsumers.test.consumer_fetch_default | string | "20MB" | Maximum amount of data the server should return for a fetch request. |
+| telegraf.kafkaConsumers.test.database | string | `""` | Name of the InfluxDB v1 database to write to (required) |
 | telegraf.kafkaConsumers.test.debug | bool | false | Run Telegraf in debug mode. |
 | telegraf.kafkaConsumers.test.enabled | bool | `false` | Enable the Telegraf Kafka consumer. |
 | telegraf.kafkaConsumers.test.fields | list | `[]` | List of Avro fields to be recorded as InfluxDB fields.  If not specified, any Avro field that is not marked as a tag will become an InfluxDB field. |
@@ -444,11 +444,11 @@ Rubin Observatory's telemetry service
 | telegraf-oss.image.repo | string | `"docker.io/library/telegraf"` | Telegraf image repository |
 | telegraf-oss.image.tag | string | `"1.32.1-alpine"` | Telegraf image tag |
 | telegraf-oss.imagePullSecrets | list | `[]` | Secret names to use for Docker pulls |
-| telegraf-oss.influxdb.database | string | `""` | Name of the InfluxDB v1 database to write to (required) |
 | telegraf-oss.influxdb.url | string | `"http://sasquatch-influxdb.sasquatch:8086"` | URL of the InfluxDB v1 instance to write to |
 | telegraf-oss.kafkaConsumers.test.collection_jitter | string | "0s" | Data collection jitter. This is used to jitter the collection by a random amount. Each plugin will sleep for a random time within jitter before collecting. |
 | telegraf-oss.kafkaConsumers.test.compression_codec | int | 3 | Compression codec. 0 : None, 1 : Gzip, 2 : Snappy, 3 : LZ4, 4 : ZSTD |
 | telegraf-oss.kafkaConsumers.test.consumer_fetch_default | string | "20MB" | Maximum amount of data the server should return for a fetch request. |
+| telegraf-oss.kafkaConsumers.test.database | string | `""` | Name of the InfluxDB v1 database to write to (required) |
 | telegraf-oss.kafkaConsumers.test.debug | bool | false | Run Telegraf in debug mode. |
 | telegraf-oss.kafkaConsumers.test.enabled | bool | `false` | Enable the Telegraf Kafka consumer. |
 | telegraf-oss.kafkaConsumers.test.fields | list | `[]` | List of Avro fields to be recorded as InfluxDB fields.  If not specified, any Avro field that is not marked as a tag will become an InfluxDB field. |

--- a/applications/sasquatch/charts/telegraf/README.md
+++ b/applications/sasquatch/charts/telegraf/README.md
@@ -15,11 +15,11 @@ Telegraf is an agent for collecting, processing, aggregating, and writing metric
 | image.repo | string | `"docker.io/library/telegraf"` | Telegraf image repository |
 | image.tag | string | `"1.32.1-alpine"` | Telegraf image tag |
 | imagePullSecrets | list | `[]` | Secret names to use for Docker pulls |
-| influxdb.database | string | `""` | Name of the InfluxDB v1 database to write to (required) |
 | influxdb.url | string | `"http://sasquatch-influxdb.sasquatch:8086"` | URL of the InfluxDB v1 instance to write to |
 | kafkaConsumers.test.collection_jitter | string | "0s" | Data collection jitter. This is used to jitter the collection by a random amount. Each plugin will sleep for a random time within jitter before collecting. |
 | kafkaConsumers.test.compression_codec | int | 3 | Compression codec. 0 : None, 1 : Gzip, 2 : Snappy, 3 : LZ4, 4 : ZSTD |
 | kafkaConsumers.test.consumer_fetch_default | string | "20MB" | Maximum amount of data the server should return for a fetch request. |
+| kafkaConsumers.test.database | string | `""` | Name of the InfluxDB v1 database to write to (required) |
 | kafkaConsumers.test.debug | bool | false | Run Telegraf in debug mode. |
 | kafkaConsumers.test.enabled | bool | `false` | Enable the Telegraf Kafka consumer. |
 | kafkaConsumers.test.fields | list | `[]` | List of Avro fields to be recorded as InfluxDB fields.  If not specified, any Avro field that is not marked as a tag will become an InfluxDB field. |

--- a/applications/sasquatch/charts/telegraf/values.yaml
+++ b/applications/sasquatch/charts/telegraf/values.yaml
@@ -60,6 +60,9 @@ kafkaConsumers:
     # increase the consumer throughput.
     replicaCount: 1
 
+    # -- Name of the InfluxDB v1 database to write to (required)
+    database: ""
+
     # -- Sends metrics to the output in batches of at most metric_batch_size
     # metrics.
     # @default -- 1000
@@ -184,8 +187,6 @@ kafkaConsumers:
 influxdb:
   # -- URL of the InfluxDB v1 instance to write to
   url: "http://sasquatch-influxdb.sasquatch:8086"
-  # -- Name of the InfluxDB v1 database to write to (required)
-  database: ""
 
 # -- Kubernetes resources requests and limits
 # @default -- See `values.yaml`

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -111,13 +111,19 @@ influxdb-enterprise:
 
 telegraf:
   enabled: true
+  influxdb:
+    url: "http://sasquatch-influxdb-enterprise-data.sasquatch:8086"
   kafkaConsumers:
-    test:
+    example:
       enabled: true
-      database: "telegraf-kafka-consumer-v1"
       replicaCount: 1
+      database: "lsst.example"
+      tags: |
+        [ "band", "instrument" ]
+      timestamp_format: "unix_ms"
+      timestamp_field: "timestamp"
       topicRegexps: |
-        [ "lsst.Test.*" ]
+        [ "lsst.example" ]
 
 kafdrop:
   cmdArgs: "--message.format=AVRO --message.keyFormat=DEFAULT --topic.deleteEnabled=true --topic.createEnabled=true"
@@ -132,9 +138,7 @@ rest-proxy:
     hostname: data-dev.lsst.cloud
   kafka:
     topicPrefixes:
-      - test
-      - lsst.dm
-      - lsst.Test
+      - lsst.example
       - lsst.tap
 
 chronograf:


### PR DESCRIPTION
- Set up lsst.example namespace and connector to write data to the enterprise InfluxDB instance on idfdev