### PR TITLE
DM-51420: Update vo-cutouts to 4.1.1

### DIFF
--- a/applications/vo-cutouts/Chart.yaml
+++ b/applications/vo-cutouts/Chart.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 description: "Image cutout service complying with IVOA SODA"
 sources:
   - "https://github.com/lsst-sqre/vo-cutouts"
-appVersion: 4.1.0
+appVersion: 4.1.1
 
 dependencies:
   - name: redis


### PR DESCRIPTION
Updates the backend worker to use the latest stack container.