### PR TITLE
DM-49692: Enable Kafka-based TAP service for all idf environments

### DIFF
--- a/applications/tap/secrets.yaml
+++ b/applications/tap/secrets.yaml
@@ -6,3 +6,7 @@ sentry-dsn:
   description: >-
     DSN URL to which Sentry trace and error logging will be sent.
   if: cadc-tap.config.enableSentry
+kafka-password:
+  description: >-
+    Password for the TAP user in Kafka.
+  if: cadc-tap.config.kafka.auth.enabled

--- a/applications/tap/values-idfdev.yaml
+++ b/applications/tap/values-idfdev.yaml
@@ -8,9 +8,15 @@ cadc-tap:
       host: "qserv-int.slac.stanford.edu:4090"
       jdbcParams: "?enabledTLSProtocols=TLSv1.3"
       passwordEnabled: true
+      image:
+        tag: "3.0.0"
 
-    sentryEnabled: true
-    sentryTracesSampleRate: "0.1"
+    kafka:
+      bootstrapServer: "sasquatch-dev-kafka-bootstrap.lsst.cloud:9094"
+      schemaRegistry:
+        url: "https://data-dev.lsst.cloud/schema-registry/"
+      auth:
+        enabled: true
 
   cloudsql:
     enabled: true

--- a/applications/tap/values-idfint.yaml
+++ b/applications/tap/values-idfint.yaml
@@ -8,9 +8,19 @@ cadc-tap:
       host: "qserv-int.slac.stanford.edu:4090"
       jdbcParams: "?enabledTLSProtocols=TLSv1.3"
       passwordEnabled: true
+      image:
+        tag: "3.0.0"
 
     sentryEnabled: true
     sentryTracesSampleRate: "0.1"
+
+    kafka:
+      bootstrapServer: "sasquatch-int-kafka-bootstrap.lsst.cloud:9094"
+      schemaRegistry:
+        url: "https://data-int.lsst.cloud/schema-registry/"
+      auth:
+        enabled: true
+
 
   cloudsql:
     enabled: true

--- a/applications/tap/values-idfprod.yaml
+++ b/applications/tap/values-idfprod.yaml
@@ -9,6 +9,13 @@ cadc-tap:
       jdbcParams: "?enabledTLSProtocols=TLSv1.3"
       passwordEnabled: true
 
+    kafka:
+      bootstrapServer: "sasquatch-kafka-bootstrap.lsst.cloud:9094"
+      schemaRegistry:
+        url: "https://data.lsst.cloud/schema-registry/"
+      auth:
+        enabled: true
+
   cloudsql:
     enabled: true
     instanceConnectionName: "science-platform-stable-6994:us-central1:science-platform-stable-0c29612b"

--- a/charts/cadc-tap/README.md
+++ b/charts/cadc-tap/README.md
@@ -22,11 +22,22 @@ IVOA TAP service
 | cloudsql.resources | object | See `values.yaml` | Resource limits and requests for the Cloud SQL Proxy container |
 | cloudsql.serviceAccount | string | None, must be set | The Google service account that has an IAM binding to the `cadc-tap` Kubernetes service accounts and has the `cloudsql.client` role, access |
 | config.backend | string | None, must be set to `pg` or `qserv` | What type of backend are we connecting to? |
+| config.database | string | `"dp02"` | Data Database name |
 | config.datalinkPayloadUrl | string | `"https://github.com/lsst/sdm_schemas/releases/download/w.2025.24/datalink-snippets.zip"` | Datalink payload URL |
 | config.gcsBucket | string | `"async-results.lsst.codes"` | Name of GCS bucket in which to store results |
 | config.gcsBucketType | string | `"GCS"` | GCS bucket type (GCS or S3) |
 | config.gcsBucketUrl | string | `"https://tap-files.lsst.codes"` | Base URL for results stored in GCS bucket |
 | config.jvmMaxHeapSize | string | `"31G"` | Java heap size, which will set the maximum size of the heap. Otherwise Java would determine it based on how much memory is available and black maths. |
