### PR TITLE
DM-51042: Set up DP1 Butler server on idfprod

### DIFF
--- a/applications/butler/values-idfprod.yaml
+++ b/applications/butler/values-idfprod.yaml
@@ -4,11 +4,15 @@ config:
   dp02ClientServerIsDefault: true
   dp02UseSlacDatastore: true
   dp02PostgresUri: postgresql://butler@dp02.rsp-sql-stable.internal:5432/dp02
+  dp1PostgresUri: postgresql://butler@dp1.rsp-sql-stable.internal:5432/dp1
   s3EndpointUrl: "https://storage.googleapis.com"
   repositories:
     dp02:
       config_uri: "file:///opt/lsst/butler/public/config/dp02-server.yaml"
       authorized_groups: ["*"]
+    dp1:
+      config_uri: "file:///opt/lsst/butler/config/dp1.yaml"
+      authorized_groups: ["g_developers", "g_cst"]
   shareNubladoSecrets: false
   additionalS3EndpointUrls:
     slac: "https://sdfdatas3.slac.stanford.edu"

--- a/environments/values-idfprod.yaml
+++ b/environments/values-idfprod.yaml
@@ -2,8 +2,8 @@ name: "idfprod"
 fqdn: "data.lsst.cloud"
 appOfAppsName: "science-platform"
 butlerServerRepositories:
-  dp01: "https://data.lsst.cloud/api/butler/repo/dp01/butler.yaml"
   dp02: "https://data.lsst.cloud/api/butler/repo/dp02/butler.yaml"
+  dp1: "https://data.lsst.cloud/api/butler/repo/dp1/butler.yaml"
 gcp:
   projectId: "science-platform-stable-6994"
   region: "us-central1"


### PR DESCRIPTION
Set up Butler server for DP1 in the production RSP at IDF.  Access is restricted to staff who are members of the g_developers and g_cst groups.