### PR TITLE
DM-50543: Disable automatic topic creation

### DIFF
--- a/applications/alert-stream-broker/README.md
+++ b/applications/alert-stream-broker/README.md
@@ -56,7 +56,8 @@ Alert transmission to community brokers
 | alert-stream-broker.clusterName | string | `"alert-broker"` | Name of a Strimzi Kafka cluster to connect to. |
 | alert-stream-broker.clusterPort | int | `9092` | Port to connect to on the Strimzi Kafka cluster. It should be an internal TLS listener. |
 | alert-stream-broker.fullnameOverride | string | `""` | Override for the full name used for Kubernetes resources; by default one will be created based on the chart name and helm release name. |
-| alert-stream-broker.kafka.config | object | `{"log.retention.bytes":"42949672960","log.retention.hours":168,"offsets.retention.minutes":10080}` | Configuration overrides for the Kafka server. |
+| alert-stream-broker.kafka.config | object | `{"auto.create.topics.enable":"false","log.retention.bytes":"42949672960","log.retention.hours":168,"offsets.retention.minutes":10080}` | Configuration overrides for the Kafka server. |
+| alert-stream-broker.kafka.config."auto.create.topics.enable" | string | `"false"` | Turns of automatic topic creation to prevent accidental topic use. |
 | alert-stream-broker.kafka.config."log.retention.bytes" | string | `"42949672960"` | Maximum retained number of bytes for a broker's data. This is a string to avoid YAML type conversion issues for large numbers. |
 | alert-stream-broker.kafka.config."log.retention.hours" | int | `168` | Number of hours for a brokers data to be retained. |
 | alert-stream-broker.kafka.config."offsets.retention.minutes" | int | `10080` | Number of minutes for a consumer group's offsets to be retained. |

--- a/applications/alert-stream-broker/charts/alert-stream-broker/README.md
+++ b/applications/alert-stream-broker/charts/alert-stream-broker/README.md
@@ -10,7 +10,8 @@ Kafka broker cluster for distributing alerts
 | clusterName | string | `"alert-broker"` | Name of a Strimzi Kafka cluster to connect to. |
 | clusterPort | int | `9092` | Port to connect to on the Strimzi Kafka cluster. It should be an internal TLS listener. |
 | fullnameOverride | string | `""` | Override for the full name used for Kubernetes resources; by default one will be created based on the chart name and helm release name. |
-| kafka.config | object | `{"log.retention.bytes":"42949672960","log.retention.hours":168,"offsets.retention.minutes":10080}` | Configuration overrides for the Kafka server. |
+| kafka.config | object | `{"auto.create.topics.enable":"false","log.retention.bytes":"42949672960","log.retention.hours":168,"offsets.retention.minutes":10080}` | Configuration overrides for the Kafka server. |
+| kafka.config."auto.create.topics.enable" | string | `"false"` | Turns of automatic topic creation to prevent accidental topic use. |
 | kafka.config."log.retention.bytes" | string | `"42949672960"` | Maximum retained number of bytes for a broker's data. This is a string to avoid YAML type conversion issues for large numbers. |
 | kafka.config."log.retention.hours" | int | `168` | Number of hours for a brokers data to be retained. |
 | kafka.config."offsets.retention.minutes" | int | `10080` | Number of minutes for a consumer group's offsets to be retained. |

--- a/applications/alert-stream-broker/charts/alert-stream-broker/values.yaml
+++ b/applications/alert-stream-broker/charts/alert-stream-broker/values.yaml
@@ -38,6 +38,9 @@ kafka:
     # -- Maximum retained number of bytes for a broker's data. This is a string
     # to avoid YAML type conversion issues for large numbers.
     log.retention.bytes: "42949672960"
+    # -- Turns of automatic topic creation to prevent accidental topic use.
+    auto.create.topics.enable: "false"
+
 
   externalListener:
     tls:


### PR DESCRIPTION
Disable automatic topic creation so typo/unintended topics are not created in the alert stream.