### PR TITLE
Add a separate connector for lsst.sal.MTM1M3TS

### DIFF
--- a/applications/sasquatch/values-summit.yaml
+++ b/applications/sasquatch/values-summit.yaml
@@ -205,10 +205,19 @@ telegraf-oss:
       debug: true
     oss-m1m3:
       enabled: true
-      metric_batch_size: 2500
+      metric_batch_size: 1500
+      max_undelivered_messages: 4000
       database: "efd"
       topicRegexps: |
-        [ "lsst.sal.MTM1M3" ]
+        [ "lsst.sal.MTM1M3([^T].*)" ]
+      debug: true
+    oss-m1m3ts:
+      enabled: true
+      metric_batch_size: 1500
+      max_undelivered_messages: 4000
+      database: "efd"
+      topicRegexps: |
+        [ "lsst.sal.MTM1M3TS" ]
       debug: true
     oss-m2:
       enabled: true
@@ -425,7 +434,7 @@ telegraf:
       offset: newest
     m1m3:
       enabled: true
-      metric_batch_size: 2500
+      metric_batch_size: 2000
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.MTM1M3" ]


### PR DESCRIPTION
- Adjust metric_batch_size and max_undelivered_messages configuration to avoid the "context deadline exceeded (Client.Timeout exceeded while awaiting headers)" error in the InfluxDB OSS instance.