### PR TITLE
Bump limits and requests for cutout workers

### DIFF
--- a/applications/vo-cutouts/values.yaml
+++ b/applications/vo-cutouts/values.yaml
@@ -97,10 +97,10 @@ cutoutWorker:
   resources:
     limits:
       cpu: "1"
-      memory: "1Gi"
+      memory: "1.5Gi"
     requests:
       cpu: "0.1"
-      memory: "550Mi"
+      memory: "700Mi"
 
   # -- Affinity rules for the cutout worker pod
   affinity: {}


### PR DESCRIPTION
We were seeing OOM kill problems on idfint.