### PR TITLE
DM-50878: Increase memory for Qserv Kafka bridge Redis

### DIFF
--- a/applications/qserv-kafka/values.yaml
+++ b/applications/qserv-kafka/values.yaml
@@ -132,10 +132,10 @@ redis:
   resources:
     limits:
       cpu: "1"
-      memory: "10Mi"
+      memory: "100Mi"
     requests:
       cpu: "10m"
-      memory: "5Mi"
+      memory: "20Mi"
 
 resultWorker:
   # -- Affinity rules for the qserv-kafka worker pods


### PR DESCRIPTION
Significantly increase the memory limit and request for the Redis for the Qserv Kafka bridge because our serialized query jobs are rather larger than I had realized if the queries are very wide, due to the size of the VOTable header and JSON schema.