### PR TITLE
DM-50879: Tweak scaling configuration for Qserv Kafka bridge

### DIFF
--- a/applications/qserv-kafka/templates/worker-hpa.yaml
+++ b/applications/qserv-kafka/templates/worker-hpa.yaml
@@ -6,12 +6,11 @@ metadata:
   labels:
     {{- include "qserv-kafka.labels" . | nindent 4 }}
 spec:
-  scaleTargetRef:
-    apiVersion: "apps/v1"
-    kind: "Deployment"
-    name: "qserv-kafka-worker"
-  minReplicas: {{ .Values.resultWorker.autoscaling.minReplicas }}
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 900
   maxReplicas: {{ .Values.resultWorker.autoscaling.maxReplicas }}
+  minReplicas: {{ .Values.resultWorker.autoscaling.minReplicas }}
   metrics:
     {{- if .Values.resultWorker.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
@@ -21,4 +20,8 @@ spec:
           type: Utilization
           averageUtilization: {{ .Values.resultWorker.autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
+  scaleTargetRef:
+    apiVersion: "apps/v1"
+    kind: "Deployment"
+    name: "qserv-kafka-worker"
 {{- end }}

--- a/applications/qserv-kafka/values-idfint.yaml
+++ b/applications/qserv-kafka/values-idfint.yaml
@@ -3,4 +3,5 @@ config:
   qservDatabaseUrl: "mysql+asyncmy://qsmaster@qserv-int.slac.stanford.edu:4090/"
   qservRestUrl: "https://qserv-int-https.slac.stanford.edu:4098/"
 resultWorker:
-  maxReplicas: 50
+  autoscaling:
+    maxReplicas: 50


### PR DESCRIPTION
Set a stabilization window of 15 minutes for scaledown, since we were scaling down a bit too quickly. Fix the configuration of the maximum number of replicas on idfint.