### PR TITLE
Bump vo-cutouts memory limit

### DIFF
--- a/applications/vo-cutouts/values.yaml
+++ b/applications/vo-cutouts/values.yaml
@@ -173,10 +173,10 @@ redis:
   resources:
     limits:
       cpu: "0.5"
-      memory: "10Mi"
+      memory: "20Mi"
     requests:
       cpu: "0.1"
-      memory: "5Mi"
+      memory: "8Mi"
 
   # -- Affinity rules for the Redis pod
   affinity: {}


### PR DESCRIPTION
The vo-cutouts Redis died with OOM during load testing. Double the memory limit and adjust the request to behavior under load.