### PR TITLE
DM-50710: Enable subdomain authenication on base and summit

### DIFF
--- a/applications/gafaelfawr/values-base.yaml
+++ b/applications/gafaelfawr/values-base.yaml
@@ -3,6 +3,7 @@ redis:
     storageClass: "rook-ceph-block"
 
 config:
+  allowSubdomains: true
   slackAlerts: true
   databaseUrl: "postgresql://gafaelfawr@postgresdb01.ls.lsst.org/gafaelfawr"
 

--- a/applications/gafaelfawr/values-summit.yaml
+++ b/applications/gafaelfawr/values-summit.yaml
@@ -3,6 +3,7 @@ redis:
     storageClass: "rook-ceph-block"
 
 config:
+  allowSubdomains: true
   slackAlerts: true
   databaseUrl: "postgresql://gafaelfawr@postgresdb01.cp.lsst.org/gafaelfawr"
 


### PR DESCRIPTION
HomeAssistant requires its own domain because it doesn't support hosting at a path, so we need to enable domain authentication on base and summit so that we can run HomeAssistant on a subdomain and still use Gafaelfawr authentication.