### PR TITLE
DM-51042: Fix connection string for prod DP1 Butler registry

### DIFF
--- a/applications/butler/values-idfprod.yaml
+++ b/applications/butler/values-idfprod.yaml
@@ -4,7 +4,7 @@ config:
   dp02ClientServerIsDefault: true
   dp02UseSlacDatastore: true
   dp02PostgresUri: postgresql://butler@dp02.rsp-sql-stable.internal:5432/dp02
-  dp1PostgresUri: postgresql://butler@dp1.rsp-sql-stable.internal:5432/dp1
+  dp1PostgresUri: postgresql://butler@alloydb-dp.rsp-sql-stable.internal:5432/dp1
   s3EndpointUrl: "https://storage.googleapis.com"
   repositories:
     dp02:


### PR DESCRIPTION
This was incorrectly pointing at Postgres instead of AlloyDB, previously.