### PR TITLE
DM-51471: Switch idfprod dp02 Butler to AlloyDB

### DIFF
--- a/applications/butler/README.md
+++ b/applications/butler/README.md
@@ -12,7 +12,7 @@ Server for Butler data abstraction service
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules for the butler deployment pod |
 | autoscaling.enabled | bool | `true` | Enable autoscaling of butler deployment |
-| autoscaling.maxReplicas | int | `10` | Maximum number of butler deployment pods  Each replica can have 40 database connections, so we need to make sure the combined connections are under the postgres connection limit. (Which is configurable, but currently set to 400 at the IDF.) |
+| autoscaling.maxReplicas | int | `20` | Maximum number of butler deployment pods  Each replica can have 40 database connections, so we need to make sure the combined connections are under the AlloyDB connection limit. (200 x num replicas as currently configured at IDF.) |
 | autoscaling.minReplicas | int | `1` | Minimum number of butler deployment pods |
 | autoscaling.targetCPUUtilizationPercentage | int | `25` | Target CPU utilization of butler deployment pods  Butler CPU usage is very low in normal operation because most things are I/O bound.  CPU usage can start creeping up if we have many queries running simultaneously (due to serialization overhead and spatial postprocessing.) In this case the thread pool and database connection pool are probably oversubscribed long before we hit 100% cpu usage, so we want to get more replicas up at fairly low CPU usage. |
 | config.additionalS3EndpointUrls | object | No additional URLs | Endpoint URLs for additional S3 services used by the Butler, as a mapping from profile name to URL. |

--- a/applications/butler/values-idfprod.yaml
+++ b/applications/butler/values-idfprod.yaml
@@ -1,7 +1,7 @@
 autoscaling:
   minReplicas: 3
 config:
-  dp02PostgresUri: postgresql://butler@dp02.rsp-sql-stable.internal:5432/dp02
+  dp02PostgresUri: postgresql://butler@alloydb-dp.rsp-sql-stable.internal:5432/dp02
   dp1PostgresUri: postgresql://butler@alloydb-dp.rsp-sql-stable.internal:5432/dp1
   s3EndpointUrl: "https://storage.googleapis.com"
   repositories:

--- a/applications/butler/values.yaml
+++ b/applications/butler/values.yaml
@@ -29,9 +29,9 @@ autoscaling:
   # -- Maximum number of butler deployment pods
   #
   # Each replica can have 40 database connections, so we need to make sure the
-  # combined connections are under the postgres connection limit. (Which is
-  # configurable, but currently set to 400 at the IDF.)
-  maxReplicas: 10
+  # combined connections are under the AlloyDB connection limit. (200 x num
+  # replicas as currently configured at IDF.)
+  maxReplicas: 20
 
   # -- Target CPU utilization of butler deployment pods
   #


### PR DESCRIPTION
Switch the dp02 Butler database in idfprod to use AlloyDB, matching idfint and the dp1 deployment.  This will help ensure the Butler server can scale its load in case there is an increased interest in the DP02-based tutorials after the DP1 release.  It will also reduce the number of different databases/database technologies deployed for Butler.