### PR TITLE
DM-50909: Prompt Processing uses inconsistent container names

### DIFF
--- a/charts/prompt-keda/templates/_service-init.tpl
+++ b/charts/prompt-keda/templates/_service-init.tpl
@@ -23,7 +23,7 @@ spec:
       containers:
       - image: "{{ .Values.initializer.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
-        name: user-container
+        name: {{ include "prompt-keda.fullname" . | trimPrefix "prompt-keda-" }}
         env:
         - name: RUBIN_INSTRUMENT
           value: {{ .Values.instrument.name }}

--- a/charts/prompt-keda/templates/scaled-job.yaml
+++ b/charts/prompt-keda/templates/scaled-job.yaml
@@ -38,7 +38,7 @@ spec:
                 name: db-auth-credentials-file
         restartPolicy: Never
         containers:
-          - name: {{ .Values.instrument.name | lower }}
+          - name: {{ include "prompt-keda.fullname" . | trimPrefix "prompt-keda-" }}
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
             imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
             command:


### PR DESCRIPTION
This PR standardizes the Keda Prompt Processing container names to match the service name and each other. This makes the logs much easier to query in Grafana.