### PR TITLE
DM-51374: Remove "direct" Butler configuration for dp02

### DIFF
--- a/applications/butler/README.md
+++ b/applications/butler/README.md
@@ -16,9 +16,7 @@ Server for Butler data abstraction service
 | autoscaling.minReplicas | int | `1` | Minimum number of butler deployment pods |
 | autoscaling.targetCPUUtilizationPercentage | int | `25` | Target CPU utilization of butler deployment pods  Butler CPU usage is very low in normal operation because most things are I/O bound.  CPU usage can start creeping up if we have many queries running simultaneously (due to serialization overhead and spatial postprocessing.) In this case the thread pool and database connection pool are probably oversubscribed long before we hit 100% cpu usage, so we want to get more replicas up at fairly low CPU usage. |
 | config.additionalS3EndpointUrls | object | No additional URLs | Endpoint URLs for additional S3 services used by the Butler, as a mapping from profile name to URL. |
-| config.dp02ClientServerIsDefault | bool | `false` | True if the 'dp02' Butler repository alias should use client/server Butler.  False if it should use DirectButler. |
 | config.dp02PostgresUri | string | No configuration file for DP02 will be generated. | Postgres connection string pointing to the registry database hosting Data Preview 0.2 data. |
-| config.dp02UseSlacDatastore | bool | `false` | True if the 'dp02' datastore files should be served from SLAC, false if they should be served from Google. |
 | config.dp1PostgresUri | string | No configuration file for DP1 will be generated. | Postgres connection string pointing to the registry database hosting Data Preview 1 data. |
 | config.enableSentry | bool | `false` | True to enable capture of trace and other diagnostics to Sentry.io. |
 | config.pathPrefix | string | `"/api/butler"` | The prefix of the path portion of the URL where the Butler service will be exposed.  For example, if the service should be exposed at `https://data.lsst.cloud/api/butler`, this should be set to `/api/butler` |

--- a/applications/butler/templates/configmap-private.yaml
+++ b/applications/butler/templates/configmap-private.yaml
@@ -19,3 +19,62 @@ data:
         dimensions: lsst.daf.butler.registry.dimensions.static.StaticDimensionRecordStorageManager
         opaque: lsst.daf.butler.registry.opaque.ByNameOpaqueTableStorageManager
       namespace: dm_51298
+
+  {{- if .Values.config.dp02PostgresUri }}
+  # Internal Butler server configuration for DP02.
+  dp02.yaml: |
+    datastore:
+      cls: lsst.daf.butler.datastores.chainedDatastore.ChainedDatastore
+      datastore_constraints:
+        # One entry per datastore in datastores section
+        # Use empty `-` if no constraint override required
+        - constraints:
+            reject:
+              - all
+        - constraints:
+            reject:
+              - all
+        - constraints:
+            reject:
+              - all
+        - constraints:
+            accept:
+              - all
+      datastores:
+        - datastore:
+            name: FileDatastore@s3://butler-us-central1-panda-dev/dc2
+            cls: lsst.daf.butler.datastores.fileDatastore.FileDatastore
+            root: s3://slac@rubin-dp02-products/
+        - datastore:
+            # Datasets of type 'raw' are stored in a separate bucket for
+            # historical reasons.
+            name: FileDatastore@s3://curation-us-central1-desc-dc2-run22i
+            cls: lsst.daf.butler.datastores.fileDatastore.FileDatastore
+            root: s3://slac@rubin-dp02-raw/
+            records:
+              table: raw_datastore_records
+        - datastore:
+            # Also for historical reasons, some files that originated in DP01
+            # are kept in a separate bucket.
+            name: FileDatastore@s3://butler-us-central1-dp01-desc-dr6
+            cls: lsst.daf.butler.datastores.fileDatastore.FileDatastore
+            root: s3://slac@rubin-dp02-dp01/
+            records:
+              table: dp01_datastore_records
+        - datastore:
+            name: FileDatastore@s3://butler-us-central1-dp02-user
+            cls: lsst.daf.butler.datastores.fileDatastore.FileDatastore
+            root: s3://butler-us-central1-dp02-user/
+            records:
+              table: user_datastore_records
+    registry:
+      db: {{ .Values.config.dp02PostgresUri }}
+      managers:
+        collections: lsst.daf.butler.registry.collections.synthIntKey.SynthIntKeyCollectionManager
+        datasets: lsst.daf.butler.registry.datasets.byDimensions.ByDimensionsDatasetRecordStorageManagerUUID
+        attributes: lsst.daf.butler.registry.attributes.DefaultButlerAttributeManager
+        datastores: lsst.daf.butler.registry.bridge.monolithic.MonolithicDatastoreRegistryBridgeManager
+        dimensions: lsst.daf.butler.registry.dimensions.static.StaticDimensionRecordStorageManager
+        opaque: lsst.daf.butler.registry.opaque.ByNameOpaqueTableStorageManager
+      namespace: dc2_20210215
+  {{- end }}

