### PR TITLE
[DM-50784] Migrate Kafka brokers at USDF to new nodes with local storage 

### DIFF
--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -96,10 +96,7 @@ Rubin Observatory's telemetry service
 | prompt-processing.enabled | bool | `false` | Whether to enable the prompt-processing subchart |
 | rest-proxy.enabled | bool | `false` | Whether to enable the REST proxy |
 | squareEvents.enabled | bool | `false` | Enable the Square Events subchart with topic and user configurations |
-| strimzi-kafka.connect.enabled | bool | `true` | Whether Kafka Connect is enabled |
-| strimzi-kafka.kafka.listeners.external.enabled | bool | `true` | Whether external listener is enabled |
-| strimzi-kafka.kafka.listeners.plain.enabled | bool | `true` | Whether internal plaintext listener is enabled |
-| strimzi-kafka.kafka.listeners.tls.enabled | bool | `true` | Whether internal TLS listener is enabled |
+| strimzi-kafka | object | `{}` |  |
 | strimzi-registry-operator.clusterName | string | `"sasquatch"` | Name of the Strimzi Kafka cluster |
 | strimzi-registry-operator.clusterNamespace | string | `"sasquatch"` | Namespace where the Strimzi Kafka cluster is deployed |
 | strimzi-registry-operator.operatorNamespace | string | `"sasquatch"` | Namespace where the strimzi-registry-operator is deployed |
@@ -521,7 +518,26 @@ Rubin Observatory's telemetry service
 | rest-proxy.service.port | int | `8082` | Kafka REST proxy service port |
 | rest-proxy.tolerations | list | `[]` | Tolerations configuration |
 | square-events.cluster.name | string | `"sasquatch"` |  |
-| strimzi-kafka.brokerStorage | object | `{"enabled":false,"migration":{"brokers":[0,1,2],"enabled":false,"rebalance":false},"size":"1.5Ti","storageClassName":"localdrive"}` | Configuration for deploying Kafka brokers with local storage |
+| strimzi-kafka.broker.affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchExpressions":[{"key":"app.kubernetes.io/name","operator":"In","values":["kafka"]}]},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for broker pod assignment |
+| strimzi-kafka.broker.enabled | bool | `false` | Enable node pool for the kafka brokers |
+| strimzi-kafka.broker.name | string | `"kafka"` | Node pool name |
+| strimzi-kafka.broker.nodeIds | string | `"[0,1,2]"` | IDs to assign to the brokers |
+| strimzi-kafka.broker.resources | object | `{"limits":{"cpu":"8","memory":"64Gi"},"requests":{"cpu":"4","memory":"32Gi"}}` | Kubernetes resources for the brokers |
+| strimzi-kafka.broker.storage.size | string | `"1.5Ti"` | Storage size for the brokers |
+| strimzi-kafka.broker.storage.storageClassName | string | None, use the default storage class | Storage class to use when requesting persistent volumes |
+| strimzi-kafka.broker.tolerations | list | `[]` | Tolerations for broker pod assignment |
+| strimzi-kafka.brokerMigration.affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchExpressions":[{"key":"app.kubernetes.io/name","operator":"In","values":["kafka"]}]},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for Kafka broker pod assignment |
+| strimzi-kafka.brokerMigration.enabled | bool | `false` | Whether to enable another node pool to migrate the kafka brokers to |
+| strimzi-kafka.brokerMigration.name | string | `"broker-migration"` | Name of the node pool |
+| strimzi-kafka.brokerMigration.nodeIDs | string | `"[6,7,8]"` | IDs to assign to the brokers |
+| strimzi-kafka.brokerMigration.rebalance.avoidBrokers | list | `[0,1,2]` | Brokers to avoid during rebalancing These are the brokers you are migrating from and you want to remove after the migration is complete. |
+| strimzi-kafka.brokerMigration.rebalance.enabled | bool | `false` | Whether to rebalance the kafka cluster |
+| strimzi-kafka.brokerMigration.resources.limits.cpu | string | `"8"` |  |
+| strimzi-kafka.brokerMigration.resources.limits.memory | string | `"64Gi"` |  |
+| strimzi-kafka.brokerMigration.resources.requests | object | `{"cpu":"4","memory":"32Gi"}` | Kubernetes resources for the brokers |
+| strimzi-kafka.brokerMigration.size | string | `"1.5Ti"` | Storage size for the brokers |
+| strimzi-kafka.brokerMigration.storageClassName | string | None, use the default storage class | Storage class name for the brokers |
+| strimzi-kafka.brokerMigration.tolerations | list | `[]` | Tolerations for Kafka broker pod assignment |
 | strimzi-kafka.cluster.monitorLabel | object | `{}` | Site wide label required for gathering Prometheus metrics if they are enabled |
 | strimzi-kafka.cluster.name | string | `"sasquatch"` | Name used for the Kafka cluster, and used by Strimzi for many annotations |
 | strimzi-kafka.connect.config."key.converter" | string | `"io.confluent.connect.avro.AvroConverter"` | Set the converter for the message ke |
@@ -533,8 +549,15 @@ Rubin Observatory's telemetry service
 | strimzi-kafka.connect.enabled | bool | `false` | Enable Kafka Connect |
 | strimzi-kafka.connect.image | string | `"ghcr.io/lsst-sqre/strimzi-0.40.0-kafka-3.7.0:tickets-DM-43491"` | Custom strimzi-kafka image with connector plugins used by sasquatch |
 | strimzi-kafka.connect.replicas | int | `3` | Number of Kafka Connect replicas to run |
-| strimzi-kafka.cruiseControl | object | `{"enabled":false,"maxReplicasPerBroker":20000}` | Configuration for the Kafka Cruise Control |
-| strimzi-kafka.kafka.affinity | object | See `values.yaml` | Affinity for Kafka pod assignment |
+| strimzi-kafka.controller.affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchExpressions":[{"key":"app.kubernetes.io/name","operator":"In","values":["kafka"]}]},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for controller pod assignment |
+| strimzi-kafka.controller.enabled | bool | `false` | Enable node pool for the kafka controllers |
+| strimzi-kafka.controller.nodeIds | string | `"[3,4,5]"` | IDs to assign to the controllers |
+| strimzi-kafka.controller.resources | object | `{"limits":{"cpu":"1","memory":"8Gi"},"requests":{"cpu":"1","memory":"8Gi"}}` | Kubernetes resources for the controllers |
+| strimzi-kafka.controller.storage.size | string | `"20Gi"` | Storage size for the controllers |
+| strimzi-kafka.controller.storage.storageClassName | string | None, use the default storage class | Storage class to use when requesting persistent volumes |
+| strimzi-kafka.controller.tolerations | list | `[]` | Tolerations for controller pod assignment |
+| strimzi-kafka.cruiseControl.enabled | bool | `false` | Enable cruise control (required for broker migration and rebalancing) |
+| strimzi-kafka.cruiseControl.maxReplicasPerBroker | int | `20000` | Maximum number of replicas per broker |
 | strimzi-kafka.kafka.config."log.retention.minutes" | int | 4320 minutes (3 days) | Number of days for a topic's data to be retained |
 | strimzi-kafka.kafka.config."message.max.bytes" | int | `10485760` | The largest record batch size allowed by Kafka |
 | strimzi-kafka.kafka.config."offsets.retention.minutes" | int | 4320 minutes (3 days) | Number of minutes for a consumer group's offsets to be retained |
@@ -551,15 +574,7 @@ Rubin Observatory's telemetry service
 | strimzi-kafka.kafka.metricsConfig.enabled | bool | `false` | Whether metric configuration is enabled |
 | strimzi-kafka.kafka.minInsyncReplicas | int | `2` | The minimum number of in-sync replicas that must be available for the producer to successfully send records Cannot be greater than the number of replicas. |
 | strimzi-kafka.kafka.replicas | int | `3` | Number of Kafka broker replicas to run |
-| strimzi-kafka.kafka.resources | object | See `values.yaml` | Kubernetes requests and limits for the Kafka brokers |
-| strimzi-kafka.kafka.storage.size | string | `"500Gi"` | Size of the backing storage disk for each of the Kafka brokers |
-| strimzi-kafka.kafka.storage.storageClassName | string | `""` | Name of a StorageClass to use when requesting persistent volumes |
-| strimzi-kafka.kafka.tolerations | list | `[]` | Tolerations for Kafka broker pod assignment |
 | strimzi-kafka.kafka.version | string | `"3.8.0"` | Version of Kafka to deploy |
