### PR TITLE
Update Prompt Processing to 6.9.0

### DIFF
--- a/applications/prompt-keda-lsstcam/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-keda-lsstcam/values-usdfprod-prompt-processing.yaml
@@ -1,7 +1,7 @@
 prompt-keda:
   image:
     pullPolicy: IfNotPresent
-    tag: 6.8.0
+    tag: 6.9.0
 
   alerts:
     username: kafka-admin

--- a/applications/prompt-keda-lsstcam/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-keda-lsstcam/values-usdfprod-prompt-processing.yaml
@@ -63,7 +63,7 @@ prompt-keda:
   apdb:
     config: s3://rubin-summit-users/apdb_config/cassandra/pp_apdb_lsstcam.yaml
 
-  logLevel: timer.lsst.activator=DEBUG timer.lsst.daf.butler=VERBOSE lsst.associateApdb=VERBOSE lsst.computeReliability=VERBOSE lsst.daf.butler=VERBOSE
+  logLevel: timer.lsst.activator=DEBUG timer.lsst.daf.butler=VERBOSE lsst.associateApdb=VERBOSE lsst.computeReliability=VERBOSE
 
   sasquatch:
     # TODO: production Sasquatch not yet ready

--- a/applications/prompt-keda-lsstcam/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-keda-lsstcam/values-usdfprod-prompt-processing.yaml
@@ -63,8 +63,7 @@ prompt-keda:
   apdb:
     config: s3://rubin-summit-users/apdb_config/cassandra/pp_apdb_lsstcam.yaml
 
-  # TODO: may need to override for debugging
-  logLevel: timer.lsst.activator=DEBUG timer.lsst.daf.butler=DEBUG lsst.associateApdb=VERBOSE lsst.computeReliability=VERBOSE lsst.daf.butler=VERBOSE
+  logLevel: timer.lsst.activator=DEBUG timer.lsst.daf.butler=VERBOSE lsst.associateApdb=VERBOSE lsst.computeReliability=VERBOSE lsst.daf.butler=VERBOSE
 
   sasquatch:
     # TODO: production Sasquatch not yet ready


### PR DESCRIPTION
This PR updates Prompt Processing and turns off the noisiest logs (in LSSTCam-prod only, for now).