### PR TITLE
DM-51450: Update to Qserv Kafka bridge 1.0.0

### DIFF
--- a/applications/qserv-kafka/Chart.yaml
+++ b/applications/qserv-kafka/Chart.yaml
@@ -5,7 +5,7 @@ version: 1.0.0
 description: "Qserv Kafka bridge"
 sources:
   - "https://github.com/lsst-sqre/qserv-kafka"
-appVersion: 0.7.0
+appVersion: 1.0.0
 
 dependencies:
   - name: "redis"

--- a/applications/qserv-kafka/README.md
+++ b/applications/qserv-kafka/README.md
@@ -31,6 +31,8 @@ Qserv Kafka bridge
 | config.qservRestTimeout | string | `"30s"` | Timeout for REST API calls in Safir `parse_timedelta` format. This includes time spent waiting for a connection if the maximum number of connections has been reached. |
 | config.qservRestUrl | string | None, must be set | URL to the Qserv REST API |
 | config.qservRestUsername | string | `nil` | Username for HTTP Basic Authentication for the Qserv REST API. If not null, the password will be assumed to be the same as the database password. |
+| config.qservRetryCount | int | `3` | How many times to retry after a Qserv API network failure |
+| config.qservRetryDelay | string | `"1s"` | How long to wait between retries after a Qserv API network failure in Safir `parse_timedelta` format |
 | config.qservUploadTimeout | string | `"5m"` | How long to allow for user table upload before timing out in Safir `parse_timedelta` format. |
 | config.resultTimeout | int | 3600 (1 hour) | How long to wait for result processing (retrieval and upload) before timing out, in seconds. This doubles as the timeout forcibly terminating result worker pods. |
 | frontend.affinity | object | `{}` | Affinity rules for the qserv-kafka frontend pod |

--- a/applications/qserv-kafka/templates/configmap.yaml
+++ b/applications/qserv-kafka/templates/configmap.yaml
@@ -28,6 +28,8 @@ data:
   {{- if .Values.config.qservRestUsername }}
   QSERV_KAFKA_QSERV_REST_USERNAME: {{ .Values.config.qservRestUsername | quote }}
   {{- end }}
+  QSERV_KAFKA_QSERV_RETRY_COUNT: {{ .Values.config.qservRetryCount | quote }}
+  QSERV_KAFKA_QSERV_RETRY_DELAY: {{ .Values.config.qservRetryDelay | quote }}
   QSERV_KAFKA_QSERV_UPLOAD_TIMEOUT: {{ .Values.config.qservUploadTimeout | quote }}
   QSERV_KAFKA_REDIS_URL: "redis://qserv-kafka-redis.{{ .Release.Namespace }}:6379/0"
   QSERV_KAFKA_RESULT_TIMEOUT: {{ .Values.config.resultTimeout | quote }}

--- a/applications/qserv-kafka/values.yaml
+++ b/applications/qserv-kafka/values.yaml
@@ -89,6 +89,13 @@ config:
   # `parse_timedelta` format.
   qservUploadTimeout: "5m"
 
+  # -- How many times to retry after a Qserv API network failure
+  qservRetryCount: 3
+
+  # -- How long to wait between retries after a Qserv API network failure in
+  # Safir `parse_timedelta` format
+  qservRetryDelay: "1s"
+
   # -- How long to wait for result processing (retrieval and upload) before
   # timing out, in seconds. This doubles as the timeout forcibly terminating
   # result worker pods.


### PR DESCRIPTION
Add configuration parameters for the retry count and delay after Qserv API network failures.