### PR TITLE
DM-51463: Upgrade TAP to version 3.2.0

### DIFF
--- a/applications/tap/values-idfdev.yaml
+++ b/applications/tap/values-idfdev.yaml
@@ -9,7 +9,7 @@ cadc-tap:
       jdbcParams: "?enabledTLSProtocols=TLSv1.3"
       passwordEnabled: true
       image:
-        tag: "3.1.0"
+        tag: "3.2.0"
 
     kafka:
       bootstrapServer: "sasquatch-dev-kafka-bootstrap.lsst.cloud:9094"

--- a/applications/tap/values-idfint.yaml
+++ b/applications/tap/values-idfint.yaml
@@ -9,7 +9,7 @@ cadc-tap:
       jdbcParams: "?enabledTLSProtocols=TLSv1.3"
       passwordEnabled: true
       image:
-        tag: "3.1.0"
+        tag: "3.2.0"
 
     sentryEnabled: true
     sentryTracesSampleRate: "0.1"

--- a/applications/tap/values-idfprod.yaml
+++ b/applications/tap/values-idfprod.yaml
@@ -9,7 +9,7 @@ cadc-tap:
       jdbcParams: "?enabledTLSProtocols=TLSv1.3"
       passwordEnabled: true
       image:
-        tag: "3.1.0"
+        tag: "3.2.0"
 
     kafka:
       bootstrapServer: "sasquatch-kafka-bootstrap.lsst.cloud:9094"


### PR DESCRIPTION
Fixes the following issues:
- Bug where any binary2 table upload appeared as an empty table
- Logging issues when sentry was not enabled
- Show correct upload size limit