### PR TITLE
Fix Argo CD RBAC rules

### DIFF
--- a/applications/argocd/values-idfdemo.yaml
+++ b/applications/argocd/values-idfdemo.yaml
@@ -32,6 +32,7 @@ argo-cd:
         p, role:developer, applications, sync, infrastructure/*, deny
         p, role:developer, applications, override, infrastructure/*, deny
         p, role:developer, applications, action/*, infrastructure/*, deny
+        p, role:developer, logs, get, */*, allow
         p, role:developer, logs, get, infrastructure/*, allow
 
   server:

--- a/applications/argocd/values-idfdev.yaml
+++ b/applications/argocd/values-idfdev.yaml
@@ -27,6 +27,7 @@ argo-cd:
         p, role:developer, applications, sync, infrastructure/*, deny
         p, role:developer, applications, override, infrastructure/*, deny
         p, role:developer, applications, action/*, infrastructure/*, deny
+        p, role:developer, logs, get, */*, allow
         p, role:developer, logs, get, infrastructure/*, allow
 
         g, adam@lsst.cloud, role:admin

--- a/applications/argocd/values-idfint.yaml
+++ b/applications/argocd/values-idfint.yaml
@@ -27,6 +27,7 @@ argo-cd:
         p, role:developer, applications, sync, infrastructure/*, deny
         p, role:developer, applications, override, infrastructure/*, deny
         p, role:developer, applications, action/*, infrastructure/*, deny
+        p, role:developer, logs, get, */*, allow
         p, role:developer, logs, get, infrastructure/*, allow
 
         g, adam@lsst.cloud, role:admin

--- a/applications/argocd/values-idfprod.yaml
+++ b/applications/argocd/values-idfprod.yaml
@@ -27,6 +27,7 @@ argo-cd:
         p, role:developer, applications, sync, infrastructure/*, deny
         p, role:developer, applications, override, infrastructure/*, deny
         p, role:developer, applications, action/*, infrastructure/*, deny
+        p, role:developer, logs, get, */*, allow
         p, role:developer, logs, get, infrastructure/*, allow
 
         g, adam@lsst.cloud, role:admin

--- a/applications/argocd/values-tacc-spherex.yaml
+++ b/applications/argocd/values-tacc-spherex.yaml
@@ -30,6 +30,7 @@ argo-cd:
         p, role:developer, applications, sync, infrastructure/*, deny
         p, role:developer, applications, override, infrastructure/*, deny
         p, role:developer, applications, action/*, infrastructure/*, deny
+        p, role:developer, logs, get, */*, allow
         p, role:developer, logs, get, infrastructure/*, allow
 
   server:

--- a/applications/argocd/values-usdfdev.yaml
+++ b/applications/argocd/values-usdfdev.yaml
@@ -33,6 +33,7 @@ argo-cd:
         p, role:developer, applications, sync, infrastructure/*, deny
         p, role:developer, applications, override, infrastructure/*, deny
         p, role:developer, applications, action/*, infrastructure/*, deny
+        p, role:developer, logs, get, */*, allow
         p, role:developer, logs, get, infrastructure/*, allow
 
         g, afausti@slac.stanford.edu, role:admin

--- a/applications/argocd/values-usdfint.yaml
+++ b/applications/argocd/values-usdfint.yaml
@@ -33,6 +33,7 @@ argo-cd:
         p, role:developer, applications, sync, infrastructure/*, deny
         p, role:developer, applications, override, infrastructure/*, deny
         p, role:developer, applications, action/*, infrastructure/*, deny
+        p, role:developer, logs, get, */*, allow
         p, role:developer, logs, get, infrastructure/*, allow
 
         g, afausti@slac.stanford.edu, role:admin

--- a/applications/argocd/values-usdfprod.yaml
+++ b/applications/argocd/values-usdfprod.yaml
@@ -33,6 +33,7 @@ argo-cd:
         p, role:developer, applications, sync, infrastructure/*, deny
         p, role:developer, applications, override, infrastructure/*, deny
         p, role:developer, applications, action/*, infrastructure/*, deny
+        p, role:developer, logs, get, */*, allow
         p, role:developer, logs, get, infrastructure/*, allow
 
         g, afausti@slac.stanford.edu, role:admin


### PR DESCRIPTION
There now needs to be an explicit wildcard allow rule for logs for developers or they would only be able to see the logs for infrastructure applications.