### PR TITLE
DM-50858: Add global.environmentName to app template

### DIFF
--- a/docs/developers/injected-values.rst
+++ b/docs/developers/injected-values.rst
@@ -29,6 +29,9 @@ However, by convention and via :command:`phalanx application create`, Phalanx ap
     The base URL for applications deployed in this Phalanx environment.
     This always uses the ``https://`` schema.
 
+``global.environmentName``
+    The name of this Phalanx environment.
+
 ``global.vaultSecretsPath``
     The base path in Vault for secrets for this environment.
     The Vault path for a secret for a given application can be formed by appending :samp:`/{application}` to this value.

--- a/src/phalanx/data/application-template.yaml.jinja
+++ b/src/phalanx/data/application-template.yaml.jinja
@@ -26,6 +26,8 @@ spec:
           value: {{ .Values.fqdn | quote }}
         - name: "global.baseUrl"
           value: "https://{{ .Values.fqdn }}"
+        - name: "global.environmentName"
+          value: {{ .Values.name | quote }}
         - name: "global.vaultSecretsPath"
           value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:

--- a/src/phalanx/services/application.py
+++ b/src/phalanx/services/application.py
@@ -278,6 +278,7 @@ class ApplicationService:
             "global.enabledServices": "@" + "@".join(enabled_apps),
             "global.host": environment.fqdn,
             "global.baseUrl": f"https://{environment.fqdn}",
+            "global.environmentName": environment.name,
             "global.vaultSecretsPath": environment.vault_path_prefix,
         }
         if environment.gcp:

--- a/tests/data/output/idfdev/lint-all-calls.json
+++ b/tests/data/output/idfdev/lint-all-calls.json
@@ -38,7 +38,7 @@
     "--values",
     "argocd/values-idfdev.yaml",
     "--set",
