### PR TITLE
DM-51004: Relax qserv-kafka pod securityContext

### DIFF
--- a/applications/qserv-kafka/templates/frontend-deployment.yaml
+++ b/applications/qserv-kafka/templates/frontend-deployment.yaml
@@ -99,7 +99,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       securityContext:
-        runAsNonRoot: true
+        runAsNonRoot: false
         runAsUser: 1000
         runAsGroup: 1000
       volumes:

--- a/applications/qserv-kafka/templates/worker-deployment.yaml
+++ b/applications/qserv-kafka/templates/worker-deployment.yaml
@@ -97,7 +97,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       securityContext:
-        runAsNonRoot: true
+        runAsNonRoot: false
         runAsUser: 1000
         runAsGroup: 1000
       volumes:


### PR DESCRIPTION
Temporarily allow containers to run as root in all the qserv-kafka pods so that we can attach a memory profiler in a debug container, without recreating the pod, when we see them leaking memory.

More info about the debug pod process:
https://rubin-obs.slack.com/docs/T02SVMGU4/F08SVEUKE7M