### PR TITLE
DM-51083: Update Times Square to 0.21.1

### DIFF
--- a/applications/times-square/Chart.yaml
+++ b/applications/times-square/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 type: application
 
 # The default version tag of the times-square docker image
-appVersion: "0.21.0"
+appVersion: "0.21.1"
 
 dependencies:
   - name: redis


### PR DESCRIPTION
This fixes dynamic default syntax for relative numbers of
weeks/months/years. E.g. +1w, -2m, +5y.

https://github.com/lsst-sqre/times-square/releases/tag/0.21.1