### PR TITLE
DM-51389: Expand use of retry in Prompt Processing

### DIFF
--- a/applications/prompt-keda-hsc/README.md
+++ b/applications/prompt-keda-hsc/README.md
@@ -60,6 +60,7 @@ KEDA Prompt Processing instance for HSC
 | prompt-keda.keda.redisStreams.lagCount | string | `"1"` |  |
 | prompt-keda.keda.redisStreams.msgListenTimeout | int | `900` |  |
 | prompt-keda.keda.redisStreams.pendingEntriesCount | string | `"1"` |  |
+| prompt-keda.keda.redisStreams.retry | int | `30` | The time to wait (in seconds) before retrying a stream connection failure. |
 | prompt-keda.keda.redisStreams.streamName | string | `"instrument:hsc"` |  |
 | prompt-keda.keda.scalingStrategy | string | `"eager"` |  |
 | prompt-keda.keda.successfulJobsHistoryLimit | int | `5` |  |

--- a/applications/prompt-keda-hsc/README.md
+++ b/applications/prompt-keda-hsc/README.md
@@ -49,21 +49,21 @@ KEDA Prompt Processing instance for HSC
 | prompt-keda.instrument.preloadPadding | int | `42` | Number of arcseconds to pad the spatial region in preloading. |
 | prompt-keda.instrument.repoWait | int | `5` | The average time to wait (in seconds) before retrying a failed connection to the shared repo. |
 | prompt-keda.instrument.skymap | string | `"hsc_rings_v1"` | Skymap to use with the instrument |
-| prompt-keda.keda.failedJobsHistoryLimit | int | `5` |  |
-| prompt-keda.keda.maxReplicaCount | int | `100` |  |
-| prompt-keda.keda.minReplicaCount | int | `3` |  |
-| prompt-keda.keda.pollingInterval | int | `2` |  |
-| prompt-keda.keda.redisStreams.activationLagCount | string | `"1"` |  |
-| prompt-keda.keda.redisStreams.consumerGroup | string | `"hsc_consumer_group"` |  |
+| prompt-keda.keda.failedJobsHistoryLimit | int | `5` | How many failed jobs should be kept available in Kubernetes. |
+| prompt-keda.keda.maxReplicaCount | int | `100` | Maximum number of replicas to scale to. |
+| prompt-keda.keda.minReplicaCount | int | `3` | Minimum number of replicas to start with. |
+| prompt-keda.keda.pollingInterval | int | `2` | Polling interval for Keda to poll scalar for scaling determination. |
+| prompt-keda.keda.redisStreams.activationLagCount | string | `"1"` | Lag count at which scaler triggers |
+| prompt-keda.keda.redisStreams.consumerGroup | string | `"hsc_consumer_group"` | Redis Consumer Group name |
 | prompt-keda.keda.redisStreams.expiration | int | `3600` | Maximum message age to process, in seconds. |
-| prompt-keda.keda.redisStreams.host | string | `"prompt-redis.prompt-redis"` |  |
-| prompt-keda.keda.redisStreams.lagCount | string | `"1"` |  |
-| prompt-keda.keda.redisStreams.msgListenTimeout | int | `900` |  |
-| prompt-keda.keda.redisStreams.pendingEntriesCount | string | `"1"` |  |
+| prompt-keda.keda.redisStreams.host | string | `"prompt-redis.prompt-redis"` | Address of Redis Streams Cluster |
+| prompt-keda.keda.redisStreams.lagCount | string | `"1"` | Number of lagging entries in the consumer group, alternative to pendingEntriesCount scaler trigger |
+| prompt-keda.keda.redisStreams.msgListenTimeout | int | `900` | Time to wait for fanned out messages before spawning new pod. |
+| prompt-keda.keda.redisStreams.pendingEntriesCount | string | `"1"` | Number of entries in the Pending Entries List for the specified consumer group in the Redis Stream |
 | prompt-keda.keda.redisStreams.retry | int | `30` | The time to wait (in seconds) before retrying a stream connection failure. |
-| prompt-keda.keda.redisStreams.streamName | string | `"instrument:hsc"` |  |
-| prompt-keda.keda.scalingStrategy | string | `"eager"` |  |
-| prompt-keda.keda.successfulJobsHistoryLimit | int | `5` |  |
+| prompt-keda.keda.redisStreams.streamName | string | `"instrument:hsc"` | Name of Redis Stream |
+| prompt-keda.keda.scalingStrategy | string | `"eager"` | Scaling algorithm |
+| prompt-keda.keda.successfulJobsHistoryLimit | int | `5` | How many completed jobs should be kept available in Kubernetes. |
 | prompt-keda.logLevel | string | log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
 | prompt-keda.mpSky_service | string | `""` | The URI to the MPSky ephemerides service. Empty value is allowed, but its handling is undefined. |
 | prompt-keda.nameOverride | string | `""` | Override the base name for resources |

--- a/applications/prompt-keda-hsc/values.yaml
+++ b/applications/prompt-keda-hsc/values.yaml
@@ -128,35 +128,35 @@ prompt-keda:
     auth_env: true
 
   keda:
-    # Minimum number of replicas to start with.
+    # -- Minimum number of replicas to start with.
     minReplicaCount: 3
-    # Maximum number of replicas to scale to.
+    # -- Maximum number of replicas to scale to.
     maxReplicaCount: 100
-    # Scaling algorithm
+    # -- Scaling algorithm
     scalingStrategy: eager
-    # Polling interval for Keda to poll scalar for scaling determination.
+    # -- Polling interval for Keda to poll scalar for scaling determination.
     pollingInterval: 2
-    # How many completed jobs should be kept available in Kubernetes.
+    # -- How many completed jobs should be kept available in Kubernetes.
     successfulJobsHistoryLimit: 5
-    # How many failed jobs should be kept available in Kubernetes.
+    # -- How many failed jobs should be kept available in Kubernetes.
     failedJobsHistoryLimit: 5
 
     redisStreams:
-      # Address of Redis Streams Cluster
+      # -- Address of Redis Streams Cluster
       host: prompt-redis.prompt-redis
-      # Name of Redis Stream
+      # -- Name of Redis Stream
       streamName: instrument:hsc
-      # Redis Consumer Group name
+      # -- Redis Consumer Group name
       consumerGroup: hsc_consumer_group
       # -- The time to wait (in seconds) before retrying a stream connection failure.
       retry: 30
-      # Time to wait for fanned out messages before spawning new pod.
+      # -- Time to wait for fanned out messages before spawning new pod.
       msgListenTimeout: 900
-      # Lag count at which scaler triggers
+      # -- Lag count at which scaler triggers
       activationLagCount: "1"
