### PR TITLE
DM-41738: Make Prompt Processing more robust to Butler connection failures

### DIFF
--- a/applications/prompt-keda-hsc/README.md
+++ b/applications/prompt-keda-hsc/README.md
@@ -47,6 +47,7 @@ KEDA Prompt Processing instance for HSC
 | prompt-keda.instrument.pipelines.main | string | None, must be set | YAML-formatted config describing which pipeline(s) should be run for which visits' raws. Fields are still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |
 | prompt-keda.instrument.pipelines.preprocessing | string | None, must be set | YAML-formatted config describing which pipeline(s) should be run before which visits' raw arrival. |
 | prompt-keda.instrument.preloadPadding | int | `42` | Number of arcseconds to pad the spatial region in preloading. |
+| prompt-keda.instrument.repoWait | int | `5` | The average time to wait (in seconds) before retrying a failed connection to the shared repo. |
 | prompt-keda.instrument.skymap | string | `"hsc_rings_v1"` | Skymap to use with the instrument |
 | prompt-keda.keda.failedJobsHistoryLimit | int | `5` |  |
 | prompt-keda.keda.maxReplicaCount | int | `100` |  |

--- a/applications/prompt-keda-hsc/values.yaml
+++ b/applications/prompt-keda-hsc/values.yaml
@@ -39,6 +39,8 @@ prompt-keda:
     # If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself.
     # @default -- None, must be set
     calibRepo: ""
+    # -- The average time to wait (in seconds) before retrying a failed connection to the shared repo.
+    repoWait: 5
     # -- YAML-formatted list of regex patterns to specify the dataset types to export.
     exportTypes: "- .*"
 

--- a/applications/prompt-keda-latiss/README.md
+++ b/applications/prompt-keda-latiss/README.md
@@ -47,6 +47,7 @@ KEDA Prompt Processing instance for LATISS
 | prompt-keda.instrument.pipelines.main | string | None, must be set | YAML-formatted config describing which pipeline(s) should be run for which visits' raws. Fields are still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |
 | prompt-keda.instrument.pipelines.preprocessing | string | None, must be set | YAML-formatted config describing which pipeline(s) should be run before which visits' raw arrival. |
 | prompt-keda.instrument.preloadPadding | int | `30` | Number of arcseconds to pad the spatial region in preloading. |
+| prompt-keda.instrument.repoWait | int | `30` | The average time to wait (in seconds) before retrying a failed connection to the shared repo. |
 | prompt-keda.instrument.skymap | string | `"latiss_v1"` | Skymap to use with the instrument |
 | prompt-keda.keda.failedJobsHistoryLimit | int | `5` |  |
 | prompt-keda.keda.maxReplicaCount | int | `30` |  |

--- a/applications/prompt-keda-latiss/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-keda-latiss/values-usdfdev-prompt-processing.yaml
@@ -21,6 +21,7 @@ prompt-keda:
         - survey: SURVEY
           pipelines: ['${PROMPT_PROCESSING_DIR}/pipelines/LATISS/Preprocessing.yaml']
     calibRepo: s3://rubin-pp-dev-users/central_repo_2
+    repoWait: 5
     exportTypes: |-
       - ".*_(config|metadata|log)"
       - "packages"

--- a/applications/prompt-keda-latiss/values.yaml
+++ b/applications/prompt-keda-latiss/values.yaml
@@ -39,6 +39,8 @@ prompt-keda:
     # If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself.
     # @default -- None, must be set
     calibRepo: ""
+    # -- The average time to wait (in seconds) before retrying a failed connection to the shared repo.
+    repoWait: 30
     # -- YAML-formatted list of regex patterns to specify the dataset types to export.
     exportTypes: "- .*"
 

--- a/applications/prompt-keda-lsstcam/README.md
+++ b/applications/prompt-keda-lsstcam/README.md
@@ -45,6 +45,7 @@ KEDA Prompt Processing instance for LSSTCam
 | prompt-keda.instrument.pipelines.main | string | None, must be set | YAML-formatted config describing which pipeline(s) should be run for which visits' raws. Fields are still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |
 | prompt-keda.instrument.pipelines.preprocessing | string | None, must be set | YAML-formatted config describing which pipeline(s) should be run before which visits' raw arrival. |
 | prompt-keda.instrument.preloadPadding | int | `50` | Number of arcseconds to pad the spatial region in preloading. |