--- a/applications/butler/templates/configmap-public.yaml
+++ b/applications/butler/templates/configmap-public.yaml
@@ -63,62 +63,22 @@ data:
 # WARNING! The files in this configmap are served publicly on the internet via unauthenticated HTTP.
 # DO NOT PUT ANY SENSITIVE INFORMATION IN THESE FILES.
 {{- if .Values.config.dp02PostgresUri }}
-   # Datastore configuration for the old setup where all files were stored in
-   # Google Cloud Storage buckets, accessed as S3.
-   {{- $dp02GcsRoots := (dict
-       "postgresUri" .Values.config.dp02PostgresUri
-       "fileDatastoreRoot" "s3://butler-us-central1-panda-dev/dc2/"
-       "rawDatastoreRoot" "s3://curation-us-central1-desc-dc2-run22i/"
-       "dp01DatastoreRoot" "s3://butler-us-central1-dp01-desc-dr6/"
-       "userDatastoreRoot" "s3://butler-us-central1-dp02-user/"
-    ) -}}
-  # End-user-facing DirectButler configuration for DP02.
-  dp02.yaml: |
-    {{ if .Values.config.dp02UseSlacDatastore }}
-    # Because this has to work with an ancient version of the Butler library from
-    # 2022, S3 profiles are not supported.  So we use a gs:// URI to access Google
-    # Cloud Storage, and s3:// to access Weka S3 at USDF.
-    {{ include "butler.dp02_config" (dict
-       "postgresUri" .Values.config.dp02PostgresUri
-       "fileDatastoreRoot" "s3://rubin-dp02-products/"
-       "rawDatastoreRoot" "s3://rubin-dp02-raw/"
-       "dp01DatastoreRoot" "s3://rubin-dp02-dp01/"
-       "userDatastoreRoot" "gs://butler-us-central1-dp02-user/"
-    )}}
-    {{ else }}
-    {{ include "butler.dp02_config" $dp02GcsRoots }}
-    {{ end }}
   # Internal Butler server configuration for DP02.
   dp02-server.yaml: |
