### PR TITLE
Enable jira-data-proxy at USDF

### DIFF
--- a/environments/values-usdfprod.yaml
+++ b/environments/values-usdfprod.yaml
@@ -17,6 +17,7 @@ applications:
   consdbtap: true
   datalinker: true
   exposurelog: true
+  jira-data-proxy: true
   livetap: true
   mobu: true
   narrativelog: true


### PR DESCRIPTION
This allows Times Square notesbooks on usdfprod to read Jira data.