### PR TITLE
DM-46313: Update Times Square

### DIFF
--- a/applications/noteburst/Chart.yaml
+++ b/applications/noteburst/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: noteburst
 version: 1.0.0
-appVersion: "0.18.0"
+appVersion: "0.19.0"
 description: Noteburst is a notebook execution service for the Rubin Science Platform.
 type: application
 home: https://noteburst.lsst.io/

--- a/applications/noteburst/README.md
+++ b/applications/noteburst/README.md
@@ -30,7 +30,7 @@ Noteburst is a notebook execution service for the Rubin Science Platform.
 | config.worker.identities | list | `[]` | Science Platform user identities that workers can acquire. Each item is an object with username and uuid keys |
 | config.worker.imageReference | string | `""` | Nublado image reference, applicable when imageSelector is "reference" |
 | config.worker.imageSelector | string | `"recommended"` | Nublado image stream to select: "recommended", "weekly" or "reference" |
-| config.worker.jobTimeout | int | `300` | The default notebook execution timeout, in seconds. |
+| config.worker.jobTimeout | int | `300` | The maximum allowed notebook execution time, in seconds. |
 | config.worker.keepAlive | string | `"hourly"` | Worker keep alive mode: "normal", "fast", "hourly", "daily", "disabled" |
 | config.worker.maxConcurrentJobs | int | `1` | Max number of concurrent notebook executions per worker |
 | config.worker.tokenLifetime | string | `"2419200"` | Worker token lifetime, in seconds. |

--- a/applications/noteburst/README.md
+++ b/applications/noteburst/README.md
@@ -31,7 +31,7 @@ Noteburst is a notebook execution service for the Rubin Science Platform.
 | config.worker.imageReference | string | `""` | Nublado image reference, applicable when imageSelector is "reference" |
 | config.worker.imageSelector | string | `"recommended"` | Nublado image stream to select: "recommended", "weekly" or "reference" |
 | config.worker.jobTimeout | int | `300` | The default notebook execution timeout, in seconds. |
-| config.worker.keepAlive | string | `"normal"` | Worker keep alive mode: "normal", "fast", "disabled" |
+| config.worker.keepAlive | string | `"hourly"` | Worker keep alive mode: "normal", "fast", "hourly", "daily", "disabled" |
 | config.worker.maxConcurrentJobs | int | `1` | Max number of concurrent notebook executions per worker |
 | config.worker.tokenLifetime | string | `"2419200"` | Worker token lifetime, in seconds. |
 | config.worker.tokenScopes | string | `"exec:notebook,read:image,read:tap,read:alertdb"` | Nublado2 worker account's token scopes as a comma-separated list. |

--- a/applications/noteburst/values-idfdev.yaml
+++ b/applications/noteburst/values-idfdev.yaml
@@ -10,7 +10,6 @@ config:
     tracesSampleRate: 1
   worker:
     workerCount: 1
-    jobTimeout: 600
     identities:
       - username: "bot-noteburst90000"
       - username: "bot-noteburst90001"

--- a/applications/noteburst/values-idfdev.yaml
+++ b/applications/noteburst/values-idfdev.yaml
@@ -10,6 +10,7 @@ config:
     tracesSampleRate: 1
   worker:
     workerCount: 1
+    jobTimeout: 600
     identities:
       - username: "bot-noteburst90000"
       - username: "bot-noteburst90001"

--- a/applications/noteburst/values.yaml
+++ b/applications/noteburst/values.yaml
@@ -170,8 +170,8 @@ config:
     # -- Nublado image reference, applicable when imageSelector is "reference"
     imageReference: ""
 
-    # -- Worker keep alive mode: "normal", "fast", "disabled"
-    keepAlive: "normal"
+    # -- Worker keep alive mode: "normal", "fast", "hourly", "daily", "disabled"
+    keepAlive: "hourly"
 
 redis:
   persistence:

--- a/applications/noteburst/values.yaml
+++ b/applications/noteburst/values.yaml
@@ -152,7 +152,7 @@ config:
     # -- Number of workers to run
     workerCount: 1
 
-    # -- The default notebook execution timeout, in seconds.
+    # -- The maximum allowed notebook execution time, in seconds.
     jobTimeout: 300
 
     # -- Max number of concurrent notebook executions per worker

--- a/applications/times-square/Chart.yaml
+++ b/applications/times-square/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 type: application
 
 # The default version tag of the times-square docker image
-appVersion: "0.18.1"
+appVersion: "0.19.0"
 
 dependencies:
   - name: redis

--- a/applications/times-square/README.md
+++ b/applications/times-square/README.md
@@ -26,7 +26,7 @@ An API service for managing and rendering parameterized Jupyter notebooks.
 | config.defaultExecutionTimeout | string | `"300"` | Default execution timeout for notebooks in seconds |
 | config.enableGitHubApp | string | `"False"` | Toggle to enable the GitHub App functionality |
 | config.githubAppId | string | `""` | GitHub application ID |
