### PR TITLE
[DM-51366] Investigate replication lag in MM2 at USDF

### DIFF
--- a/applications/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
@@ -158,7 +158,6 @@ spec:
           {{- toYaml . | nindent 10 }}
         {{- end }}
     version: {{ .Values.kafka.version | quote }}
-    replicas: {{ .Values.kafka.replicas }}
     listeners:
     {{- if .Values.kafka.listeners.plain.enabled }}
       # internal listener without tls encryption and with scram-sha-512 authentication

--- a/applications/sasquatch/charts/strimzi-kafka/templates/mirrormaker2.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/mirrormaker2.yaml
@@ -47,6 +47,8 @@ spec:
     targetCluster: "target"
     sourceConnector:
       tasksMax: 128
+      autoRestart:
+        enabled: true
       config:
         replication.factor: 3
         offset-syncs.topic.replication.factor: 3
@@ -84,9 +86,13 @@ spec:
         producer.request.timeout.ms: 240000
         consumer.request.timeout.ms: 240000
     heartbeatConnector:
+      autoRestart:
+        enabled: true
       config:
         heartbeats.topic.replication.factor: 3
     checkpointConnector:
+      autoRestart:
+        enabled: true
       config:
         checkpoints.topic.replication.factor: 3
         # Frequency of checks for new consumer groups.

--- a/applications/sasquatch/charts/strimzi-kafka/templates/mirrormaker2.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/mirrormaker2.yaml
@@ -46,7 +46,7 @@ spec:
   - sourceCluster: "source"
     targetCluster: "target"
     sourceConnector:
-      tasksMax: 32
+      tasksMax: 128
       config:
         replication.factor: 3
         offset-syncs.topic.replication.factor: 3

--- a/applications/sasquatch/charts/strimzi-kafka/templates/mirrormaker2.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/mirrormaker2.yaml
@@ -108,4 +108,36 @@ spec:
     limits:
       cpu: {{ .Values.mirrormaker2.resources.limits.cpu | quote }}
       memory: {{ .Values.mirrormaker2.resources.limits.memory | quote }}
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaUser
+metadata:
+  name: {{ .Values.cluster.name }}-connect
+  labels:
+    strimzi.io/cluster: {{ .Values.cluster.name }}
+spec:
+  authentication:
+    type: tls
+  authorization:
+    type: simple
+    acls:
+      - resource:
+          type: group
+          name: {{ .Values.cluster.name }}-connect
+        operations:
+          - Read
+      - resource:
+          type: group
+          name: "*"
+          patternType: literal
+        operations:
+          - All
+      - resource:
+          type: topic
+          name: "*"
+          patternType: literal
+        type: allow
+        host: "*"
+        operations:
+          - All
 {{ end }}

--- a/applications/sasquatch/charts/strimzi-kafka/templates/mirrormaker2.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/mirrormaker2.yaml
@@ -74,6 +74,12 @@ spec:
         # See also message.max.bytes broker configuration.
         producer.max.request.size: 10485760
         producer.buffer.memory: 10485760
+        # Increase the maximum number of messages fetched per request.
+        # This can improve throughput when you have just a few topic partitions that
+        # handle large numbers of messages.
+        consumer.fetch.max.bytes: 52428800
+        consumer.max.partition.fetch.bytes: 1048576
+        consumer.max.poll.records: 500
         # Increase request timeout
         producer.request.timeout.ms: 240000
         consumer.request.timeout.ms: 240000

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -29,11 +29,6 @@ strimzi-kafka:
         - broker: 2
           annotations:
             metallb.universe.tf/address-pool: sdf-rubin-ingest
-  connect:
-    enabled: true
-    config:
-      # -- Increase the request timeout for Kafka Connect to 120 seconds
-      request.timeout.ms: 120000
   mirrormaker2:
     enabled: true
     source:


### PR DESCRIPTION
When there's network performance degradation between Summit-USDF we typically see timeouts in MM2 and the replication tasks handling more data are the ones that fall behind. 

Even with 128 MM2 tasks we still have 37 topic-partitions per task and we can't control which topic-partitions are assigned to each task. So for example, a high throughput topic-partition like `lsst.sal.MTHexapod.application-0` can be assigned to the same MM2 task along with other high throughput topics.  

Even if this works in normal conditions, with the usual throughput when all topics are synced, this imbalance in MM2 makes some tasks to progress too slowly when there's a back log to replicate.

To fix the imbalance in the distribution of topic-partitions to MM2 tasks the ultimate solution is to add more partitions for the high throughput topics, in particular for MTHexapod and MTM2. We are planing on doing this in the next Summit maintenance window. 

For the moment, to speed MM2 I've fine tuned MM2 SourceConnector configuration to increase the number of messages fetched per request and increased the number of tasks from 32 to 128. That seem's the max configuration for the number of workers we have at the moment.

In the process I realized there's a new autoRestart option for the MM2 connectors that might help when there are connector failures, so I'm also enabling that.