### PR TITLE
DM-51298: Update Butler server for updated release

### DIFF
--- a/applications/butler/Chart.yaml
+++ b/applications/butler/Chart.yaml
@@ -4,4 +4,4 @@ version: 1.0.0
 description: Server for Butler data abstraction service
 sources:
   - https://github.com/lsst/daf_butler
-appVersion: server-3.1.0
+appVersion: server-3.2.0

--- a/applications/butler/templates/configmap-private.yaml
+++ b/applications/butler/templates/configmap-private.yaml
@@ -8,7 +8,7 @@ data:
       cls: lsst.daf.butler.datastores.fileDatastore.FileDatastore
       records:
         table: file_datastore_records
-      root: s3://gcs@butler-us-central1-dp1/DM-51058/
+      root: s3://gcs@butler-us-central1-dp1/DM-51298/
     registry:
       db: {{ .Values.config.dp1PostgresUri }}
       managers:
@@ -18,4 +18,4 @@ data:
         datastores: lsst.daf.butler.registry.bridge.monolithic.MonolithicDatastoreRegistryBridgeManager
         dimensions: lsst.daf.butler.registry.dimensions.static.StaticDimensionRecordStorageManager
         opaque: lsst.daf.butler.registry.opaque.ByNameOpaqueTableStorageManager
-      namespace: dm_51058
+      namespace: dm_51298


### PR DESCRIPTION
Point the IDF Butler server at a new release of DP1, and update the Butler server to include a new file transfer feature being released in v29.1