-| strimzi-kafka.kafkaController.enabled | bool | `false` | Enable Kafka Controller |
-| strimzi-kafka.kafkaController.resources | object | See `values.yaml` | Kubernetes requests and limits for the Kafka Controller |
-| strimzi-kafka.kafkaController.storage.size | string | `"20Gi"` | Size of the backing storage disk for each of the Kafka controllers |
-| strimzi-kafka.kafkaController.storage.storageClassName | string | `""` | Name of a StorageClass to use when requesting persistent volumes |
 | strimzi-kafka.kafkaExporter.enableSaramaLogging | bool | `false` | Enable Sarama logging for pod |
 | strimzi-kafka.kafkaExporter.enabled | bool | `false` | Enable Kafka exporter |
 | strimzi-kafka.kafkaExporter.groupRegex | string | `".*"` | Consumer groups to monitor |
@@ -567,7 +582,6 @@ Rubin Observatory's telemetry service
 | strimzi-kafka.kafkaExporter.resources | object | See `values.yaml` | Kubernetes requests and limits for the Kafka exporter |
 | strimzi-kafka.kafkaExporter.showAllOffsets | bool | `true` | Whether to show all offsets or just offsets from connected groups |
 | strimzi-kafka.kafkaExporter.topicRegex | string | `".*"` | Kafka topics to monitor |
-| strimzi-kafka.kraft.enabled | bool | `false` | Enable KRaft mode for Kafka |
 | strimzi-kafka.mirrormaker2.enabled | bool | `false` | Enable replication in the target (passive) cluster |
 | strimzi-kafka.mirrormaker2.replicas | int | `3` | Number of Mirror Maker replicas to run |
 | strimzi-kafka.mirrormaker2.replication.policy.class | string | `"org.apache.kafka.connect.mirror.IdentityReplicationPolicy"` | Replication policy. |

--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -533,7 +533,7 @@ Rubin Observatory's telemetry service
 | strimzi-kafka.connect.enabled | bool | `false` | Enable Kafka Connect |
 | strimzi-kafka.connect.image | string | `"ghcr.io/lsst-sqre/strimzi-0.40.0-kafka-3.7.0:tickets-DM-43491"` | Custom strimzi-kafka image with connector plugins used by sasquatch |
 | strimzi-kafka.connect.replicas | int | `3` | Number of Kafka Connect replicas to run |
-| strimzi-kafka.cruiseControl | object | `{"enabled":false}` | Configuration for the Kafka Cruise Control |
+| strimzi-kafka.cruiseControl | object | `{"enabled":false,"maxReplicasPerBroker":20000}` | Configuration for the Kafka Cruise Control |
 | strimzi-kafka.kafka.affinity | object | See `values.yaml` | Affinity for Kafka pod assignment |
 | strimzi-kafka.kafka.config."log.retention.minutes" | int | 4320 minutes (3 days) | Number of days for a topic's data to be retained |
 | strimzi-kafka.kafka.config."message.max.bytes" | int | `10485760` | The largest record batch size allowed by Kafka |

--- a/applications/sasquatch/charts/strimzi-kafka/README.md
+++ b/applications/sasquatch/charts/strimzi-kafka/README.md
@@ -6,7 +6,26 @@ A subchart to deploy Strimzi Kafka components for Sasquatch.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| brokerStorage | object | `{"enabled":false,"migration":{"brokers":[0,1,2],"enabled":false,"rebalance":false},"size":"1.5Ti","storageClassName":"localdrive"}` | Configuration for deploying Kafka brokers with local storage |
+| broker.affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchExpressions":[{"key":"app.kubernetes.io/name","operator":"In","values":["kafka"]}]},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for broker pod assignment |
+| broker.enabled | bool | `false` | Enable node pool for the kafka brokers |
+| broker.name | string | `"kafka"` | Node pool name |
+| broker.nodeIds | string | `"[0,1,2]"` | IDs to assign to the brokers |
+| broker.resources | object | `{"limits":{"cpu":"8","memory":"64Gi"},"requests":{"cpu":"4","memory":"32Gi"}}` | Kubernetes resources for the brokers |
+| broker.storage.size | string | `"1.5Ti"` | Storage size for the brokers |
+| broker.storage.storageClassName | string | None, use the default storage class | Storage class to use when requesting persistent volumes |
+| broker.tolerations | list | `[]` | Tolerations for broker pod assignment |
+| brokerMigration.affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchExpressions":[{"key":"app.kubernetes.io/name","operator":"In","values":["kafka"]}]},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for Kafka broker pod assignment |
+| brokerMigration.enabled | bool | `false` | Whether to enable another node pool to migrate the kafka brokers to |
+| brokerMigration.name | string | `"broker-migration"` | Name of the node pool |
+| brokerMigration.nodeIDs | string | `"[6,7,8]"` | IDs to assign to the brokers |
+| brokerMigration.rebalance.avoidBrokers | list | `[0,1,2]` | Brokers to avoid during rebalancing These are the brokers you are migrating from and you want to remove after the migration is complete. |
+| brokerMigration.rebalance.enabled | bool | `false` | Whether to rebalance the kafka cluster |
+| brokerMigration.resources.limits.cpu | string | `"8"` |  |
+| brokerMigration.resources.limits.memory | string | `"64Gi"` |  |
+| brokerMigration.resources.requests | object | `{"cpu":"4","memory":"32Gi"}` | Kubernetes resources for the brokers |
+| brokerMigration.size | string | `"1.5Ti"` | Storage size for the brokers |
+| brokerMigration.storageClassName | string | None, use the default storage class | Storage class name for the brokers |
+| brokerMigration.tolerations | list | `[]` | Tolerations for Kafka broker pod assignment |
 | cluster.monitorLabel | object | `{}` | Site wide label required for gathering Prometheus metrics if they are enabled |
 | cluster.name | string | `"sasquatch"` | Name used for the Kafka cluster, and used by Strimzi for many annotations |
 | connect.config."key.converter" | string | `"io.confluent.connect.avro.AvroConverter"` | Set the converter for the message ke |
@@ -18,8 +37,15 @@ A subchart to deploy Strimzi Kafka components for Sasquatch.
 | connect.enabled | bool | `false` | Enable Kafka Connect |
 | connect.image | string | `"ghcr.io/lsst-sqre/strimzi-0.40.0-kafka-3.7.0:tickets-DM-43491"` | Custom strimzi-kafka image with connector plugins used by sasquatch |
 | connect.replicas | int | `3` | Number of Kafka Connect replicas to run |
-| cruiseControl | object | `{"enabled":false,"maxReplicasPerBroker":20000}` | Configuration for the Kafka Cruise Control |
-| kafka.affinity | object | See `values.yaml` | Affinity for Kafka pod assignment |
+| controller.affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchExpressions":[{"key":"app.kubernetes.io/name","operator":"In","values":["kafka"]}]},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for controller pod assignment |
+| controller.enabled | bool | `false` | Enable node pool for the kafka controllers |
+| controller.nodeIds | string | `"[3,4,5]"` | IDs to assign to the controllers |
+| controller.resources | object | `{"limits":{"cpu":"1","memory":"8Gi"},"requests":{"cpu":"1","memory":"8Gi"}}` | Kubernetes resources for the controllers |
+| controller.storage.size | string | `"20Gi"` | Storage size for the controllers |
+| controller.storage.storageClassName | string | None, use the default storage class | Storage class to use when requesting persistent volumes |
+| controller.tolerations | list | `[]` | Tolerations for controller pod assignment |
+| cruiseControl.enabled | bool | `false` | Enable cruise control (required for broker migration and rebalancing) |
+| cruiseControl.maxReplicasPerBroker | int | `20000` | Maximum number of replicas per broker |
 | kafka.config."log.retention.minutes" | int | 4320 minutes (3 days) | Number of days for a topic's data to be retained |
 | kafka.config."message.max.bytes" | int | `10485760` | The largest record batch size allowed by Kafka |
 | kafka.config."offsets.retention.minutes" | int | 4320 minutes (3 days) | Number of minutes for a consumer group's offsets to be retained |
