### PR TITLE
DM-51412:  Add support for returning hips lists for multiple data releases

### DIFF
--- a/applications/datalinker/Chart.yaml
+++ b/applications/datalinker/Chart.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 description: IVOA DataLink-based service and data discovery
 sources:
   - https://github.com/lsst-sqre/datalinker
-appVersion: 3.2.0
+appVersion: 3.3.0
 annotations:
   phalanx.lsst.io/docs: |
     - id: "DMTN-238"

--- a/applications/datalinker/README.md
+++ b/applications/datalinker/README.md
@@ -11,7 +11,10 @@ IVOA DataLink-based service and data discovery
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules for the datalinker deployment pod |
+| config.hipsDatasets | object | `{}` | HiPS dataset configurations mapping dataset names to their base URLs |
+| config.hipsDefaultDataset | string | `""` | Default dataset for legacy /api/hips endpoints (optional) If not set it will use hips_base_url |
 | config.hipsPathPrefix | string | `"/api/hips"` | URL path prefix for the HiPS API (must match the configuration of the hips service) |
+| config.hipsV2PathPrefix | string | `"/api/hips/v2"` | URL path prefix for the HiPS v2 API (must match the configuration of the hips service) |
 | config.linksLifetime | string | `"1h"` | Lifetime of the `{links}` reply. Should be set to match the lifetime of links returned by the Butler server |
 | config.logLevel | string | `"INFO"` | Logging level |
 | config.pathPrefix | string | `"/api/datalink"` | URL path prefix for DataLink and related APIs |