-| config.githubCheckRunTimeout | string | `"900"` | Timeout for GitHub check runs in seconds |
+| config.githubCheckRunTimeout | string | `"3600"` | Timeout for GitHub check runs in seconds |
 | config.githubOrgs | string | `"lsst,lsst-sqre,lsst-dm,lsst-ts,lsst-sitcom,lsst-pst"` | GitHub organizations that can sync repos to Times Square (comma-separated). |
 | config.htmlKeyMigration.dryRun | bool | `true` | Whether to run the HTML key migration job as a dry-run only |
 | config.htmlKeyMigration.enabled | bool | `false` |  |

--- a/applications/times-square/README.md
+++ b/applications/times-square/README.md
@@ -37,7 +37,7 @@ An API service for managing and rendering parameterized Jupyter notebooks.
 | config.redisCacheUrl | string | Points to embedded Redis | URL for Redis html / noteburst job cache database |
 | config.redisQueueUrl | string | Points to embedded Redis | URL for Redis arq queue database |
 | config.sentryTracesSampleRate | float | `0` |  |
-| config.updateSchema | bool | false to disable schema upgrades | Whether to run the database migration job |
+| config.updateSchema | string | false to disable schema upgrades | Whether to run the database migration job |
 | config.worker.enableLivenessCheck | bool | `true` | Enable liveness checks for the arq queue |
 | fullnameOverride | string | `""` | Override the full name for resources (includes the release name) |
 | global.baseUrl | string | Set by times-square Argo CD Application | Base URL for the environment |

--- a/applications/times-square/values-idfdev.yaml
+++ b/applications/times-square/values-idfdev.yaml
@@ -8,7 +8,7 @@ config:
   updateSchema: "True"
   githubAppId: "196798"
   enableGitHubApp: "True"
-  githubCheckRunTimeout: "600" # 10 minutes
+  githubCheckRunTimeout: "3600" # 60 minutes
   defaultExecutionTimeout: "60" # 1 minute
   sentryTracesSampleRate: 1
 cloudsql:

--- a/applications/times-square/values-idfdev.yaml
+++ b/applications/times-square/values-idfdev.yaml
@@ -8,8 +8,7 @@ config:
   updateSchema: "True"
   githubAppId: "196798"
   enableGitHubApp: "True"
-  githubCheckRunTimeout: "3600" # 60 minutes
-  defaultExecutionTimeout: "60" # 1 minute
+  githubCheckRunTimeout: "900" # 15 minutes
   sentryTracesSampleRate: 1
 cloudsql:
   enabled: true

--- a/applications/times-square/values-idfdev.yaml
+++ b/applications/times-square/values-idfdev.yaml
@@ -5,7 +5,6 @@ ingress:
 config:
   logLevel: "DEBUG"
   databaseUrl: "postgresql://times-square@localhost/times-square"
-  updateSchema: "True"
   githubAppId: "196798"
   enableGitHubApp: "True"
   githubCheckRunTimeout: "900" # 15 minutes

--- a/applications/times-square/values-idfdev.yaml
+++ b/applications/times-square/values-idfdev.yaml
@@ -5,6 +5,7 @@ ingress:
 config:
   logLevel: "DEBUG"
   databaseUrl: "postgresql://times-square@localhost/times-square"
+  updateSchema: "True"
   githubAppId: "196798"
   enableGitHubApp: "True"
   githubCheckRunTimeout: "600" # 10 minutes

--- a/applications/times-square/values.yaml
+++ b/applications/times-square/values.yaml
@@ -121,7 +121,7 @@ config:
 
   # -- Whether to run the database migration job
   # @default -- false to disable schema upgrades
-  updateSchema: false
+  updateSchema: "true"
 
   # -- URL for Redis html / noteburst job cache database
   # @default -- Points to embedded Redis

--- a/applications/times-square/values.yaml
+++ b/applications/times-square/values.yaml
@@ -121,7 +121,7 @@ config:
 
   # -- Whether to run the database migration job
   # @default -- false to disable schema upgrades
-  updateSchema: "true"
+  updateSchema: "false"
 
   # -- URL for Redis html / noteburst job cache database
   # @default -- Points to embedded Redis

--- a/applications/times-square/values.yaml
+++ b/applications/times-square/values.yaml
@@ -141,7 +141,7 @@ config:
   githubOrgs: "lsst,lsst-sqre,lsst-dm,lsst-ts,lsst-sitcom,lsst-pst"
 
   # -- Timeout for GitHub check runs in seconds
-  githubCheckRunTimeout: "900" # 15 minutes
+  githubCheckRunTimeout: "3600" # 1 hour
 
   # -- Default execution timeout for notebooks in seconds
   defaultExecutionTimeout: "300" # 5 minutes


### PR DESCRIPTION
Deployment of Times Square 0.19.0 and Noteburst 0.19.0. The Times Square deployment includes a schema migration.