### PR TITLE
DM-51015: Update Times Square to 0.20.0

### DIFF
--- a/applications/times-square/Chart.yaml
+++ b/applications/times-square/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 type: application
 
 # The default version tag of the times-square docker image
-appVersion: "0.19.0"
+appVersion: "0.20.0"
 
 dependencies:
   - name: redis

--- a/applications/times-square/README.md
+++ b/applications/times-square/README.md
@@ -34,7 +34,7 @@ An API service for managing and rendering parameterized Jupyter notebooks.
 | config.logLevel | string | `"INFO"` | Logging level: "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL" |
 | config.name | string | `"times-square"` | Name of the service. |
 | config.nbstripoutMigration.dryRun | bool | `true` | Whether to run the nbstripout migration job as a dry-run only |
-| config.nbstripoutMigration.enabled | bool | `false` | Whether to run the nbstripout migration job as a pre-install/upgrade hook |
+| config.nbstripoutMigration.enabled | bool | `true` | Whether to run the nbstripout migration job as a pre-install/upgrade hook |
 | config.nbstripoutMigration.onDemand | bool | `false` | Whether to run the job on demand or as a hook (default) |
 | config.profile | string | `"production"` | Run profile: "production" or "development" |
 | config.redisCacheUrl | string | Points to embedded Redis | URL for Redis html / noteburst job cache database |

--- a/applications/times-square/README.md
+++ b/applications/times-square/README.md
@@ -29,10 +29,12 @@ An API service for managing and rendering parameterized Jupyter notebooks.
 | config.githubCheckRunTimeout | string | `"3600"` | Timeout for GitHub check runs in seconds |
 | config.githubOrgs | string | `"lsst,lsst-sqre,lsst-dm,lsst-ts,lsst-sitcom,lsst-pst"` | GitHub organizations that can sync repos to Times Square (comma-separated). |
 | config.htmlKeyMigration.dryRun | bool | `true` | Whether to run the HTML key migration job as a dry-run only |
-| config.htmlKeyMigration.enabled | bool | `false` |  |
+| config.htmlKeyMigration.enabled | bool | `false` | Whether to run the HTML key migration job as a pre-install/upgrade hook |
 | config.htmlKeyMigration.page | string | `""` | The name of the page to migrate, if set |
 | config.logLevel | string | `"INFO"` | Logging level: "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL" |
 | config.name | string | `"times-square"` | Name of the service. |
+| config.nbstripoutMigration.dryRun | bool | `true` | Whether to run the nbstripout migration job as a dry-run only |
+| config.nbstripoutMigration.enabled | bool | `false` | Whether to run the nbstripout migration job as a pre-install/upgrade hook |
 | config.profile | string | `"production"` | Run profile: "production" or "development" |
 | config.redisCacheUrl | string | Points to embedded Redis | URL for Redis html / noteburst job cache database |
 | config.redisQueueUrl | string | Points to embedded Redis | URL for Redis arq queue database |

--- a/applications/times-square/README.md
+++ b/applications/times-square/README.md
@@ -33,7 +33,7 @@ An API service for managing and rendering parameterized Jupyter notebooks.
 | config.htmlKeyMigration.page | string | `""` | The name of the page to migrate, if set |
 | config.logLevel | string | `"INFO"` | Logging level: "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL" |
 | config.name | string | `"times-square"` | Name of the service. |
-| config.nbstripoutMigration.dryRun | bool | `true` | Whether to run the nbstripout migration job as a dry-run only |
+| config.nbstripoutMigration.dryRun | bool | `false` | Whether to run the nbstripout migration job as a dry-run only |
 | config.nbstripoutMigration.enabled | bool | `true` | Whether to run the nbstripout migration job as a pre-install/upgrade hook |
 | config.nbstripoutMigration.onDemand | bool | `false` | Whether to run the job on demand or as a hook (default) |
 | config.profile | string | `"production"` | Run profile: "production" or "development" |

--- a/applications/times-square/README.md
+++ b/applications/times-square/README.md
@@ -35,6 +35,7 @@ An API service for managing and rendering parameterized Jupyter notebooks.
 | config.name | string | `"times-square"` | Name of the service. |
 | config.nbstripoutMigration.dryRun | bool | `true` | Whether to run the nbstripout migration job as a dry-run only |
 | config.nbstripoutMigration.enabled | bool | `false` | Whether to run the nbstripout migration job as a pre-install/upgrade hook |