+| prompt-keda.instrument.repoWait | int | `30` | The average time to wait (in seconds) before retrying a failed connection to the shared repo. |
 | prompt-keda.instrument.skymap | string | `"lsst_cells_v1"` | Skymap to use with the instrument |
 | prompt-keda.keda.failedJobsHistoryLimit | int | `5` |  |
 | prompt-keda.keda.maxReplicaCount | int | `30` |  |

--- a/applications/prompt-keda-lsstcam/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-keda-lsstcam/values-usdfdev-prompt-processing.yaml
@@ -22,6 +22,7 @@ prompt-keda:
         - survey: SURVEY
           pipelines: ['${PROMPT_PROCESSING_DIR}/pipelines/LSSTCam/Preprocessing.yaml']
     calibRepo: s3://rubin-pp-dev-users/central_repo_2
+    repoWait: 5
 
   s3:
     imageBucket: rubin-pp-dev

--- a/applications/prompt-keda-lsstcam/values.yaml
+++ b/applications/prompt-keda-lsstcam/values.yaml
@@ -39,6 +39,8 @@ prompt-keda:
     # If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself.
     # @default -- None, must be set
     calibRepo: ""
+    # -- The average time to wait (in seconds) before retrying a failed connection to the shared repo.
+    repoWait: 30
     # -- YAML-formatted list of regex patterns to specify the dataset types to export.
     exportTypes: "- .*"
 

--- a/applications/prompt-keda-lsstcamimsim/README.md
+++ b/applications/prompt-keda-lsstcamimsim/README.md
@@ -47,6 +47,7 @@ KEDA Prompt Processing instance for LSSTCam-imSim.
 | prompt-keda.instrument.pipelines.main | string | None, must be set | YAML-formatted config describing which pipeline(s) should be run for which visits' raws. Fields are still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |
 | prompt-keda.instrument.pipelines.preprocessing | string | None, must be set | YAML-formatted config describing which pipeline(s) should be run before which visits' raw arrival. |
 | prompt-keda.instrument.preloadPadding | int | `50` | Number of arcseconds to pad the spatial region in preloading. |
+| prompt-keda.instrument.repoWait | int | `5` | The average time to wait (in seconds) before retrying a failed connection to the shared repo. |
 | prompt-keda.instrument.skymap | string | `"DC2_cells_v1"` | Skymap to use with the instrument |
 | prompt-keda.keda.failedJobsHistoryLimit | int | `5` |  |
 | prompt-keda.keda.maxReplicaCount | int | `800` |  |

--- a/applications/prompt-keda-lsstcamimsim/values.yaml
+++ b/applications/prompt-keda-lsstcamimsim/values.yaml
@@ -39,6 +39,8 @@ prompt-keda:
     # If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself.
     # @default -- None, must be set
     calibRepo: ""
+    # -- The average time to wait (in seconds) before retrying a failed connection to the shared repo.
+    repoWait: 5
     # -- YAML-formatted list of regex patterns to specify the dataset types to export.
     exportTypes: "- .*"
 

--- a/applications/prompt-keda-lsstcomcam/README.md
+++ b/applications/prompt-keda-lsstcomcam/README.md
@@ -44,6 +44,7 @@ KEDA Prompt Processing instance for LSSTComCam.
 | prompt-keda.instrument.pipelines.main | string | None, must be set | YAML-formatted config describing which pipeline(s) should be run for which visits' raws. Fields are still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |
 | prompt-keda.instrument.pipelines.preprocessing | string | None, must be set | YAML-formatted config describing which pipeline(s) should be run before which visits' raw arrival. |
 | prompt-keda.instrument.preloadPadding | int | `50` | Number of arcseconds to pad the spatial region in preloading. |
+| prompt-keda.instrument.repoWait | int | `5` | The average time to wait (in seconds) before retrying a failed connection to the shared repo. |
 | prompt-keda.instrument.skymap | string | `"lsst_cells_v1"` | Skymap to use with the instrument |
 | prompt-keda.keda.failedJobsHistoryLimit | int | `5` |  |
 | prompt-keda.keda.maxReplicaCount | int | `200` |  |

--- a/applications/prompt-keda-lsstcomcam/values.yaml
+++ b/applications/prompt-keda-lsstcomcam/values.yaml
@@ -39,6 +39,8 @@ prompt-keda:
     # If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself.
     # @default -- None, must be set
     calibRepo: ""
+    # -- The average time to wait (in seconds) before retrying a failed connection to the shared repo.
+    repoWait: 5
     # -- YAML-formatted list of regex patterns to specify the dataset types to export.
     exportTypes: "- .*"
 

