### PR TITLE
DM-50878: Add metrics events for qserv-kafka

### DIFF
--- a/applications/qserv-kafka/Chart.yaml
+++ b/applications/qserv-kafka/Chart.yaml
@@ -5,7 +5,7 @@ version: 1.0.0
 description: "Qserv Kafka bridge"
 sources:
   - "https://github.com/lsst-sqre/qserv-kafka"
-appVersion: 0.2.0
+appVersion: 0.3.0
 
 dependencies:
   - name: "redis"

--- a/applications/qserv-kafka/README.md
+++ b/applications/qserv-kafka/README.md
@@ -17,6 +17,11 @@ Qserv Kafka bridge
 | config.logLevel | string | `"INFO"` | Logging level |
 | config.logProfile | string | `"production"` | Logging profile (`production` for JSON, `development` for human-friendly) |
 | config.maxWorkerJobs | int | `2` | Maximum number of arq jobs each worker can process simultaneously |
+| config.metrics.application | string | `"qservkafka"` | Name under which to log metrics. Generally there is no reason to change this. |
+| config.metrics.enabled | bool | `false` | Whether to enable sending metrics |
+| config.metrics.events.topicPrefix | string | `"lsst.square.metrics.events"` | Topic prefix for events. It may sometimes be useful to change this in development environments. |
+| config.metrics.schemaManager.registryUrl | string | Sasquatch in the local cluster | URL of the Confluent-compatible schema registry server |
+| config.metrics.schemaManager.suffix | string | `""` | Suffix to add to all registered subjects. This is sometimes useful for experimentation during development. |
 | config.qservDatabaseOverflow | int | `50` | Extra database connections that may be opened in excess of the pool size to handle surges in load. This is used primarily by the frontend for jobs that complete immediately. |
 | config.qservDatabasePoolSize | int | `2` | Database pool size. This is the number of MySQL connections that will be held open regardless of load. This should generally be set to the same as `maxWorkerJobs`. |
 | config.qservDatabaseUrl | string | None, must be set | URL to the Qserv MySQL interface (must use a scheme of `mysql+asyncmy`) |

--- a/applications/qserv-kafka/templates/configmap.yaml
+++ b/applications/qserv-kafka/templates/configmap.yaml
@@ -5,6 +5,9 @@ metadata:
   labels:
     {{- include "qserv-kafka.labels" . | nindent 4 }}
 data:
+  METRICS_APPLICATION: {{ .Values.config.metrics.application | quote }}
+  METRICS_ENABLED: {{ .Values.config.metrics.enabled | quote }}
+  METRICS_EVENTS_TOPIC_PREFIX: {{ .Values.config.metrics.events.topicPrefix | quote }}
   QSERV_KAFKA_CONSUMER_GROUP_ID: {{ .Values.config.consumerGroupId | quote }}
   QSERV_KAFKA_JOB_CANCEL_TOPIC: {{ .Values.config.jobCancelTopic | quote }}
   QSERV_KAFKA_JOB_RUN_TOPIC: {{ .Values.config.jobRunTopic | quote }}
@@ -22,3 +25,5 @@ data:
   QSERV_KAFKA_REDIS_URL: "redis://qserv-kafka-redis.{{ .Release.Namespace }}:6379/0"
   QSERV_KAFKA_RESULT_TIMEOUT: {{ .Values.config.resultTimeout | quote }}
   QSERV_KAFKA_REWRITE_BASE_URL: {{ .Values.global.baseUrl | quote }}
+  SCHEMA_MANAGER_REGISTRY_URL: {{ .Values.config.metrics.schemaManager.registryUrl | quote }}
+  SCHEMA_MANAGER_SUFFIX: {{ .Values.config.metrics.schemaManager.suffix | quote }}

--- a/applications/qserv-kafka/values-idfdev.yaml
+++ b/applications/qserv-kafka/values-idfdev.yaml
@@ -1,4 +1,6 @@
 config:
   logLevel: "DEBUG"
+  metrics:
+    enabled: true
   qservDatabaseUrl: "mysql+asyncmy://qsmaster@qserv-int.slac.stanford.edu:4090/"
   qservRestUrl: "https://qserv-int-https.slac.stanford.edu:4098/"

--- a/applications/qserv-kafka/values.yaml
+++ b/applications/qserv-kafka/values.yaml
@@ -25,6 +25,28 @@ config:
   # -- Maximum number of arq jobs each worker can process simultaneously
   maxWorkerJobs: 2
 
+  metrics:
+    # -- Whether to enable sending metrics
+    enabled: false
+
+    # -- Name under which to log metrics. Generally there is no reason to
+    # change this.
+    application: "qservkafka"
+
+    events:
+      # -- Topic prefix for events. It may sometimes be useful to change this
+      # in development environments.
+      topicPrefix: "lsst.square.metrics.events"
+
+    schemaManager:
+      # -- URL of the Confluent-compatible schema registry server
+      # @default -- Sasquatch in the local cluster
+      registryUrl: "http://sasquatch-schema-registry.sasquatch.svc.cluster.local:8081"
+
+      # -- Suffix to add to all registered subjects. This is sometimes useful
+      # for experimentation during development.
+      suffix: ""
+
   # -- Extra database connections that may be opened in excess of the pool
   # size to handle surges in load. This is used primarily by the frontend for
   # jobs that complete immediately.

--- a/applications/sasquatch/charts/app-metrics/values.yaml
+++ b/applications/sasquatch/charts/app-metrics/values.yaml
@@ -26,6 +26,9 @@ globalAppConfig:
   nublado:
     influxTags:
       - "username"
+  qservkafka:
+    influxTags:
+      - "username"
   sia:
     influxTags:
       - "username"

--- a/applications/sasquatch/charts/tap/templates/kafka-users.yaml
+++ b/applications/sasquatch/charts/tap/templates/kafka-users.yaml
@@ -57,3 +57,19 @@ spec:
         host: "*"
         operations:
           - All
+      - host: '*'
+        operations:
+          - "Read"
+        resource:
+          name: "app-metrics-events"
+          patternType: "prefix"
+          type: "group"
+      - host: '*'
+        operations:
+          - "Describe"
+          - "Read"
+          - "Write"
+        resource:
+          name: "lsst.square.metrics.events.qservkafka"
+          patternType: "literal"
+          type: "topic"

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -166,6 +166,7 @@ app-metrics:
     - mobu
     - noteburst
     - nublado
+    - qservkafka
     - sia
     - wobbly
 

--- a/applications/sasquatch/values-idfint.yaml
+++ b/applications/sasquatch/values-idfint.yaml
@@ -130,6 +130,7 @@ app-metrics:
     - mobu
     - noteburst
     - nublado
+    - qservkafka
     - sia
     - wobbly
 

--- a/applications/sasquatch/values-idfprod.yaml
+++ b/applications/sasquatch/values-idfprod.yaml
@@ -99,6 +99,7 @@ app-metrics:
     - mobu
     - noteburst
     - nublado
+    - qservkafka
     - wobbly
 
 backup:


### PR DESCRIPTION
Add the Sasquatch configuration to enable metrics events for the Qserv Kafka bridge and add configuration of metrics events to the qserv-kafka application. Enable metrics on idfdev.