### PR TITLE
[DM-51317] Upgrade Kafka to version 3.9.0 on IDF and USDF environments 

### DIFF
--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -1,5 +1,6 @@
 strimzi-kafka:
   kafka:
+    version: "3.9.0"
     listeners:
       tls:
         enabled: true

--- a/applications/sasquatch/values-idfint.yaml
+++ b/applications/sasquatch/values-idfint.yaml
@@ -1,5 +1,6 @@
 strimzi-kafka:
   kafka:
+    version: "3.9.0"
     listeners:
       tls:
         enabled: true

--- a/applications/sasquatch/values-idfprod.yaml
+++ b/applications/sasquatch/values-idfprod.yaml
@@ -1,5 +1,6 @@
 strimzi-kafka:
   kafka:
+    version: "3.9.0"
     listeners:
       tls:
         enabled: true

--- a/applications/sasquatch/values-roundtable-dev.yaml
+++ b/applications/sasquatch/values-roundtable-dev.yaml
@@ -1,5 +1,6 @@
 strimzi-kafka:
   kafka:
+    version: "3.9.0"
     listeners:
       plain:
         enabled: false

--- a/applications/sasquatch/values-roundtable-prod.yaml
+++ b/applications/sasquatch/values-roundtable-prod.yaml
@@ -1,5 +1,6 @@
 strimzi-kafka:
   kafka:
+    version: "3.9.0"
     listeners:
       plain:
         enabled: false

--- a/applications/sasquatch/values-usdfdev.yaml
+++ b/applications/sasquatch/values-usdfdev.yaml
@@ -1,5 +1,6 @@
 strimzi-kafka:
   kafka:
+    version: "3.9.0"
     listeners:
       tls:
         enabled: true

--- a/applications/sasquatch/values-usdfint.yaml
+++ b/applications/sasquatch/values-usdfint.yaml
@@ -1,5 +1,6 @@
 strimzi-kafka:
   kafka:
+    version: "3.9.0"
     listeners:
       tls:
         enabled: true

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -1,5 +1,6 @@
 strimzi-kafka:
   kafka:
+    version: "3.9.0"
     config:
       # -- Replica lag time can't be smaller than request.timeout.ms configuration in kafka connect.
       replica.lag.time.max.ms: 120000


### PR DESCRIPTION
Strimzi 0.46.0 drops support to Kafka < 3.9.0 move Kafka to version 3.9.0 first.
Since Telescope environments will upgrade Kafka later, we are upgrading Kafka on IDF and USDF environments only and the Strimzi upgrade is temporarily on [this branch](https://github.com/lsst-sqre/phalanx/pull/4648)
