### PR TITLE
[DM-50887] Review InfluxDB OSS query limits for the USDF dev environment

### DIFF
--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -68,7 +68,7 @@ Rubin Observatory's telemetry service
 | influxdb.ingress.path | string | `"/influxdb(/\|$)(.*)"` | Path for the ingress |
 | influxdb.ingress.tls | bool | `false` | Whether to obtain TLS certificates for the ingress hostname |
 | influxdb.initScripts.enabled | bool | `false` | Whether to enable the InfluxDB custom initialization script |
-| influxdb.livenessProbe.initialDelaySeconds | int | `90` | Liveness probe initial delay in seconds |
+| influxdb.livenessProbe.initialDelaySeconds | int | `180` | Liveness probe initial delay in seconds |
 | influxdb.persistence.enabled | bool | `true` | Whether to use persistent volume claims. By default, `storageClass` is undefined, choosing the default provisioner (standard on GKE). |
 | influxdb.persistence.size | string | 1TiB for teststand deployments | Persistent volume size |
 | influxdb.resources | object | See `values.yaml` | Kubernetes resource requests and limits |

--- a/applications/sasquatch/values-usdfdev.yaml
+++ b/applications/sasquatch/values-usdfdev.yaml
@@ -53,6 +53,9 @@ influxdb:
 customInfluxDBIngress:
   enabled: true
   hostname: usdf-rsp-dev.slac.stanford.edu
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
 
 kafka-connect-manager:
   enabled: true

--- a/applications/sasquatch/values-usdfdev.yaml
+++ b/applications/sasquatch/values-usdfdev.yaml
@@ -45,6 +45,10 @@ influxdb:
   persistence:
     enabled: true
     size: 15Ti
+  config:
+    coordinator:
+      query-timeout: 300s
+
 
 customInfluxDBIngress:
   enabled: true

--- a/applications/sasquatch/values.yaml
+++ b/applications/sasquatch/values.yaml
@@ -40,7 +40,7 @@ influxdb:
 
   livenessProbe:
     # -- Liveness probe initial delay in seconds
-    initialDelaySeconds: 90
+    initialDelaySeconds: 180
 
   persistence:
     # -- Whether to use persistent volume claims. By default, `storageClass`


### PR DESCRIPTION
A query limit of 15s was introduced in a commit in January as an attempt to control a behavior we observed at the Summit dashboards that still use InfluxDB OSS, and it leaked to the USDF dev configuration.
Using the same query timeout as in USDF prod, which is 300s and setting the nginx proxy timeout to the same value.
The database is taking longer to initialize so increasing initialDelaySeconds to 180s.
