### PR TITLE
Disable several detectors in next-visit-fanout due to low quality flats

### DIFF
--- a/applications/next-visit-fan-out/values-usdfprod-prompt-processing.yaml
+++ b/applications/next-visit-fan-out/values-usdfprod-prompt-processing.yaml
@@ -36,3 +36,10 @@ detectorConfig:
     # 78: False
     # 79: False
     # 80: False
+    1: False
+    19: False
+    30: False
+    68: False
+    158: False
+    169: False
+    187: False


### PR DESCRIPTION
Note: detector 120 was on this list but was already disabled.