### PR TITLE
DM-51209: atlantis - allowedRepos is a comma-separated string

### DIFF
--- a/applications/atlantis/README.md
+++ b/applications/atlantis/README.md
@@ -7,12 +7,11 @@ Tool for github terraform workflows: https://runatlantis.io
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules for the atlantis deployment pod |
-| config.repoAllowList | list | `[]` | The GitHub repos that atlantis will accept webooks from: [docs](https://www.runatlantis.io/docs/server-configuration.html#repo-allowlist) |
 | config.repoConfig | object | See `values.yaml` | Content for the [server-side repo config](https://www.runatlantis.io/docs/server-side-repo-config.html) file |
 | config.serverConfig | object | See `values.yaml` | Content for the [server config](https://www.runatlantis.io/docs/server-configuration.html) file. Note the format of the keys (kebab-case) |
 | config.serverConfig.automerge | bool | `false` | Whether to automatically merge PRs after plans have been applied (see [docs](https://www.runatlantis.io/docs/automerging.html)) |
 | config.serverConfig.log-level | string | `"info"` | One of: debug, info, warn, or error. |
-| config.serverConfig.repo-allowlist | list | `[]` | The GitHub repos that atlantis will accept webooks from: [docs](https://www.runatlantis.io/docs/server-configuration.html#repo-allowlist) |
+| config.serverConfig.repo-allowlist | string | `""` | Specification of GitHub repos that Atlantis will accept webooks from: [docs](https://www.runatlantis.io/docs/server-configuration.html#repo-allowlist) |
 | config.serverConfig.web-basic-auth | bool | `false` | We're delegating auth for the web UI to gafaelfawr |
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |

--- a/applications/atlantis/values-roundtable-dev.yaml
+++ b/applications/atlantis/values-roundtable-dev.yaml
@@ -4,4 +4,4 @@ persistence:
 config:
   googleServiceAccount: "atlantis@roundtable-dev-abe2.iam.gserviceaccount.com"
   serverConfig:
-    repo-allowlist: []
+    repo-allowlist: "github.com/lsst-sqre/prodromos"

--- a/applications/atlantis/values.yaml
+++ b/applications/atlantis/values.yaml
@@ -3,10 +3,6 @@
 # Declare variables to be passed into your templates.
 
 config:
-  # -- The GitHub repos that atlantis will accept webooks from:
-  # [docs](https://www.runatlantis.io/docs/server-configuration.html#repo-allowlist)
-  repoAllowList: []
-
   # -- A GCP service account that has the appropriate powers and allows the
   # Kubernetes service account to impersonate it.
   # googleServiceAccount:
@@ -33,9 +29,9 @@ config:
     hide-unchanged-plan-comments: true
     # -- One of: debug, info, warn, or error.
     log-level: "info"
-    # -- The GitHub repos that atlantis will accept webooks from:
+    # -- Specification of GitHub repos that Atlantis will accept webooks from:
     # [docs](https://www.runatlantis.io/docs/server-configuration.html#repo-allowlist)
-    repo-allowlist: []
+    repo-allowlist: ""
     # -- We're delegating auth for the web UI to gafaelfawr
     web-basic-auth: false
     autoplan-modules: true

--- a/environments/values-roundtable-dev.yaml
+++ b/environments/values-roundtable-dev.yaml
@@ -11,7 +11,7 @@ onepassword:
 vaultPathPrefix: "secret/phalanx/roundtable-dev"
 
 applications:
-  atlantis: true
+  atlantis: false
   eups-distributor: true
   giftless: true
   jira-data-proxy: true


### PR DESCRIPTION
DM-51209: atlantis - disable in roundtable-dev

The GitHub atlantis app must be installed in at least on repo for
atlantis to start. Since the roundtable-prod Atlantis is now serving the
one repo we use Atlantis for (prodromos), there are no repos we can
attach the dev Atlantis app to, so let's disable the dev Atlantis
instance.

* Disable `atlantis` in roundtable-dev
* Get rid of vestigial Helm value