-      #  Number of lagging entries in the consumer group, alternative to pendingEntriesCount scaler trigger
+      # -- Number of lagging entries in the consumer group, alternative to pendingEntriesCount scaler trigger
       lagCount: "1"
-      # Number of entries in the Pending Entries List for the specified consumer group in the Redis Stream
+      # -- Number of entries in the Pending Entries List for the specified consumer group in the Redis Stream
       pendingEntriesCount: "1"
       # -- Maximum message age to process, in seconds.
       expiration: 3600

--- a/applications/prompt-keda-hsc/values.yaml
+++ b/applications/prompt-keda-hsc/values.yaml
@@ -148,6 +148,8 @@ prompt-keda:
       streamName: instrument:hsc
       # Redis Consumer Group name
       consumerGroup: hsc_consumer_group
+      # -- The time to wait (in seconds) before retrying a stream connection failure.
+      retry: 30
       # Time to wait for fanned out messages before spawning new pod.
       msgListenTimeout: 900
       # Lag count at which scaler triggers

--- a/applications/prompt-keda-latiss/README.md
+++ b/applications/prompt-keda-latiss/README.md
@@ -60,6 +60,7 @@ KEDA Prompt Processing instance for LATISS
 | prompt-keda.keda.redisStreams.lagCount | string | `"1"` |  |
 | prompt-keda.keda.redisStreams.msgListenTimeout | int | `900` |  |
 | prompt-keda.keda.redisStreams.pendingEntriesCount | string | `"1"` |  |
+| prompt-keda.keda.redisStreams.retry | int | `30` | The time to wait (in seconds) before retrying a stream connection failure. |
 | prompt-keda.keda.redisStreams.streamName | string | `"instrument:latiss"` |  |
 | prompt-keda.keda.scalingStrategy | string | `"eager"` |  |
 | prompt-keda.keda.successfulJobsHistoryLimit | int | `5` |  |

--- a/applications/prompt-keda-latiss/README.md
+++ b/applications/prompt-keda-latiss/README.md
@@ -49,21 +49,21 @@ KEDA Prompt Processing instance for LATISS
 | prompt-keda.instrument.preloadPadding | int | `30` | Number of arcseconds to pad the spatial region in preloading. |
 | prompt-keda.instrument.repoWait | int | `30` | The average time to wait (in seconds) before retrying a failed connection to the shared repo. |
 | prompt-keda.instrument.skymap | string | `"latiss_v1"` | Skymap to use with the instrument |
-| prompt-keda.keda.failedJobsHistoryLimit | int | `5` |  |
-| prompt-keda.keda.maxReplicaCount | int | `30` |  |
-| prompt-keda.keda.minReplicaCount | int | `3` |  |
-| prompt-keda.keda.pollingInterval | int | `2` |  |
-| prompt-keda.keda.redisStreams.activationLagCount | string | `"1"` |  |
-| prompt-keda.keda.redisStreams.consumerGroup | string | `"latiss_consumer_group"` |  |
+| prompt-keda.keda.failedJobsHistoryLimit | int | `5` | How many failed jobs should be kept available in Kubernetes. |
+| prompt-keda.keda.maxReplicaCount | int | `30` | Maximum number of replicas to scale to. |
+| prompt-keda.keda.minReplicaCount | int | `3` | Minimum number of replicas to start with. |
+| prompt-keda.keda.pollingInterval | int | `2` | Polling interval for Keda to poll scalar for scaling determination. |
+| prompt-keda.keda.redisStreams.activationLagCount | string | `"1"` | Lag count at which scaler triggers |
+| prompt-keda.keda.redisStreams.consumerGroup | string | `"latiss_consumer_group"` | Redis Consumer Group name |
 | prompt-keda.keda.redisStreams.expiration | int | `3600` | Maximum message age to process, in seconds. |
-| prompt-keda.keda.redisStreams.host | string | `"prompt-redis.prompt-redis"` |  |
-| prompt-keda.keda.redisStreams.lagCount | string | `"1"` |  |
-| prompt-keda.keda.redisStreams.msgListenTimeout | int | `900` |  |
-| prompt-keda.keda.redisStreams.pendingEntriesCount | string | `"1"` |  |
+| prompt-keda.keda.redisStreams.host | string | `"prompt-redis.prompt-redis"` | Address of Redis Streams Cluster |
+| prompt-keda.keda.redisStreams.lagCount | string | `"1"` | Number of lagging entries in the consumer group, alternative to pendingEntriesCount scaler trigger |
+| prompt-keda.keda.redisStreams.msgListenTimeout | int | `900` | Time to wait for fanned out messages before spawning new pod. |
+| prompt-keda.keda.redisStreams.pendingEntriesCount | string | `"1"` | Number of entries in the Pending Entries List for the specified consumer group in the Redis Stream |
 | prompt-keda.keda.redisStreams.retry | int | `30` | The time to wait (in seconds) before retrying a stream connection failure. |
-| prompt-keda.keda.redisStreams.streamName | string | `"instrument:latiss"` |  |
-| prompt-keda.keda.scalingStrategy | string | `"eager"` |  |
-| prompt-keda.keda.successfulJobsHistoryLimit | int | `5` |  |
+| prompt-keda.keda.redisStreams.streamName | string | `"instrument:latiss"` | Name of Redis Stream |
+| prompt-keda.keda.scalingStrategy | string | `"eager"` | Scaling algorithm |
+| prompt-keda.keda.successfulJobsHistoryLimit | int | `5` | How many completed jobs should be kept available in Kubernetes. |
 | prompt-keda.logLevel | string | log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
 | prompt-keda.mpSky_service | string | `""` | The URI to the MPSky ephemerides service. Empty value is allowed, but its handling is undefined. |
 | prompt-keda.nameOverride | string | `""` | Override the base name for resources |

--- a/applications/prompt-keda-latiss/values.yaml
+++ b/applications/prompt-keda-latiss/values.yaml
@@ -146,6 +146,8 @@ prompt-keda:
       streamName: instrument:latiss
       # Redis Consumer Group name
       consumerGroup: latiss_consumer_group
+      # -- The time to wait (in seconds) before retrying a stream connection failure.
+      retry: 30
       # Time to wait for fanned out messages before spawning new pod.
       msgListenTimeout: 900
       # Lag count at which scaler triggers

--- a/applications/prompt-keda-latiss/values.yaml
+++ b/applications/prompt-keda-latiss/values.yaml
@@ -126,35 +126,35 @@ prompt-keda:
     auth_env: true
 
   keda:
-    # Minimum number of replicas to start with.
+    # -- Minimum number of replicas to start with.
     minReplicaCount: 3
-    # Maximum number of replicas to scale to.
+    # -- Maximum number of replicas to scale to.
     maxReplicaCount: 30
-    # Scaling algorithm
+    # -- Scaling algorithm
     scalingStrategy: eager