--- a/applications/datalinker/templates/configmap.yaml
+++ b/applications/datalinker/templates/configmap.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "datalinker"
+  labels:
+    {{- include "datalinker.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    cutoutSyncUrl: "{{ .Values.global.baseUrl }}/api/cutout/sync"
+    hipsBaseUrl: "{{ .Values.global.baseUrl }}/api/hips"
+    {{- if .Values.config.tapMetadataUrl }}
+    tapMetadataDir: "/tmp/tap-metadata"
+    tapMetadataUrl: {{ .Values.config.tapMetadataUrl | quote }}
+    {{- end }}
+    {{- .Values.config | toYaml | nindent 4 }}

--- a/applications/datalinker/templates/deployment.yaml
+++ b/applications/datalinker/templates/deployment.yaml
@@ -13,6 +13,8 @@ spec:
     metadata:
       {{- with .Values.podAnnotations }}
       annotations:
+        # Force the pod to restart when the config map is updated.
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
@@ -26,30 +28,12 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           env:
-            - name: "DATALINKER_CUTOUT_SYNC_URL"
-              value: "{{ .Values.global.baseUrl }}/api/cutout/sync"
-            - name: "DATALINKER_LINKS_LIFETIME"
-              value: {{ .Values.config.linksLifetime | quote }}
-            - name: "DATALINKER_HIPS_BASE_URL"
-              value: "{{ .Values.global.baseUrl }}/api/hips"
-            - name: "DATALINKER_LOG_LEVEL"
-              value: {{ .Values.config.logLevel | quote }}
-            - name: "DATALINKER_PATH_PREFIX"
-              value: {{ .Values.config.pathPrefix | quote }}
-            - name: "DATALINKER_HIPS_PATH_PREFIX"
-              value: {{ .Values.config.hipsPathPrefix | quote }}
             {{- if .Values.config.slackAlerts }}
             - name: "DATALINKER_SLACK_WEBHOOK"
               valueFrom:
                 secretKeyRef:
                   name: "datalinker"
                   key: "slack-webhook"
-            {{- end }}
-            {{- if .Values.config.tapMetadataUrl }}
-            - name: "DATALINKER_TAP_METADATA_DIR"
-              value: "/tmp/tap-metadata"
-            - name: "DATALINKER_TAP_METADATA_URL"
-              value: {{ .Values.config.tapMetadataUrl | quote }}
             {{- end }}
             - name: "DATALINKER_TOKEN"
               valueFrom:
@@ -81,6 +65,9 @@ spec:
           volumeMounts:
             - name: "tmp"
               mountPath: "/tmp"
+            - name: "config"
+              mountPath: "/etc/datalinker"
+              readOnly: true
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -97,3 +84,6 @@ spec:
       volumes:
         - name: "tmp"
           emptyDir: {}
+        - name: "config"
+          configMap:
+            name: "datalinker"

--- a/applications/datalinker/templates/ingress-anonymous.yaml
+++ b/applications/datalinker/templates/ingress-anonymous.yaml
@@ -27,3 +27,12 @@ template:
                   name: "datalinker"
                   port:
                     number: 8080
+            {{- range $dataset, $url := .Values.config.hipsDatasets }}
+            - path: "{{ $.Values.config.hipsV2PathPrefix }}/{{ $dataset }}/list"
+              pathType: "Exact"
+              backend:
+                service:
+                  name: "datalinker"
+                  port:
+                    number: 8080
+            {{- end }}

--- a/applications/datalinker/values-idfdev.yaml
+++ b/applications/datalinker/values-idfdev.yaml
@@ -1,2 +1,25 @@
 config:
   slackAlerts: true
+  hipsDefaultDataset: "dp02"
+  hipsDatasets:
+    dp02:
+      url: "https://data-dev.lsst.cloud/api/hips/v2/dp02"
+      paths:
+        - "images/color_gri"
+        - "images/color_riz"
+        - "images/band_u"
+        - "images/band_g"
+        - "images/band_r"
+        - "images/band_i"
+        - "images/band_z"
+        - "images/band_y"
+        - "images/2MASS/Color"
+    dp1:
+      url: "https://data-dev.lsst.cloud/api/hips/v2/dp1"
+      paths:
+        - "color_gri"
+        - "color_grz"
+        - "color_izy"
+        - "color_riz"
+        - "color_ugr"
+        - "color_uug"

--- a/applications/datalinker/values-idfint.yaml
+++ b/applications/datalinker/values-idfint.yaml
@@ -1,2 +1,25 @@
 config:
   slackAlerts: true
+  hipsDefaultDataset: "dp1"
+  hipsDatasets:
+    dp02:
+      url: "https://data-int.lsst.cloud/api/hips/v2/dp02"
+      paths:
+        - "images/color_gri"
+        - "images/color_riz"
+        - "images/band_u"
+        - "images/band_g"
+        - "images/band_r"
+        - "images/band_i"
+        - "images/band_z"
+        - "images/band_y"
+        - "images/2MASS/Color"
+    dp1:
+      url: "https://data-int.lsst.cloud/api/hips/v2/dp1"
+      paths:
+        - "color_gri"
+        - "color_grz"
+        - "color_izy"
+        - "color_riz"
+        - "color_ugr"
+        - "color_uug"

--- a/applications/datalinker/values.yaml
+++ b/applications/datalinker/values.yaml
@@ -20,6 +20,18 @@ ingress:
   annotations: {}
 
 config:
+
+  # -- Default dataset for legacy /api/hips endpoints (optional)
+  # If not set it will use hips_base_url
+  hipsDefaultDataset: ""
+
+  # -- HiPS dataset configurations mapping dataset names to their base URLs
+  hipsDatasets: {}
+
+  # -- URL path prefix for the HiPS v2 API (must match the configuration of the
+  # hips service)
+  hipsV2PathPrefix: "/api/hips/v2"
+
   # -- URL path prefix for the HiPS API (must match the configuration of the
   # hips service)
   hipsPathPrefix: "/api/hips"


### PR DESCRIPTION
### Summary of changes
- Enable new helm chart properties to allow datalinker to handle multiple hips lists
- Move datalinker ENV variables to configmap to handle more complex structure
- Update datalinker ingress to handle new /v2 path

**Before merging**: switch datalinker image back to for idfdev & upgrade app version