### PR TITLE
DM-51295: Increase memory request and limit for Semaphore

### DIFF
--- a/applications/semaphore/values.yaml
+++ b/applications/semaphore/values.yaml
@@ -51,10 +51,10 @@ ingress:
 resources:
   limits:
     cpu: "1"
-    memory: "128Mi"
+    memory: "512Mi"
   requests:
     cpu: "2m"
-    memory: "50Mi"
+    memory: "75Mi"
 
 autoscaling:
   enabled: false


### PR DESCRIPTION
In scale testing with 10,000 users, we found that the memory use can increase to 200MB. This extra head room should give us lots of margin.

The request is also increased slightly to better match baseline usage after heavy loads.