@@ -36,15 +62,7 @@ A subchart to deploy Strimzi Kafka components for Sasquatch.
 | kafka.metricsConfig.enabled | bool | `false` | Whether metric configuration is enabled |
 | kafka.minInsyncReplicas | int | `2` | The minimum number of in-sync replicas that must be available for the producer to successfully send records Cannot be greater than the number of replicas. |
 | kafka.replicas | int | `3` | Number of Kafka broker replicas to run |
-| kafka.resources | object | See `values.yaml` | Kubernetes requests and limits for the Kafka brokers |
-| kafka.storage.size | string | `"500Gi"` | Size of the backing storage disk for each of the Kafka brokers |
-| kafka.storage.storageClassName | string | `""` | Name of a StorageClass to use when requesting persistent volumes |
-| kafka.tolerations | list | `[]` | Tolerations for Kafka broker pod assignment |
 | kafka.version | string | `"3.8.0"` | Version of Kafka to deploy |
-| kafkaController.enabled | bool | `false` | Enable Kafka Controller |
-| kafkaController.resources | object | See `values.yaml` | Kubernetes requests and limits for the Kafka Controller |
-| kafkaController.storage.size | string | `"20Gi"` | Size of the backing storage disk for each of the Kafka controllers |
-| kafkaController.storage.storageClassName | string | `""` | Name of a StorageClass to use when requesting persistent volumes |
 | kafkaExporter.enableSaramaLogging | bool | `false` | Enable Sarama logging for pod |
 | kafkaExporter.enabled | bool | `false` | Enable Kafka exporter |
 | kafkaExporter.groupRegex | string | `".*"` | Consumer groups to monitor |
@@ -52,7 +70,6 @@ A subchart to deploy Strimzi Kafka components for Sasquatch.
 | kafkaExporter.resources | object | See `values.yaml` | Kubernetes requests and limits for the Kafka exporter |
 | kafkaExporter.showAllOffsets | bool | `true` | Whether to show all offsets or just offsets from connected groups |
 | kafkaExporter.topicRegex | string | `".*"` | Kafka topics to monitor |
-| kraft.enabled | bool | `false` | Enable KRaft mode for Kafka |
 | mirrormaker2.enabled | bool | `false` | Enable replication in the target (passive) cluster |
 | mirrormaker2.replicas | int | `3` | Number of Mirror Maker replicas to run |
 | mirrormaker2.replication.policy.class | string | `"org.apache.kafka.connect.mirror.IdentityReplicationPolicy"` | Replication policy. |

--- a/applications/sasquatch/charts/strimzi-kafka/README.md
+++ b/applications/sasquatch/charts/strimzi-kafka/README.md
@@ -18,7 +18,7 @@ A subchart to deploy Strimzi Kafka components for Sasquatch.
 | connect.enabled | bool | `false` | Enable Kafka Connect |
 | connect.image | string | `"ghcr.io/lsst-sqre/strimzi-0.40.0-kafka-3.7.0:tickets-DM-43491"` | Custom strimzi-kafka image with connector plugins used by sasquatch |
 | connect.replicas | int | `3` | Number of Kafka Connect replicas to run |
-| cruiseControl | object | `{"enabled":false}` | Configuration for the Kafka Cruise Control |
+| cruiseControl | object | `{"enabled":false,"maxReplicasPerBroker":20000}` | Configuration for the Kafka Cruise Control |
 | kafka.affinity | object | See `values.yaml` | Affinity for Kafka pod assignment |
 | kafka.config."log.retention.minutes" | int | 4320 minutes (3 days) | Number of days for a topic's data to be retained |
 | kafka.config."message.max.bytes" | int | `10485760` | The largest record batch size allowed by Kafka |

--- a/applications/sasquatch/charts/strimzi-kafka/templates/kafka-metrics-configmap.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/kafka-metrics-configmap.yaml
@@ -130,7 +130,6 @@ data:
       type: GAUGE
       labels:
         quantile: "0.$4"
-    {{- if .Values.kraft.enabled }}
     # KRaft mode: uncomment the following lines to export KRaft related metrics
     # KRaft overall related metrics
     # distinguish between always increasing COUNTER (total and max) and variable GAUGE (all others) metrics
@@ -152,5 +151,4 @@ data:
     - pattern: "kafka.server<type=broker-metadata-metrics><>(.+):"
       name: kafka_server_brokermetadatametrics_$1
       type: GAUGE
-    {{- end }}
 {{- end}}

--- a/applications/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.kafkaController.enabled }}
+{{- if .Values.controller.enabled }}
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaNodePool
 metadata:
@@ -6,7 +6,7 @@ metadata:
   labels:
     strimzi.io/cluster: {{ .Values.cluster.name }}
   annotations:
-    strimzi.io/next-node-ids: "[3,4,5]"
+    strimzi.io/next-node-ids: {{ .Values.controller.nodeIds | quote }}
 spec:
   replicas: {{ .Values.kafka.replicas }}
   roles:
@@ -16,137 +16,118 @@ spec:
     volumes:
     - id: 0
       type: persistent-claim
-      size: {{ .Values.kafkaController.storage.size }}
-      {{- if .Values.kafkaController.storage.storageClassName }}
-      class: {{ .Values.kafkaController.storage.storageClassName }}
-      {{- end}}
-      deleteClaim: false
-  {{- with .Values.kafkaController.resources }}
-  resources:
-    {{- toYaml . | nindent 6 }}
-  {{- end }}
-{{- end }}
-{{- if not .Values.brokerStorage.enabled }}
----
-apiVersion: kafka.strimzi.io/v1beta2
-kind: KafkaNodePool
-metadata:
-  name: kafka
-  labels:
-    strimzi.io/cluster: {{ .Values.cluster.name }}
-  annotations:
-    strimzi.io/next-node-ids: "[0,1,2]"
-spec:
-  replicas: {{ .Values.kafka.replicas }}
-  roles:
-    - broker
-  storage:
-    type: jbod
-    volumes:
-    - id: 0
-      type: persistent-claim
-      size: {{ .Values.kafka.storage.size }}
-      {{- if .Values.kafka.storage.storageClassName }}
-      class: {{ .Values.kafka.storage.storageClassName }}
-      {{- end}}
-      deleteClaim: false
-  {{- with .Values.kafka.resources }}
-  resources:
-    {{- toYaml . | nindent 6 }}
-  {{- end }}
-{{- end }}
-{{- if .Values.brokerStorage.enabled }}
----
-apiVersion: kafka.strimzi.io/v1beta2
-kind: KafkaNodePool
-metadata:
-  name: {{ .Values.brokerStorage.nodePoolName }}
-  labels:
-    strimzi.io/cluster: {{ .Values.cluster.name }}
-  annotations:
-    strimzi.io/next-node-ids: {{ .Values.brokerStorage.nodeIds | quote}}
-spec:
-  replicas: {{ .Values.kafka.replicas }}
-  roles:
-    - broker
-  storage:
-    type: jbod
-    volumes:
-    - id: 0
-      type: persistent-claim
-      size: {{ .Values.brokerStorage.size }}
-      {{- if .Values.brokerStorage.storageClassName }}
-      class: {{ .Values.brokerStorage.storageClassName }}
+      size: {{ .Values.controller.storage.size }}
+      {{- if .Values.controller.storage.storageClassName }}
+      class: {{ .Values.controller.storage.storageClassName }}
       {{- end}}
       deleteClaim: false
   template:
     pod:
-      {{- with .Values.brokerStorage.affinity }}
+      {{- with .Values.controller.affinity }}
       affinity:
         {{- toYaml . | nindent 10 }}
       {{- end }}
-      {{- with .Values.brokerStorage.tolerations }}
+      {{- with .Values.controller.tolerations }}
       tolerations:
         {{- toYaml . | nindent 10 }}
       {{- end}}
