### PR TITLE
DM-51236: hips - update terminology

### DIFF
--- a/applications/hips/Chart.yaml
+++ b/applications/hips/Chart.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 description: HiPS tile server backed by Google Cloud Storage
 sources:
   - https://github.com/lsst-sqre/crawlspace
-appVersion: 2.0.0
+appVersion: 3.0.0
 annotations:
   phalanx.lsst.io/docs: |
     - id: "DMTN-230"

--- a/applications/hips/README.md
+++ b/applications/hips/README.md
@@ -15,8 +15,8 @@ HiPS tile server backed by Google Cloud Storage
 | autoscaling.maxReplicas | int | `100` | Maximum number of hips deployment pods |
 | autoscaling.minReplicas | int | `1` | Minimum number of hips deployment pods |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU utilization of hips deployment pods |
-| config.datasets | string | None, must be set | A mapping of dataset names to locations in GCS. /api/hips/v2/<dataset-name> will serve files out of the corresponding GCS bucket. |
-| config.defaultDatasetName | string | `nil` |  |
+| config.buckets | string | None, must be set | A mapping of bucket keys to GCS buckets. /api/hips/v2/<bucket-key> will serve files out of the corresponding GCS bucket. |
+| config.defaultBucket | string | `nil` | The name (not the key) of bucket to serve from the v1 endpoint (/api/hips) |
 | config.gcsProject | string | None, must be set | Google Cloud project in which the underlying storage is located |
 | config.logLevel | string | `"INFO"` | Choose from the text form of Python logging levels |
 | config.serviceAccount | string | None, must be set | The Google service account that has an IAM binding to the `hips` Kubernetes service account and has access to the storage bucket |

--- a/applications/hips/values-idfdev.yaml
+++ b/applications/hips/values-idfdev.yaml
@@ -1,9 +1,7 @@
 config:
   gcsProject: "data-curation-prod-fbdb"
-  datasets:
-    dp02:
-      gcsBucket: "static-us-central1-dp02-hips"
-    dp1:
-      gcsBucket: static-us-central1-dp1-hips
-  defaultDatasetName: "dp02"
+  buckets:
+    dp02: "static-us-central1-dp02-hips"
+    dp1: "static-us-central1-dp1-hips"
+  defaultBucket: "static-us-central1-dp02-hips"
   serviceAccount: "crawlspace-hips@science-platform-dev-7696.iam.gserviceaccount.com"

--- a/applications/hips/values-idfint.yaml
+++ b/applications/hips/values-idfint.yaml
@@ -2,10 +2,8 @@ replicaCount: 4
 
 config:
   gcsProject: "data-curation-prod-fbdb"
-  datasets:
-    dp02:
-      gcsBucket: "static-us-central1-dp02-hips"
-    dp1:
-      gcsBucket: static-us-central1-dp1-hips
-  defaultDatasetName: "dp02"
+  buckets:
+    dp02: "static-us-central1-dp02-hips"
+    dp1: "static-us-central1-dp1-hips"
+  defaultBucket: "static-us-central1-dp02-hips"
   serviceAccount: "crawlspace-hips@science-platform-int-dc5d.iam.gserviceaccount.com"

--- a/applications/hips/values-idfprod.yaml
+++ b/applications/hips/values-idfprod.yaml
@@ -2,8 +2,7 @@ replicaCount: 4
 
 config:
   gcsProject: "data-curation-prod-fbdb"
-  datasets:
-    dp02:
-      gcsBucket: "static-us-central1-dp02-hips"
-  defaultDatasetName: "dp02"
+  buckets:
+    dp02: "static-us-central1-dp02-hips"
+  defaultBucket: "static-us-central1-dp02-hips"
   serviceAccount: "crawlspace-hips@science-platform-stable-6994.iam.gserviceaccount.com"

--- a/applications/hips/values.yaml
+++ b/applications/hips/values.yaml
@@ -10,21 +10,17 @@ config:
   # @default -- None, must be set
   gcsProject: ""
 
-  # -- A mapping of dataset names to locations in GCS.
-  # /api/hips/v2/<dataset-name> will serve files out of the corresponding GCS
+  # -- A mapping of bucket keys to GCS buckets.
+  # /api/hips/v2/<bucket-key> will serve files out of the corresponding GCS
   # bucket.
   # @default -- None, must be set
-  datasets: null
-    # -- Dataset name
-    # dp02:
-    #   -- Name of Google Cloud Storage bucket holding the HiPS files
-    #   gcsBucket: somebucket
-    # dp1:
-    #   -- Name of Google Cloud Storage bucket holding the HiPS files
-    #   gcsBucket: somebucket
+  buckets: null
+    # dp02: somebucket
+    # dp1: somebucket
 
-  # The name of the dataset to serve from the v1 endpoint (/api/hips)
-  defaultDatasetName: null
+  # -- The name (not the key) of bucket to serve from the v1 endpoint
+  # (/api/hips)
+  defaultBucket: null
   # -- Choose from the text form of Python logging levels
   logLevel: "INFO"
 


### PR DESCRIPTION
~After modifying [DMTN-230](https://dmtn-230.lsst.io), I realized I used "data set" when I should have been using "release" :cry:~

And after talking to @rra, I changed the terminology to not have anything to do with HiPS at all :)

Goes with ~https://github.com/lsst-sqre/crawlspace/pull/94~ https://github.com/lsst-sqre/crawlspace/pull/95

### Testing

```
curl --fail-with-body -H "Authorization: Bearer $MY_TOKEN" https://data-dev.lsst.cloud/api/hips/images/2MASS/Color/Moc.fits && \
curl --fail-with-body --head -H "Authorization: Bearer $MY_TOKEN" https://data-dev.lsst.cloud/api/hips/images/2MASS/Color/Moc.fits && \
curl --fail-with-body -H "Authorization: Bearer $MY_TOKEN" https://data-dev.lsst.cloud/api/hips/v2/dp02/images/2MASS/Color/Moc.fits && \
curl --head --fail-with-body -H "Authorization: Bearer $MY_TOKEN" https://data-dev.lsst.cloud/api/hips/images/2MASS/Color/Moc.fits && \
curl --fail-with-body -H "Authorization: Bearer $MY_TOKEN" https://data-dev.lsst.cloud/api/hips/v2/dp1/DM-51280/DRP/DP1/v29_0_0/DM-50260/color_gri/Norder10/Dir30000/Npix33417.png --output testfile.png && \
curl --head --fail-with-body -H "Authorization: Bearer $MY_TOKEN" https://data-dev.lsst.cloud/api/hips/v2/dp1/DM-51280/DRP/DP1/v29_0_0/DM-50260/color_gri/Norder10/Dir30000/Npix33417.png
```