+| config.kafka | object | `{"auth":{"enabled":false},"bootstrapServer":"sasquatch-dev-kafka-bootstrap.lsst.cloud:9094","schemaRegistry":{"url":""},"topics":{"jobDelete":"lsst.tap.job-delete","jobRun":"lsst.tap.job-run","jobStatus":"lsst.tap.job-status"}}` | Kafka configuration |
+| config.kafka.auth | object | `{"enabled":false}` | Authentication configuration |
+| config.kafka.auth.enabled | bool | `false` | Whether auth is enabled |
+| config.kafka.bootstrapServer | string | `"sasquatch-dev-kafka-bootstrap.lsst.cloud:9094"` | Bootstrap Server |
+| config.kafka.schemaRegistry | object | `{"url":""}` | Schema Registry Configuration |
+| config.kafka.schemaRegistry.url | string | `""` | URL |
+| config.kafka.topics | object | `{"jobDelete":"lsst.tap.job-delete","jobRun":"lsst.tap.job-run","jobStatus":"lsst.tap.job-status"}` | Kafka topics |
+| config.kafka.topics.jobDelete | string | `"lsst.tap.job-delete"` | Job Delete topic |
+| config.kafka.topics.jobRun | string | `"lsst.tap.job-run"` | Job Run topic |
+| config.kafka.topics.jobStatus | string | `"lsst.tap.job-status"` | Job Status topic |
 | config.pg.database | string | None, must be set if backend is `pg` | Database to connect to |
 | config.pg.host | string | None, must be set if backend is `pg` | Host to connect to |
 | config.pg.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the TAP image |

--- a/charts/cadc-tap/templates/tap-deployment.yaml
+++ b/charts/cadc-tap/templates/tap-deployment.yaml
@@ -44,7 +44,7 @@ spec:
                 -Dtapschemauser.url=jdbc:mysql://{{ .Values.config.tapSchemaAddress }}/
                 -Dtapschemauser.maxActive=100
                 -Duws.driverClassName=org.postgresql.Driver
-                -Duws.maxActive=100
+                -Duws.maxActive=8
                 {{- if .Values.cloudsql.enabled }}
                 -Duws.password=$UWS_DB_PASSWORD
                 -Duws.username={{ required "cloudsql.database must be specified" .Values.cloudsql.database }}
@@ -70,10 +70,27 @@ spec:
                 -Dgcs_bucket={{ .Values.config.gcsBucket }}
                 -Dgcs_bucket_url={{ .Values.config.gcsBucketUrl }}
                 -Dgcs_bucket_type={{ .Values.config.gcsBucketType }}
+                -Ddatabase={{ .Values.config.database }}
+                 {{- if .Values.config.kafka.auth.enabled }}
+                -Dkafka.username=tap
+                -Dkafka.password=$KAFKA_PASSWORD
+                -Dkafka.bootstrap.server={{ .Values.config.kafka.bootstrapServer }}
+                -Dkafka.query.topic={{ .Values.config.kafka.topics.jobRun }}
+                -Dkafka.status.topic={{ .Values.config.kafka.topics.jobStatus }}
+                -Dkafka.delete.topic={{ .Values.config.kafka.topics.jobDelete }}
+                -Dschema.registry.url={{ .Values.config.kafka.schemaRegistry.url }}
+                {{- end }}
                 -Dbase_url={{ .Values.global.baseUrl }}
                 -Dpath_prefix=/api/{{ .Values.ingress.path }}
                 -Dca.nrc.cadc.util.PropertiesReader.dir=/config/
                 -Xmx{{ .Values.config.jvmMaxHeapSize }}
+            {{- if .Values.config.kafka.auth.enabled }}
+            - name: "KAFKA_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  name: "cadc-tap"
+                  key: "kafka-password"
+            {{- end }}
             {{- if (and (eq .Values.config.backend "qserv") .Values.config.qserv.passwordEnabled) }}
             - name: "QSERV_DB_PASSWORD"
               valueFrom:

--- a/charts/cadc-tap/values.yaml
+++ b/charts/cadc-tap/values.yaml
@@ -110,6 +110,9 @@ config:
   # -- GCS bucket type (GCS or S3)
   gcsBucketType: "GCS"
 
+  # -- Data Database name
+  database: "dp02"
+
   # -- Java heap size, which will set the maximum size of the heap. Otherwise
   # Java would determine it based on how much memory is available and black
   # maths.
@@ -126,6 +129,36 @@ config:
 
   # -- Whether Sentry is enabled in this environment
   sentryEnabled: false
+
+  # -- Kafka configuration
+  kafka:
+
+    # -- Bootstrap Server
+    bootstrapServer: "sasquatch-dev-kafka-bootstrap.lsst.cloud:9094"
+
+    # -- Schema Registry Configuration
+    schemaRegistry:
+
+      # -- URL
+      url: ""
+
+    # -- Kafka topics
+    topics:
+
+      # -- Job Run topic
+      jobRun: "lsst.tap.job-run"
+
+      # -- Job Status topic
+      jobStatus: "lsst.tap.job-status"
+
+      # -- Job Delete topic
+      jobDelete: "lsst.tap.job-delete"
+
+    # -- Authentication configuration
+    auth:
+
+      # -- Whether auth is enabled
+      enabled: false
 
 mockdb:
   # -- Spin up a container to pretend to be the database.


### PR DESCRIPTION
Changes the TAP service for the idf environments to use the Kafka-bridge based approach instead of direct JDBC connections.