### PR TITLE
DM-51121: Switch proxies used for Qserv on idfdev

### DIFF
--- a/applications/qserv-kafka/values-idfdev.yaml
+++ b/applications/qserv-kafka/values-idfdev.yaml
@@ -3,7 +3,7 @@ config:
   metrics:
     enabled: true
   qservDatabaseUrl: "mysql+asyncmy://qsmaster@qserv-int.slac.stanford.edu:4090/"
-  qservRestUrl: "https://134.79.23.197:4048/"
+  qservRestUrl: "https://134.79.23.197:4098/"
 image:
   tag: "tickets-DM-51121"
   pullPolicy: "Always"


### PR DESCRIPTION
Test a new proxy using NGINX instead of socat.