### PR TITLE
DM-51382: Allow multiple rewrite rules for TAP service

### DIFF
--- a/applications/tap/values-idfdev.yaml
+++ b/applications/tap/values-idfdev.yaml
@@ -9,7 +9,7 @@ cadc-tap:
       jdbcParams: "?enabledTLSProtocols=TLSv1.3"
       passwordEnabled: true
       image:
-        tag: "3.0.0"
+        tag: "3.1.0"
 
     kafka:
       bootstrapServer: "sasquatch-dev-kafka-bootstrap.lsst.cloud:9094"
@@ -17,6 +17,10 @@ cadc-tap:
         url: "https://data-dev.lsst.cloud/schema-registry/"
       auth:
         enabled: true
+
+    urlRewrite:
+      enabled: true
+      rules: "ivoa.ObsCore:access_url, dp02_dc2_catalogs.ObsCore:access_url, dp1_v29.ObsCore:access_url"
 
   cloudsql:
     enabled: true

--- a/applications/tap/values-idfint.yaml
+++ b/applications/tap/values-idfint.yaml
@@ -9,7 +9,7 @@ cadc-tap:
       jdbcParams: "?enabledTLSProtocols=TLSv1.3"
       passwordEnabled: true
       image:
-        tag: "3.0.0"
+        tag: "3.1.0"
 
     sentryEnabled: true
     sentryTracesSampleRate: "0.1"
@@ -21,6 +21,9 @@ cadc-tap:
       auth:
         enabled: true
 
+    urlRewrite:
+      enabled: true
+      rules: "ivoa.ObsCore:access_url, dp02_dc2_catalogs.ObsCore:access_url, dp1_v29.ObsCore:access_url"
 
   cloudsql:
     enabled: true

--- a/applications/tap/values-idfprod.yaml
+++ b/applications/tap/values-idfprod.yaml
@@ -9,7 +9,7 @@ cadc-tap:
       jdbcParams: "?enabledTLSProtocols=TLSv1.3"
       passwordEnabled: true
       image:
-        tag: "3.0.0"
+        tag: "3.1.0"
 
     kafka:
       bootstrapServer: "sasquatch-kafka-bootstrap.lsst.cloud:9094"
@@ -17,6 +17,10 @@ cadc-tap:
         url: "https://data.lsst.cloud/schema-registry/"
       auth:
         enabled: true
+
+    urlRewrite:
+      enabled: true
+      rules: "ivoa.ObsCore:access_url, dp02_dc2_catalogs.ObsCore:access_url, dp1_v29.ObsCore:access_url"
 
   cloudsql:
     enabled: true

--- a/charts/cadc-tap/README.md
+++ b/charts/cadc-tap/README.md
@@ -53,6 +53,9 @@ IVOA TAP service
 | config.sentryEnabled | bool | `false` | Whether Sentry is enabled in this environment |
 | config.serviceName | string | None, must be set | Name of the service from Gafaelfawr's perspective, used for metrics reporting |
 | config.tapSchemaAddress | string | `"cadc-tap-schema-db:3306"` | Address to a MySQL database containing TAP schema data |
+| config.urlRewrite | object | `{"enabled":true,"rules":"ivoa.ObsCore:access_url"}` | Rules for renaming Columns |
+| config.urlRewrite.enabled | bool | `true` | Whether it is enabled |
+| config.urlRewrite.rules | string | `"ivoa.ObsCore:access_url"` | String with a comma-separated list of schema.table:column rules |
 | config.vaultSecretName | string | `""` | Vault secret name, this is appended to the global path to find the vault secrets associated with this deployment. |
 | fullnameOverride | string | `"cadc-tap"` | Override the full name for resources (includes the release name) |
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |

--- a/charts/cadc-tap/templates/configmap.yaml
+++ b/charts/cadc-tap/templates/configmap.yaml
@@ -21,3 +21,8 @@ data:
 
     # authentication provider
     ca.nrc.cadc.auth.IdentityManager=org.opencadc.auth.StandardIdentityManager
+  tap-config.properties: |
+    # URL rewrite configuration
+    url.rewrite.enabled={{ .Values.config.urlRewrite.enabled | default true }}
+    # Format: table1:column1,table2:column2,table3:column3
+    url.rewrite.rules={{ .Values.config.urlRewrite.rules | default "ivoa.ObsCore:access_url" }}

--- a/charts/cadc-tap/templates/tap-deployment.yaml
+++ b/charts/cadc-tap/templates/tap-deployment.yaml
@@ -83,6 +83,8 @@ spec:
                 -Dbase_url={{ .Values.global.baseUrl }}
                 -Dpath_prefix=/api/{{ .Values.ingress.path }}
                 -Dca.nrc.cadc.util.PropertiesReader.dir=/config/
+                -Durl.rewrite.enabled={{ .Values.config.urlRewrite.enabled | default true }}
+                -Durl.rewrite.rules="{{ .Values.config.urlRewrite.rules | default "ivoa.ObsCore:access_url" }}"
                 -Xmx{{ .Values.config.jvmMaxHeapSize }}
             {{- if .Values.config.kafka.auth.enabled }}
             - name: "KAFKA_PASSWORD"

--- a/charts/cadc-tap/values.yaml
+++ b/charts/cadc-tap/values.yaml
@@ -160,6 +160,15 @@ config:
       # -- Whether auth is enabled
       enabled: false
 
+  # -- Rules for renaming Columns
+  urlRewrite:
+
+    # -- Whether it is enabled
+    enabled: true
+
+    # -- String with a comma-separated list of schema.table:column rules
+    rules: "ivoa.ObsCore:access_url"
+
 mockdb:
   # -- Spin up a container to pretend to be the database.
   enabled: false


### PR DESCRIPTION
Upgrades TAP service to **3.1.0** which includes:

- DM-51382 Make URL Rewriting optional, read urlRewriteRules from env by @stvoutsin in https://github.com/lsst-sqre/lsst-tap-service/pull/149
- Read URL_REWRITE_RULES from env and use to determine whether a table-column needs to be formatted/rewritten.
- Fix some formatting issues
- Reduce logging
- Remove upstream patch classes
- Upgrade uws uws-server and cadc-rest libraries

Changes in TAP service chart configuration to allow defining list of schema.table:columns to rewrite