### PR TITLE
Turn off forced-source handling for Prompt Processing.

### DIFF
--- a/applications/prompt-keda-lsstcam/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-keda-lsstcam/values-usdfprod-prompt-processing.yaml
@@ -21,7 +21,7 @@ prompt-keda:
       main: |-
         - survey: BLOCK-365  # FBS SV Field Survey
           pipelines:
-          - ${PROMPT_PROCESSING_DIR}/pipelines/LSSTCam/ApPipe.yaml
+          - ${PROMPT_PROCESSING_DIR}/pipelines/LSSTCam/ApPipe-noForced.yaml
           - ${PROMPT_PROCESSING_DIR}/pipelines/LSSTCam/SingleFrame.yaml
           - ${PROMPT_PROCESSING_DIR}/pipelines/LSSTCam/Isr.yaml
         - survey: BLOCK-T427  # Daytime checkout
@@ -35,7 +35,7 @@ prompt-keda:
       preprocessing: |-
         # Run to enable solar system processing in SingleFrame
         - survey: BLOCK-365
-          pipelines: ['${PROMPT_PROCESSING_DIR}/pipelines/LSSTCam/Preprocessing.yaml']
+          pipelines: ['${PROMPT_PROCESSING_DIR}/pipelines/LSSTCam/Preprocessing-noForced.yaml']
         - {survey: "", pipelines: []}
         # Don't preprocess anything unknown
         - {pipelines: []}


### PR DESCRIPTION
Some invalid DiaObjects are generating an excessive number of forced sources. Turn them off until the APDB can be cleaned up.