-  {{- with .Values.kafka.resources }}
+  {{- with .Values.controller.resources }}
+  resources:
+    {{- toYaml . | nindent 6 }}
+  {{- end }}
+{{- end }}
+{{- if .Values.broker.enabled }}
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaNodePool
+metadata:
+  name: {{ .Values.broker.name }}
+  labels:
+    strimzi.io/cluster: {{ .Values.cluster.name }}
+  annotations:
+    strimzi.io/next-node-ids: {{ .Values.broker.nodeIds | quote }}
+spec:
+  replicas: {{ .Values.kafka.replicas }}
+  roles:
+    - broker
+  storage:
+    type: jbod
+    volumes:
+    - id: 0
+      type: persistent-claim
+      size: {{ .Values.broker.storage.size }}
+      {{- if .Values.broker.storage.storageClassName }}
+      class: {{ .Values.broker.storage.storageClassName }}
+      {{- end}}
+      deleteClaim: false
+  template:
+    pod:
+      {{- with .Values.broker.affinity }}
+      affinity:
+        {{- toYaml . | nindent 10 }}
+      {{- end }}
+      {{- with .Values.broker.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 10 }}
+      {{- end}}
+  {{- with .Values.broker.resources }}
+  resources:
+    {{- toYaml . | nindent 6 }}
+  {{- end }}
+{{- end }}
+{{- if .Values.brokerMigration.enabled }}
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaNodePool
+metadata:
+  name: {{ .Values.brokerMigration.name }}
+  labels:
+    strimzi.io/cluster: {{ .Values.cluster.name }}
+  annotations:
+    strimzi.io/next-node-ids: {{ .Values.brokerMigration.nodeIds | quote}}
+spec:
+  replicas: {{ .Values.kafka.replicas }}
+  roles:
+    - broker
+  storage:
+    type: jbod
+    volumes:
+    - id: 0
+      type: persistent-claim
+      size: {{ .Values.brokerMigration.storage.size }}
+      {{- if .Values.brokerMigration.storage.storageClassName }}
+      class: {{ .Values.brokerMigration.storage.storageClassName }}
+      {{- end}}
+      deleteClaim: false
+  template:
+    pod:
+      {{- with .Values.brokerMigration.affinity }}
+      affinity:
+        {{- toYaml . | nindent 10 }}
+      {{- end }}
+      {{- with .Values.brokerMigration.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 10 }}
+      {{- end}}
+  {{- with .Values.brokerMigration.resources }}
   resources:
     {{- toYaml . | nindent 6 }}
   {{- end }}
 {{- end }}
 
-{{- if .Values.brokerStorageMigration.enabled }}
----
-apiVersion: kafka.strimzi.io/v1beta2
-kind: KafkaNodePool
-metadata:
-  name: {{ .Values.brokerStorageMigration.nodePoolName }}
-  labels:
-    strimzi.io/cluster: {{ .Values.cluster.name }}
-  annotations:
-    strimzi.io/next-node-ids: {{ .Values.brokerStorageMigration.nodeIds | quote}}
-spec:
-  replicas: {{ .Values.kafka.replicas }}
-  roles:
-    - broker
-  storage:
-    type: jbod
-    volumes:
-    - id: 0
-      type: persistent-claim
-      size: {{ .Values.brokerStorageMigration.size }}
-      {{- if .Values.brokerStorageMigration.storageClassName }}
-      class: {{ .Values.brokerStorageMigration.storageClassName }}
-      {{- end}}
-      deleteClaim: false
-  template:
-    pod:
-      {{- with .Values.brokerStorageMigration.affinity }}
-      affinity:
-        {{- toYaml . | nindent 10 }}
-      {{- end }}
-      {{- with .Values.brokerStorageMigration.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 10 }}
-      {{- end}}
-  {{- with .Values.kafka.resources }}
-  resources:
-    {{- toYaml . | nindent 6 }}
-  {{- end }}
-{{- end }}
-{{- if and .Values.brokerStorageMigration.enabled .Values.brokerStorageMigration.rebalance.enabled }}
+{{- if and .Values.brokerMigration.enabled .Values.brokerMigration.rebalance.enabled }}
 ---
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaRebalance
 metadata:
-  name: broker-migration-rebalance
+  name: rebalance
   labels:
     strimzi.io/cluster: {{ .Values.cluster.name }}
   annotations:
     strimzi.io/rebalance-auto-approval: "true"
 spec:
   mode: remove-brokers
-  {{- with .Values.brokerStorageMigration.rebalance.removeBrokers }}
+  {{- with .Values.brokerMigration.rebalance.avoidBrokers }}
   brokers:
     {{- toYaml . | nindent 6 }}
   {{- end }}
@@ -157,9 +138,7 @@ kind: Kafka
 metadata:
   name: {{ .Values.cluster.name }}
   annotations:
-    {{- if .Values.kraft.enabled }}
     strimzi.io/kraft: enabled
-    {{- end }}
     strimzi.io/node-pools: enabled
 spec:
   kafka:
@@ -177,11 +156,11 @@ spec:
         {{- with .Values.kafka.tolerations }}
         tolerations:
           {{- toYaml . | nindent 10 }}
-        {{- end}}
+        {{- end }}
     version: {{ .Values.kafka.version | quote }}
     replicas: {{ .Values.kafka.replicas }}
     listeners:
-      {{- if .Values.kafka.listeners.plain.enabled }}
+    {{- if .Values.kafka.listeners.plain.enabled }}
       # internal listener without tls encryption and with scram-sha-512 authentication
       # used by clients inside the Kubernetes cluster
       - name: plain
@@ -190,8 +169,9 @@ spec:
         tls: false
         authentication:
           type: scram-sha-512
-      {{- end }}
-      {{- if .Values.kafka.listeners.tls.enabled }}
+    {{- end }}
+
+    {{- if .Values.kafka.listeners.tls.enabled }}
       # internal listener with tls encryption and mutual tls authentication
       # used by the schema registry and kafka connect clients
       - name: tls
@@ -200,8 +180,8 @@ spec:
         tls: true
         authentication:
           type: tls
-      {{- end }}
-      {{- if .Values.kafka.listeners.external.enabled }}
+    {{- end }}
+    {{- if .Values.kafka.listeners.external.enabled }}
       # external listener of type loadbalancer with tls encryption and scram-sha-512
       # authentication used by clients outside the Kubernetes cluster
       - name: external
@@ -223,7 +203,7 @@ spec:
             {{- end }}
           {{- if .Values.kafka.externalListener.brokers }}
           brokers:
-            {{- range $broker := .Values.kafka.externalListener.brokers }}
+          {{- range $broker := .Values.kafka.externalListener.brokers }}
             - broker: {{ $broker.broker }}
               loadBalancerIP: {{ $broker.loadBalancerIP }}
               advertisedHost: {{ $broker.host }}
@@ -232,7 +212,7 @@ spec:
                 {{- range $key, $value  := $broker.annotations }}
                 {{ $key }}: {{ $value }}
                 {{- end}}
-            {{- end }}
+          {{- end }}
           {{- end }}
           {{- if and (.Values.kafka.externalListener.tls.enabled) (.Values.kafka.externalListener.bootstrap.host) }}
           brokerCertChainAndKey:
@@ -240,16 +220,15 @@ spec:
             certificate: tls.crt
             key: tls.key
           {{- end }}
-      {{- end }}
-
+    {{- end }}
     authorization:
       type: simple
-{{- if .Values.superusers }}
+      {{- if .Values.superusers }}
       superUsers:
-{{- range .Values.superusers }}
+        {{- range .Values.superusers }}
         - {{ . }}
-{{- end }}
-{{- end }}
+        {{- end }}
+      {{- end }}
     config:
       offsets.topic.replication.factor:  {{ .Values.kafka.replicas }}
       transaction.state.log.replication.factor:  {{ .Values.kafka.replicas }}
@@ -267,20 +246,6 @@ spec:
           name: kafka-metrics
           key: kafka-metrics-config.yml
     {{- end }}
-    storage:
-      type: jbod
-      volumes:
-        # Note that storage is configured per replica. If there are 3 replicas,
-        # and 2 volumes in this array, each replica will get 2
-        # PersistentVolumeClaims for the configured size, for a total of 6
-        # volumes.
-      - id: 0
-        type: persistent-claim
-        size: {{ .Values.kafka.storage.size }}
-        {{- if .Values.kafka.storage.storageClassName }}
-        class: {{ .Values.kafka.storage.storageClassName }}
-        {{- end}}
-        deleteClaim: false
   entityOperator:
     topicOperator: {}
     userOperator: {}