+| config.nbstripoutMigration.onDemand | bool | `false` | Whether to run the job on demand or as a hook (default) |
 | config.profile | string | `"production"` | Run profile: "production" or "development" |
 | config.redisCacheUrl | string | Points to embedded Redis | URL for Redis html / noteburst job cache database |
 | config.redisQueueUrl | string | Points to embedded Redis | URL for Redis arq queue database |

--- a/applications/times-square/templates/job-html-key-migrate.yaml
+++ b/applications/times-square/templates/job-html-key-migrate.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "times-square-schema-update"
+  name: "times-square-html-key-migrator"
   labels:
     {{- include "times-square.labels" . | nindent 4 }}
     app.kubernetes.io/component: "html-key-migrator"

--- a/applications/times-square/templates/job-nbstripout.yaml
+++ b/applications/times-square/templates/job-nbstripout.yaml
@@ -3,10 +3,12 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: "times-square-nbstripout"
+  {{- if not .Values.config.nbstripoutMigration.onDemand }}
   annotations:
     helm.sh/hook: "pre-install,pre-upgrade"
     helm.sh/hook-delete-policy: "before-hook-creation"
     helm.sh/hook-weight: "2"  # schema update has 1, so run after it
+  {{- end }}
   labels:
     {{- include "times-square.labels" . | nindent 4 }}
 spec:

--- a/applications/times-square/templates/job-nbstripout.yaml
+++ b/applications/times-square/templates/job-nbstripout.yaml
@@ -1,0 +1,104 @@
+{{- if .Values.config.nbstripoutMigration.enabled -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "times-square-nbstripout"
+  annotations:
+    helm.sh/hook: "pre-install,pre-upgrade"
+    helm.sh/hook-delete-policy: "before-hook-creation"
+    helm.sh/hook-weight: "2"  # schema update has 1, so run after it
+  labels:
+    {{- include "times-square.labels" . | nindent 4 }}
+spec:
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "times-square.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: "nbstripout"
+        times-square-redis-client: "true"
+    spec:
+      {{- if .Values.cloudsql.enabled }}
+      serviceAccountName: {{ include "times-square.serviceAccountName" . }}
+      {{- else }}
+      automountServiceAccountToken: false
+      {{- end }}
+      containers:
+        - name: "times-square"
+          command:
+            - "times-square"
+            - "nbstripout"
+            {{- if .Values.config.nbstripoutMigration.dryRun }}
+            - "--dry-run"
+            {{- end }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+            readOnlyRootFilesystem: true
+          envFrom:
+            - configMapRef:
+                name: {{ include "times-square.fullname" . }}
+          env:
+            - name: "TS_GAFAELFAWR_TOKEN"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "times-square.fullname" . }}-gafaelfawr-token
+                  key: "token"
+            - name: "TS_DATABASE_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "times-square.fullname" . }}-secret
+                  key: "TS_DATABASE_PASSWORD"
+            - name: "TS_GITHUB_WEBHOOK_SECRET"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "times-square.fullname" . }}-secret
+                  key: "TS_GITHUB_WEBHOOK_SECRET"
+            - name: "TS_GITHUB_WEBHOOK_SECRET"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "times-square.fullname" . }}-secret
+                  key: "TS_GITHUB_WEBHOOK_SECRET"
+            - name: "TS_GITHUB_APP_PRIVATE_KEY"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "times-square.fullname" . }}-secret
+                  key: "TS_GITHUB_APP_PRIVATE_KEY"
+            - name: "TS_SLACK_WEBHOOK_URL"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "times-square.fullname" . }}-secret
+                  key: "TS_SLACK_WEBHOOK_URL"
+      {{- if .Values.cloudsql.enabled }}
+      initContainers:
+        {{- include "times-square.cloudsqlSidecar" . | nindent 8 }}
+      {{- end }}
+      restartPolicy: "Never"
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/applications/times-square/templates/job-schema-update.yaml
+++ b/applications/times-square/templates/job-schema-update.yaml
@@ -4,7 +4,6 @@ kind: Job
 metadata:
   name: "times-square-schema-update"
   annotations:
