### PR TITLE
DM-51209: Atlantis in roundtable prod

### DIFF
--- a/applications/atlantis/values-roundtable-dev.yaml
+++ b/applications/atlantis/values-roundtable-dev.yaml
@@ -4,4 +4,4 @@ persistence:
 config:
   googleServiceAccount: "atlantis@roundtable-dev-abe2.iam.gserviceaccount.com"
   serverConfig:
-    repo-allowlist: "github.com/lsst-sqre/prodromos"
+    repo-allowlist: []

--- a/applications/atlantis/values-roundtable-prod.yaml
+++ b/applications/atlantis/values-roundtable-prod.yaml
@@ -1,0 +1,7 @@
+persistence:
+  storageClass: standard-rwo
+
+config:
+  googleServiceAccount: "atlantis@roundtable-prod-f6fd.iam.gserviceaccount.com"
+  serverConfig:
+    repo-allowlist: "github.com/lsst-sqre/prodromos"

--- a/applications/atlantis/values.yaml
+++ b/applications/atlantis/values.yaml
@@ -18,8 +18,7 @@ config:
   repoConfig:
     repos:
     - id: "/.*/"
-      apply_requirements: ["approved", "mergeable", "undiverged"]
-      import_requirements: ["approved", "mergeable", "undiverged"]
+      apply_requirements: ["mergeable", "undiverged"]
 
   # -- Content for the [server
   # config](https://www.runatlantis.io/docs/server-configuration.html) file.

--- a/environments/values-roundtable-prod.yaml
+++ b/environments/values-roundtable-prod.yaml
@@ -11,6 +11,7 @@ onepassword:
 vaultPathPrefix: "secret/phalanx/roundtable-prod"
 
 applications:
+  atlantis: true
   checkerboard: true
   eups-distributor: true
   giftless: true


### PR DESCRIPTION
Release Atlantis into Roundtable prod. This will let us apply Prodromos
Terraform config from there instead of Roundtable dev.

I'd like to do this now because I'm about to submit a PR to give the
Roundtable prod Atlantis Google service destructive powers for Google
Cloud Monitoring resources in all of our Google accounts, and I don't
think the dev Atlantis should have those powers.