-    {{ if .Values.config.dp02UseSlacDatastore }}
-    {{ include "butler.dp02_config" (dict
+    {{- include "butler.dp02_config" (dict
        "postgresUri" .Values.config.dp02PostgresUri
        "fileDatastoreRoot" "s3://slac@rubin-dp02-products/"
        "rawDatastoreRoot" "s3://slac@rubin-dp02-raw/"
        "dp01DatastoreRoot" "s3://slac@rubin-dp02-dp01/"
        "userDatastoreRoot" "s3://butler-us-central1-dp02-user/"
     )}}
-    {{ else }}
-    {{ include "butler.dp02_config" $dp02GcsRoots }}
-    {{ end }}
   # Repository index for END USERS defining aliases for Butler configurations.
   # This is NOT the configuration used internally for Butler server itself.
   # It is also NOT the configuration that should be used by Phalanx services
   # connecting to the Butler server.
-  #
-  # We provide both DirectButler and RemoteButler versions of dp02 because some
-  # users rely on functionality not yet available via RemoteButler.  The default in production is
-  # DirectButler because RemoteButler is not available in the current recommended RSP image.
-  # On dev and int it is RemoteButler -- the Community Science team is testing the new system.
   idf-repositories.yaml: |
-    {{- $dp02Direct := print .Values.global.baseUrl .Values.config.pathPrefix "/configs/dp02.yaml" -}}
-    {{- $dp02Remote := print .Values.global.baseUrl .Values.config.pathPrefix "/repo/dp02/butler.yaml" -}}
-    {{- if .Values.config.dp02ClientServerIsDefault }}
+    {{ $dp02Remote := print .Values.global.baseUrl .Values.config.pathPrefix "/repo/dp02/butler.yaml" -}}
     dp02: {{ $dp02Remote }}
-    {{- else }}
-    dp02: {{ $dp02Direct }}
-    {{- end }}
-    dp02-direct: {{ $dp02Direct }}
     dp02-remote: {{ $dp02Remote }}
     dp1: "{{.Values.global.baseUrl}}{{.Values.config.pathPrefix}}/repo/dp1/butler.yaml"
 {{- end }}

--- a/applications/butler/templates/configmap-public.yaml
+++ b/applications/butler/templates/configmap-public.yaml
@@ -1,4 +1,13 @@
-{{- define "butler.dp02_config" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: butler-public
+data:
+# WARNING! The files in this configmap are served publicly on the internet via unauthenticated HTTP.
+# DO NOT PUT ANY SENSITIVE INFORMATION IN THESE FILES.
+{{- if .Values.config.dp02PostgresUri }}
+  # Internal Butler server configuration for DP02.
+  dp02-server.yaml: |
     datastore:
       cls: lsst.daf.butler.datastores.chainedDatastore.ChainedDatastore
       datastore_constraints:
@@ -20,13 +29,13 @@
         - datastore:
             name: FileDatastore@s3://butler-us-central1-panda-dev/dc2
             cls: lsst.daf.butler.datastores.fileDatastore.FileDatastore
-            root: {{ .fileDatastoreRoot }}
+            root: s3://slac@rubin-dp02-products/
         - datastore:
             # Datasets of type 'raw' are stored in a separate bucket for
             # historical reasons.
             name: FileDatastore@s3://curation-us-central1-desc-dc2-run22i
             cls: lsst.daf.butler.datastores.fileDatastore.FileDatastore
-            root: {{ .rawDatastoreRoot }}
+            root: s3://slac@rubin-dp02-raw/
             records:
               table: raw_datastore_records
         - datastore:
@@ -34,17 +43,17 @@
             # are kept in a separate bucket.
             name: FileDatastore@s3://butler-us-central1-dp01-desc-dr6
             cls: lsst.daf.butler.datastores.fileDatastore.FileDatastore
-            root: {{ .dp01DatastoreRoot }}
+            root: s3://slac@rubin-dp02-dp01/
             records:
               table: dp01_datastore_records
         - datastore:
             name: FileDatastore@s3://butler-us-central1-dp02-user
             cls: lsst.daf.butler.datastores.fileDatastore.FileDatastore
-            root: {{ .userDatastoreRoot }}
+            root: s3://butler-us-central1-dp02-user/
             records:
               table: user_datastore_records
     registry:
-      db: {{ .postgresUri }}
+      db: {{ .Values.config.dp02PostgresUri }}
       managers:
         collections: lsst.daf.butler.registry.collections.synthIntKey.SynthIntKeyCollectionManager
         datasets: lsst.daf.butler.registry.datasets.byDimensions.ByDimensionsDatasetRecordStorageManagerUUID
@@ -53,25 +62,6 @@
         dimensions: lsst.daf.butler.registry.dimensions.static.StaticDimensionRecordStorageManager
         opaque: lsst.daf.butler.registry.opaque.ByNameOpaqueTableStorageManager
       namespace: dc2_20210215
-{{- end }}
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: butler-public
-data:
-# WARNING! The files in this configmap are served publicly on the internet via unauthenticated HTTP.
-# DO NOT PUT ANY SENSITIVE INFORMATION IN THESE FILES.
-{{- if .Values.config.dp02PostgresUri }}
-  # Internal Butler server configuration for DP02.
-  dp02-server.yaml: |
-    {{- include "butler.dp02_config" (dict
-       "postgresUri" .Values.config.dp02PostgresUri
-       "fileDatastoreRoot" "s3://slac@rubin-dp02-products/"
-       "rawDatastoreRoot" "s3://slac@rubin-dp02-raw/"
-       "dp01DatastoreRoot" "s3://slac@rubin-dp02-dp01/"
-       "userDatastoreRoot" "s3://butler-us-central1-dp02-user/"
-    )}}
   # Repository index for END USERS defining aliases for Butler configurations.
   # This is NOT the configuration used internally for Butler server itself.
   # It is also NOT the configuration that should be used by Phalanx services

--- a/applications/butler/templates/configmap-public.yaml
+++ b/applications/butler/templates/configmap-public.yaml
@@ -2,66 +2,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: butler-public
-data:
 # WARNING! The files in this configmap are served publicly on the internet via unauthenticated HTTP.
 # DO NOT PUT ANY SENSITIVE INFORMATION IN THESE FILES.
-{{- if .Values.config.dp02PostgresUri }}
-  # Internal Butler server configuration for DP02.
-  dp02-server.yaml: |
-    datastore:
-      cls: lsst.daf.butler.datastores.chainedDatastore.ChainedDatastore
-      datastore_constraints:
-        # One entry per datastore in datastores section
-        # Use empty `-` if no constraint override required
-        - constraints:
-            reject:
-              - all
-        - constraints:
-            reject:
-              - all
-        - constraints:
-            reject:
-              - all
-        - constraints:
-            accept:
-              - all
-      datastores:
-        - datastore:
-            name: FileDatastore@s3://butler-us-central1-panda-dev/dc2
-            cls: lsst.daf.butler.datastores.fileDatastore.FileDatastore
-            root: s3://slac@rubin-dp02-products/
-        - datastore:
-            # Datasets of type 'raw' are stored in a separate bucket for
-            # historical reasons.
-            name: FileDatastore@s3://curation-us-central1-desc-dc2-run22i
-            cls: lsst.daf.butler.datastores.fileDatastore.FileDatastore
-            root: s3://slac@rubin-dp02-raw/
-            records:
-              table: raw_datastore_records
-        - datastore:
-            # Also for historical reasons, some files that originated in DP01
-            # are kept in a separate bucket.
-            name: FileDatastore@s3://butler-us-central1-dp01-desc-dr6
-            cls: lsst.daf.butler.datastores.fileDatastore.FileDatastore
-            root: s3://slac@rubin-dp02-dp01/
-            records:
-              table: dp01_datastore_records
-        - datastore:
-            name: FileDatastore@s3://butler-us-central1-dp02-user
-            cls: lsst.daf.butler.datastores.fileDatastore.FileDatastore
-            root: s3://butler-us-central1-dp02-user/
-            records:
-              table: user_datastore_records
-    registry:
-      db: {{ .Values.config.dp02PostgresUri }}
-      managers:
-        collections: lsst.daf.butler.registry.collections.synthIntKey.SynthIntKeyCollectionManager
-        datasets: lsst.daf.butler.registry.datasets.byDimensions.ByDimensionsDatasetRecordStorageManagerUUID
-        attributes: lsst.daf.butler.registry.attributes.DefaultButlerAttributeManager
-        datastores: lsst.daf.butler.registry.bridge.monolithic.MonolithicDatastoreRegistryBridgeManager
-        dimensions: lsst.daf.butler.registry.dimensions.static.StaticDimensionRecordStorageManager
-        opaque: lsst.daf.butler.registry.opaque.ByNameOpaqueTableStorageManager
-      namespace: dc2_20210215
+data:
   # Repository index for END USERS defining aliases for Butler configurations.
   # This is NOT the configuration used internally for Butler server itself.
   # It is also NOT the configuration that should be used by Phalanx services
@@ -71,4 +14,3 @@ data:
     dp02: {{ $dp02Remote }}
     dp02-remote: {{ $dp02Remote }}
     dp1: "{{.Values.global.baseUrl}}{{.Values.config.pathPrefix}}/repo/dp1/butler.yaml"
-{{- end }}

--- a/applications/butler/values-idfdev.yaml
+++ b/applications/butler/values-idfdev.yaml
@@ -8,7 +8,7 @@ config:
   s3EndpointUrl: "https://storage.googleapis.com"
   repositories:
     dp02:
-      config_uri: "file:///opt/lsst/butler/public/config/dp02-server.yaml"
+      config_uri: "file:///opt/lsst/butler/config/dp02.yaml"
       authorized_groups: ["*"]
     dp1:
       config_uri: "file:///opt/lsst/butler/config/dp1.yaml"

--- a/applications/butler/values-idfdev.yaml
+++ b/applications/butler/values-idfdev.yaml
@@ -2,10 +2,8 @@ image:
   pullPolicy: Always
 
 config:
-  dp02ClientServerIsDefault: true
   # butler-registry-dp02-dev Google Cloud SQL instance in science-platform-dev
   dp02PostgresUri: postgresql://butler@dp02.rsp-sql-dev.internal:5432/dp02
-  dp02UseSlacDatastore: true
   dp1PostgresUri: postgresql://butler@dp1.rsp-sql-dev.internal:5432/dp1
   s3EndpointUrl: "https://storage.googleapis.com"
   repositories:

--- a/applications/butler/values-idfint.yaml
+++ b/applications/butler/values-idfint.yaml
@@ -6,7 +6,7 @@ config:
   s3EndpointUrl: "https://storage.googleapis.com"
   repositories:
     dp02:
-      config_uri: "file:///opt/lsst/butler/public/config/dp02-server.yaml"
+      config_uri: "file:///opt/lsst/butler/config/dp02.yaml"
       authorized_groups: ["*"]
     dp1:
       config_uri: "file:///opt/lsst/butler/config/dp1.yaml"

--- a/applications/butler/values-idfint.yaml
+++ b/applications/butler/values-idfint.yaml
@@ -1,8 +1,6 @@
 autoscaling:
   minReplicas: 3
 config:
-  dp02ClientServerIsDefault: true
-  dp02UseSlacDatastore: true
   dp02PostgresUri: postgresql://butler@dp02.rsp-sql-int.internal:5432/dp02
   dp1PostgresUri: postgresql://butler@dp1.rsp-sql-int.internal:5432/dp1
   s3EndpointUrl: "https://storage.googleapis.com"

--- a/applications/butler/values-idfprod.yaml
+++ b/applications/butler/values-idfprod.yaml
@@ -6,7 +6,7 @@ config:
   s3EndpointUrl: "https://storage.googleapis.com"
   repositories:
     dp02:
-      config_uri: "file:///opt/lsst/butler/public/config/dp02-server.yaml"
+      config_uri: "file:///opt/lsst/butler/config/dp02.yaml"
       authorized_groups: ["*"]
     dp1:
       config_uri: "file:///opt/lsst/butler/config/dp1.yaml"

--- a/applications/butler/values-idfprod.yaml
+++ b/applications/butler/values-idfprod.yaml
@@ -1,8 +1,6 @@
 autoscaling:
   minReplicas: 3
 config:
-  dp02ClientServerIsDefault: true
-  dp02UseSlacDatastore: true
   dp02PostgresUri: postgresql://butler@dp02.rsp-sql-stable.internal:5432/dp02
   dp1PostgresUri: postgresql://butler@alloydb-dp.rsp-sql-stable.internal:5432/dp1
   s3EndpointUrl: "https://storage.googleapis.com"

--- a/applications/butler/values.yaml
+++ b/applications/butler/values.yaml
@@ -101,14 +101,6 @@ config:
   # @default -- No configuration file for DP1 will be generated.
   dp1PostgresUri: ""
 
-  # -- True if the 'dp02' Butler repository alias should use client/server
-  # Butler.  False if it should use DirectButler.
-  dp02ClientServerIsDefault: false
-
-  # -- True if the 'dp02' datastore files should be served from SLAC, false
-  # if they should be served from Google.
-  dp02UseSlacDatastore: false
-
   # -- Postgres username used to connect to the Butler DB
   # @default -- Use values specified in per-repository Butler config files.
   pguser: ""


### PR DESCRIPTION
Remove the configuration file that users formerly used to access Butler directly, without going through Butler server.