### PR TITLE
[DM-50709] Add support for writing to multiple InfluxDB v1 instances

### DIFF
--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -590,7 +590,7 @@ Rubin Observatory's telemetry service
 | telegraf.image.repo | string | `"docker.io/library/telegraf"` | Telegraf image repository |
 | telegraf.image.tag | string | `"1.32.1-alpine"` | Telegraf image tag |
 | telegraf.imagePullSecrets | list | `[]` | Secret names to use for Docker pulls |
-| telegraf.influxdb.url | string | `"http://sasquatch-influxdb.sasquatch:8086"` | URL of the InfluxDB v1 instance to write to |
+| telegraf.influxdb.urls | list | `["http://sasquatch-influxdb.sasquatch:8086"]` | URL of the InfluxDB v1 instance to write to |
 | telegraf.kafkaConsumers.test.collection_jitter | string | "0s" | Data collection jitter. This is used to jitter the collection by a random amount. Each plugin will sleep for a random time within jitter before collecting. |
 | telegraf.kafkaConsumers.test.compression_codec | int | 3 | Compression codec. 0 : None, 1 : Gzip, 2 : Snappy, 3 : LZ4, 4 : ZSTD |
 | telegraf.kafkaConsumers.test.consumer_fetch_default | string | "20MB" | Maximum amount of data the server should return for a fetch request. |
@@ -627,7 +627,7 @@ Rubin Observatory's telemetry service
 | telegraf-oss.image.repo | string | `"docker.io/library/telegraf"` | Telegraf image repository |
 | telegraf-oss.image.tag | string | `"1.32.1-alpine"` | Telegraf image tag |
 | telegraf-oss.imagePullSecrets | list | `[]` | Secret names to use for Docker pulls |
-| telegraf-oss.influxdb.url | string | `"http://sasquatch-influxdb.sasquatch:8086"` | URL of the InfluxDB v1 instance to write to |
+| telegraf-oss.influxdb.urls | list | `["http://sasquatch-influxdb.sasquatch:8086"]` | URL of the InfluxDB v1 instance to write to |
 | telegraf-oss.kafkaConsumers.test.collection_jitter | string | "0s" | Data collection jitter. This is used to jitter the collection by a random amount. Each plugin will sleep for a random time within jitter before collecting. |
 | telegraf-oss.kafkaConsumers.test.compression_codec | int | 3 | Compression codec. 0 : None, 1 : Gzip, 2 : Snappy, 3 : LZ4, 4 : ZSTD |
 | telegraf-oss.kafkaConsumers.test.consumer_fetch_default | string | "20MB" | Maximum amount of data the server should return for a fetch request. |

--- a/applications/sasquatch/charts/telegraf/README.md
+++ b/applications/sasquatch/charts/telegraf/README.md
@@ -15,7 +15,7 @@ Telegraf is an agent for collecting, processing, aggregating, and writing metric
 | image.repo | string | `"docker.io/library/telegraf"` | Telegraf image repository |
 | image.tag | string | `"1.32.1-alpine"` | Telegraf image tag |
 | imagePullSecrets | list | `[]` | Secret names to use for Docker pulls |
-| influxdb.url | string | `"http://sasquatch-influxdb.sasquatch:8086"` | URL of the InfluxDB v1 instance to write to |
+| influxdb.urls | list | `["http://sasquatch-influxdb.sasquatch:8086"]` | URL of the InfluxDB v1 instance to write to |
 | kafkaConsumers.test.collection_jitter | string | "0s" | Data collection jitter. This is used to jitter the collection by a random amount. Each plugin will sleep for a random time within jitter before collecting. |
 | kafkaConsumers.test.compression_codec | int | 3 | Compression codec. 0 : None, 1 : Gzip, 2 : Snappy, 3 : LZ4, 4 : ZSTD |
 | kafkaConsumers.test.consumer_fetch_default | string | "20MB" | Maximum amount of data the server should return for a fetch request. |