--- a/applications/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
@@ -55,16 +55,16 @@ spec:
     {{- toYaml . | nindent 6 }}
   {{- end }}
 {{- end }}
-{{- if or .Values.brokerStorage.enabled .Values.brokerStorage.migration.enabled }}
+{{- if .Values.brokerStorage.enabled }}
 ---
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaNodePool
 metadata:
-  name: kafka-local-storage
+  name: {{ .Values.brokerStorage.nodePoolName }}
   labels:
     strimzi.io/cluster: {{ .Values.cluster.name }}
   annotations:
-    strimzi.io/next-node-ids: "[6,7,8]"
+    strimzi.io/next-node-ids: {{ .Values.brokerStorage.nodeIds | quote}}
 spec:
   replicas: {{ .Values.kafka.replicas }}
   roles:
@@ -94,19 +94,59 @@ spec:
     {{- toYaml . | nindent 6 }}
   {{- end }}
 {{- end }}
-{{- if and .Values.brokerStorage.migration.enabled .Values.brokerStorage.migration.rebalance }}
+
+{{- if .Values.brokerStorageMigration.enabled }}
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaNodePool
+metadata:
+  name: {{ .Values.brokerStorageMigration.nodePoolName }}
+  labels:
+    strimzi.io/cluster: {{ .Values.cluster.name }}
+  annotations:
+    strimzi.io/next-node-ids: {{ .Values.brokerStorageMigration.nodeIds | quote}}
+spec:
+  replicas: {{ .Values.kafka.replicas }}
+  roles:
+    - broker
+  storage:
+    type: jbod
+    volumes:
+    - id: 0
+      type: persistent-claim
+      size: {{ .Values.brokerStorageMigration.size }}
+      {{- if .Values.brokerStorageMigration.storageClassName }}
+      class: {{ .Values.brokerStorageMigration.storageClassName }}
+      {{- end}}
+      deleteClaim: false
+  template:
+    pod:
+      {{- with .Values.brokerStorageMigration.affinity }}
+      affinity:
+        {{- toYaml . | nindent 10 }}
+      {{- end }}
+      {{- with .Values.brokerStorageMigration.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 10 }}
+      {{- end}}
+  {{- with .Values.kafka.resources }}
+  resources:
+    {{- toYaml . | nindent 6 }}
+  {{- end }}
+{{- end }}
+{{- if and .Values.brokerStorageMigration.enabled .Values.brokerStorageMigration.rebalance.enabled }}
 ---
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaRebalance
 metadata:
-  name: broker-migration
+  name: broker-migration-rebalance
   labels:
     strimzi.io/cluster: {{ .Values.cluster.name }}
   annotations:
     strimzi.io/rebalance-auto-approval: "true"
 spec:
   mode: remove-brokers
-  {{- with .Values.brokerStorage.migration.brokers }}
+  {{- with .Values.brokerStorageMigration.rebalance.removeBrokers }}
   brokers:
     {{- toYaml . | nindent 6 }}
   {{- end }}

--- a/applications/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
@@ -309,5 +309,7 @@ spec:
     {{- end }}
   {{- end }}
   {{ if .Values.cruiseControl.enabled }}
-  cruiseControl: {}
+  cruiseControl:
+    config:
+      max.replicas.per.broker: {{ .Values.cruiseControl.maxReplicasPerBroker }}
   {{- end }}

--- a/applications/sasquatch/charts/strimzi-kafka/values.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/values.yaml
@@ -20,13 +20,6 @@ kafka:
   # Cannot be greater than the number of replicas.
   minInsyncReplicas: 2
 
-  storage:
-    # -- Size of the backing storage disk for each of the Kafka brokers
-    size: 500Gi
-
-    # -- Name of a StorageClass to use when requesting persistent volumes
-    storageClassName: ""
-
   config:
     # -- Number of minutes for a consumer group's offsets to be retained
     # @default -- 4320 minutes (3 days)
@@ -112,8 +105,22 @@ kafka:
     #     annotations:
     #       metallb.universe.tf/address-pool: sdf-dmz
 
-  # -- Affinity for Kafka pod assignment
-  # @default -- See `values.yaml`
+controller:
+  # -- Enable node pool for the kafka controllers
+  enabled: false
+
+  # -- IDs to assign to the controllers
+  nodeIds: "[3,4,5]"
+
+  storage:
+    # -- Storage size for the controllers
+    size: 20Gi
+
+    # -- Storage class to use when requesting persistent volumes
+    # @default -- None, use the default storage class
+    storageClassName: ""
+
+  # -- Affinity for controller pod assignment
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -125,11 +132,52 @@ kafka:
                   - kafka
           topologyKey: "kubernetes.io/hostname"
 
-  # -- Tolerations for Kafka broker pod assignment
+  # -- Tolerations for controller pod assignment
   tolerations: []
 
-  # -- Kubernetes requests and limits for the Kafka brokers
-  # @default -- See `values.yaml`
+  # -- Kubernetes resources for the controllers
+  resources:
+    requests:
+      memory: 8Gi
+      cpu: "1"
+    limits:
+      memory: 8Gi
+      cpu: "1"
+
+broker:
+  # -- Enable node pool for the kafka brokers
+  enabled: false
+
+  # -- Node pool name
+  name: kafka
+
+  # -- IDs to assign to the brokers
+  nodeIds: "[0,1,2]"
+
+  storage:
+    # -- Storage size for the brokers
+    size: 1.5Ti
+
+    # -- Storage class to use when requesting persistent volumes
+    # @default -- None, use the default storage class
+    storageClassName: ""
+
+  # -- Affinity for broker pod assignment
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+              - key: "app.kubernetes.io/name"
+                operator: In
+                values:
+                  - kafka
+          topologyKey: "kubernetes.io/hostname"
+
+  # -- Tolerations for broker pod assignment
+  tolerations: []
+
+  # -- Kubernetes resources for the brokers
   resources:
     requests:
       memory: 32Gi
@@ -138,24 +186,60 @@ kafka:
       memory: 64Gi
       cpu: "8"
 
-kraft:
-  # -- Enable KRaft mode for Kafka
+cruiseControl:
+  # -- Enable cruise control (required for broker migration and rebalancing)
   enabled: false
 
-kafkaController:
-  # -- Enable Kafka Controller
+  # -- Maximum number of replicas per broker
+  maxReplicasPerBroker: 20000
+
+brokerMigration:
+  # -- Whether to enable another node pool to migrate the kafka brokers to
   enabled: false
 
-  storage:
-    # -- Size of the backing storage disk for each of the Kafka controllers
-    size: 20Gi
+  # -- Name of the node pool
+  name: broker-migration
 
-    # -- Name of a StorageClass to use when requesting persistent volumes
-    storageClassName: ""
+  # -- IDs to assign to the brokers
+  nodeIDs: "[6,7,8]"
 
-  # -- Kubernetes requests and limits for the Kafka Controller
-  # @default -- See `values.yaml`
+  # -- Storage size for the brokers
+  size: 1.5Ti
+
+  # -- Storage class name for the brokers
+  # @default -- None, use the default storage class
+  storageClassName: ""
+
+  rebalance:
+    # -- Whether to rebalance the kafka cluster
+    enabled: false
+
+    # -- Brokers to avoid during rebalancing
+    # These are the brokers you are migrating from and you want to remove
+    # after the migration is complete.
+    avoidBrokers:
+      - 0
+      - 1
+      - 2
+
+  # -- Affinity for Kafka broker pod assignment
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+              - key: "app.kubernetes.io/name"
+                operator: In
+                values:
+                  - kafka
+          topologyKey: "kubernetes.io/hostname"
+
+
+  # -- Tolerations for Kafka broker pod assignment
+  tolerations: []
+
   resources:
+    # -- Kubernetes resources for the brokers
     requests:
       memory: 32Gi
       cpu: "4"
@@ -281,21 +365,3 @@ mirrormaker2:
 
       # -- Replication policy.
       class: "org.apache.kafka.connect.mirror.IdentityReplicationPolicy"
