### PR TITLE
Add default value for the Telegraf registry URL

### DIFF
--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -632,6 +632,7 @@ Rubin Observatory's telemetry service
 | telegraf.nodeSelector | object | `{}` | Node labels for pod assignment |
 | telegraf.podAnnotations | object | `{}` | Annotations for the Telegraf pods |
 | telegraf.podLabels | object | `{}` | Labels for the Telegraf pods |
+| telegraf.registry.url | string | `"http://sasquatch-schema-registry.sasquatch:8081"` | Schema Registry URL |
 | telegraf.resources | object | See `values.yaml` | Kubernetes resources requests and limits |
 | telegraf.tolerations | list | `[]` | Tolerations for pod assignment |
 | telegraf-oss.affinity | object | `{}` | Affinity for pod assignment |
@@ -669,5 +670,6 @@ Rubin Observatory's telemetry service
 | telegraf-oss.nodeSelector | object | `{}` | Node labels for pod assignment |
 | telegraf-oss.podAnnotations | object | `{}` | Annotations for the Telegraf pods |
 | telegraf-oss.podLabels | object | `{}` | Labels for the Telegraf pods |
+| telegraf-oss.registry.url | string | `"http://sasquatch-schema-registry.sasquatch:8081"` | Schema Registry URL |
 | telegraf-oss.resources | object | See `values.yaml` | Kubernetes resources requests and limits |
 | telegraf-oss.tolerations | list | `[]` | Tolerations for pod assignment |

--- a/applications/sasquatch/charts/telegraf/README.md
+++ b/applications/sasquatch/charts/telegraf/README.md
@@ -41,5 +41,6 @@ Telegraf is an agent for collecting, processing, aggregating, and writing metric
 | nodeSelector | object | `{}` | Node labels for pod assignment |
 | podAnnotations | object | `{}` | Annotations for the Telegraf pods |
 | podLabels | object | `{}` | Labels for the Telegraf pods |
+| registry.url | string | `"http://sasquatch-schema-registry.sasquatch:8081"` | Schema Registry URL |
 | resources | object | See `values.yaml` | Kubernetes resources requests and limits |
 | tolerations | list | `[]` | Tolerations for pod assignment |

--- a/applications/sasquatch/charts/telegraf/values.yaml
+++ b/applications/sasquatch/charts/telegraf/values.yaml
@@ -189,6 +189,10 @@ influxdb:
   urls:
     - "http://sasquatch-influxdb.sasquatch:8086"
 
+registry:
+  # -- Schema Registry URL
+  url: "http://sasquatch-schema-registry.sasquatch:8081"
+
 # -- Kubernetes resources requests and limits
 # @default -- See `values.yaml`
 resources:


### PR DESCRIPTION
Missing default value for the Telegraf registry URL in chart configuration.