--- a/applications/sasquatch/charts/telegraf/templates/_helpers.tpl
+++ b/applications/sasquatch/charts/telegraf/templates/_helpers.tpl
@@ -20,23 +20,24 @@ data:
       debug = {{ default false .value.debug }}
       omit_hostname = true
 
+    {{- $database := .value.database }}
+    {{- range .influxdbUrls }}
     [[outputs.influxdb]]
       namedrop = ["telegraf_*"]
-      urls = [
-        {{ .influxdbUrl | quote }}
-      ]
-      database = {{ .value.database | quote }}
+      urls = [{{ . | quote }}]
+      database = {{ $database | quote }}
       username = "${INFLUXDB_USER}"
       password = "${INFLUXDB_PASSWORD}"
+    {{ end }}
 
+    {{- range .influxdbUrls }}
     [[outputs.influxdb]]
       namepass = ["telegraf_*"]
-      urls = [
-        {{ .influxdbUrl | quote }}
-      ]
+      urls = [{{ . | quote }}]
       database = "telegraf"
       username = "${INFLUXDB_USER}"
       password = "${INFLUXDB_PASSWORD}"
+    {{ end }}
 
     [[inputs.kafka_consumer]]
       brokers = [

--- a/applications/sasquatch/charts/telegraf/templates/configmap.yaml
+++ b/applications/sasquatch/charts/telegraf/templates/configmap.yaml
@@ -1,5 +1,5 @@
 {{- range $key, $value := .Values.kafkaConsumers }}
 
-{{ include "configmap" (dict "key" $key "value" $value "influxdbUrl" $.Values.influxdb.url ) }}
+{{ include "configmap" (dict "key" $key "value" $value "influxdbUrls" $.Values.influxdb.urls ) }}
 
 {{- end }}

--- a/applications/sasquatch/charts/telegraf/values.yaml
+++ b/applications/sasquatch/charts/telegraf/values.yaml
@@ -186,7 +186,8 @@ kafkaConsumers:
 
 influxdb:
   # -- URL of the InfluxDB v1 instance to write to
-  url: "http://sasquatch-influxdb.sasquatch:8086"
+  urls:
+    - "http://sasquatch-influxdb.sasquatch:8086"
 
 # -- Kubernetes resources requests and limits
 # @default -- See `values.yaml`

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -112,7 +112,9 @@ influxdb-enterprise:
 telegraf:
   enabled: true
   influxdb:
-    url: "http://sasquatch-influxdb-enterprise-data.sasquatch:8086"
+    urls:
+      - "http://sasquatch-influxdb-enterprise-data.sasquatch:8086"
+      - "http://sasquatch-influxdb.sasquatch:8086"
   kafkaConsumers:
     example:
       enabled: true

--- a/applications/sasquatch/values-summit.yaml
+++ b/applications/sasquatch/values-summit.yaml
@@ -360,7 +360,8 @@ telegraf-oss:
 telegraf:
   enabled: true
   influxdb:
-    url: "http://sasquatch-influxdb-enterprise-data.sasquatch:8086"
+    urls:
+      - "http://sasquatch-influxdb-enterprise-data.sasquatch:8086"
   kafkaConsumers:
     # Application connectors
     obsenv:

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -272,7 +272,9 @@ influxdb-enterprise-active:
 telegraf:
   enabled: true
   influxdb:
-    url: "http://sasquatch-influxdb-enterprise-data.sasquatch:8086"
+    urls:
+      - "http://sasquatch-influxdb-enterprise-data.sasquatch:8086"
+      - "http://sasquatch-influxdb-enterprise-active-data.sasquatch:8086"
   kafkaConsumers:
     # Sasquatch backpack connector
     backpack:


### PR DESCRIPTION
To add support for writing to multiple InfluxDB v1 instances we repeat the [[outputs.influxdb]] section for each instance (rather than listing multiple URLs in a single key)
Update telegraf configuration for all environments and enable dual write at USDF prod for the current production and to the active instance.