### PR TITLE
DM-51058: Switch DP1 Butler to new data release

### DIFF
--- a/applications/butler/templates/configmap-private.yaml
+++ b/applications/butler/templates/configmap-private.yaml
@@ -8,7 +8,7 @@ data:
       cls: lsst.daf.butler.datastores.fileDatastore.FileDatastore
       records:
         table: file_datastore_records
-      root: s3://gcs@butler-us-central1-dp1/DM-50578/
+      root: s3://gcs@butler-us-central1-dp1/DM-51058/
     registry:
       db: {{ .Values.config.dp1PostgresUri }}
       managers:
@@ -18,4 +18,4 @@ data:
         datastores: lsst.daf.butler.registry.bridge.monolithic.MonolithicDatastoreRegistryBridgeManager
         dimensions: lsst.daf.butler.registry.dimensions.static.StaticDimensionRecordStorageManager
         opaque: lsst.daf.butler.registry.opaque.ByNameOpaqueTableStorageManager
-      namespace: dm_50578
+      namespace: dm_51058


### PR DESCRIPTION
Switch the DP1 Butler to an updated data release that includes difference images and a few calibration dataset types that were omitted in error.