-    # Polling interval for Keda to poll scalar for scaling determination.
+    # -- Polling interval for Keda to poll scalar for scaling determination.
     pollingInterval: 2
-    # How many completed jobs should be kept available in Kubernetes.
+    # -- How many completed jobs should be kept available in Kubernetes.
     successfulJobsHistoryLimit: 5
-    # How many failed jobs should be kept available in Kubernetes.
+    # -- How many failed jobs should be kept available in Kubernetes.
     failedJobsHistoryLimit: 5
 
     redisStreams:
-      # Address of Redis Streams Cluster
+      # -- Address of Redis Streams Cluster
       host: prompt-redis.prompt-redis
-      # Name of Redis Stream
+      # -- Name of Redis Stream
       streamName: instrument:latiss
-      # Redis Consumer Group name
+      # -- Redis Consumer Group name
       consumerGroup: latiss_consumer_group
       # -- The time to wait (in seconds) before retrying a stream connection failure.
       retry: 30
-      # Time to wait for fanned out messages before spawning new pod.
+      # -- Time to wait for fanned out messages before spawning new pod.
       msgListenTimeout: 900
-      # Lag count at which scaler triggers
+      # -- Lag count at which scaler triggers
       activationLagCount: "1"
-      #  Number of lagging entries in the consumer group, alternative to pendingEntriesCount scaler trigger
+      # -- Number of lagging entries in the consumer group, alternative to pendingEntriesCount scaler trigger
       lagCount: "1"
-      # Number of entries in the Pending Entries List for the specified consumer group in the Redis Stream
+      # -- Number of entries in the Pending Entries List for the specified consumer group in the Redis Stream
       pendingEntriesCount: "1"
       # -- Maximum message age to process, in seconds.
       expiration: 3600

--- a/applications/prompt-keda-lsstcam/README.md
+++ b/applications/prompt-keda-lsstcam/README.md
@@ -58,6 +58,7 @@ KEDA Prompt Processing instance for LSSTCam
 | prompt-keda.keda.redisStreams.lagCount | string | `"1"` |  |
 | prompt-keda.keda.redisStreams.msgListenTimeout | int | `900` |  |
 | prompt-keda.keda.redisStreams.pendingEntriesCount | string | `"1"` |  |
+| prompt-keda.keda.redisStreams.retry | int | `30` | The time to wait (in seconds) before retrying a stream connection failure. |
 | prompt-keda.keda.redisStreams.streamName | string | `"instrument:lsstcam"` |  |
 | prompt-keda.keda.scalingStrategy | string | `"eager"` |  |
 | prompt-keda.keda.successfulJobsHistoryLimit | int | `5` |  |

--- a/applications/prompt-keda-lsstcam/README.md
+++ b/applications/prompt-keda-lsstcam/README.md
@@ -47,21 +47,21 @@ KEDA Prompt Processing instance for LSSTCam
 | prompt-keda.instrument.preloadPadding | int | `50` | Number of arcseconds to pad the spatial region in preloading. |
 | prompt-keda.instrument.repoWait | int | `30` | The average time to wait (in seconds) before retrying a failed connection to the shared repo. |
 | prompt-keda.instrument.skymap | string | `"lsst_cells_v1"` | Skymap to use with the instrument |
-| prompt-keda.keda.failedJobsHistoryLimit | int | `5` |  |
-| prompt-keda.keda.maxReplicaCount | int | `30` |  |
-| prompt-keda.keda.minReplicaCount | int | `3` |  |
-| prompt-keda.keda.pollingInterval | int | `2` |  |
-| prompt-keda.keda.redisStreams.activationLagCount | string | `"1"` |  |
-| prompt-keda.keda.redisStreams.consumerGroup | string | `"lsstcam_consumer_group"` |  |
+| prompt-keda.keda.failedJobsHistoryLimit | int | `5` | How many failed jobs should be kept available in Kubernetes. |
+| prompt-keda.keda.maxReplicaCount | int | `30` | Maximum number of replicas to scale to. |
+| prompt-keda.keda.minReplicaCount | int | `3` | Minimum number of replicas to start with. |
+| prompt-keda.keda.pollingInterval | int | `2` | Polling interval for Keda to poll scalar for scaling determination. |
+| prompt-keda.keda.redisStreams.activationLagCount | string | `"1"` | Lag count at which scaler triggers |
+| prompt-keda.keda.redisStreams.consumerGroup | string | `"lsstcam_consumer_group"` | Redis Consumer Group name |
 | prompt-keda.keda.redisStreams.expiration | int | `3600` | Maximum message age to process, in seconds. |
-| prompt-keda.keda.redisStreams.host | string | `"prompt-redis.prompt-redis"` |  |
-| prompt-keda.keda.redisStreams.lagCount | string | `"1"` |  |
-| prompt-keda.keda.redisStreams.msgListenTimeout | int | `900` |  |
-| prompt-keda.keda.redisStreams.pendingEntriesCount | string | `"1"` |  |
+| prompt-keda.keda.redisStreams.host | string | `"prompt-redis.prompt-redis"` | Address of Redis Streams Cluster |
+| prompt-keda.keda.redisStreams.lagCount | string | `"1"` | Number of lagging entries in the consumer group, alternative to pendingEntriesCount scaler trigger |
+| prompt-keda.keda.redisStreams.msgListenTimeout | int | `900` | Time to wait for fanned out messages before spawning new pod. |
+| prompt-keda.keda.redisStreams.pendingEntriesCount | string | `"1"` | Number of entries in the Pending Entries List for the specified consumer group in the Redis Stream |
 | prompt-keda.keda.redisStreams.retry | int | `30` | The time to wait (in seconds) before retrying a stream connection failure. |
-| prompt-keda.keda.redisStreams.streamName | string | `"instrument:lsstcam"` |  |
-| prompt-keda.keda.scalingStrategy | string | `"eager"` |  |
-| prompt-keda.keda.successfulJobsHistoryLimit | int | `5` |  |
+| prompt-keda.keda.redisStreams.streamName | string | `"instrument:lsstcam"` | Name of Redis Stream |
+| prompt-keda.keda.scalingStrategy | string | `"eager"` | Scaling algorithm |
+| prompt-keda.keda.successfulJobsHistoryLimit | int | `5` | How many completed jobs should be kept available in Kubernetes. |
 | prompt-keda.logLevel | string | log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
 | prompt-keda.mpSky_service | string | `""` | The URI to the MPSky ephemerides service. Empty value is allowed, but its handling is undefined. |
 | prompt-keda.nameOverride | string | `""` | Override the base name for resources |

--- a/applications/prompt-keda-lsstcam/values.yaml
+++ b/applications/prompt-keda-lsstcam/values.yaml
@@ -153,6 +153,8 @@ prompt-keda:
       streamName: instrument:lsstcam
       # Redis Consumer Group name
       consumerGroup: lsstcam_consumer_group
