### PR TITLE
Grant Ross Roundtable Argo CD access

### DIFF
--- a/applications/argocd/values-roundtable-prod.yaml
+++ b/applications/argocd/values-roundtable-prod.yaml
@@ -25,6 +25,7 @@ argo-cd:
         g, jsick@lsst.cloud, role:admin
         g, rra@lsst.cloud, role:admin
         g, svoutsin@lsst.cloud, role:admin
+        g, roceb@lsst.cloud, role:admin
       scopes: "[email]"
 
   server:


### PR DESCRIPTION
For eups-distributor. Eventually we want to use RBAC to limit modifications to just that application, but do the easy thing for now.