### PR TITLE
DM-51220: Update consdb to add can_see_sky and zernike coefficients

### DIFF
--- a/applications/consdb/values-base.yaml
+++ b/applications/consdb/values-base.yaml
@@ -8,15 +8,15 @@ lfa:
 hinfo:
   latiss:
     enable: true
-    tag: "tickets-DM-51220"
+    tag: "25.6.1"
     logConfig: "consdb.hinfo=DEBUG"
   lsstcomcam:
     enable: false
-    tag: "25.5.2"
+    tag: "25.6.1"
     logConfig: "consdb.hinfo=DEBUG"
   lsstcam:
     enable: true
-    tag: "25.5.2"
+    tag: "25.6.1"
 pq:
   image:
     tag: "main"

--- a/applications/consdb/values-base.yaml
+++ b/applications/consdb/values-base.yaml
@@ -8,7 +8,7 @@ lfa:
 hinfo:
   latiss:
     enable: true
-    tag: "25.5.2"
+    tag: "tickets-DM-51220"
     logConfig: "consdb.hinfo=DEBUG"
   lsstcomcam:
     enable: false

--- a/applications/consdb/values-summit.yaml
+++ b/applications/consdb/values-summit.yaml
@@ -8,15 +8,15 @@ lfa:
 hinfo:
   latiss:
     enable: true
-    tag: "25.5.2"
+    tag: "25.6.1"
     logConfig: "consdb.hinfo=DEBUG"
   lsstcomcam:
     enable: true
-    tag: "25.5.2"
+    tag: "25.6.1"
     logConfig: "consdb.hinfo=DEBUG"
   lsstcam:
     enable: true
-    tag: "25.5.2"
+    tag: "25.6.1"
 pq:
   image:
     tag: "25.3.2"

--- a/applications/consdb/values-tucson-teststand.yaml
+++ b/applications/consdb/values-tucson-teststand.yaml
@@ -8,15 +8,15 @@ lfa:
 hinfo:
   latiss:
     enable: true
-    tag: "25.3.2"
+    tag: "25.6.1"
     logConfig: "consdb.hinfo=DEBUG"
   lsstcomcam:
     enable: true
-    tag: "25.3.2"
+    tag: "25.6.1"
     logConfig: "consdb.hinfo=DEBUG"
   lsstcam:
     enable: true
-    tag: "25.3.2"
+    tag: "25.6.1"
 
 pq:
   image:

--- a/applications/consdbtap/values-usdfdev.yaml
+++ b/applications/consdbtap/values-usdfdev.yaml
@@ -2,7 +2,7 @@ cadc-tap:
   tapSchema:
     image:
       repository: "lsstsqre/tap-schema-usdf-dev-cdb"
-      tag: "w.2025.16"
+      tag: "tickets-DM-51220"
 
   config:
     datalinkPayloadUrl: "https://github.com/lsst/sdm_schemas/releases/download/w.2025.16/datalink-snippets.zip"

--- a/applications/consdbtap/values-usdfint.yaml
+++ b/applications/consdbtap/values-usdfint.yaml
@@ -2,7 +2,7 @@ cadc-tap:
   tapSchema:
     image:
       repository: "lsstsqre/tap-schema-usdf-prod-cdb"
-      tag: "w.2025.16"
+      tag: "tickets-DM-51220"
 
   config:
     datalinkPayloadUrl: "https://github.com/lsst/sdm_schemas/releases/download/w.2025.16/datalink-snippets.zip"

--- a/applications/consdbtap/values-usdfprod.yaml
+++ b/applications/consdbtap/values-usdfprod.yaml
@@ -2,7 +2,7 @@ cadc-tap:
   tapSchema:
     image:
       repository: "lsstsqre/tap-schema-usdf-prod-cdb"
-      tag: "w.2025.16"
+      tag: "tickets-DM-51220"
 
   config:
     datalinkPayloadUrl: "https://github.com/lsst/sdm_schemas/releases/download/w.2025.16/datalink-snippets.zip"


### PR DESCRIPTION
* Updates hinfo in BTS, TTS, and summit
* Updates consdb tap to use ticket branch