+      # -- The time to wait (in seconds) before retrying a stream connection failure.
+      retry: 30
       # Time to wait for fanned out messages before spawning new pod.
       msgListenTimeout: 900
       # Lag count at which scaler triggers

--- a/applications/prompt-keda-lsstcam/values.yaml
+++ b/applications/prompt-keda-lsstcam/values.yaml
@@ -133,35 +133,35 @@ prompt-keda:
     exportOutputs: true
 
   keda:
-    # Minimum number of replicas to start with.
+    # -- Minimum number of replicas to start with.
     minReplicaCount: 3
-    # Maximum number of replicas to scale to.
+    # -- Maximum number of replicas to scale to.
     maxReplicaCount: 30
-    # Scaling algorithm
+    # -- Scaling algorithm
     scalingStrategy: eager
-    # Polling interval for Keda to poll scalar for scaling determination.
+    # -- Polling interval for Keda to poll scalar for scaling determination.
     pollingInterval: 2
-    # How many completed jobs should be kept available in Kubernetes.
+    # -- How many completed jobs should be kept available in Kubernetes.
     successfulJobsHistoryLimit: 5
-    # How many failed jobs should be kept available in Kubernetes.
+    # -- How many failed jobs should be kept available in Kubernetes.
     failedJobsHistoryLimit: 5
 
     redisStreams:
-      # Address of Redis Streams Cluster
+      # -- Address of Redis Streams Cluster
       host: prompt-redis.prompt-redis
-      # Name of Redis Stream
+      # -- Name of Redis Stream
       streamName: instrument:lsstcam
-      # Redis Consumer Group name
+      # -- Redis Consumer Group name
       consumerGroup: lsstcam_consumer_group
       # -- The time to wait (in seconds) before retrying a stream connection failure.
       retry: 30
-      # Time to wait for fanned out messages before spawning new pod.
+      # -- Time to wait for fanned out messages before spawning new pod.
       msgListenTimeout: 900
-      # Lag count at which scaler triggers
+      # -- Lag count at which scaler triggers
       activationLagCount: "1"
-      #  Number of lagging entries in the consumer group, alternative to pendingEntriesCount scaler trigger
+      # -- Number of lagging entries in the consumer group, alternative to pendingEntriesCount scaler trigger
       lagCount: "1"
-      # Number of entries in the Pending Entries List for the specified consumer group in the Redis Stream
+      # -- Number of entries in the Pending Entries List for the specified consumer group in the Redis Stream
       pendingEntriesCount: "1"
       # -- Maximum message age to process, in seconds.
       expiration: 3600

--- a/applications/prompt-keda-lsstcamimsim/README.md
+++ b/applications/prompt-keda-lsstcamimsim/README.md
@@ -60,6 +60,7 @@ KEDA Prompt Processing instance for LSSTCam-imSim.
 | prompt-keda.keda.redisStreams.lagCount | string | `"1"` |  |
 | prompt-keda.keda.redisStreams.msgListenTimeout | int | `900` |  |
 | prompt-keda.keda.redisStreams.pendingEntriesCount | string | `"1"` |  |
+| prompt-keda.keda.redisStreams.retry | int | `30` | The time to wait (in seconds) before retrying a stream connection failure. |
 | prompt-keda.keda.redisStreams.streamName | string | `"instrument:lsstcamimsim"` |  |
 | prompt-keda.keda.scalingStrategy | string | `"eager"` |  |
 | prompt-keda.keda.successfulJobsHistoryLimit | int | `5` |  |

--- a/applications/prompt-keda-lsstcamimsim/README.md
+++ b/applications/prompt-keda-lsstcamimsim/README.md
@@ -49,21 +49,21 @@ KEDA Prompt Processing instance for LSSTCam-imSim.
 | prompt-keda.instrument.preloadPadding | int | `50` | Number of arcseconds to pad the spatial region in preloading. |
 | prompt-keda.instrument.repoWait | int | `5` | The average time to wait (in seconds) before retrying a failed connection to the shared repo. |
 | prompt-keda.instrument.skymap | string | `"DC2_cells_v1"` | Skymap to use with the instrument |
-| prompt-keda.keda.failedJobsHistoryLimit | int | `5` |  |
-| prompt-keda.keda.maxReplicaCount | int | `800` |  |
-| prompt-keda.keda.minReplicaCount | int | `3` |  |
-| prompt-keda.keda.pollingInterval | int | `2` |  |
-| prompt-keda.keda.redisStreams.activationLagCount | string | `"1"` |  |
-| prompt-keda.keda.redisStreams.consumerGroup | string | `"lsstcamimsim_consumer_group"` |  |
+| prompt-keda.keda.failedJobsHistoryLimit | int | `5` | How many failed jobs should be kept available in Kubernetes. |
+| prompt-keda.keda.maxReplicaCount | int | `800` | Maximum number of replicas to scale to. |
+| prompt-keda.keda.minReplicaCount | int | `3` | Minimum number of replicas to start with. |
+| prompt-keda.keda.pollingInterval | int | `2` | Polling interval for Keda to poll scalar for scaling determination. |
+| prompt-keda.keda.redisStreams.activationLagCount | string | `"1"` | Lag count at which scaler triggers |
+| prompt-keda.keda.redisStreams.consumerGroup | string | `"lsstcamimsim_consumer_group"` | Redis Consumer Group name |
 | prompt-keda.keda.redisStreams.expiration | int | `3600` | Maximum message age to process, in seconds. |
-| prompt-keda.keda.redisStreams.host | string | `"prompt-redis.prompt-redis"` |  |
-| prompt-keda.keda.redisStreams.lagCount | string | `"1"` |  |
-| prompt-keda.keda.redisStreams.msgListenTimeout | int | `900` |  |
-| prompt-keda.keda.redisStreams.pendingEntriesCount | string | `"1"` |  |
+| prompt-keda.keda.redisStreams.host | string | `"prompt-redis.prompt-redis"` | Address of Redis Streams Cluster |
+| prompt-keda.keda.redisStreams.lagCount | string | `"1"` | Number of lagging entries in the consumer group, alternative to pendingEntriesCount scaler trigger |
+| prompt-keda.keda.redisStreams.msgListenTimeout | int | `900` | Time to wait for fanned out messages before spawning new pod. |
+| prompt-keda.keda.redisStreams.pendingEntriesCount | string | `"1"` | Number of entries in the Pending Entries List for the specified consumer group in the Redis Stream |
 | prompt-keda.keda.redisStreams.retry | int | `30` | The time to wait (in seconds) before retrying a stream connection failure. |
