### PR TITLE
[DM-51126] Increase liveness probe initial delay

### DIFF
--- a/applications/sasquatch/values-usdfdev.yaml
+++ b/applications/sasquatch/values-usdfdev.yaml
@@ -71,6 +71,8 @@ strimzi-kafka:
         cpu: "1"
 
 influxdb:
+  livenessProbe:
+    initialDelaySeconds: 360
   ingress:
     enabled: false
     hostname: usdf-rsp-dev.slac.stanford.edu


### PR DESCRIPTION
- InfluxDB OSS at USDF dev is taking longer to initialize