### PR TITLE
Allow direct, non-portal ingress to s3proxy.

### DIFF
--- a/applications/s3proxy/templates/ingress.yaml
+++ b/applications/s3proxy/templates/ingress.yaml
@@ -8,8 +8,6 @@ config:
   authCacheDuration: 5m
   baseUrl: {{ .Values.global.baseUrl | quote }}
   loginRedirect: true
-  onlyServices:
-    - portal
   scopes:
     all:
       - "read:image"


### PR DESCRIPTION
This allows it to be used to serve images to authenticated users beyond the portal.