-| prompt-keda.keda.redisStreams.streamName | string | `"instrument:lsstcamimsim"` |  |
-| prompt-keda.keda.scalingStrategy | string | `"eager"` |  |
-| prompt-keda.keda.successfulJobsHistoryLimit | int | `5` |  |
+| prompt-keda.keda.redisStreams.streamName | string | `"instrument:lsstcamimsim"` | Name of Redis Stream |
+| prompt-keda.keda.scalingStrategy | string | `"eager"` | Scaling algorithm |
+| prompt-keda.keda.successfulJobsHistoryLimit | int | `5` | How many completed jobs should be kept available in Kubernetes. |
 | prompt-keda.logLevel | string | log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
 | prompt-keda.mpSky_service | string | `""` | The URI to the MPSky ephemerides service. Empty value is allowed, but its handling is undefined. |
 | prompt-keda.nameOverride | string | `""` | Override the base name for resources |

--- a/applications/prompt-keda-lsstcamimsim/values.yaml
+++ b/applications/prompt-keda-lsstcamimsim/values.yaml
@@ -133,37 +133,37 @@ prompt-keda:
     exportOutputs: true
 
   keda:
-    # Minimum number of replicas to start with.
+    # -- Minimum number of replicas to start with.
     minReplicaCount: 3
-    # Maximum number of replicas to scale to.
     # Expect to need roughly n_detector × request_latency / survey_cadence pods
     # For 120s latency and 30s cadence, this is 756.
+    # -- Maximum number of replicas to scale to.
     maxReplicaCount: 800
-    # Scaling algorithm
+    # -- Scaling algorithm
     scalingStrategy: eager
-    # Polling interval for Keda to poll scalar for scaling determination.
+    # -- Polling interval for Keda to poll scalar for scaling determination.
     pollingInterval: 2
-    # How many completed jobs should be kept available in Kubernetes.
+    # -- How many completed jobs should be kept available in Kubernetes.
     successfulJobsHistoryLimit: 5
-    # How many failed jobs should be kept available in Kubernetes.
+    # -- How many failed jobs should be kept available in Kubernetes.
     failedJobsHistoryLimit: 5
 
     redisStreams:
-      # Address of Redis Streams Cluster
+      # -- Address of Redis Streams Cluster
       host: prompt-redis.prompt-redis
-      # Name of Redis Stream
+      # -- Name of Redis Stream
       streamName: instrument:lsstcamimsim
-      # Redis Consumer Group name
+      # -- Redis Consumer Group name
       consumerGroup: lsstcamimsim_consumer_group
       # -- The time to wait (in seconds) before retrying a stream connection failure.
       retry: 30
-      # Time to wait for fanned out messages before spawning new pod.
+      # -- Time to wait for fanned out messages before spawning new pod.
       msgListenTimeout: 900
-      # Lag count at which scaler triggers
+      # -- Lag count at which scaler triggers
       activationLagCount: "1"
-      #  Number of lagging entries in the consumer group, alternative to pendingEntriesCount scaler trigger
+      # -- Number of lagging entries in the consumer group, alternative to pendingEntriesCount scaler trigger
       lagCount: "1"
-      # Number of entries in the Pending Entries List for the specified consumer group in the Redis Stream
+      # -- Number of entries in the Pending Entries List for the specified consumer group in the Redis Stream
       pendingEntriesCount: "1"
       # -- Maximum message age to process, in seconds.
       expiration: 3600

--- a/applications/prompt-keda-lsstcamimsim/values.yaml
+++ b/applications/prompt-keda-lsstcamimsim/values.yaml
@@ -155,6 +155,8 @@ prompt-keda:
       streamName: instrument:lsstcamimsim
       # Redis Consumer Group name
       consumerGroup: lsstcamimsim_consumer_group
+      # -- The time to wait (in seconds) before retrying a stream connection failure.
+      retry: 30
       # Time to wait for fanned out messages before spawning new pod.
       msgListenTimeout: 900
       # Lag count at which scaler triggers

--- a/applications/prompt-keda-lsstcomcam/README.md
+++ b/applications/prompt-keda-lsstcomcam/README.md
@@ -57,6 +57,7 @@ KEDA Prompt Processing instance for LSSTComCam.
 | prompt-keda.keda.redisStreams.lagCount | string | `"1"` |  |
 | prompt-keda.keda.redisStreams.msgListenTimeout | int | `900` |  |
 | prompt-keda.keda.redisStreams.pendingEntriesCount | string | `"1"` |  |
+| prompt-keda.keda.redisStreams.retry | int | `30` | The time to wait (in seconds) before retrying a stream connection failure. |
 | prompt-keda.keda.redisStreams.streamName | string | `"instrument:lsstcomcam"` |  |
 | prompt-keda.keda.scalingStrategy | string | `"eager"` |  |
 | prompt-keda.keda.successfulJobsHistoryLimit | int | `5` |  |

--- a/applications/prompt-keda-lsstcomcam/README.md
+++ b/applications/prompt-keda-lsstcomcam/README.md
@@ -46,21 +46,21 @@ KEDA Prompt Processing instance for LSSTComCam.
 | prompt-keda.instrument.preloadPadding | int | `50` | Number of arcseconds to pad the spatial region in preloading. |
 | prompt-keda.instrument.repoWait | int | `5` | The average time to wait (in seconds) before retrying a failed connection to the shared repo. |
 | prompt-keda.instrument.skymap | string | `"lsst_cells_v1"` | Skymap to use with the instrument |
-| prompt-keda.keda.failedJobsHistoryLimit | int | `5` |  |
-| prompt-keda.keda.maxReplicaCount | int | `200` |  |
-| prompt-keda.keda.minReplicaCount | int | `3` |  |
-| prompt-keda.keda.pollingInterval | int | `2` |  |
-| prompt-keda.keda.redisStreams.activationLagCount | string | `"1"` |  |
-| prompt-keda.keda.redisStreams.consumerGroup | string | `"lsstcomcam_consumer_group"` |  |
+| prompt-keda.keda.failedJobsHistoryLimit | int | `5` | How many failed jobs should be kept available in Kubernetes. |
+| prompt-keda.keda.maxReplicaCount | int | `200` | Maximum number of replicas to scale to. |
+| prompt-keda.keda.minReplicaCount | int | `3` | Minimum number of replicas to start with. |
+| prompt-keda.keda.pollingInterval | int | `2` | Polling interval for Keda to poll scalar for scaling determination. |
+| prompt-keda.keda.redisStreams.activationLagCount | string | `"1"` | Lag count at which scaler triggers |
+| prompt-keda.keda.redisStreams.consumerGroup | string | `"lsstcomcam_consumer_group"` | Redis Consumer Group name |
 | prompt-keda.keda.redisStreams.expiration | int | `3600` | Maximum message age to process, in seconds. |
