### PR TITLE
Switch ukidacdev cert-manager to route53

### DIFF
--- a/applications/argocd/values-ukidacdev.yaml
+++ b/applications/argocd/values-ukidacdev.yaml
@@ -8,4 +8,4 @@ argo-cd:
   server:
     ingress:
       hostname: "rsp-test.lsst.ac.uk"
-      tls: false
+      tls: true

--- a/applications/cert-manager/values-ukidacdev.yaml
+++ b/applications/cert-manager/values-ukidacdev.yaml
@@ -1,2 +1,4 @@
 config:
-  createIssuer: false
+  route53:
+    awsAccessKeyId: "AKIAU52KVHTMUM5LRCMD"
+    hostedZone: "Z06436303FKUL106EU52"

--- a/applications/ingress-nginx/values-ukidacdev.yaml
+++ b/applications/ingress-nginx/values-ukidacdev.yaml
@@ -9,7 +9,3 @@ ingress-nginx:
       annotations:
         kubernetes.io/ingress.class: "openstack"
         loadbalancer.openstack.org/enable-health-monitor: "false"
-    extraArgs:
-      default-ssl-certificate: ingress-nginx/ingress-certificate
-vaultCertificate:
-  enabled: true


### PR DESCRIPTION
Update the ukidacdev environment to use Let's Encrypt DNS and Route53 for TLS instead of using an external certificate.