--- a/applications/prompt-keda-lsstcomcamsim/README.md
+++ b/applications/prompt-keda-lsstcomcamsim/README.md
@@ -47,6 +47,7 @@ KEDA Prompt Processing instance for LSSTComCamSim
 | prompt-keda.instrument.pipelines.main | string | None, must be set | YAML-formatted config describing which pipeline(s) should be run for which visits' raws. Fields are still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |
 | prompt-keda.instrument.pipelines.preprocessing | string | None, must be set | YAML-formatted config describing which pipeline(s) should be run before which visits' raw arrival. |
 | prompt-keda.instrument.preloadPadding | int | `50` | Number of arcseconds to pad the spatial region in preloading. |
+| prompt-keda.instrument.repoWait | int | `5` | The average time to wait (in seconds) before retrying a failed connection to the shared repo. |
 | prompt-keda.instrument.skymap | string | `"ops_rehersal_prep_2k_v1"` | Skymap to use with the instrument |
 | prompt-keda.keda.failedJobsHistoryLimit | int | `5` |  |
 | prompt-keda.keda.maxReplicaCount | int | `150` |  |

--- a/applications/prompt-keda-lsstcomcamsim/values.yaml
+++ b/applications/prompt-keda-lsstcomcamsim/values.yaml
@@ -40,6 +40,8 @@ prompt-keda:
     # If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself.
     # @default -- None, must be set
     calibRepo: ""
+    # -- The average time to wait (in seconds) before retrying a failed connection to the shared repo.
+    repoWait: 5
     # -- YAML-formatted list of regex patterns to specify the dataset types to export.
     exportTypes: "- .*"
 

--- a/charts/prompt-keda/README.md
+++ b/charts/prompt-keda/README.md
@@ -47,6 +47,7 @@ Event-driven processing of camera images
 | instrument.pipelines.main | string | None, must be set | YAML-formatted config describing which pipeline(s) should be run for which visits' raws. Fields are still in flux; see [the source code](https://github.com/lsst-dm/prompt_processing/blob/main/python/activator/config.py) for examples. |
 | instrument.pipelines.preprocessing | string | None, must be set | YAML-formatted config describing which pipeline(s) should be run before which visits' raw arrival. |
 | instrument.preloadPadding | int | `30` | Number of arcseconds to pad the spatial region in preloading. |
+| instrument.repoWait | int | `30` | The average time to wait (in seconds) before retrying a failed connection to the shared repo. |
 | instrument.skymap | string | `""` | Skymap to use with the instrument |
 | keda.failedJobsHistoryLimit | int | `25` |  |
 | keda.maxReplicaCount | int | `10` |  |

--- a/charts/prompt-keda/templates/_service-init.tpl
+++ b/charts/prompt-keda/templates/_service-init.tpl
@@ -39,6 +39,8 @@ spec:
           value: {{ .Values.instrument.skymap }}
         - name: CALIB_REPO
           value: {{ .Values.instrument.calibRepo }}
+        - name: REPO_RETRY_DELAY
+          value: {{ .Values.instrument.repoWait | toString | quote }}
         - name: LSST_DISABLE_BUCKET_VALIDATION
           value: {{ .Values.s3.disableBucketValidation | toString | quote }}
         - name: CONFIG_APDB

--- a/charts/prompt-keda/templates/scaled-job.yaml
+++ b/charts/prompt-keda/templates/scaled-job.yaml
@@ -79,6 +79,8 @@ spec:
                 value: {{ .Values.imageNotifications.imageTimeout | toString | quote }}
               - name: CALIB_REPO
                 value: {{ .Values.instrument.calibRepo }}
+              - name: REPO_RETRY_DELAY
+                value: {{ .Values.instrument.repoWait | toString | quote }}
               - name: LSST_DISABLE_BUCKET_VALIDATION
                 value: {{ .Values.s3.disableBucketValidation | toString | quote }}
               - name: CONFIG_APDB

--- a/charts/prompt-keda/values.yaml
+++ b/charts/prompt-keda/values.yaml
@@ -43,6 +43,8 @@ instrument:
   # If `registry.centralRepoFile` is set, this URI points to a local redirect instead of the central repo itself.
   # @default -- None, must be set
   calibRepo: ""
+  # -- The average time to wait (in seconds) before retrying a failed connection to the shared repo.
+  repoWait: 30
   # -- Dataset types to export.
   exportTypes: "- .*"
 


### PR DESCRIPTION
This PR adds config settings for retries to both the Prompt Processing service and its init job.