### PR TITLE
DM-50719: Fix group access for base and summit

### DIFF
--- a/applications/argocd/values-base.yaml
+++ b/applications/argocd/values-base.yaml
@@ -10,7 +10,7 @@ argo-cd:
         requestedScopes: ["openid", "profile", "email", "groups"]
     rbac:
       policy.csv: |
-        g, k8s-manke, role:admin
+        g, k8s-manke-admins, role:admin
         g, sqre, role:admin
 
         g, rsp-bts, role:readonly

--- a/applications/argocd/values-summit.yaml
+++ b/applications/argocd/values-summit.yaml
@@ -10,7 +10,7 @@ argo-cd:
         requestedScopes: ["openid", "profile", "email", "groups"]
     rbac:
       policy.csv: |
-        g, k8s-yagan-admin, role:admin
+        g, k8s-yagan-admins, role:admin
         g, sqre, role:admin
 
         g, rsp-summit, role:readonly

--- a/applications/gafaelfawr/values-base.yaml
+++ b/applications/gafaelfawr/values-base.yaml
@@ -32,9 +32,11 @@ config:
   # Allow access by GitHub team.
   groupMapping:
     "admin:jupyterlab":
+      - "k8s-manke-admins"
       - "sqre"
     "exec:admin":
       - "integration-testers"
+      - "k8s-manke-admins"
       - "sqre"
     "exec:internal-tools":
       - "rsp-bts"
@@ -47,6 +49,7 @@ config:
     "read:tap":
       - "rsp-bts"
     "write:sasquatch":
+      - "k8s-manke-admins"
       - "sqre"
 
   initialAdmins:

--- a/applications/gafaelfawr/values-summit.yaml
+++ b/applications/gafaelfawr/values-summit.yaml
@@ -29,12 +29,12 @@ config:
   oidcServer:
     enabled: true
 
-  # Allow access by GitHub team.
   groupMapping:
     "admin:jupyterlab":
+      - "k8s-yagan-admins"
       - "sqre"
     "exec:admin":
-      - "k8s-yagan-admin"
+      - "k8s-yagan-admins"
       - "sqre"
     "exec:internal-tools":
       - "rsp-summit"
@@ -47,6 +47,7 @@ config:
     "read:tap":
       - "rsp-summit"
     "write:sasquatch":
+      - "k8s-yagan-admins"
       - "sqre"
 
   initialAdmins:


### PR DESCRIPTION
Add k8s-manke-admins and k8s-yagan-admins to the Gafaelfawr role configuration on base and summit, respectively, and fix the name of the groups for Argo CD access at base and summit.