### PR TITLE
DM-50710: Add TLS for nvr-control

### DIFF
--- a/applications/nvr-control/templates/ingress.yaml
+++ b/applications/nvr-control/templates/ingress.yaml
@@ -15,6 +15,7 @@ template:
   metadata:
     name: nvr-control
     annotations:
+      cert-manager.io/cluster-issuer: "letsencrypt-dns"
       nginx.ingress.kubernetes.io/configuration-snippet: |
         proxy_set_header X-Rubin-NVR-Proxied-User operator;
       {{- with .Values.ingress.annotations }}
@@ -22,13 +23,17 @@ template:
       {{- end }}
   spec:
     rules:
-      - host: {{ required "global.host must be set" .Values.global.host }}
+      - host: "nvr.{{ required "global.host must be set" .Values.global.host }}"
         http:
           paths:
-            - path: /nvr
+            - path: /
               pathType: Prefix
               backend:
                 service:
                   name: nvr-control
                   port:
                     name: http
+    tls:
+      - hosts:
+          - "nvr.{{ .Values.global.host }}"
+        secretName: "nvr-tls"


### PR DESCRIPTION
HomeAssistant requires its own domain because it can't run on a path, so add the configuration for it to get its own TLS certificate.