### PR TITLE
DM-50615: Data Transfer Monitoring Kafka User

### DIFF
--- a/applications/sasquatch/Chart.yaml
+++ b/applications/sasquatch/Chart.yaml
@@ -87,6 +87,9 @@ dependencies:
   - name: consdb
     condition: consdb.enabled
     version: 1.0.0
+  - name: data-transfer-monitoring
+    condition: data-transfer-monitoring.enabled
+    version: 1.0.0
 
 annotations:
   phalanx.lsst.io/docs: |

--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -42,6 +42,7 @@ Rubin Observatory's telemetry service
 | customInfluxDBIngress.enabled | bool | `false` | Whether to enable the custom ingress for InfluxDB OSS |
 | customInfluxDBIngress.hostname | string | None, must be set if the ingress is enabled | Hostname of the ingress |
 | customInfluxDBIngress.path | string | `"/influxdb(/\|$)(.*)"` | Path for the ingress |
+| data-transfer-monitoring.enabled | bool | `false` | Whether to enable the data-transfer-monitoring subchart |
 | influxdb-enterprise-active.enabled | bool | `false` | Whether to enable influxdb-enterprise-active |
 | influxdb-enterprise-standby.enabled | bool | `false` | Whether to enable influxdb-enterprise-standby |
 | influxdb-enterprise.enabled | bool | `false` | Whether to enable influxdb-enterprise |
@@ -141,6 +142,7 @@ Rubin Observatory's telemetry service
 | consdb.cluster.name | string | `"sasquatch"` | Name of the Strimzi cluster. Synchronize this with the cluster name in the parent Sasquatch chart. |
 | control-system.cluster.name | string | `"sasquatch"` | Name of the Strimzi cluster. Synchronize this with the cluster name in the parent Sasquatch chart. |
 | control-system.topics | list | `[]` | Create lsst.s3.* related topics for the ts-salkafka user. |
+| data-transfer-monitoring.cluster.name | string | `"sasquatch"` | Name of the Strimzi cluster. Synchronize this with the cluster name in the parent Sasquatch chart. |
 | influxdb-enterprise.bootstrap.auth.secretName | string | `"sasquatch"` | Enable authentication of the data nodes using this secret, by creating a username and password for an admin account. The secret must contain keys `username` and `password`. |
 | influxdb-enterprise.bootstrap.ddldml.configMap | string | Do not run DDL or DML | A config map containing DDL and DML that define databases, retention policies, and inject some data.  The keys `ddl` and `dml` must exist, even if one of them is empty.  DDL is executed before DML to ensure databases and retention policies exist. |
 | influxdb-enterprise.bootstrap.ddldml.resources | object | `{}` | Kubernetes resources and limits for the bootstrap job |

--- a/applications/sasquatch/charts/data-transfer-monitoring/Chart.yaml
+++ b/applications/sasquatch/charts/data-transfer-monitoring/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: data-transfer-monitoring
+version: 1.0.0
+description: Sasquatch configuration for Data Transfer Monitoring
+type: application

--- a/applications/sasquatch/charts/data-transfer-monitoring/README.md
+++ b/applications/sasquatch/charts/data-transfer-monitoring/README.md
@@ -1,0 +1,9 @@
+# data-transfer-monitoring
+
+Sasquatch configuration for Data Transfer Monitoring
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| cluster.name | string | `"sasquatch"` | Name of the Strimzi cluster. Synchronize this with the cluster name in the parent Sasquatch chart. |

--- a/applications/sasquatch/charts/data-transfer-monitoring/templates/kafka-users.yaml
+++ b/applications/sasquatch/charts/data-transfer-monitoring/templates/kafka-users.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaUser
+metadata:
+  name: data-transfer-monitoring
+  labels:
+    strimzi.io/cluster: {{ .Values.cluster.name }}
+spec:
+  authentication:
+    type: scram-sha-512
+    password:
+      valueFrom:
+        secretKeyRef:
+          name: sasquatch
+          key: data-transfer-monitoring-password
+  authorization:
+    type: simple
+    acls:
+      - resource:
+          type: group
+          name: "*"
+          patternType: literal
+        operations:
+          - All
+      - resource:
+          type: topic
+          name: "lsst.sal.MTCamera.logevent_endReadout"
+          patternType: literal
+        type: allow
+        host: "*"
+        operations:
+          - Read
+          - Describe

--- a/applications/sasquatch/charts/data-transfer-monitoring/values.yaml
+++ b/applications/sasquatch/charts/data-transfer-monitoring/values.yaml
@@ -1,0 +1,6 @@
+## Default values.yaml for the Data Transfer Monitoring subchart
+
+cluster:
+  # -- Name of the Strimzi cluster. Synchronize this with the cluster name in
+  # the parent Sasquatch chart.
+  name: sasquatch

--- a/applications/sasquatch/values-summit.yaml
+++ b/applications/sasquatch/values-summit.yaml
@@ -654,3 +654,6 @@ consdb:
 
 prompt-processing:
   enabled: true
+
+data-transfer-monitoring:
+  enabled: true

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -501,3 +501,6 @@ prompt-processing:
 
 consdb:
   enabled: true
+
+data-transfer-monitoring:
+  enabled: true

--- a/applications/sasquatch/values.yaml
+++ b/applications/sasquatch/values.yaml
@@ -350,6 +350,10 @@ consdb:
   # -- Whether to enable the consdb subchart
   enabled: false
 
+data-transfer-monitoring:
+  # -- Whether to enable the data-transfer-monitoring subchart
+  enabled: false
+
 global:
   # -- Base URL for the environment
   # @default -- Set by Argo CD


### PR DESCRIPTION
Add `data-transfer-monitoring` Kafka user to allow read access to the `lsst.sal.MTCamera.logevent_endReadout` topic to view end readout events.  This is used to create metrics of file transfers from the Summit by combining data from the Kafka file notifications.  The `data-transfer-monitoring` user is enabled at Summit and USDF.  Summit will be used for primary connectivity.