-| prompt-keda.keda.redisStreams.host | string | `"prompt-redis.prompt-redis"` |  |
-| prompt-keda.keda.redisStreams.lagCount | string | `"1"` |  |
-| prompt-keda.keda.redisStreams.msgListenTimeout | int | `900` |  |
-| prompt-keda.keda.redisStreams.pendingEntriesCount | string | `"1"` |  |
+| prompt-keda.keda.redisStreams.host | string | `"prompt-redis.prompt-redis"` | Address of Redis Streams Cluster |
+| prompt-keda.keda.redisStreams.lagCount | string | `"1"` | Number of lagging entries in the consumer group, alternative to pendingEntriesCount scaler trigger |
+| prompt-keda.keda.redisStreams.msgListenTimeout | int | `900` | Time to wait for fanned out messages before spawning new pod. |
+| prompt-keda.keda.redisStreams.pendingEntriesCount | string | `"1"` | Number of entries in the Pending Entries List for the specified consumer group in the Redis Stream |
 | prompt-keda.keda.redisStreams.retry | int | `30` | The time to wait (in seconds) before retrying a stream connection failure. |
-| prompt-keda.keda.redisStreams.streamName | string | `"instrument:lsstcomcam"` |  |
-| prompt-keda.keda.scalingStrategy | string | `"eager"` |  |
-| prompt-keda.keda.successfulJobsHistoryLimit | int | `5` |  |
+| prompt-keda.keda.redisStreams.streamName | string | `"instrument:lsstcomcam"` | Name of Redis Stream |
+| prompt-keda.keda.scalingStrategy | string | `"eager"` | Scaling algorithm |
+| prompt-keda.keda.successfulJobsHistoryLimit | int | `5` | How many completed jobs should be kept available in Kubernetes. |
 | prompt-keda.logLevel | string | log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
 | prompt-keda.mpSky_service | string | `""` | The URI to the MPSky ephemerides service. Empty value is allowed, but its handling is undefined. |
 | prompt-keda.nameOverride | string | `""` | Override the base name for resources |

--- a/applications/prompt-keda-lsstcomcam/values.yaml
+++ b/applications/prompt-keda-lsstcomcam/values.yaml
@@ -127,37 +127,37 @@ prompt-keda:
     auth_env: true
 
   keda:
-    # Minimum number of replicas to start with.
+    # -- Minimum number of replicas to start with.
     minReplicaCount: 3
-    # Maximum number of replicas to scale to.
     # Expect to need roughly n_detector × request_latency / survey_cadence pods
     # For 120s latency and 30s cadence, this is 756.
+    # -- Maximum number of replicas to scale to.
     maxReplicaCount: 200
-    # Scaling algorithm
+    # -- Scaling algorithm
     scalingStrategy: eager
-    # Polling interval for Keda to poll scalar for scaling determination.
+    # -- Polling interval for Keda to poll scalar for scaling determination.
     pollingInterval: 2
-    # How many completed jobs should be kept available in Kubernetes.
+    # -- How many completed jobs should be kept available in Kubernetes.
     successfulJobsHistoryLimit: 5
-    # How many failed jobs should be kept available in Kubernetes.
+    # -- How many failed jobs should be kept available in Kubernetes.
     failedJobsHistoryLimit: 5
 
     redisStreams:
-      # Address of Redis Streams Cluster
+      # -- Address of Redis Streams Cluster
       host: prompt-redis.prompt-redis
-      # Name of Redis Stream
+      # -- Name of Redis Stream
       streamName: instrument:lsstcomcam
-      # Redis Consumer Group name
+      # -- Redis Consumer Group name
       consumerGroup: lsstcomcam_consumer_group
       # -- The time to wait (in seconds) before retrying a stream connection failure.
       retry: 30
-      # Time to wait for fanned out messages before spawning new pod.
+      # -- Time to wait for fanned out messages before spawning new pod.
       msgListenTimeout: 900
-      # Lag count at which scaler triggers
+      # -- Lag count at which scaler triggers
       activationLagCount: "1"
-      #  Number of lagging entries in the consumer group, alternative to pendingEntriesCount scaler trigger
+      # -- Number of lagging entries in the consumer group, alternative to pendingEntriesCount scaler trigger
       lagCount: "1"
-      # Number of entries in the Pending Entries List for the specified consumer group in the Redis Stream
+      # -- Number of entries in the Pending Entries List for the specified consumer group in the Redis Stream
       pendingEntriesCount: "1"
       # -- Maximum message age to process, in seconds.
       expiration: 3600

--- a/applications/prompt-keda-lsstcomcam/values.yaml
+++ b/applications/prompt-keda-lsstcomcam/values.yaml
@@ -149,6 +149,8 @@ prompt-keda:
       streamName: instrument:lsstcomcam
       # Redis Consumer Group name
       consumerGroup: lsstcomcam_consumer_group
+      # -- The time to wait (in seconds) before retrying a stream connection failure.
+      retry: 30
       # Time to wait for fanned out messages before spawning new pod.
       msgListenTimeout: 900
       # Lag count at which scaler triggers

--- a/applications/prompt-keda-lsstcomcamsim/README.md
+++ b/applications/prompt-keda-lsstcomcamsim/README.md
@@ -49,21 +49,21 @@ KEDA Prompt Processing instance for LSSTComCamSim
 | prompt-keda.instrument.preloadPadding | int | `50` | Number of arcseconds to pad the spatial region in preloading. |
 | prompt-keda.instrument.repoWait | int | `5` | The average time to wait (in seconds) before retrying a failed connection to the shared repo. |
 | prompt-keda.instrument.skymap | string | `"ops_rehersal_prep_2k_v1"` | Skymap to use with the instrument |
-| prompt-keda.keda.failedJobsHistoryLimit | int | `5` |  |
-| prompt-keda.keda.maxReplicaCount | int | `150` |  |
-| prompt-keda.keda.minReplicaCount | int | `3` |  |
-| prompt-keda.keda.pollingInterval | int | `2` |  |
-| prompt-keda.keda.redisStreams.activationLagCount | string | `"1"` |  |
-| prompt-keda.keda.redisStreams.consumerGroup | string | `"lsstcomcamsim_consumer_group"` |  |
+| prompt-keda.keda.failedJobsHistoryLimit | int | `5` | How many failed jobs should be kept available in Kubernetes. |
+| prompt-keda.keda.maxReplicaCount | int | `150` | Maximum number of replicas to scale to. |
+| prompt-keda.keda.minReplicaCount | int | `3` | Minimum number of replicas to start with. |
+| prompt-keda.keda.pollingInterval | int | `2` | Polling interval for Keda to poll scalar for scaling determination. |
+| prompt-keda.keda.redisStreams.activationLagCount | string | `"1"` | Lag count at which scaler triggers |
+| prompt-keda.keda.redisStreams.consumerGroup | string | `"lsstcomcamsim_consumer_group"` | Redis Consumer Group name |
 | prompt-keda.keda.redisStreams.expiration | int | `3600` | Maximum message age to process, in seconds. |
