### PR TITLE
Lower memory limits for datalinker

### DIFF
--- a/applications/datalinker/values.yaml
+++ b/applications/datalinker/values.yaml
@@ -55,10 +55,10 @@ nodeSelector: {}
 resources:
   limits:
     cpu: "1"
-    memory: "500Mi"
+    memory: "300Mi"
   requests:
     cpu: "50m"
-    memory: "200Mi"
+    memory: "125Mi"
 
 # -- Tolerations for the datalinker deployment pod
 tolerations: []


### PR DESCRIPTION
Lower the datalinker memory limits and requests to reflect current usage. These were raised earlier due to a memory leak that has now been fixed.