### PR TITLE
DM-51358: Update Qserv Kafka bridge to 0.6.0

### DIFF
--- a/applications/qserv-kafka/Chart.yaml
+++ b/applications/qserv-kafka/Chart.yaml
@@ -5,7 +5,7 @@ version: 1.0.0
 description: "Qserv Kafka bridge"
 sources:
   - "https://github.com/lsst-sqre/qserv-kafka"
-appVersion: 0.5.0
+appVersion: 0.6.0
 
 dependencies:
   - name: "redis"

--- a/applications/qserv-kafka/README.md
+++ b/applications/qserv-kafka/README.md
@@ -26,7 +26,8 @@ Qserv Kafka bridge
 | config.qservDatabasePoolSize | int | `2` | Database pool size. This is the number of MySQL connections that will be held open regardless of load. This should generally be set to the same as `maxWorkerJobs`. |
 | config.qservDatabaseUrl | string | None, must be set | URL to the Qserv MySQL interface (must use a scheme of `mysql+asyncmy`) |
 | config.qservPollInterval | string | `"1s"` | Interval at which Qserv is polled for query status in Safir `parse_timedelta` format |
-| config.qservRestMaxConnections | int | `20` | Maximum simultaneous connections to open to the REST API. |
+| config.qservRestMaxConnections | int | `20` | Maximum simultaneous connections to open to the REST API |
+| config.qservRestSendApiVersion | bool | `true` | Whether to send the expected API version in REST API calls to Qserv |
 | config.qservRestTimeout | string | `"30s"` | Timeout for REST API calls in Safir `parse_timedelta` format. This includes time spent waiting for a connection if the maximum number of connections has been reached. |
 | config.qservRestUrl | string | None, must be set | URL to the Qserv REST API |
 | config.qservUploadTimeout | string | `"5m"` | How long to allow for user table upload before timing out in Safir `parse_timedelta` format. |

--- a/applications/qserv-kafka/templates/configmap.yaml
+++ b/applications/qserv-kafka/templates/configmap.yaml
@@ -20,6 +20,9 @@ data:
   QSERV_KAFKA_QSERV_DATABASE_URL: {{ .Values.config.qservDatabaseUrl | quote }}
   QSERV_KAFKA_QSERV_POLL_INTERVAL: {{ .Values.config.qservPollInterval | quote }}
   QSERV_KAFKA_QSERV_REST_MAX_CONNECTIONS: {{ .Values.config.qservRestMaxConnections | quote }}
+  {{- if not .Values.config.qservRestSendApiVersion }}
+  QSERV_KAFKA_QSERV_REST_SEND_API_VERSION: "false"
+  {{- end }}
   QSERV_KAFKA_QSERV_REST_TIMEOUT: {{ .Values.config.qservRestTimeout | quote }}
   QSERV_KAFKA_QSERV_REST_URL: {{ .Values.config.qservRestUrl | quote }}
   QSERV_KAFKA_QSERV_UPLOAD_TIMEOUT: {{ .Values.config.qservUploadTimeout | quote }}

--- a/applications/qserv-kafka/values-idfdev.yaml
+++ b/applications/qserv-kafka/values-idfdev.yaml
@@ -3,6 +3,7 @@ config:
   metrics:
     enabled: true
   qservDatabaseUrl: "mysql+asyncmy://qsmaster@qserv-int.slac.stanford.edu:4090/"
+  qservRestSendApiVersion: false
   qservRestUrl: "https://134.79.23.197:4098/"
 frontend:
   allowRootDebug: true

--- a/applications/qserv-kafka/values-idfint.yaml
+++ b/applications/qserv-kafka/values-idfint.yaml
@@ -3,6 +3,7 @@ config:
   metrics:
     enabled: true
   qservDatabaseUrl: "mysql+asyncmy://qsmaster@qserv-int.slac.stanford.edu:4090/"
+  qservRestSendApiVersion: false
   qservRestUrl: "https://qserv-int-https.slac.stanford.edu:4098/"
 frontend:
   allowRootDebug: true

--- a/applications/qserv-kafka/values.yaml
+++ b/applications/qserv-kafka/values.yaml
@@ -65,8 +65,11 @@ config:
   # `parse_timedelta` format
   qservPollInterval: "1s"
 
-  # -- Maximum simultaneous connections to open to the REST API.
+  # -- Maximum simultaneous connections to open to the REST API
   qservRestMaxConnections: 20
+
+  # -- Whether to send the expected API version in REST API calls to Qserv
+  qservRestSendApiVersion: true
 
   # -- Timeout for REST API calls in Safir `parse_timedelta` format. This
   # includes time spent waiting for a connection if the maximum number of


### PR DESCRIPTION
Add the new configuration option to disable sending API versions to the Qserv REST API, and enable it for idfdev and idfint.