### PR TITLE
DM-51083: Update times-square to 0.21.0

### DIFF
--- a/applications/times-square/Chart.yaml
+++ b/applications/times-square/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 type: application
 
 # The default version tag of the times-square docker image
-appVersion: "0.20.1"
+appVersion: "0.21.0"
 
 dependencies:
   - name: redis


### PR DESCRIPTION
This version of Times Square supports dynamic defaults for date parameters.

https://github.com/lsst-sqre/times-square/pull/104