### PR TITLE
DM-50932: Support for Atlantis Google Cloud Monitoring provisioning

### DIFF
--- a/applications/atlantis/secrets.yaml
+++ b/applications/atlantis/secrets.yaml
@@ -33,3 +33,10 @@ sentry-auth-token:
     A Sentry Auth Token for provisioning Sentry resources. This probably comes
     from a Sentry custom integration, likely the Prodromos integration:
     https://rubin-observatory.sentry.io/settings/developer-settings/prodromo-8704f6/
+
+google-cloud-monitoring-slack-token:
+  description: >-
+    A Slack Bot OAuth token to inject into Google Cloud Monitoring Terraform
+    config. This token will be provisioned in Google Cloud Monitoring
+    Notification Channel resources and will be used by Google Cloud to auth to
+    Slack to post notifications from Google Cloud Monitoring alerts.

--- a/applications/atlantis/templates/statefulset.yaml
+++ b/applications/atlantis/templates/statefulset.yaml
@@ -72,6 +72,14 @@ spec:
             secretKeyRef:
               name: "atlantis"
               key: "sentry-auth-token"
+
+          # Needed for provisioning Google Cloud Monitoring Notification
+          # Channels
+        - name: "TF_VAR_google_cloud_monitoring_slack_token"
+          valueFrom:
+            secretKeyRef:
+              name: "atlantis"
+              key: "google-cloud-monitoring-slack-token"
         ports:
         - name: "http"
           containerPort: 8080


### PR DESCRIPTION
Add a `google-cloud-monitoring-slack-token` secret, which is a Slack Bot OAuth token to inject into Google Cloud Monitoring Terraform config. This token will be provisioned in Google Cloud Monitoring Notification Channel resources and will be used by Google Cloud to auth to Slack to post notifications from Google Cloud Monitoring alerts.