### PR TITLE
DM-51075: Update Butler server for transfer_from

### DIFF
--- a/applications/butler/Chart.yaml
+++ b/applications/butler/Chart.yaml
@@ -4,4 +4,4 @@ version: 1.0.0
 description: Server for Butler data abstraction service
 sources:
   - https://github.com/lsst/daf_butler
-appVersion: server-3.0.0
+appVersion: server-3.1.0


### PR DESCRIPTION
Update Butler server to add a new `file_transfer` endpoint used by `transfer_from`.