### PR TITLE
DM-50668: Fix partitions and up max byte retention

### DIFF
--- a/applications/alert-stream-broker/charts/alert-stream-broker/templates/kafka-topics.yaml
+++ b/applications/alert-stream-broker/charts/alert-stream-broker/templates/kafka-topics.yaml
@@ -125,7 +125,7 @@ spec:
   config:
     cleanup.policy: "delete"
     retention.ms: {{ .Values.maxMillisecondsRetained }} # 7 days
-    retention.bytes: {{ .Values.maxBytesRetained }}
+    retention.bytes: {{ .Values.lsstcamMaxBytesRetained }}
     compression.type: {{ .Values.topicCompression }}
     # The default timestamp is the creation time of the alert.
     # To get the ingestion rate, we need this to be the log

--- a/applications/alert-stream-broker/values-usdfdev-alert-stream-broker.yaml
+++ b/applications/alert-stream-broker/values-usdfdev-alert-stream-broker.yaml
@@ -126,8 +126,9 @@ alert-stream-broker:
   comcamTopicReplicas: 1
 
   lsstcamTopicName: lsst-alerts-v7.4
-  lsstamTopicPartitions: 45
+  lsstcamTopicPartitions: 45
   lsstcamTopicReplicas: 1
+  lsstcamMaxBytesRetained: "300000000000"
 
   # Compression set to snappy to balance alert packet compression speed and size.
   topicCompression: snappy


### PR DESCRIPTION
Fix partition config so `lsst-alerts-v7.4` has 45 partitions and up the partition retention to 300 GB.