-
-# -- Configuration for the Kafka Cruise Control
-cruiseControl:
-  enabled: false
-  maxReplicasPerBroker: 20000
-
-# -- Configuration for deploying Kafka brokers with local storage
-brokerStorage:
-  enabled: false
-  migration:
-    enabled: false
-    rebalance: false
-    brokers:
-      - 0
-      - 1
-      - 2
-  size: 1.5Ti
-  storageClassName: localdrive

--- a/applications/sasquatch/charts/strimzi-kafka/values.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/values.yaml
@@ -285,6 +285,7 @@ mirrormaker2:
 # -- Configuration for the Kafka Cruise Control
 cruiseControl:
   enabled: false
+  maxReplicasPerBroker: 20000
 
 # -- Configuration for deploying Kafka brokers with local storage
 brokerStorage:

--- a/applications/sasquatch/values-base.yaml
+++ b/applications/sasquatch/values-base.yaml
@@ -25,11 +25,12 @@ strimzi-kafka:
       log.message.timestamp.type: LogAppendTime
       log.retention.hours: 30
       log.retention.ms: 108000000
-    storage:
-      storageClassName: rook-ceph-block
-      size: 1Ti
     listeners:
+      tls:
+        enabled: true
       plain:
+        enabled: true
+      external:
         enabled: true
     externalListener:
       tls:
@@ -47,13 +48,6 @@ strimzi-kafka:
         - broker: 8
           loadBalancerIP: "139.229.151.174"
           host: sasquatch-base-kafka-2.lsst.codes
-    resources:
-      requests:
-        memory: 128Gi
-        cpu: 32
-      limits:
-        memory: 128Gi
-        cpu: 32
     metricsConfig:
       enabled: true
   kafkaExporter:
@@ -68,9 +62,7 @@ strimzi-kafka:
       limits:
         cpu: "8"
         memory: 1Gi
-  kraft:
-    enabled: true
-  kafkaController:
+  controller:
     enabled: true
     resources:
       requests:
@@ -79,35 +71,13 @@ strimzi-kafka:
       limits:
         memory: 8Gi
         cpu: "2"
-  users:
-    replicator:
-      enabled: true
-    telegraf:
-      enabled: true
-  registry:
-    ingress:
-      enabled: true
-      annotations:
-        nginx.ingress.kubernetes.io/rewrite-target: /$2
-      hostname: base-lsp.lsst.codes
-      path: /schema-registry(/|$)(.*)
-  connect:
-    config:
-      key.converter: org.apache.kafka.connect.json.JsonConverter
-      key.converter.schemas.enable: false
-  cruiseControl:
+  broker:
     enabled: true
-  brokerStorage:
-    enabled: true
-    migration:
-      enabled: false
-      rebalance: false
-      brokers:
-        - 0
-        - 1
-        - 2
-    size: 1.5Ti
-    storageClassName: localdrive
+    name: "kafka-local-storage"
+    nodeIds: "[6,7,8]"
+    storage:
+      size: 1.5Ti
+      storageClassName: localdrive
     affinity:
       nodeAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:
@@ -122,6 +92,32 @@ strimzi-kafka:
         operator: "Equal"
         value: "true"
         effect: "NoSchedule"
+    resources:
+      requests:
+        memory: 128Gi
+        cpu: 32
+      limits:
+        memory: 128Gi
+        cpu: 32
+  users:
+    replicator:
+      enabled: true
+    telegraf:
+      enabled: true
+  registry:
+    ingress:
+      enabled: true
+      annotations:
+        nginx.ingress.kubernetes.io/rewrite-target: /$2
+      hostname: base-lsp.lsst.codes
+      path: /schema-registry(/|$)(.*)
+  connect:
+    enabled: true
+    config:
+      key.converter: org.apache.kafka.connect.json.JsonConverter
+      key.converter.schemas.enable: false
+  cruiseControl:
+    enabled: true
 
 influxdb:
   ingress:

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -1,5 +1,12 @@
 strimzi-kafka:
   kafka:
+    listeners:
+      tls:
+        enabled: true
+      plain:
+        enabled: true
+      external:
+        enabled: true
     externalListener:
       tls:
         enabled: true
@@ -16,22 +23,24 @@ strimzi-kafka:
         - broker: 2
           loadBalancerIP: "34.172.163.125"
           host: sasquatch-dev-kafka-2.lsst.cloud
-    resources:
-      requests:
-        memory: 16Gi
-        cpu: 2
-      limits:
-        memory: 16Gi
-        cpu: 2
   users:
     replicator:
       enabled: true
     telegraf:
       enabled: true
-  kraft:
+  controller:
     enabled: true
-  kafkaController:
+    resources:
+      requests:
+        memory: 8Gi
+        cpu: "1"
+      limits:
+        memory: 8Gi
+        cpu: "1"
+  broker:
     enabled: true
+    storage:
+      size: 500Gi
     resources:
       requests:
         memory: 16Gi
@@ -39,7 +48,6 @@ strimzi-kafka:
       limits:
         memory: 16Gi
         cpu: "2"
-
   registry:
     ingress:
       enabled: true

--- a/applications/sasquatch/values-idfint.yaml
+++ b/applications/sasquatch/values-idfint.yaml
@@ -1,12 +1,18 @@
 strimzi-kafka:
   kafka:
+    listeners:
+      tls:
+        enabled: true
+      plain:
+        enabled: true
+      external:
+        enabled: true
     externalListener:
       tls:
         enabled: true
       bootstrap:
         loadBalancerIP: "35.188.187.82"
         host: sasquatch-int-kafka-bootstrap.lsst.cloud
-
       brokers:
         - broker: 0
           loadBalancerIP: "34.171.69.125"
@@ -24,20 +30,29 @@ strimzi-kafka:
       topicsPattern: "registry-schemas, lsst.sal.*, lsst.dm.*"
     resources:
       requests:
-        cpu: 2
+        cpu: "2"
         memory: 4Gi
       limits:
-        cpu: 4
+        cpu: "4"
         memory: 8Gi
   users:
     replicator:
       enabled: true
     telegraf:
       enabled: true
-  kraft:
+  controller:
     enabled: true
-  kafkaController:
+    resources:
+      requests:
+        memory: 8Gi
+        cpu: "1"
+      limits:
+        memory: 8Gi
+        cpu: "1"
+  broker:
     enabled: true
+    storage:
+      size: 500Gi
     resources:
       requests:
         memory: 16Gi
@@ -45,6 +60,8 @@ strimzi-kafka:
       limits:
         memory: 16Gi
         cpu: "2"
+  connect:
+    enabled: true
   registry:
     ingress:
       enabled: true

--- a/applications/sasquatch/values-idfprod.yaml
+++ b/applications/sasquatch/values-idfprod.yaml
@@ -1,12 +1,18 @@
 strimzi-kafka:
   kafka:
+    listeners:
+      tls:
+        enabled: true
+      plain:
+        enabled: true
+      external:
+        enabled: true
     externalListener:
       tls:
         enabled: true
       bootstrap:
         loadBalancerIP: "34.55.132.0"
         host: sasquatch-kafka-bootstrap.lsst.cloud
-
       brokers:
         - broker: 3
           loadBalancerIP: "34.122.37.250"
@@ -20,9 +26,7 @@ strimzi-kafka:
   users:
     telegraf:
       enabled: true
-  kraft:
-    enabled: true
-  kafkaController:
+  controller:
     enabled: true
     resources:
       requests:
@@ -31,6 +35,17 @@ strimzi-kafka:
       limits:
         memory: 8Gi
         cpu: "1"
+  broker:
+    enabled: true
+    storage:
+      size: 500Gi
+    resources:
+      requests:
+        memory: 16Gi
+        cpu: "2"
+      limits:
+        memory: 16Gi
+        cpu: "2"
   registry:
     ingress:
       enabled: true
@@ -38,8 +53,6 @@ strimzi-kafka:
         nginx.ingress.kubernetes.io/rewrite-target: /$2
       hostname: data.lsst.cloud
       path: /schema-registry(/|$)(.*)
-  connect:
-    enabled: false
 
 influxdb:
   ingress:

--- a/applications/sasquatch/values-roundtable-dev.yaml
+++ b/applications/sasquatch/values-roundtable-dev.yaml
@@ -1,6 +1,5 @@
 strimzi-kafka:
   kafka:
-    replicas: 3
     listeners:
       plain:
         enabled: false
@@ -8,6 +7,17 @@ strimzi-kafka:
         enabled: true
       external:
         enabled: false
+  controller:
+    enabled: true
+    resources:
+      requests:
+        memory: 8Gi
+        cpu: "2"
+      limits:
+        memory: 8Gi
+        cpu: "2"
+  broker:
+    enabled: true
     storage:
       size: 100Gi
       storageClassName: "premium-rwo"
@@ -41,24 +51,8 @@ strimzi-kafka:
       limits:
         memory: 16Gi
         cpu: 2
-  kraft:
-    enabled: true
-  kafkaController:
-    enabled: true
-    resources:
-      requests:
-        memory: 8Gi
-        cpu: "2"
-      limits:
-        memory: 8Gi
-        cpu: "2"
-  users:
-    telegraf:
-      enabled: false
-
   connect:
     enabled: false
-
   mirrormaker2:
     enabled: false
 

--- a/applications/sasquatch/values-roundtable-prod.yaml
+++ b/applications/sasquatch/values-roundtable-prod.yaml
@@ -1,6 +1,5 @@
 strimzi-kafka:
   kafka:
-    replicas: 3
     listeners:
       plain:
         enabled: false
@@ -8,6 +7,17 @@ strimzi-kafka:
         enabled: true
       external:
         enabled: false
+  controller:
+    enabled: true
+    resources:
+      requests:
+        memory: 8Gi
+        cpu: "2"
+      limits:
+        memory: 8Gi
+        cpu: "2"
+  broker:
+    enabled: true
     storage:
       size: 100Gi
       storageClassName: "premium-rwo"
@@ -41,25 +51,8 @@ strimzi-kafka:
       limits:
         memory: 16Gi
         cpu: 2
-
-  kraft:
-    enabled: true
-  kafkaController:
-    enabled: true
-    resources:
-      requests:
-        memory: 8Gi
-        cpu: "2"
-      limits:
-        memory: 8Gi
-        cpu: "2"
-  users:
-    telegraf:
-      enabled: false
-
   connect:
     enabled: false
-
   mirrormaker2:
     enabled: false
 

--- a/applications/sasquatch/values-summit.yaml
+++ b/applications/sasquatch/values-summit.yaml
@@ -9,8 +9,13 @@ strimzi-kafka:
       log.message.timestamp.type: LogAppendTime
       log.retention.minutes: 10080
       offsets.retention.minutes: 10080
-    storage:
-      storageClassName: rook-ceph-block
+    listeners:
+      tls:
+        enabled: true
+      plain:
+        enabled: true
+      external:
+        enabled: true
     externalListener:
       tls:
         enabled: true
@@ -27,13 +32,6 @@ strimzi-kafka:
         - broker: 8
           loadBalancerIP: "139.229.180.94"
           host: sasquatch-summit-kafka-8.lsst.codes
-    resources:
-      requests:
-        memory: 256Gi
-        cpu: 64
-      limits:
-        memory: 256Gi
-        cpu: 64
     metricsConfig:
       enabled: true
   kafkaExporter:
@@ -47,9 +45,7 @@ strimzi-kafka:
         memory: 512Mi
       limits:
         memory: 1024Mi
-  kraft:
-    enabled: true
-  kafkaController:
+  controller:
     enabled: true
     resources:
       requests:
@@ -58,6 +54,35 @@ strimzi-kafka:
       limits:
         memory: 8Gi
         cpu: "2"
+  broker:
+    enabled: true
+    name: "kafka-local-storage"
+    nodeIds: "[6,7,8]"
+    storage:
+      size: 15Ti
+      storageClassName: localdrive
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: kafka-broker
+                  operator: In
+                  values:
+                    - "true"
+    # -- Tolerations for Kafka broker pod assignment
+    tolerations:
+      - key: "kafka-broker"
+        operator: "Equal"
+        value: "true"
+        effect: "NoSchedule"
+    resources:
+      requests:
+        memory: 256Gi
+        cpu: 64
+      limits:
+        memory: 256Gi
+        cpu: 64
   users:
     replicator:
       enabled: true
@@ -72,32 +97,9 @@ strimzi-kafka:
       path: /schema-registry(/|$)(.*)
   connect:
     enabled: false
-    config:
-      key.converter: org.apache.kafka.connect.json.JsonConverter
-      key.converter.schemas.enable: false
   cruiseControl:
     enabled: true
-  brokerStorage:
-    enabled: true
-    storageClassName: localdrive
-    size: 15Ti
-    migration:
-      enabled: false
-      rebalance: false
-    affinity:
-      nodeAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-          nodeSelectorTerms:
-            - matchExpressions:
-                - key: kafka-broker
-                  operator: In
-                  values:
-                    - "true"
-    tolerations:
-      - key: "kafka-broker"
-        operator: "Equal"
-        value: "true"
-        effect: "NoSchedule"
+
 influxdb:
   image:
     tag: "1.8.10"

--- a/applications/sasquatch/values-tucson-teststand.yaml
+++ b/applications/sasquatch/values-tucson-teststand.yaml
@@ -3,8 +3,13 @@ strimzi-kafka:
     monitorLabel:
       lsst.io/monitor: "true"
   kafka:
-    storage:
-      storageClassName: rook-ceph-block
+    listeners:
+      tls:
+        enabled: true
+      plain:
+        enabled: true
+      external:
+        enabled: true
     externalListener:
       tls:
         enabled: true
@@ -21,13 +26,6 @@ strimzi-kafka:
         - broker: 2
           loadBalancerIP: "140.252.146.47"
           host: sasquatch-tts-kafka-2.lsst.codes
-    resources:
-      requests:
-        memory: 8Gi
-        cpu: 1
-      limits:
-        memory: 8Gi
-        cpu: 1
     metricsConfig:
       enabled: true
   kafkaExporter:
@@ -43,17 +41,19 @@ strimzi-kafka:
   users:
     telegraf:
       enabled: true
-  registry:
-    ingress:
-      enabled: true
-      annotations:
-        nginx.ingress.kubernetes.io/rewrite-target: /$2
-      hostname: tucson-teststand.lsst.codes
-      path: /schema-registry(/|$)(.*)
-  kraft:
+  controller:
     enabled: true
-  kafkaController:
+    resources:
+      requests:
+        memory: 8Gi
+        cpu: "1"
+      limits:
+        memory: 8Gi
+        cpu: "1"
+  broker:
     enabled: true
+    storage:
+      size: 500Gi
     resources:
       requests:
         memory: 16Gi
@@ -61,6 +61,13 @@ strimzi-kafka:
       limits:
         memory: 16Gi
         cpu: "2"
+  registry:
+    ingress:
+      enabled: true
+      annotations:
+        nginx.ingress.kubernetes.io/rewrite-target: /$2
+      hostname: tucson-teststand.lsst.codes
+      path: /schema-registry(/|$)(.*)
 
 influxdb:
   persistence:

--- a/applications/sasquatch/values-usdfdev.yaml
+++ b/applications/sasquatch/values-usdfdev.yaml
@@ -1,5 +1,12 @@
 strimzi-kafka:
   kafka:
+    listeners:
+      tls:
+        enabled: true
+      plain:
+        enabled: true
+      external:
+        enabled: true
     externalListener:
       tls:
         enabled: true
@@ -33,10 +40,35 @@ strimzi-kafka:
       enabled: true
     telegraf:
       enabled: true
-  kraft:
+  controller:
     enabled: true
-  kafkaController:
+    resources:
+      requests:
+        memory: 8Gi
+        cpu: "1"
+      limits:
+        memory: 8Gi
+        cpu: "1"
+  broker:
     enabled: true
+    storage:
+      size: 500Gi
+    resources:
+      requests:
+        memory: 16Gi
+        cpu: "2"
+      limits:
+        memory: 16Gi
+        cpu: "2"
+  connect:
+    enabled: true
+    resources:
+      requests:
+        memory: 8Gi
+        cpu: "1"
+      limits:
+        memory: 8Gi
+        cpu: "1"
 
 influxdb:
   ingress:

--- a/applications/sasquatch/values-usdfint.yaml
+++ b/applications/sasquatch/values-usdfint.yaml
@@ -1,4 +1,28 @@
 strimzi-kafka:
+  kafka:
+    listeners:
+      tls:
+        enabled: true
+      plain:
+        enabled: true
+      external:
+        enabled: true
+    externalListener:
+      tls:
+        enabled: true
+      bootstrap:
+        annotations:
+          metallb.universe.tf/address-pool: sdf-rubin-ingest
+      brokers:
+        - broker: 0
+          annotations:
+            metallb.universe.tf/address-pool: sdf-rubin-ingest
+        - broker: 1
+          annotations:
+            metallb.universe.tf/address-pool: sdf-rubin-ingest
+        - broker: 2
+          annotations:
+            metallb.universe.tf/address-pool: sdf-rubin-ingest
   mirrormaker2:
     enabled: false
     source:
@@ -14,10 +38,26 @@ strimzi-kafka:
   users:
     telegraf:
       enabled: true
-  kraft:
+  controller:
     enabled: true
-  kafkaController:
+    resources:
+      requests:
+        memory: 8Gi
+        cpu: "1"
+      limits:
+        memory: 8Gi
+        cpu: "1"
+  broker:
     enabled: true
+    storage:
+      size: 500Gi
+    resources:
+      requests:
+        memory: 16Gi
+        cpu: "2"
+      limits:
+        memory: 16Gi
+        cpu: "2"
 
 influxdb:
   ingress:

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -87,9 +87,7 @@ strimzi-kafka:
     rebalance:
       enabled: true
       removeBrokers:
-        - 6
         - 7
-        - 8
     affinity:
       nodeAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -87,7 +87,9 @@ strimzi-kafka:
     rebalance:
       enabled: true
       removeBrokers:
+        - 6
         - 7
+        - 8
     affinity:
       nodeAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -12,13 +12,13 @@ strimzi-kafka:
         annotations:
           metallb.universe.tf/address-pool: sdf-rubin-ingest
       brokers:
-        - broker: 6
+        - broker: 0
           annotations:
             metallb.universe.tf/address-pool: sdf-rubin-ingest
-        - broker: 7
+        - broker: 1
           annotations:
             metallb.universe.tf/address-pool: sdf-rubin-ingest
-        - broker: 8
+        - broker: 2
           annotations:
             metallb.universe.tf/address-pool: sdf-rubin-ingest
 
@@ -51,45 +51,16 @@ strimzi-kafka:
     enabled: true
   cruiseControl:
     enabled: true
-  brokerStorage:
-    enabled: true
-    nodePoolName: kafka-local-storage
-    nodeIds: "[6,7,8]"
-    storageClassName: zfs--rubin-efd
-    size: 1.5Ti
-    affinity:
-      nodeAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-          nodeSelectorTerms:
-            - matchExpressions:
-                - key: kubernetes.io/hostname
-                  operator: In
-                  values:
-                    - sdfk8sn004
-                    - sdfk8sn003
-                    - sdfk8sn007
-      podAntiAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-                - key: strimzi.io/cluster
-                  operator: In
-                  values:
-                    - sasquatch
-            topologyKey: kubernetes.io/hostname
-
   brokerStorageMigration:
+    enabled: false
+    rebalance:
+      enabled: false
+  brokerStorage:
     enabled: true
     nodePoolName: kafka
     nodeIds: "[0,1,2]"
     storageClassName: zfs--rubin-efd
     size: 5Ti
-    rebalance:
-      enabled: true
-      removeBrokers:
-        - 6
-        - 7
-        - 8
     affinity:
       nodeAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -5,6 +5,13 @@ strimzi-kafka:
       replica.lag.time.max.ms: 120000
       log.retention.minutes: 10080
       offsets.retention.minutes: 10080
+    listeners:
+      tls:
+        enabled: true
+      plain:
+        enabled: true
+      external:
+        enabled: true
     externalListener:
       tls:
         enabled: true
@@ -21,13 +28,11 @@ strimzi-kafka:
         - broker: 2
           annotations:
             metallb.universe.tf/address-pool: sdf-rubin-ingest
-
   connect:
     enabled: true
     config:
       # -- Increase the request timeout for Kafka Connect to 120 seconds
       request.timeout.ms: 120000
-
   mirrormaker2:
     enabled: true
     source:
@@ -45,22 +50,15 @@ strimzi-kafka:
       enabled: true
     telegraf:
       enabled: true
-  kraft:
+  controller:
     enabled: true
-  kafkaController:
+  broker:
     enabled: true
-  cruiseControl:
-    enabled: true
-  brokerStorageMigration:
-    enabled: false
-    rebalance:
-      enabled: false
-  brokerStorage:
-    enabled: true
-    nodePoolName: kafka
+    name: kafka
     nodeIds: "[0,1,2]"
-    storageClassName: zfs--rubin-efd
-    size: 5Ti
+    storage:
+      size: 5Ti
+      storageClassName: zfs--rubin-efd
     affinity:
       nodeAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:
@@ -81,6 +79,8 @@ strimzi-kafka:
                   values:
                     - sasquatch
             topologyKey: kubernetes.io/hostname
+  cruiseControl:
+    enabled: true
 
 influxdb:
   enabled: false

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -53,15 +53,13 @@ strimzi-kafka:
     enabled: true
   brokerStorage:
     enabled: true
+    nodePoolName: kafka-local-storage
+    nodeIds: "[6,7,8]"
+    storageClassName: zfs--rubin-efd
     migration:
       enabled: false
       rebalance: false
-      brokers:
-        - 3
-        - 4
-        - 5
     size: 1.5Ti
-    storageClassName: zfs--rubin-efd
     affinity:
       nodeAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:
@@ -82,6 +80,11 @@ strimzi-kafka:
                   values:
                     - sasquatch
             topologyKey: kubernetes.io/hostname
+
+  brokerStorageMigration:
+    enabled: false
+    rebalance:
+      enabled: false
 
 influxdb:
   enabled: false

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -56,9 +56,6 @@ strimzi-kafka:
     nodePoolName: kafka-local-storage
     nodeIds: "[6,7,8]"
     storageClassName: zfs--rubin-efd
-    migration:
-      enabled: false
-      rebalance: false
     size: 1.5Ti
     affinity:
       nodeAffinity:
@@ -82,9 +79,37 @@ strimzi-kafka:
             topologyKey: kubernetes.io/hostname
 
   brokerStorageMigration:
-    enabled: false
+    enabled: true
+    nodePoolName: kafka
+    nodeIds: "[0,1,2]"
+    storageClassName: zfs--rubin-efd
+    size: 5Ti
     rebalance:
-      enabled: false
+      enabled: true
+      removeBrokers:
+        - 6
+        - 7
+        - 8
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: kubernetes.io/hostname
+                  operator: In
+                  values:
+                    - sdfk8so001
+                    - sdfk8so005
+                    - sdfk8so006
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+                - key: strimzi.io/cluster
+                  operator: In
+                  values:
+                    - sasquatch
+            topologyKey: kubernetes.io/hostname
 
 influxdb:
   enabled: false

--- a/applications/sasquatch/values.yaml
+++ b/applications/sasquatch/values.yaml
@@ -1,24 +1,7 @@
 # Default values for Sasquatch.
 
 # Override strimzi-kafka subchart configuration.
-strimzi-kafka:
-  kafka:
-    listeners:
-      tls:
-        # -- Whether internal TLS listener is enabled
-        enabled: true
-
-      plain:
-        # -- Whether internal plaintext listener is enabled
-        enabled: true
-
-      external:
-        # -- Whether external listener is enabled
-        enabled: true
-
-  connect:
-    # -- Whether Kafka Connect is enabled
-    enabled: true
+strimzi-kafka: {}
 
 strimzi-registry-operator:
   # -- Name of the Strimzi Kafka cluster


### PR DESCRIPTION
Refactor Kafka configuration, in particular:
- Make Kraft mode the only option
- Remove unused storage configuration
- Individual resources configuration for controller, broker and broker migration nodepools
- Use similar configuration structure for controller, broker and broker migration nodepools
- Update kafka configuration for all environments
Perform migration of Kafka brokers at USDF to new data nodes.