-  annotations:
     helm.sh/hook: "pre-install,pre-upgrade"
     helm.sh/hook-delete-policy: "hook-succeeded"
     helm.sh/hook-weight: "1"

--- a/applications/times-square/values-idfdev.yaml
+++ b/applications/times-square/values-idfdev.yaml
@@ -9,6 +9,9 @@ config:
   enableGitHubApp: "True"
   githubCheckRunTimeout: "900" # 15 minutes
   sentryTracesSampleRate: 1
+  nbstripoutMigration:
+    enabled: true
+    dryRun: false
 cloudsql:
   enabled: true
   instanceConnectionName: "science-platform-dev-7696:us-central1:science-platform-dev-e9e11de2"

--- a/applications/times-square/values-idfdev.yaml
+++ b/applications/times-square/values-idfdev.yaml
@@ -12,6 +12,7 @@ config:
   nbstripoutMigration:
     enabled: true
     dryRun: false
+    onDemand: true
 cloudsql:
   enabled: true
   instanceConnectionName: "science-platform-dev-7696:us-central1:science-platform-dev-e9e11de2"

--- a/applications/times-square/values-idfdev.yaml
+++ b/applications/times-square/values-idfdev.yaml
@@ -9,10 +9,6 @@ config:
   enableGitHubApp: "True"
   githubCheckRunTimeout: "900" # 15 minutes
   sentryTracesSampleRate: 1
-  nbstripoutMigration:
-    enabled: true
-    dryRun: false
-    onDemand: true
 cloudsql:
   enabled: true
   instanceConnectionName: "science-platform-dev-7696:us-central1:science-platform-dev-e9e11de2"

--- a/applications/times-square/values.yaml
+++ b/applications/times-square/values.yaml
@@ -167,7 +167,7 @@ config:
     onDemand: false
 
     # -- Whether to run the nbstripout migration job as a dry-run only
-    dryRun: true
+    dryRun: false
 
   worker:
     # -- Enable liveness checks for the arq queue

--- a/applications/times-square/values.yaml
+++ b/applications/times-square/values.yaml
@@ -161,7 +161,7 @@ config:
 
   nbstripoutMigration:
     # -- Whether to run the nbstripout migration job as a pre-install/upgrade hook
-    enabled: false
+    enabled: true
 
     # -- Whether to run the job on demand or as a hook (default)
     onDemand: false

--- a/applications/times-square/values.yaml
+++ b/applications/times-square/values.yaml
@@ -163,6 +163,9 @@ config:
     # -- Whether to run the nbstripout migration job as a pre-install/upgrade hook
     enabled: false
 
+    # -- Whether to run the job on demand or as a hook (default)
+    onDemand: false
+
     # -- Whether to run the nbstripout migration job as a dry-run only
     dryRun: true
 

--- a/applications/times-square/values.yaml
+++ b/applications/times-square/values.yaml
@@ -149,11 +149,8 @@ config:
   # Sentry tracing sample rate
   sentryTracesSampleRate: 0.0
 
-  worker:
-    # -- Enable liveness checks for the arq queue
-    enableLivenessCheck: true
-
   htmlKeyMigration:
+    # -- Whether to run the HTML key migration job as a pre-install/upgrade hook
     enabled: false
 
     # -- Whether to run the HTML key migration job as a dry-run only
@@ -161,6 +158,17 @@ config:
 
     # -- The name of the page to migrate, if set
     page: ""
+
+  nbstripoutMigration:
+    # -- Whether to run the nbstripout migration job as a pre-install/upgrade hook
+    enabled: false
+
+    # -- Whether to run the nbstripout migration job as a dry-run only
+    dryRun: true
+
+  worker:
+    # -- Enable liveness checks for the arq queue
+    enableLivenessCheck: true
 
 cloudsql:
   # -- Enable the Cloud SQL Auth Proxy sidecar, used with Cloud SQL databases


### PR DESCRIPTION
This version strips notebook outputs and kernel specs from notebooks before storage. This should improve efficiency and prevent errors related to notebooks being saved with kernel info that isn't appropriate to the noteburst context.

See https://github.com/lsst-sqre/times-square/pull/101