### PR TITLE
DM-51103: Update Times Square to 0.22.0

### DIFF
--- a/applications/times-square/Chart.yaml
+++ b/applications/times-square/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 type: application
 
 # The default version tag of the times-square docker image
-appVersion: "0.21.1"
+appVersion: "0.22.0"
 
 dependencies:
   - name: redis

--- a/applications/times-square/values.yaml
+++ b/applications/times-square/values.yaml
@@ -121,7 +121,7 @@ config:
 
   # -- Whether to run the database migration job
   # @default -- false to disable schema upgrades
-  updateSchema: false
+  updateSchema: true
 
   # -- URL for Redis html / noteburst job cache database
   # @default -- Points to embedded Redis


### PR DESCRIPTION
This version features scheduled runs of notebooks.

https://github.com/lsst-sqre/times-square/pull/108