### PR TITLE
DM-51004: Set up Qserv Kafka bridge debugging

### DIFF
--- a/applications/qserv-kafka/README.md
+++ b/applications/qserv-kafka/README.md
@@ -31,6 +31,7 @@ Qserv Kafka bridge
 | config.qservRestUrl | string | None, must be set | URL to the Qserv REST API |
 | config.resultTimeout | int | 3600 (1 hour) | How long to wait for result processing (retrieval and upload) before timing out, in seconds. This doubles as the timeout forcibly terminating result worker pods. |
 | frontend.affinity | object | `{}` | Affinity rules for the qserv-kafka frontend pod |
+| frontend.allowRootDebug | bool | `false` | Whether to allow containers to run as root. Set to true to allow use of debug containers to diagnose issues such as memory leaks. |
 | frontend.nodeSelector | object | `{}` | Node selection rules for the qserv-kafka frontend pod |
 | frontend.podAnnotations | object | `{}` | Annotations for the qserv-kafka frontend pod |
 | frontend.resources | object | See `values.yaml` | Resource limits and requests for the qserv-kafka frontend pod |
@@ -51,6 +52,7 @@ Qserv Kafka bridge
 | redis.persistence.volumeClaimName | string | `nil` | Use an existing PVC, not dynamic provisioning. If this is set, the size, storageClass, and accessMode settings are ignored. |
 | redis.resources | object | See `values.yaml` | Resource limits and requests for the Redis pod |
 | resultWorker.affinity | object | `{}` | Affinity rules for the qserv-kafka worker pods |
+| resultWorker.allowRootDebug | bool | `false` | Whether to allow containers to run as root. Set to true to allow use of debug containers to diagnose issues such as memory leaks. |
 | resultWorker.autoscaling.enabled | bool | `true` | Enable autoscaling of qserv-kafka result workers |
 | resultWorker.autoscaling.maxReplicas | int | `10` | Maximum number of qserv-kafka worker pods. Each replica will open database connections up to the configured pool size and overflow limits, so make sure the combined connections are under the postgres connection limit. |
 | resultWorker.autoscaling.minReplicas | int | `1` | Minimum number of qserv-kafka worker pods |

--- a/applications/qserv-kafka/templates/frontend-deployment.yaml
+++ b/applications/qserv-kafka/templates/frontend-deployment.yaml
@@ -99,7 +99,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       securityContext:
-        runAsNonRoot: false
+        runAsNonRoot: {{ not .Values.frontend.allowRootDebug }}
         runAsUser: 1000
         runAsGroup: 1000
       volumes:

--- a/applications/qserv-kafka/templates/worker-deployment.yaml
+++ b/applications/qserv-kafka/templates/worker-deployment.yaml
@@ -97,7 +97,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       securityContext:
-        runAsNonRoot: false
+        runAsNonRoot: {{ not .Values.resultWorker.allowRootDebug }}
         runAsUser: 1000
         runAsGroup: 1000
       volumes:

--- a/applications/qserv-kafka/values-idfdev.yaml
+++ b/applications/qserv-kafka/values-idfdev.yaml
@@ -4,3 +4,10 @@ config:
     enabled: true
   qservDatabaseUrl: "mysql+asyncmy://qsmaster@qserv-int.slac.stanford.edu:4090/"
   qservRestUrl: "https://qserv-int-https.slac.stanford.edu:4098/"
+image:
+  tag: "tickets-DM-51004"
+  pullPolicy: "Always"
+frontend:
+  allowRootDebug: true
+resultWorker:
+  allowRootDebug: true

--- a/applications/qserv-kafka/values-idfint.yaml
+++ b/applications/qserv-kafka/values-idfint.yaml
@@ -4,6 +4,12 @@ config:
     enabled: true
   qservDatabaseUrl: "mysql+asyncmy://qsmaster@qserv-int.slac.stanford.edu:4090/"
   qservRestUrl: "https://qserv-int-https.slac.stanford.edu:4098/"
+image:
+  tag: "tickets-DM-51004"
+  pullPolicy: "Always"
+frontend:
+  allowRootDebug: true
 resultWorker:
+  allowRootDebug: true
   autoscaling:
     maxReplicas: 50

--- a/applications/qserv-kafka/values.yaml
+++ b/applications/qserv-kafka/values.yaml
@@ -102,6 +102,10 @@ frontend:
   # -- Affinity rules for the qserv-kafka frontend pod
   affinity: {}
 
+  # -- Whether to allow containers to run as root. Set to true to allow use of
+  # debug containers to diagnose issues such as memory leaks.
+  allowRootDebug: false
+
   # -- Node selection rules for the qserv-kafka frontend pod
   nodeSelector: {}
 
@@ -162,6 +166,10 @@ redis:
 resultWorker:
   # -- Affinity rules for the qserv-kafka worker pods
   affinity: {}
+
+  # -- Whether to allow containers to run as root. Set to true to allow use of
+  # debug containers to diagnose issues such as memory leaks.
+  allowRootDebug: false
 
   autoscaling:
     # -- Enable autoscaling of qserv-kafka result workers


### PR DESCRIPTION
Use a development image of the Qserv Kafka bridge on idfdev and idfint. Add a values setting to enable root debugging of the containers, off by default, and enable ot on idfdev and idfint.