### PR TITLE
DM-51427: Update Nublado to 8.8.8

### DIFF
--- a/applications/nublado/Chart.yaml
+++ b/applications/nublado/Chart.yaml
@@ -5,12 +5,12 @@ description: JupyterHub and custom spawner for the Rubin Science Platform
 sources:
   - https://github.com/lsst-sqre/nublado
 home: https://nublado.lsst.io/
-appVersion: 8.8.6
+appVersion: 8.8.8
 
 dependencies:
   - name: jupyterhub
     # This is the Zero To Jupyterhub version (and quay.io/jupyterhub/k8s-hub)
-    version: "4.1.0"
+    version: "4.2.0"
     repository: https://jupyterhub.github.io/helm-chart/
 
 annotations:

--- a/applications/nublado/README.md
+++ b/applications/nublado/README.md
@@ -148,7 +148,7 @@ JupyterHub and custom spawner for the Rubin Science Platform
 | jupyterhub.hub.extraVolumeMounts | list | `hub-config` and the Gafaelfawr token | Additional volume mounts for JupyterHub |
 | jupyterhub.hub.extraVolumes | list | The `hub-config` `ConfigMap` and the Gafaelfawr token | Additional volumes to make available to JupyterHub |
 | jupyterhub.hub.image.name | string | `"ghcr.io/lsst-sqre/nublado-jupyterhub"` | Image to use for JupyterHub |
-| jupyterhub.hub.image.tag | string | `"8.8.0"` | Tag of image to use for JupyterHub |
+| jupyterhub.hub.image.tag | string | `"8.8.8"` | Tag of image to use for JupyterHub |
 | jupyterhub.hub.loadRoles.server.scopes | list | See `values.yaml` | Default scopes for the user's lab, overridden to allow the lab to delete itself (which we use for our added menu items) |
 | jupyterhub.hub.networkPolicy.enabled | bool | `false` | Whether to enable the default `NetworkPolicy` (currently, the upstream one does not work correctly) |
 | jupyterhub.hub.resources | object | See `values.yaml` | Resource limits and requests |

--- a/applications/nublado/values-base.yaml
+++ b/applications/nublado/values-base.yaml
@@ -29,7 +29,7 @@ controller:
         - name: "inithome"
           image:
             repository: "ghcr.io/lsst-sqre/nublado-inithome"
-            tag: "8.8.0"
+            tag: "8.8.8"
           privileged: true
           volumeMounts:
             - containerPath: "/home"

--- a/applications/nublado/values-idfdemo.yaml
+++ b/applications/nublado/values-idfdemo.yaml
@@ -27,7 +27,7 @@ controller:
         - name: "inithome"
           image:
             repository: "us-central1-docker.pkg.dev/rubin-shared-services-71ec/sciplat/inithome"
-            tag: "8.8.2"
+            tag: "8.8.8"
           privileged: true
           volumeMounts:
             - containerPath: "/home"

--- a/applications/nublado/values-idfdev.yaml
+++ b/applications/nublado/values-idfdev.yaml
@@ -46,7 +46,7 @@ controller:
         - name: "inithome"
           image:
             repository: "us-central1-docker.pkg.dev/rubin-shared-services-71ec/sciplat/inithome"
-            tag: "8.8.2"
+            tag: "8.8.8"
           privileged: true
           volumeMounts:
             - containerPath: "/home"

--- a/applications/nublado/values-idfint.yaml
+++ b/applications/nublado/values-idfint.yaml
@@ -56,7 +56,7 @@ controller:
         - name: "inithome"
           image:
             repository: "us-central1-docker.pkg.dev/rubin-shared-services-71ec/sciplat/inithome"
-            tag: "8.8.2"
+            tag: "8.8.8"
           privileged: true
           volumeMounts:
             - containerPath: "/home"

--- a/applications/nublado/values-idfprod.yaml
+++ b/applications/nublado/values-idfprod.yaml
@@ -24,7 +24,7 @@ controller:
         - name: "inithome"
           image:
             repository: "us-central1-docker.pkg.dev/rubin-shared-services-71ec/sciplat/inithome"
-            tag: "8.8.2"
+            tag: "8.8.8"
           privileged: true
           volumeMounts:
             - containerPath: "/home"

--- a/applications/nublado/values-summit.yaml
+++ b/applications/nublado/values-summit.yaml
@@ -28,7 +28,7 @@ controller:
         - name: "inithome"
           image:
             repository: "ghcr.io/lsst-sqre/nublado-inithome"
-            tag: "8.8.0"
+            tag: "8.8.8"
           privileged: true
           volumeMounts:
             - containerPath: "/home"

--- a/applications/nublado/values-tucson-teststand.yaml
+++ b/applications/nublado/values-tucson-teststand.yaml
@@ -32,7 +32,7 @@ controller:
         - name: "inithome"
           image:
             repository: "ghcr.io/lsst-sqre/nublado-inithome"
-            tag: "8.8.0"
+            tag: "8.8.8"
           privileged: true
           volumeMounts:
             - containerPath: "/home"

--- a/applications/nublado/values-ukidacdev.yaml
+++ b/applications/nublado/values-ukidacdev.yaml
@@ -14,7 +14,7 @@ controller:
         - name: "inithome"
           image:
             repository: "ghcr.io/lsst-sqre/nublado-inithome"
-            tag: "8.8.0"
+            tag: "8.8.8"
           privileged: true
           volumeMounts:
             - containerPath: "/home"

--- a/applications/nublado/values-ukidacprod.yaml
+++ b/applications/nublado/values-ukidacprod.yaml
@@ -14,7 +14,7 @@ controller:
         - name: "inithome"
           image:
             repository: "ghcr.io/lsst-sqre/nublado-inithome"
-            tag: "8.8.0"
+            tag: "8.8.8"
           privileged: true
           volumeMounts:
             - containerPath: "/home"

--- a/applications/nublado/values.yaml
+++ b/applications/nublado/values.yaml
@@ -474,7 +474,7 @@ jupyterhub:
       name: "ghcr.io/lsst-sqre/nublado-jupyterhub"
 
       # -- Tag of image to use for JupyterHub
-      tag: "8.8.0"
+      tag: "8.8.8"
 
     # -- Resource limits and requests
     # @default -- See `values.yaml`


### PR DESCRIPTION
Update Nublado to 8.8.8 and the Zero to JupyterHub chart to 4.2.0. Fix the version numbers for the init containers to match the correct release version.