### PR TITLE
DM-51004: Adjust requests and limits for Qserv bridge

### DIFF
--- a/applications/qserv-kafka/values.yaml
+++ b/applications/qserv-kafka/values.yaml
@@ -117,10 +117,10 @@ frontend:
   resources:
     limits:
       cpu: "1"
-      memory: "200Mi"
+      memory: "300Mi"
     requests:
       cpu: "100m"
-      memory: "100Mi"
+      memory: "145Mi"
 
   # -- Tolerations for the qserv-kafka frontend pod
   tolerations: []
@@ -201,10 +201,10 @@ resultWorker:
   resources:
     limits:
       cpu: "1"
-      memory: "600Mi"
+      memory: "300Mi"
     requests:
       cpu: "1"
-      memory: "300Mi"
+      memory: "145Mi"
 
   # -- Tolerations for the qserv-kafka worker pods
   tolerations: []


### PR DESCRIPTION
Adjust the memory requests and limits for the Qserv Kafka bridge now that we think the memory leak has stabilized.