-| prompt-keda.keda.redisStreams.host | string | `"prompt-redis.prompt-redis"` |  |
-| prompt-keda.keda.redisStreams.lagCount | string | `"1"` |  |
-| prompt-keda.keda.redisStreams.msgListenTimeout | int | `900` |  |
-| prompt-keda.keda.redisStreams.pendingEntriesCount | string | `"1"` |  |
+| prompt-keda.keda.redisStreams.host | string | `"prompt-redis.prompt-redis"` | Address of Redis Streams Cluster |
+| prompt-keda.keda.redisStreams.lagCount | string | `"1"` | Number of lagging entries in the consumer group, alternative to pendingEntriesCount scaler trigger |
+| prompt-keda.keda.redisStreams.msgListenTimeout | int | `900` | Time to wait for fanned out messages before spawning new pod. |
+| prompt-keda.keda.redisStreams.pendingEntriesCount | string | `"1"` | Number of entries in the Pending Entries List for the specified consumer group in the Redis Stream |
 | prompt-keda.keda.redisStreams.retry | int | `30` | The time to wait (in seconds) before retrying a stream connection failure. |
-| prompt-keda.keda.redisStreams.streamName | string | `"instrument:lsstcomcamsim"` |  |
-| prompt-keda.keda.scalingStrategy | string | `"eager"` |  |
-| prompt-keda.keda.successfulJobsHistoryLimit | int | `5` |  |
+| prompt-keda.keda.redisStreams.streamName | string | `"instrument:lsstcomcamsim"` | Name of Redis Stream |
+| prompt-keda.keda.scalingStrategy | string | `"eager"` | Scaling algorithm |
+| prompt-keda.keda.successfulJobsHistoryLimit | int | `5` | How many completed jobs should be kept available in Kubernetes. |
 | prompt-keda.logLevel | string | log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
 | prompt-keda.mpSky_service | string | `""` | The URI to the MPSky ephemerides service. Empty value is allowed, but its handling is undefined. |
 | prompt-keda.nameOverride | string | `""` | Override the base name for resources |

--- a/applications/prompt-keda-lsstcomcamsim/README.md
+++ b/applications/prompt-keda-lsstcomcamsim/README.md
@@ -60,6 +60,7 @@ KEDA Prompt Processing instance for LSSTComCamSim
 | prompt-keda.keda.redisStreams.lagCount | string | `"1"` |  |
 | prompt-keda.keda.redisStreams.msgListenTimeout | int | `900` |  |
 | prompt-keda.keda.redisStreams.pendingEntriesCount | string | `"1"` |  |
+| prompt-keda.keda.redisStreams.retry | int | `30` | The time to wait (in seconds) before retrying a stream connection failure. |
 | prompt-keda.keda.redisStreams.streamName | string | `"instrument:lsstcomcamsim"` |  |
 | prompt-keda.keda.scalingStrategy | string | `"eager"` |  |
 | prompt-keda.keda.successfulJobsHistoryLimit | int | `5` |  |

--- a/applications/prompt-keda-lsstcomcamsim/values.yaml
+++ b/applications/prompt-keda-lsstcomcamsim/values.yaml
@@ -129,35 +129,35 @@ prompt-keda:
     auth_env: true
 
   keda:
-    # Minimum number of replicas to start with.
+    # -- Minimum number of replicas to start with.
     minReplicaCount: 3
-    # Maximum number of replicas to scale to.
+    # -- Maximum number of replicas to scale to.
     maxReplicaCount: 150
-    # Scaling algorithm
+    # -- Scaling algorithm
     scalingStrategy: eager
-    # Polling interval for Keda to poll scalar for scaling determination.
+    # -- Polling interval for Keda to poll scalar for scaling determination.
     pollingInterval: 2
-    # How many completed jobs should be kept available in Kubernetes.
+    # -- How many completed jobs should be kept available in Kubernetes.
     successfulJobsHistoryLimit: 5
-    # How many failed jobs should be kept available in Kubernetes.
+    # -- How many failed jobs should be kept available in Kubernetes.
     failedJobsHistoryLimit: 5
 
     redisStreams:
-      # Address of Redis Streams Cluster
+      # -- Address of Redis Streams Cluster
       host: prompt-redis.prompt-redis
-      # Name of Redis Stream
+      # -- Name of Redis Stream
       streamName: instrument:lsstcomcamsim
-      # Redis Consumer Group name
+      # -- Redis Consumer Group name
       consumerGroup: lsstcomcamsim_consumer_group
       # -- The time to wait (in seconds) before retrying a stream connection failure.
       retry: 30
-      # Time to wait for fanned out messages before spawning new pod.
+      # -- Time to wait for fanned out messages before spawning new pod.
       msgListenTimeout: 900
-      # Lag count at which scaler triggers
+      # -- Lag count at which scaler triggers
       activationLagCount: "1"
-      #  Number of lagging entries in the consumer group, alternative to pendingEntriesCount scaler trigger
+      # -- Number of lagging entries in the consumer group, alternative to pendingEntriesCount scaler trigger
       lagCount: "1"
-      # Number of entries in the Pending Entries List for the specified consumer group in the Redis Stream
+      # -- Number of entries in the Pending Entries List for the specified consumer group in the Redis Stream
       pendingEntriesCount: "1"
       # -- Maximum message age to process, in seconds.
       expiration: 3600

--- a/applications/prompt-keda-lsstcomcamsim/values.yaml
+++ b/applications/prompt-keda-lsstcomcamsim/values.yaml
@@ -149,6 +149,8 @@ prompt-keda:
       streamName: instrument:lsstcomcamsim
       # Redis Consumer Group name
       consumerGroup: lsstcomcamsim_consumer_group
+      # -- The time to wait (in seconds) before retrying a stream connection failure.
+      retry: 30
       # Time to wait for fanned out messages before spawning new pod.
       msgListenTimeout: 900
       # Lag count at which scaler triggers

--- a/charts/prompt-keda/README.md
+++ b/charts/prompt-keda/README.md
@@ -60,6 +60,7 @@ Event-driven processing of camera images
 | keda.redisStreams.lagCount | string | `"1"` |  |
 | keda.redisStreams.msgListenTimeout | int | `900` |  |
 | keda.redisStreams.pendingEntriesCount | string | `"1"` |  |
+| keda.redisStreams.retry | int | `30` | The time to wait (in seconds) before retrying a stream connection failure. |
 | keda.redisStreams.streamName | string | `""` |  |
 | keda.scalingStrategy | string | `"eager"` |  |
 | keda.successfulJobsHistoryLimit | int | `25` |  |