-    "global.enabledServices=@argocd@gafaelfawr@mobu@nublado@portal@postgres,global.host=data-dev.lsst.cloud,global.baseUrl=https://data-dev.lsst.cloud,global.vaultSecretsPath=secret/phalanx/idfdev,global.gcpProjectId=science-platform-dev-7696,global.gcpRegion=us-central1"
+    "global.enabledServices=@argocd@gafaelfawr@mobu@nublado@portal@postgres,global.host=data-dev.lsst.cloud,global.baseUrl=https://data-dev.lsst.cloud,global.environmentName=idfdev,global.vaultSecretsPath=secret/phalanx/idfdev,global.gcpProjectId=science-platform-dev-7696,global.gcpRegion=us-central1"
   ],
   [
     "lint",
@@ -49,7 +49,7 @@
     "--values",
     "argocd/values-minikube.yaml",
     "--set",
-    "global.enabledServices=@argocd@gafaelfawr@mobu@postgres,global.host=minikube.lsst.cloud,global.baseUrl=https://minikube.lsst.cloud,global.vaultSecretsPath=secret/phalanx/minikube"
+    "global.enabledServices=@argocd@gafaelfawr@mobu@postgres,global.host=minikube.lsst.cloud,global.baseUrl=https://minikube.lsst.cloud,global.environmentName=minikube,global.vaultSecretsPath=secret/phalanx/minikube"
   ],
   [
     "lint",
@@ -60,7 +60,7 @@
     "--values",
     "argocd/values-usdfdev-prompt-processing.yaml",
     "--set",
-    "global.enabledServices=@argocd,global.host=usdf-prompt-processing-dev.slac.stanford.edu,global.baseUrl=https://usdf-prompt-processing-dev.slac.stanford.edu,global.vaultSecretsPath=secret/rubin/usdf-prompt-processing-dev"
+    "global.enabledServices=@argocd,global.host=usdf-prompt-processing-dev.slac.stanford.edu,global.baseUrl=https://usdf-prompt-processing-dev.slac.stanford.edu,global.environmentName=usdfdev-prompt-processing,global.vaultSecretsPath=secret/rubin/usdf-prompt-processing-dev"
   ],
   [
     "dependency",
@@ -76,7 +76,7 @@
     "--values",
     "gafaelfawr/values-idfdev.yaml",
     "--set",
-    "global.enabledServices=@argocd@gafaelfawr@mobu@nublado@portal@postgres,global.host=data-dev.lsst.cloud,global.baseUrl=https://data-dev.lsst.cloud,global.vaultSecretsPath=secret/phalanx/idfdev,global.gcpProjectId=science-platform-dev-7696,global.gcpRegion=us-central1"
+    "global.enabledServices=@argocd@gafaelfawr@mobu@nublado@portal@postgres,global.host=data-dev.lsst.cloud,global.baseUrl=https://data-dev.lsst.cloud,global.environmentName=idfdev,global.vaultSecretsPath=secret/phalanx/idfdev,global.gcpProjectId=science-platform-dev-7696,global.gcpRegion=us-central1"
   ],
   [
     "lint",
@@ -87,7 +87,7 @@
     "--values",
     "gafaelfawr/values-minikube.yaml",
     "--set",
-    "global.enabledServices=@argocd@gafaelfawr@mobu@postgres,global.host=minikube.lsst.cloud,global.baseUrl=https://minikube.lsst.cloud,global.vaultSecretsPath=secret/phalanx/minikube"
+    "global.enabledServices=@argocd@gafaelfawr@mobu@postgres,global.host=minikube.lsst.cloud,global.baseUrl=https://minikube.lsst.cloud,global.environmentName=minikube,global.vaultSecretsPath=secret/phalanx/minikube"
   ],
   [
     "dependency",
@@ -103,7 +103,7 @@
     "--values",
     "nublado/values-idfdev.yaml",
     "--set",
-    "global.enabledServices=@argocd@gafaelfawr@mobu@nublado@portal@postgres,global.host=data-dev.lsst.cloud,global.baseUrl=https://data-dev.lsst.cloud,global.vaultSecretsPath=secret/phalanx/idfdev,global.gcpProjectId=science-platform-dev-7696,global.gcpRegion=us-central1"
+    "global.enabledServices=@argocd@gafaelfawr@mobu@nublado@portal@postgres,global.host=data-dev.lsst.cloud,global.baseUrl=https://data-dev.lsst.cloud,global.environmentName=idfdev,global.vaultSecretsPath=secret/phalanx/idfdev,global.gcpProjectId=science-platform-dev-7696,global.gcpRegion=us-central1"
   ],
   [
     "dependency",
@@ -119,7 +119,7 @@
     "--values",
     "portal/values-idfdev.yaml",
     "--set",
-    "global.enabledServices=@argocd@gafaelfawr@mobu@nublado@portal@postgres,global.host=data-dev.lsst.cloud,global.baseUrl=https://data-dev.lsst.cloud,global.vaultSecretsPath=secret/phalanx/idfdev,global.gcpProjectId=science-platform-dev-7696,global.gcpRegion=us-central1"
+    "global.enabledServices=@argocd@gafaelfawr@mobu@nublado@portal@postgres,global.host=data-dev.lsst.cloud,global.baseUrl=https://data-dev.lsst.cloud,global.environmentName=idfdev,global.vaultSecretsPath=secret/phalanx/idfdev,global.gcpProjectId=science-platform-dev-7696,global.gcpRegion=us-central1"
   ],
   [
     "dependency",
@@ -135,7 +135,7 @@
     "--values",
     "postgres/values-idfdev.yaml",
     "--set",
-    "global.enabledServices=@argocd@gafaelfawr@mobu@nublado@portal@postgres,global.host=data-dev.lsst.cloud,global.baseUrl=https://data-dev.lsst.cloud,global.vaultSecretsPath=secret/phalanx/idfdev,global.gcpProjectId=science-platform-dev-7696,global.gcpRegion=us-central1"
+    "global.enabledServices=@argocd@gafaelfawr@mobu@nublado@portal@postgres,global.host=data-dev.lsst.cloud,global.baseUrl=https://data-dev.lsst.cloud,global.environmentName=idfdev,global.vaultSecretsPath=secret/phalanx/idfdev,global.gcpProjectId=science-platform-dev-7696,global.gcpRegion=us-central1"
   ],
   [
     "lint",
@@ -146,6 +146,6 @@
     "--values",
     "postgres/values-minikube.yaml",
     "--set",
-    "global.enabledServices=@argocd@gafaelfawr@mobu@postgres,global.host=minikube.lsst.cloud,global.baseUrl=https://minikube.lsst.cloud,global.vaultSecretsPath=secret/phalanx/minikube"
+    "global.enabledServices=@argocd@gafaelfawr@mobu@postgres,global.host=minikube.lsst.cloud,global.baseUrl=https://minikube.lsst.cloud,global.environmentName=minikube,global.vaultSecretsPath=secret/phalanx/minikube"
   ]
 ]

