### PR TITLE
DM-50728: Bump Qserv Kafka bridge memory again

### DIFF
--- a/applications/qserv-kafka/values.yaml
+++ b/applications/qserv-kafka/values.yaml
@@ -171,10 +171,10 @@ resultWorker:
   resources:
     limits:
       cpu: "1"
-      memory: "400Mi"
+      memory: "600Mi"
     requests:
       cpu: "1"
-      memory: "125Mi"
+      memory: "300Mi"
 
   # -- Tolerations for the qserv-kafka worker pods
   tolerations: []


### PR DESCRIPTION
The new release seems to use more memory in the steady state, so increase the memory requests and limits again.