--- a/charts/prompt-keda/README.md
+++ b/charts/prompt-keda/README.md
@@ -49,21 +49,21 @@ Event-driven processing of camera images
 | instrument.preloadPadding | int | `30` | Number of arcseconds to pad the spatial region in preloading. |
 | instrument.repoWait | int | `30` | The average time to wait (in seconds) before retrying a failed connection to the shared repo. |
 | instrument.skymap | string | `""` | Skymap to use with the instrument |
-| keda.failedJobsHistoryLimit | int | `25` |  |
-| keda.maxReplicaCount | int | `10` |  |
-| keda.minReplicaCount | int | `3` |  |
-| keda.pollingInterval | int | `2` |  |
-| keda.redisStreams.activationLagCount | string | `"1"` |  |
-| keda.redisStreams.consumerGroup | string | `""` |  |
+| keda.failedJobsHistoryLimit | int | `25` | How many failed jobs should be kept available in Kubernetes. |
+| keda.maxReplicaCount | int | `10` | Maximum number of replicas to scale to. |
+| keda.minReplicaCount | int | `3` | Minimum number of replicas to start with. |
+| keda.pollingInterval | int | `2` | Polling interval for Keda to poll scalar for scaling determination. |
+| keda.redisStreams.activationLagCount | string | `"1"` | Lag count at which scaler triggers |
+| keda.redisStreams.consumerGroup | string | `""` | Redis Consumer Group name |
 | keda.redisStreams.expiration | int | `3600` | Maximum message age to process, in seconds. |
-| keda.redisStreams.host | string | `""` |  |
-| keda.redisStreams.lagCount | string | `"1"` |  |
-| keda.redisStreams.msgListenTimeout | int | `900` |  |
-| keda.redisStreams.pendingEntriesCount | string | `"1"` |  |
+| keda.redisStreams.host | string | `""` | Address of Redis Streams Cluster |
+| keda.redisStreams.lagCount | string | `"1"` | Number of lagging entries in the consumer group, alternative to pendingEntriesCount scaler trigger |
+| keda.redisStreams.msgListenTimeout | int | `900` | Time to wait for fanned out messages before spawning new pod. |
+| keda.redisStreams.pendingEntriesCount | string | `"1"` | Number of entries in the Pending Entries List for the specified consumer group in the Redis Stream |
 | keda.redisStreams.retry | int | `30` | The time to wait (in seconds) before retrying a stream connection failure. |
-| keda.redisStreams.streamName | string | `""` |  |
-| keda.scalingStrategy | string | `"eager"` |  |
-| keda.successfulJobsHistoryLimit | int | `25` |  |
+| keda.redisStreams.streamName | string | `""` | Name of Redis Stream |
+| keda.scalingStrategy | string | `"eager"` | Scaling algorithm |
+| keda.successfulJobsHistoryLimit | int | `25` | How many completed jobs should be kept available in Kubernetes. |
 | logLevel | string | log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING. | Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level). |
 | mpSky_service | string | `""` | The URI to the MPSky ephemerides service. Empty value is allowed, but its handling is undefined. |
 | nameOverride | string | `""` | Override the base name for resources |

--- a/charts/prompt-keda/templates/scaled-job.yaml
+++ b/charts/prompt-keda/templates/scaled-job.yaml
@@ -165,6 +165,8 @@ spec:
                 value: {{ .Values.keda.redisStreams.streamName}}
               - name: REDIS_STREAM_CONSUMER_GROUP
                 value: {{ .Values.keda.redisStreams.consumerGroup}}
+              - name: REDIS_RETRY_DELAY
+                value: {{ .Values.keda.redisStreams.retry | toString | quote }}
               - name: FANNED_OUT_MSG_LISTEN_TIMEOUT
                 value: {{ .Values.keda.redisStreams.msgListenTimeout | toString | quote }}
             volumeMounts:

--- a/charts/prompt-keda/values.yaml
+++ b/charts/prompt-keda/values.yaml
@@ -131,35 +131,35 @@ sasquatch:
   auth_env: true
 
 keda:
-  # Minimum number of replicas to start with.
+  # -- Minimum number of replicas to start with.
   minReplicaCount: 3
-  # Maximum number of replicas to scale to.
+  # -- Maximum number of replicas to scale to.
   maxReplicaCount: 10
-  # Scaling algorithm
+  # -- Scaling algorithm
   scalingStrategy: eager
-  # Polling interval for Keda to poll scalar for scaling determination.
+  # -- Polling interval for Keda to poll scalar for scaling determination.
   pollingInterval: 2
-  # How many completed jobs should be kept available in Kubernetes.
+  # -- How many completed jobs should be kept available in Kubernetes.
   successfulJobsHistoryLimit: 25
-  # How many failed jobs should be kept available in Kubernetes.
+  # -- How many failed jobs should be kept available in Kubernetes.
   failedJobsHistoryLimit: 25
 
   redisStreams:
-    # Address of Redis Streams Cluster
+    # -- Address of Redis Streams Cluster
     host: ""
-    # Name of Redis Stream
+    # -- Name of Redis Stream
     streamName: ""
-    # Redis Consumer Group name
+    # -- Redis Consumer Group name
     consumerGroup: ""
     # -- The time to wait (in seconds) before retrying a stream connection failure.
     retry: 30
-    # Time to wait for fanned out messages before spawning new pod.
+    # -- Time to wait for fanned out messages before spawning new pod.
     msgListenTimeout: 900
-    # Lag count at which scaler triggers
+    # -- Lag count at which scaler triggers
     activationLagCount: "1"
-    #  Number of lagging entries in the consumer group, alternative to pendingEntriesCount scaler trigger
+    # -- Number of lagging entries in the consumer group, alternative to pendingEntriesCount scaler trigger
     lagCount: "1"
-    # Number of entries in the Pending Entries List for the specified consumer group in the Redis Stream
+    # -- Number of entries in the Pending Entries List for the specified consumer group in the Redis Stream
     pendingEntriesCount: "1"
     # -- Maximum message age to process, in seconds.
     expiration: 3600

--- a/charts/prompt-keda/values.yaml
+++ b/charts/prompt-keda/values.yaml
@@ -151,6 +151,8 @@ keda:
     streamName: ""
     # Redis Consumer Group name
     consumerGroup: ""
+    # -- The time to wait (in seconds) before retrying a stream connection failure.
+    retry: 30
     # Time to wait for fanned out messages before spawning new pod.
     msgListenTimeout: 900
     # Lag count at which scaler triggers


### PR DESCRIPTION
This PR adds a config hook for Redis retries and makes documentation for Redis settings visible in the readmes.