--- a/tests/data/output/idfdev/lint-git-calls.json
+++ b/tests/data/output/idfdev/lint-git-calls.json
@@ -31,7 +31,7 @@
     "--values",
     "argocd/values-idfdev.yaml",
     "--set",
-    "global.enabledServices=@argocd@gafaelfawr@mobu@nublado@portal@postgres,global.host=data-dev.lsst.cloud,global.baseUrl=https://data-dev.lsst.cloud,global.vaultSecretsPath=secret/phalanx/idfdev,global.gcpProjectId=science-platform-dev-7696,global.gcpRegion=us-central1"
+    "global.enabledServices=@argocd@gafaelfawr@mobu@nublado@portal@postgres,global.host=data-dev.lsst.cloud,global.baseUrl=https://data-dev.lsst.cloud,global.environmentName=idfdev,global.vaultSecretsPath=secret/phalanx/idfdev,global.gcpProjectId=science-platform-dev-7696,global.gcpRegion=us-central1"
   ],
   [
     "dependency",
@@ -47,7 +47,7 @@
     "--values",
     "gafaelfawr/values-idfdev.yaml",
     "--set",
-    "global.enabledServices=@argocd@gafaelfawr@mobu@nublado@portal@postgres,global.host=data-dev.lsst.cloud,global.baseUrl=https://data-dev.lsst.cloud,global.vaultSecretsPath=secret/phalanx/idfdev,global.gcpProjectId=science-platform-dev-7696,global.gcpRegion=us-central1"
+    "global.enabledServices=@argocd@gafaelfawr@mobu@nublado@portal@postgres,global.host=data-dev.lsst.cloud,global.baseUrl=https://data-dev.lsst.cloud,global.environmentName=idfdev,global.vaultSecretsPath=secret/phalanx/idfdev,global.gcpProjectId=science-platform-dev-7696,global.gcpRegion=us-central1"
   ],
   [
     "lint",
@@ -58,7 +58,7 @@
     "--values",
     "gafaelfawr/values-minikube.yaml",
     "--set",
-    "global.enabledServices=@argocd@gafaelfawr@mobu@postgres,global.host=minikube.lsst.cloud,global.baseUrl=https://minikube.lsst.cloud,global.vaultSecretsPath=secret/phalanx/minikube"
+    "global.enabledServices=@argocd@gafaelfawr@mobu@postgres,global.host=minikube.lsst.cloud,global.baseUrl=https://minikube.lsst.cloud,global.environmentName=minikube,global.vaultSecretsPath=secret/phalanx/minikube"
   ],
   [
     "dependency",
@@ -74,6 +74,6 @@
     "--values",
     "portal/values-idfdev.yaml",
     "--set",
-    "global.enabledServices=@argocd@gafaelfawr@mobu@nublado@portal@postgres,global.host=data-dev.lsst.cloud,global.baseUrl=https://data-dev.lsst.cloud,global.vaultSecretsPath=secret/phalanx/idfdev,global.gcpProjectId=science-platform-dev-7696,global.gcpRegion=us-central1"
+    "global.enabledServices=@argocd@gafaelfawr@mobu@nublado@portal@postgres,global.host=data-dev.lsst.cloud,global.baseUrl=https://data-dev.lsst.cloud,global.environmentName=idfdev,global.vaultSecretsPath=secret/phalanx/idfdev,global.gcpProjectId=science-platform-dev-7696,global.gcpRegion=us-central1"
   ]
 ]

--- a/tests/data/output/idfdev/lint-set-values.json
+++ b/tests/data/output/idfdev/lint-set-values.json
@@ -2,6 +2,7 @@
   "global.enabledServices=@argocd@gafaelfawr@mobu@nublado@portal@postgres",
   "global.host=data-dev.lsst.cloud",
   "global.baseUrl=https://data-dev.lsst.cloud",
+  "global.environmentName=idfdev",
   "global.vaultSecretsPath=secret/phalanx/idfdev",
   "global.gcpProjectId=science-platform-dev-7696",
   "global.gcpRegion=us-central1"


### PR DESCRIPTION
Currently this used by some apps to provide the environment name as the `SENTRY_ENVIRONMENT` variable, but it could be useful for other things.