### PR TITLE
DM-50846: Support OCI repos in the Phalanx CLI

### DIFF
--- a/src/phalanx/storage/config.py
+++ b/src/phalanx/storage/config.py
@@ -300,7 +300,7 @@ class ConfigStorage:
         for dependency in chart.get("dependencies", []):
             if "repository" in dependency:
                 repository = dependency["repository"]
-                if not repository.startswith("file:"):
+                if not repository.startswith(("file:", "oci:")):
                     repo_urls.add(repository)
         return repo_urls
 


### PR DESCRIPTION
[`helm repo` commands aren't supported for OCI repos](https://github.com/helm/helm/issues/10565#issuecomment-1015531100).

Without this, I can't `phalanx application template` an app with a helm dependency from an OCI registry, like:

```
- name: "grafana-operator"
  repository: "oci://ghcr.io/grafana/helm-charts"
  version: "v5.17.1"
```

I'm not sure if there's anywhere else in the Phalanx CLI code we need to modify to account for this.