### PR TITLE
DM-50035: Prompt Processing APDB download metric misses failed operations

### DIFF
--- a/applications/prompt-keda-hsc/values.yaml
+++ b/applications/prompt-keda-hsc/values.yaml
@@ -108,7 +108,7 @@ prompt-keda:
 
   # -- Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level).
   # @default -- log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING.
-  logLevel: "timer.lsst.activator=DEBUG timer.lsst.daf.butler=DEBUG lsst.associateApdb=VERBOSE lsst.computeReliability=VERBOSE lsst.daf.butler=VERBOSE"
+  logLevel: "timer.lsst.activator=DEBUG timer.lsst.daf.butler=DEBUG lsst.associateApdb=VERBOSE lsst.loadDiaCatalogs=VERBOSE lsst.computeReliability=VERBOSE lsst.daf.butler=VERBOSE"
 
   sasquatch:
     # -- Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload.

--- a/applications/prompt-keda-latiss/values.yaml
+++ b/applications/prompt-keda-latiss/values.yaml
@@ -106,7 +106,7 @@ prompt-keda:
 
   # -- Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level).
   # @default -- log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING.
-  logLevel: "timer.lsst.activator=DEBUG timer.lsst.daf.butler=DEBUG lsst.associateApdb=VERBOSE lsst.computeReliability=VERBOSE lsst.daf.butler=VERBOSE"
+  logLevel: "timer.lsst.activator=DEBUG timer.lsst.daf.butler=DEBUG lsst.associateApdb=VERBOSE lsst.loadDiaCatalogs=VERBOSE lsst.computeReliability=VERBOSE lsst.daf.butler=VERBOSE"
 
   sasquatch:
     # -- Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload.

--- a/applications/prompt-keda-lsstcam/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-keda-lsstcam/values-usdfprod-prompt-processing.yaml
@@ -89,7 +89,7 @@ prompt-keda:
   apdb:
     config: s3://rubin-summit-users/apdb_config/cassandra/pp_apdb_lsstcam.yaml
 
-  logLevel: timer.lsst.activator=DEBUG timer.lsst.daf.butler=VERBOSE lsst.associateApdb=VERBOSE lsst.computeReliability=VERBOSE lsst.daf.butler=VERBOSE
+  logLevel: timer.lsst.activator=DEBUG timer.lsst.daf.butler=VERBOSE lsst.associateApdb=VERBOSE lsst.loadDiaCatalogs=VERBOSE lsst.computeReliability=VERBOSE lsst.daf.butler=VERBOSE
 
   sasquatch:
     # TODO: production Sasquatch not yet ready

--- a/applications/prompt-keda-lsstcam/values.yaml
+++ b/applications/prompt-keda-lsstcam/values.yaml
@@ -108,7 +108,7 @@ prompt-keda:
 
   # -- Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level).
   # @default -- log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING.
-  logLevel: "timer.lsst.activator=DEBUG timer.lsst.daf.butler=DEBUG lsst.associateApdb=VERBOSE lsst.computeReliability=VERBOSE lsst.daf.butler=VERBOSE"
+  logLevel: "timer.lsst.activator=DEBUG timer.lsst.daf.butler=DEBUG lsst.associateApdb=VERBOSE lsst.loadDiaCatalogs=VERBOSE lsst.computeReliability=VERBOSE lsst.daf.butler=VERBOSE"
 
   sasquatch:
     # -- Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload.

--- a/applications/prompt-keda-lsstcamimsim/values.yaml
+++ b/applications/prompt-keda-lsstcamimsim/values.yaml
@@ -108,7 +108,7 @@ prompt-keda:
 
   # -- Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level).
   # @default -- log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING.
-  logLevel: "timer.lsst.activator=DEBUG timer.lsst.daf.butler=DEBUG lsst.associateApdb=VERBOSE lsst.computeReliability=VERBOSE lsst.daf.butler=VERBOSE"
+  logLevel: "timer.lsst.activator=DEBUG timer.lsst.daf.butler=DEBUG lsst.associateApdb=VERBOSE lsst.loadDiaCatalogs=VERBOSE lsst.computeReliability=VERBOSE lsst.daf.butler=VERBOSE"
 
   sasquatch:
     # -- Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload.

--- a/applications/prompt-keda-lsstcomcam/values.yaml
+++ b/applications/prompt-keda-lsstcomcam/values.yaml
@@ -107,7 +107,7 @@ prompt-keda:
 
   # -- Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level).
   # @default -- log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING.
-  logLevel: "timer.lsst.activator=DEBUG timer.lsst.daf.butler=DEBUG lsst.associateApdb=VERBOSE lsst.computeReliability=VERBOSE lsst.daf.butler=VERBOSE"
+  logLevel: "timer.lsst.activator=DEBUG timer.lsst.daf.butler=DEBUG lsst.associateApdb=VERBOSE lsst.loadDiaCatalogs=VERBOSE lsst.computeReliability=VERBOSE lsst.daf.butler=VERBOSE"
 
   sasquatch:
     # -- Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload.

--- a/applications/prompt-keda-lsstcomcamsim/values.yaml
+++ b/applications/prompt-keda-lsstcomcamsim/values.yaml
@@ -109,7 +109,7 @@ prompt-keda:
 
   # -- Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level).
   # @default -- log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING.
-  logLevel: "timer.lsst.activator=DEBUG timer.lsst.daf.butler=DEBUG lsst.associateApdb=VERBOSE lsst.computeReliability=VERBOSE lsst.daf.butler=VERBOSE"
+  logLevel: "timer.lsst.activator=DEBUG timer.lsst.daf.butler=DEBUG lsst.associateApdb=VERBOSE lsst.loadDiaCatalogs=VERBOSE lsst.computeReliability=VERBOSE lsst.daf.butler=VERBOSE"
 
   sasquatch:
     # -- Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload.


### PR DESCRIPTION
This PR adds `loadDiaCatalogs` to the set of Prompt Processing tasks that have verbose logging turned on. This exposes timing metrics from lsst/ap_association#292 in both the development and production environments.