### PR TITLE
[DM-51457] Review Sasquatch resources requests and limits and set more reasonable defaults

### DIFF
--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -179,7 +179,7 @@ Rubin Observatory's telemetry service
 | influxdb-enterprise.data.podSecurityContext | object | `{}` | Pod security context for data pods |
 | influxdb-enterprise.data.preruncmds | list | `[]` | Commands to run in data pods before InfluxDB is started. Each list entry should have a _cmd_ key with the command to run and an optional _description_ key describing that command |
 | influxdb-enterprise.data.replicas | int | `1` | Number of data replicas to run |
-| influxdb-enterprise.data.resources | object | `{}` | Kubernetes resources and limits for the meta container |
+| influxdb-enterprise.data.resources | object | `{"limits":{"cpu":2,"memory":"8Gi"},"requests":{"cpu":1,"memory":"4Gi"}}` | Kubernetes resources and limits for the meta container |
 | influxdb-enterprise.data.securityContext | object | `{}` | Security context for meta pods |
 | influxdb-enterprise.data.service.annotations | object | `{}` | Extra annotations for the data service |
 | influxdb-enterprise.data.service.externalIPs | list | Do not allocate external IPs | External IPs for the data service |
@@ -217,7 +217,7 @@ Rubin Observatory's telemetry service
 | influxdb-enterprise.meta.podSecurityContext | object | `{}` | Pod security context for meta pods |
 | influxdb-enterprise.meta.preruncmds | list | `[]` | Commands to run in meta pods before InfluxDB is started. Each list entry should have a _cmd_ key with the command to run and an optional _description_ key describing that command |
 | influxdb-enterprise.meta.replicas | int | `3` | Number of meta pods to run |
-| influxdb-enterprise.meta.resources | object | `{}` | Kubernetes resources and limits for the meta container |
+| influxdb-enterprise.meta.resources | object | `{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Kubernetes resources and limits for the meta container |
 | influxdb-enterprise.meta.securityContext | object | `{}` | Security context for meta pods |
 | influxdb-enterprise.meta.service.annotations | object | `{}` | Extra annotations for the meta service |
 | influxdb-enterprise.meta.service.externalIPs | list | Do not allocate external IPs | External IPs for the meta service |
@@ -269,7 +269,7 @@ Rubin Observatory's telemetry service
 | influxdb-enterprise-active.data.podSecurityContext | object | `{}` | Pod security context for data pods |
 | influxdb-enterprise-active.data.preruncmds | list | `[]` | Commands to run in data pods before InfluxDB is started. Each list entry should have a _cmd_ key with the command to run and an optional _description_ key describing that command |
 | influxdb-enterprise-active.data.replicas | int | `1` | Number of data replicas to run |
-| influxdb-enterprise-active.data.resources | object | `{}` | Kubernetes resources and limits for the meta container |
+| influxdb-enterprise-active.data.resources | object | `{"limits":{"cpu":2,"memory":"8Gi"},"requests":{"cpu":1,"memory":"4Gi"}}` | Kubernetes resources and limits for the meta container |
 | influxdb-enterprise-active.data.securityContext | object | `{}` | Security context for meta pods |
 | influxdb-enterprise-active.data.service.annotations | object | `{}` | Extra annotations for the data service |
 | influxdb-enterprise-active.data.service.externalIPs | list | Do not allocate external IPs | External IPs for the data service |
@@ -307,7 +307,7 @@ Rubin Observatory's telemetry service
 | influxdb-enterprise-active.meta.podSecurityContext | object | `{}` | Pod security context for meta pods |
 | influxdb-enterprise-active.meta.preruncmds | list | `[]` | Commands to run in meta pods before InfluxDB is started. Each list entry should have a _cmd_ key with the command to run and an optional _description_ key describing that command |
 | influxdb-enterprise-active.meta.replicas | int | `3` | Number of meta pods to run |
-| influxdb-enterprise-active.meta.resources | object | `{}` | Kubernetes resources and limits for the meta container |
+| influxdb-enterprise-active.meta.resources | object | `{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Kubernetes resources and limits for the meta container |
 | influxdb-enterprise-active.meta.securityContext | object | `{}` | Security context for meta pods |
 | influxdb-enterprise-active.meta.service.annotations | object | `{}` | Extra annotations for the meta service |
 | influxdb-enterprise-active.meta.service.externalIPs | list | Do not allocate external IPs | External IPs for the meta service |
@@ -359,7 +359,7 @@ Rubin Observatory's telemetry service
 | influxdb-enterprise-standby.data.podSecurityContext | object | `{}` | Pod security context for data pods |
 | influxdb-enterprise-standby.data.preruncmds | list | `[]` | Commands to run in data pods before InfluxDB is started. Each list entry should have a _cmd_ key with the command to run and an optional _description_ key describing that command |
 | influxdb-enterprise-standby.data.replicas | int | `1` | Number of data replicas to run |
-| influxdb-enterprise-standby.data.resources | object | `{}` | Kubernetes resources and limits for the meta container |
+| influxdb-enterprise-standby.data.resources | object | `{"limits":{"cpu":2,"memory":"8Gi"},"requests":{"cpu":1,"memory":"4Gi"}}` | Kubernetes resources and limits for the meta container |
 | influxdb-enterprise-standby.data.securityContext | object | `{}` | Security context for meta pods |
 | influxdb-enterprise-standby.data.service.annotations | object | `{}` | Extra annotations for the data service |
 | influxdb-enterprise-standby.data.service.externalIPs | list | Do not allocate external IPs | External IPs for the data service |
@@ -397,7 +397,7 @@ Rubin Observatory's telemetry service
 | influxdb-enterprise-standby.meta.podSecurityContext | object | `{}` | Pod security context for meta pods |
 | influxdb-enterprise-standby.meta.preruncmds | list | `[]` | Commands to run in meta pods before InfluxDB is started. Each list entry should have a _cmd_ key with the command to run and an optional _description_ key describing that command |
 | influxdb-enterprise-standby.meta.replicas | int | `3` | Number of meta pods to run |
-| influxdb-enterprise-standby.meta.resources | object | `{}` | Kubernetes resources and limits for the meta container |
+| influxdb-enterprise-standby.meta.resources | object | `{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Kubernetes resources and limits for the meta container |
 | influxdb-enterprise-standby.meta.securityContext | object | `{}` | Security context for meta pods |
 | influxdb-enterprise-standby.meta.service.annotations | object | `{}` | Extra annotations for the meta service |
 | influxdb-enterprise-standby.meta.service.externalIPs | list | Do not allocate external IPs | External IPs for the meta service |
@@ -537,7 +537,7 @@ Rubin Observatory's telemetry service
 | strimzi-kafka.broker.enabled | bool | `false` | Enable node pool for the kafka brokers |
 | strimzi-kafka.broker.name | string | `"kafka"` | Node pool name |
 | strimzi-kafka.broker.nodeIds | string | `"[0,1,2]"` | IDs to assign to the brokers |
-| strimzi-kafka.broker.resources | object | `{"limits":{"cpu":"8","memory":"64Gi"},"requests":{"cpu":"4","memory":"32Gi"}}` | Kubernetes resources for the brokers |
+| strimzi-kafka.broker.resources | object | `{"limits":{"cpu":2,"memory":"8Gi"},"requests":{"cpu":1,"memory":"4Gi"}}` | Kubernetes resources for the brokers |
 | strimzi-kafka.broker.storage.size | string | `"1.5Ti"` | Storage size for the brokers |
 | strimzi-kafka.broker.storage.storageClassName | string | None, use the default storage class | Storage class to use when requesting persistent volumes |
 | strimzi-kafka.broker.tolerations | list | `[]` | Tolerations for broker pod assignment |
@@ -547,9 +547,6 @@ Rubin Observatory's telemetry service
 | strimzi-kafka.brokerMigration.nodeIDs | string | `"[6,7,8]"` | IDs to assign to the brokers |
 | strimzi-kafka.brokerMigration.rebalance.avoidBrokers | list | `[0,1,2]` | Brokers to avoid during rebalancing These are the brokers you are migrating from and you want to remove after the migration is complete. |
 | strimzi-kafka.brokerMigration.rebalance.enabled | bool | `false` | Whether to rebalance the kafka cluster |
-| strimzi-kafka.brokerMigration.resources.limits.cpu | string | `"8"` |  |
-| strimzi-kafka.brokerMigration.resources.limits.memory | string | `"64Gi"` |  |
-| strimzi-kafka.brokerMigration.resources.requests | object | `{"cpu":"4","memory":"32Gi"}` | Kubernetes resources for the brokers |
 | strimzi-kafka.brokerMigration.size | string | `"1.5Ti"` | Storage size for the brokers |
 | strimzi-kafka.brokerMigration.storageClassName | string | None, use the default storage class | Storage class name for the brokers |
 | strimzi-kafka.brokerMigration.tolerations | list | `[]` | Tolerations for Kafka broker pod assignment |
@@ -564,10 +561,11 @@ Rubin Observatory's telemetry service
 | strimzi-kafka.connect.enabled | bool | `false` | Enable Kafka Connect |
 | strimzi-kafka.connect.image | string | `"ghcr.io/lsst-sqre/strimzi-0.40.0-kafka-3.7.0:tickets-DM-43491"` | Custom strimzi-kafka image with connector plugins used by sasquatch |
 | strimzi-kafka.connect.replicas | int | `3` | Number of Kafka Connect replicas to run |
+| strimzi-kafka.connect.resources | object | See `values.yaml` | Kubernetes requests and limits for Kafka Connect |
 | strimzi-kafka.controller.affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchExpressions":[{"key":"app.kubernetes.io/name","operator":"In","values":["kafka"]}]},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for controller pod assignment |
 | strimzi-kafka.controller.enabled | bool | `false` | Enable node pool for the kafka controllers |
 | strimzi-kafka.controller.nodeIds | string | `"[3,4,5]"` | IDs to assign to the controllers |
-| strimzi-kafka.controller.resources | object | `{"limits":{"cpu":"1","memory":"8Gi"},"requests":{"cpu":"1","memory":"8Gi"}}` | Kubernetes resources for the controllers |
+| strimzi-kafka.controller.resources | object | `{"limits":{"cpu":"1","memory":"4Gi"},"requests":{"cpu":"500m","memory":"2Gi"}}` | Kubernetes resources for the controllers |
 | strimzi-kafka.controller.storage.size | string | `"20Gi"` | Storage size for the controllers |
 | strimzi-kafka.controller.storage.storageClassName | string | None, use the default storage class | Storage class to use when requesting persistent volumes |
 | strimzi-kafka.controller.tolerations | list | `[]` | Tolerations for controller pod assignment |
@@ -601,6 +599,7 @@ Rubin Observatory's telemetry service
 | strimzi-kafka.mirrormaker2.replicas | int | `3` | Number of Mirror Maker replicas to run |
 | strimzi-kafka.mirrormaker2.replication.policy.class | string | `"org.apache.kafka.connect.mirror.IdentityReplicationPolicy"` | Replication policy. |
 | strimzi-kafka.mirrormaker2.replication.policy.separator | string | `""` | Convention used to rename topics when the DefaultReplicationPolicy replication policy is used. Default is "" when the IdentityReplicationPolicy replication policy is used. |
+| strimzi-kafka.mirrormaker2.resources | object | `{"limits":{"cpu":1,"memory":"4Gi"},"requests":{"cpu":"500m","memory":"2Gi"}}` | Kubernetes resources for MirrorMaker2 |
 | strimzi-kafka.mirrormaker2.source.bootstrapServer | string | None, must be set if enabled | Source (active) cluster to replicate from |
 | strimzi-kafka.mirrormaker2.source.topicsPattern | string | `"registry-schemas, lsst.sal.*"` | Topic replication from the source cluster defined as a comma-separated list or regular expression pattern |
 | strimzi-kafka.registry.ingress.annotations | object | `{}` | Annotations that will be added to the Ingress resource |

--- a/applications/sasquatch/charts/influxdb-enterprise/README.md
+++ b/applications/sasquatch/charts/influxdb-enterprise/README.md
@@ -46,7 +46,7 @@ Run InfluxDB Enterprise on Kubernetes
 | data.podSecurityContext | object | `{}` | Pod security context for data pods |
 | data.preruncmds | list | `[]` | Commands to run in data pods before InfluxDB is started. Each list entry should have a _cmd_ key with the command to run and an optional _description_ key describing that command |
 | data.replicas | int | `1` | Number of data replicas to run |
-| data.resources | object | `{}` | Kubernetes resources and limits for the meta container |
+| data.resources | object | `{"limits":{"cpu":2,"memory":"8Gi"},"requests":{"cpu":1,"memory":"4Gi"}}` | Kubernetes resources and limits for the meta container |
 | data.securityContext | object | `{}` | Security context for meta pods |
 | data.service.annotations | object | `{}` | Extra annotations for the data service |
 | data.service.externalIPs | list | Do not allocate external IPs | External IPs for the data service |
@@ -84,7 +84,7 @@ Run InfluxDB Enterprise on Kubernetes
 | meta.podSecurityContext | object | `{}` | Pod security context for meta pods |
 | meta.preruncmds | list | `[]` | Commands to run in meta pods before InfluxDB is started. Each list entry should have a _cmd_ key with the command to run and an optional _description_ key describing that command |
 | meta.replicas | int | `3` | Number of meta pods to run |
-| meta.resources | object | `{}` | Kubernetes resources and limits for the meta container |
+| meta.resources | object | `{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Kubernetes resources and limits for the meta container |
 | meta.securityContext | object | `{}` | Security context for meta pods |
 | meta.service.annotations | object | `{}` | Extra annotations for the meta service |
 | meta.service.externalIPs | list | Do not allocate external IPs | External IPs for the meta service |

--- a/applications/sasquatch/charts/influxdb-enterprise/values.yaml
+++ b/applications/sasquatch/charts/influxdb-enterprise/values.yaml
@@ -219,7 +219,13 @@ meta:
   env: {}
 
   # -- Kubernetes resources and limits for the meta container
-  resources: {}
+  resources:
+    requests:
+      memory: 128Mi
+      cpu: 100m
+    limits:
+      memory: 1Gi
+      cpu: 1
 
 data:
   # -- Number of data replicas to run
@@ -405,4 +411,10 @@ data:
   env: {}
 
   # -- Kubernetes resources and limits for the meta container
-  resources: {}
+  resources:
+    requests:
+      memory: 4Gi
+      cpu: 1
+    limits:
+      memory: 8Gi
+      cpu: 2

--- a/applications/sasquatch/charts/kafdrop/values.yaml
+++ b/applications/sasquatch/charts/kafdrop/values.yaml
@@ -79,11 +79,11 @@ ingress:
 # @default -- See `values.yaml`
 resources:
   requests:
-    memory: 200Mi
-    cpu: 1
+    memory: 500Mi
+    cpu: 200m
   limits:
-    memory: 4Gi
-    cpu: 2
+    memory: 2Gi
+    cpu: 1
 
 # -- Node selector configuration
 nodeSelector: {}

--- a/applications/sasquatch/charts/rest-proxy/values.yaml
+++ b/applications/sasquatch/charts/rest-proxy/values.yaml
@@ -73,11 +73,11 @@ kafka:
 # @default -- See `values.yaml`
 resources:
   requests:
-    memory: 200Mi
-    cpu: 1
+    memory: 500Mi
+    cpu: 200m
   limits:
-    memory: 4Gi
-    cpu: 2
+    memory: 1Gi
+    cpu: 1
 
 # -- Node selector configuration
 nodeSelector: {}

--- a/applications/sasquatch/charts/strimzi-kafka/README.md
+++ b/applications/sasquatch/charts/strimzi-kafka/README.md
@@ -10,7 +10,7 @@ A subchart to deploy Strimzi Kafka components for Sasquatch.
 | broker.enabled | bool | `false` | Enable node pool for the kafka brokers |
 | broker.name | string | `"kafka"` | Node pool name |
 | broker.nodeIds | string | `"[0,1,2]"` | IDs to assign to the brokers |
-| broker.resources | object | `{"limits":{"cpu":"8","memory":"64Gi"},"requests":{"cpu":"4","memory":"32Gi"}}` | Kubernetes resources for the brokers |
+| broker.resources | object | `{"limits":{"cpu":2,"memory":"8Gi"},"requests":{"cpu":1,"memory":"4Gi"}}` | Kubernetes resources for the brokers |
 | broker.storage.size | string | `"1.5Ti"` | Storage size for the brokers |
 | broker.storage.storageClassName | string | None, use the default storage class | Storage class to use when requesting persistent volumes |
 | broker.tolerations | list | `[]` | Tolerations for broker pod assignment |
@@ -20,9 +20,6 @@ A subchart to deploy Strimzi Kafka components for Sasquatch.
 | brokerMigration.nodeIDs | string | `"[6,7,8]"` | IDs to assign to the brokers |
 | brokerMigration.rebalance.avoidBrokers | list | `[0,1,2]` | Brokers to avoid during rebalancing These are the brokers you are migrating from and you want to remove after the migration is complete. |
 | brokerMigration.rebalance.enabled | bool | `false` | Whether to rebalance the kafka cluster |
-| brokerMigration.resources.limits.cpu | string | `"8"` |  |
-| brokerMigration.resources.limits.memory | string | `"64Gi"` |  |
-| brokerMigration.resources.requests | object | `{"cpu":"4","memory":"32Gi"}` | Kubernetes resources for the brokers |
 | brokerMigration.size | string | `"1.5Ti"` | Storage size for the brokers |
 | brokerMigration.storageClassName | string | None, use the default storage class | Storage class name for the brokers |
 | brokerMigration.tolerations | list | `[]` | Tolerations for Kafka broker pod assignment |
@@ -37,10 +34,11 @@ A subchart to deploy Strimzi Kafka components for Sasquatch.
 | connect.enabled | bool | `false` | Enable Kafka Connect |
 | connect.image | string | `"ghcr.io/lsst-sqre/strimzi-0.40.0-kafka-3.7.0:tickets-DM-43491"` | Custom strimzi-kafka image with connector plugins used by sasquatch |
 | connect.replicas | int | `3` | Number of Kafka Connect replicas to run |
+| connect.resources | object | See `values.yaml` | Kubernetes requests and limits for Kafka Connect |
 | controller.affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchExpressions":[{"key":"app.kubernetes.io/name","operator":"In","values":["kafka"]}]},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for controller pod assignment |
 | controller.enabled | bool | `false` | Enable node pool for the kafka controllers |
 | controller.nodeIds | string | `"[3,4,5]"` | IDs to assign to the controllers |
-| controller.resources | object | `{"limits":{"cpu":"1","memory":"8Gi"},"requests":{"cpu":"1","memory":"8Gi"}}` | Kubernetes resources for the controllers |
+| controller.resources | object | `{"limits":{"cpu":"1","memory":"4Gi"},"requests":{"cpu":"500m","memory":"2Gi"}}` | Kubernetes resources for the controllers |
 | controller.storage.size | string | `"20Gi"` | Storage size for the controllers |
 | controller.storage.storageClassName | string | None, use the default storage class | Storage class to use when requesting persistent volumes |
 | controller.tolerations | list | `[]` | Tolerations for controller pod assignment |
@@ -74,6 +72,7 @@ A subchart to deploy Strimzi Kafka components for Sasquatch.
 | mirrormaker2.replicas | int | `3` | Number of Mirror Maker replicas to run |
 | mirrormaker2.replication.policy.class | string | `"org.apache.kafka.connect.mirror.IdentityReplicationPolicy"` | Replication policy. |
 | mirrormaker2.replication.policy.separator | string | `""` | Convention used to rename topics when the DefaultReplicationPolicy replication policy is used. Default is "" when the IdentityReplicationPolicy replication policy is used. |
+| mirrormaker2.resources | object | `{"limits":{"cpu":1,"memory":"4Gi"},"requests":{"cpu":"500m","memory":"2Gi"}}` | Kubernetes resources for MirrorMaker2 |
 | mirrormaker2.source.bootstrapServer | string | None, must be set if enabled | Source (active) cluster to replicate from |
 | mirrormaker2.source.topicsPattern | string | `"registry-schemas, lsst.sal.*"` | Topic replication from the source cluster defined as a comma-separated list or regular expression pattern |
 | registry.ingress.annotations | object | `{}` | Annotations that will be added to the Ingress resource |

--- a/applications/sasquatch/charts/strimzi-kafka/values.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/values.yaml
@@ -138,10 +138,10 @@ controller:
   # -- Kubernetes resources for the controllers
   resources:
     requests:
-      memory: 8Gi
-      cpu: "1"
+      memory: 2Gi
+      cpu: 500m
     limits:
-      memory: 8Gi
+      memory: 4Gi
       cpu: "1"
 
 broker:
@@ -180,11 +180,11 @@ broker:
   # -- Kubernetes resources for the brokers
   resources:
     requests:
-      memory: 32Gi
-      cpu: "4"
+      memory: 4Gi
+      cpu: 1
     limits:
-      memory: 64Gi
-      cpu: "8"
+      memory: 8Gi
+      cpu: 2
 
 cruiseControl:
   # -- Enable cruise control (required for broker migration and rebalancing)
@@ -238,15 +238,6 @@ brokerMigration:
   # -- Tolerations for Kafka broker pod assignment
   tolerations: []
 
-  resources:
-    # -- Kubernetes resources for the brokers
-    requests:
-      memory: 32Gi
-      cpu: "4"
-    limits:
-      memory: 64Gi
-      cpu: "8"
-
 kafkaExporter:
   # -- Enable Kafka exporter
   enabled: false
@@ -268,7 +259,13 @@ kafkaExporter:
 
   # -- Kubernetes requests and limits for the Kafka exporter
   # @default -- See `values.yaml`
-  resources: {}
+  resources:
+    requests:
+      memory: 512Mi
+      cpu: 1
+    limits:
+      memory: 1Gi
+      cpu: 2
 
 connect:
   # -- Enable Kafka Connect
@@ -299,6 +296,16 @@ connect:
     # -- URL for the schema registry
     value.converter.schema.registry.url: http://sasquatch-schema-registry.sasquatch:8081
 
+  # -- Kubernetes requests and limits for Kafka Connect
+  # @default -- See `values.yaml`
+  resources:
+    requests:
+      memory: 2Gi
+      cpu: 1
+    limits:
+      memory: 4Gi
+      cpu: 2
+
 registry:
   ingress:
     # -- Whether to enable an ingress for the Schema Registry
@@ -318,11 +325,11 @@ registry:
   # @default -- See `values.yaml`
   resources:
     requests:
-      memory: "128Mi"
-      cpu: "5m"
+      memory: 1Gi
+      cpu: 100m
     limits:
-      memory: "2Gi"
-      cpu: "1"
+      memory: 2Gi
+      cpu: 1
 
 
 # -- A list of usernames for users who should have global admin permissions.
@@ -365,3 +372,12 @@ mirrormaker2:
 
       # -- Replication policy.
       class: "org.apache.kafka.connect.mirror.IdentityReplicationPolicy"
+
+  # -- Kubernetes resources for MirrorMaker2
+  resources:
+    requests:
+      memory: 2Gi
+      cpu: 500m
+    limits:
+      memory: 4Gi
+      cpu: 1

--- a/applications/sasquatch/values-base.yaml
+++ b/applications/sasquatch/values-base.yaml
@@ -8,13 +8,6 @@ strimzi-kafka:
       policy:
         separator: "."
         class: "org.apache.kafka.connect.mirror.DefaultReplicationPolicy"
-    resources:
-      requests:
-        cpu: 2
-        memory: 4Gi
-      limits:
-        cpu: 4
-        memory: 8Gi
   cluster:
     monitorLabel:
       lsst.io/monitor: "true"
@@ -55,22 +48,8 @@ strimzi-kafka:
     logging: debug
     enableSaramaLogging: true
     showAllOffsets: false
-    resources:
-      requests:
-        cpu: "3"
-        memory: 512Mi
-      limits:
-        cpu: "8"
-        memory: 1Gi
   controller:
     enabled: true
-    resources:
-      requests:
-        memory: 8Gi
-        cpu: "2"
-      limits:
-        memory: 8Gi
-        cpu: "2"
   broker:
     enabled: true
     name: "kafka-local-storage"

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -31,24 +31,10 @@ strimzi-kafka:
       enabled: true
   controller:
     enabled: true
-    resources:
-      requests:
-        memory: 8Gi
-        cpu: "1"
-      limits:
-        memory: 8Gi
-        cpu: "1"
   broker:
     enabled: true
     storage:
       size: 500Gi
-    resources:
-      requests:
-        memory: 16Gi
-        cpu: "2"
-      limits:
-        memory: 16Gi
-        cpu: "2"
   registry:
     ingress:
       enabled: true
@@ -61,13 +47,6 @@ influxdb:
   ingress:
     enabled: false
     hostname: data-dev.lsst.cloud
-  resources:
-    requests:
-      memory: 16Gi
-      cpu: 2
-    limits:
-      memory: 16Gi
-      cpu: 2
 
 customInfluxDBIngress:
   enabled: true
@@ -91,13 +70,6 @@ influxdb-enterprise:
       secret:
         name: sasquatch
         key: influxdb-enterprise-shared-secret
-    resources:
-      requests:
-        memory: 2Gi
-        cpu: 1
-      limits:
-        memory: 4Gi
-        cpu: 2
   data:
     replicas: 2
     config:
@@ -110,13 +82,6 @@ influxdb-enterprise:
       enabled: true
       accessMode: ReadWriteOnce
       size: 1Ti
-    resources:
-      requests:
-        memory: 8Gi
-        cpu: 2
-      limits:
-        memory: 16Gi
-        cpu: 4
 
 telegraf:
   enabled: true

--- a/applications/sasquatch/values-idfint.yaml
+++ b/applications/sasquatch/values-idfint.yaml
@@ -29,13 +29,6 @@ strimzi-kafka:
     source:
       bootstrapServer: sasquatch-dev-kafka-bootstrap.lsst.cloud:9094
       topicsPattern: "registry-schemas, lsst.sal.*, lsst.dm.*"
-    resources:
-      requests:
-        cpu: "2"
-        memory: 4Gi
-      limits:
-        cpu: "4"
-        memory: 8Gi
   users:
     replicator:
       enabled: true
@@ -43,24 +36,10 @@ strimzi-kafka:
       enabled: true
   controller:
     enabled: true
-    resources:
-      requests:
-        memory: 8Gi
-        cpu: "1"
-      limits:
-        memory: 8Gi
-        cpu: "1"
   broker:
     enabled: true
     storage:
       size: 500Gi
-    resources:
-      requests:
-        memory: 16Gi
-        cpu: "2"
-      limits:
-        memory: 16Gi
-        cpu: "2"
   registry:
     ingress:
       enabled: true
@@ -73,13 +52,6 @@ influxdb:
   ingress:
     enabled: false
     hostname: data-int.lsst.cloud
-  resources:
-    requests:
-      memory: 16Gi
-      cpu: 2
-    limits:
-      memory: 16Gi
-      cpu: 2
 
 customInfluxDBIngress:
   enabled: true

--- a/applications/sasquatch/values-idfprod.yaml
+++ b/applications/sasquatch/values-idfprod.yaml
@@ -29,24 +29,10 @@ strimzi-kafka:
       enabled: true
   controller:
     enabled: true
-    resources:
-      requests:
-        memory: 8Gi
-        cpu: "1"
-      limits:
-        memory: 8Gi
-        cpu: "1"
   broker:
     enabled: true
     storage:
       size: 500Gi
-    resources:
-      requests:
-        memory: 16Gi
-        cpu: "2"
-      limits:
-        memory: 16Gi
-        cpu: "2"
   registry:
     ingress:
       enabled: true
@@ -59,13 +45,6 @@ influxdb:
   ingress:
     enabled: false
     hostname: data.lsst.cloud
-  resources:
-    requests:
-      memory: 8Gi
-      cpu: 1
-    limits:
-      memory: 8Gi
-      cpu: 1
 
 customInfluxDBIngress:
   enabled: true

--- a/applications/sasquatch/values-roundtable-dev.yaml
+++ b/applications/sasquatch/values-roundtable-dev.yaml
@@ -10,13 +10,6 @@ strimzi-kafka:
         enabled: false
   controller:
     enabled: true
-    resources:
-      requests:
-        memory: 8Gi
-        cpu: "2"
-      limits:
-        memory: 8Gi
-        cpu: "2"
   broker:
     enabled: true
     storage:
@@ -45,13 +38,6 @@ strimzi-kafka:
         operator: Equal
         value: "kafka"
         effect: NoExecute
-    resources:
-      requests:
-        memory: 16Gi
-        cpu: 2
-      limits:
-        memory: 16Gi
-        cpu: 2
   connect:
     enabled: false
   mirrormaker2:

--- a/applications/sasquatch/values-roundtable-prod.yaml
+++ b/applications/sasquatch/values-roundtable-prod.yaml
@@ -10,13 +10,6 @@ strimzi-kafka:
         enabled: false
   controller:
     enabled: true
-    resources:
-      requests:
-        memory: 8Gi
-        cpu: "2"
-      limits:
-        memory: 8Gi
-        cpu: "2"
   broker:
     enabled: true
     storage:
@@ -45,13 +38,6 @@ strimzi-kafka:
         operator: Equal
         value: "kafka"
         effect: NoExecute
-    resources:
-      requests:
-        memory: 16Gi
-        cpu: 2
-      limits:
-        memory: 16Gi
-        cpu: 2
   connect:
     enabled: false
   mirrormaker2:

--- a/applications/sasquatch/values-summit.yaml
+++ b/applications/sasquatch/values-summit.yaml
@@ -39,21 +39,8 @@ strimzi-kafka:
     logging: debug
     enableSaramaLogging: true
     showAllOffsets: false
-    resources:
-      requests:
-        cpu: "4"
-        memory: 512Mi
-      limits:
-        memory: 1024Mi
   controller:
     enabled: true
-    resources:
-      requests:
-        memory: 8Gi
-        cpu: "2"
-      limits:
-        memory: 8Gi
-        cpu: "2"
   broker:
     enabled: true
     name: "kafka-local-storage"
@@ -140,13 +127,6 @@ influxdb-enterprise:
       secret:
         name: sasquatch
         key: influxdb-enterprise-shared-secret
-    resources:
-      requests:
-        memory: 2Gi
-        cpu: 2
-      limits:
-        memory: 4Gi
-        cpu: 4
   data:
     replicas: 2
     ingress:

--- a/applications/sasquatch/values-summit.yaml
+++ b/applications/sasquatch/values-summit.yaml
@@ -148,10 +148,11 @@ influxdb-enterprise:
                   values:
                     - yagan15
                     - yagan16
-    # -- InfluxDB Enterprise data pod resources, 2x8 cores cluster license
     resources:
       requests:
         memory: 256Gi
+        # The InfluxDB Enterprise license is limited to 16 cpu, the
+        # active instance uses a 2 node x 8 cpu setup
         cpu: 8
       limits:
         memory: 256Gi
@@ -405,6 +406,13 @@ chronograf:
     GENERIC_API_KEY: sub
     PUBLIC_URL: https://summit-lsp.lsst.codes
     STATUS_FEED_URL: https://raw.githubusercontent.com/lsst-sqre/rsp_broadcast/main/jsonfeeds/summit.json
+  resources:
+    requests:
+      memory: 16Gi
+      cpu: 1
+    limits:
+      memory: 64Gi
+      cpu: 4
 
 kapacitor:
   persistence:

--- a/applications/sasquatch/values-tucson-teststand.yaml
+++ b/applications/sasquatch/values-tucson-teststand.yaml
@@ -40,24 +40,10 @@ strimzi-kafka:
     enabled: true
     enableSaramaLogging: true
     showAllOffsets: false
-    resources:
-      requests:
-        cpu: 1
-        memory: 128Mi
-      limits:
-        cpu: 2
-        memory: 256Mi
   controller:
     enabled: true
     storage:
       storageClassName: "rook-ceph-block"
-    resources:
-      requests:
-        memory: 8Gi
-        cpu: "2"
-      limits:
-        memory: 8Gi
-        cpu: "2"
   broker:
     enabled: true
     name: "kafka"
@@ -65,13 +51,6 @@ strimzi-kafka:
     storage:
       size: 500Gi
       storageClassName: "rook-ceph-block"
-    resources:
-      requests:
-        memory: 16Gi
-        cpu: 4
-      limits:
-        memory: 16Gi
-        cpu: 4
   users:
     replicator:
       enabled: true

--- a/applications/sasquatch/values-usdfdev.yaml
+++ b/applications/sasquatch/values-usdfdev.yaml
@@ -29,13 +29,6 @@ strimzi-kafka:
     source:
       bootstrapServer: sasquatch-base-kafka-bootstrap.lsst.codes:9094
       topicsPattern: "registry-schemas, lsst.sal.*, lsst.dm.*"
-    resources:
-      requests:
-        cpu: 2
-        memory: 4Gi
-      limits:
-        cpu: 4
-        memory: 8Gi
   users:
     replicator:
       enabled: true
@@ -43,33 +36,12 @@ strimzi-kafka:
       enabled: true
   controller:
     enabled: true
-    resources:
-      requests:
-        memory: 8Gi
-        cpu: "1"
-      limits:
-        memory: 8Gi
-        cpu: "1"
   broker:
     enabled: true
     storage:
       size: 500Gi
-    resources:
-      requests:
-        memory: 16Gi
-        cpu: "2"
-      limits:
-        memory: 16Gi
-        cpu: "2"
   connect:
     enabled: true
-    resources:
-      requests:
-        memory: 8Gi
-        cpu: "1"
-      limits:
-        memory: 8Gi
-        cpu: "1"
 
 influxdb:
   livenessProbe:

--- a/applications/sasquatch/values-usdfint.yaml
+++ b/applications/sasquatch/values-usdfint.yaml
@@ -41,24 +41,10 @@ strimzi-kafka:
       enabled: true
   controller:
     enabled: true
-    resources:
-      requests:
-        memory: 8Gi
-        cpu: "1"
-      limits:
-        memory: 8Gi
-        cpu: "1"
   broker:
     enabled: true
     storage:
       size: 500Gi
-    resources:
-      requests:
-        memory: 16Gi
-        cpu: "2"
-      limits:
-        memory: 16Gi
-        cpu: "2"
 
 influxdb:
   ingress:

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -104,13 +104,6 @@ influxdb-enterprise-standby:
       secret:
         name: sasquatch
         key: influxdb-enterprise-standby-shared-secret
-    resources:
-      requests:
-        memory: 2Gi
-        cpu: 2
-      limits:
-        memory: 4Gi
-        cpu: 4
   data:
     replicas: 1
     affinity:
@@ -174,12 +167,6 @@ influxdb-enterprise-active:
         name: sasquatch
         key: influxdb-enterprise-active-shared-secret
     resources:
-      requests:
-        memory: 8Gi
-        cpu: 4
-      limits:
-        memory: 8Gi
-        cpu: 4
   data:
     replicas: 2
     affinity:

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -75,6 +75,13 @@ strimzi-kafka:
                   values:
                     - sasquatch
             topologyKey: kubernetes.io/hostname
+    resources:
+      requests:
+        cpu: 8
+        memory: 64Gi
+      limits:
+        cpu: 8
+        memory: 64Gi
   cruiseControl:
     enabled: true
 
@@ -138,6 +145,8 @@ influxdb-enterprise-standby:
     resources:
       requests:
         memory: 96Gi
+        # The InfluxDB Enterprise license is limited to 16 cpu, the
+        # standby instance uses a 1 node x 16 cpu setup
         cpu: 16
       limits:
         memory: 96Gi
@@ -202,6 +211,8 @@ influxdb-enterprise-active:
     resources:
       requests:
         memory: 192Gi
+        # The InfluxDB Enterprise license is limited to 16 cpu, the
+        # active instance uses a 2 node x 8 cpu setup
         cpu: 8
       limits:
         memory: 192Gi
@@ -460,6 +471,13 @@ chronograf:
     GENERIC_API_KEY: sub
     PUBLIC_URL: https://usdf-rsp.slac.stanford.edu/
     STATUS_FEED_URL: https://raw.githubusercontent.com/lsst-sqre/rsp_broadcast/main/jsonfeeds/usdfprod.json
+  resources:
+    requests:
+      memory: 16Gi
+      cpu: 1
+    limits:
+      memory: 64Gi
+      cpu: 4
 
 kapacitor:
   influxURL: http://sasquatch-influxdb-enterprise-active-data.sasquatch:8086

--- a/applications/sasquatch/values.yaml
+++ b/applications/sasquatch/values.yaml
@@ -141,11 +141,11 @@ influxdb:
   # @default -- See `values.yaml`
   resources:
     requests:
-      memory: 96Gi
-      cpu: 8
+      memory: 4Gi
+      cpu: 1
     limits:
-      memory: 96Gi
-      cpu: 8
+      memory: 8Gi
+      cpu: 2
 
 customInfluxDBIngress:
   # -- Whether to enable the custom ingress for InfluxDB OSS
@@ -243,11 +243,11 @@ chronograf:
   # @default -- See `values.yaml`
   resources:
     requests:
-      memory: 4Gi
+      memory: 2Gi
       cpu: 1
     limits:
-      memory: 64Gi
-      cpu: 4
+      memory: 4Gi
+      cpu: 2
 
 kapacitor:
   # -- Whether to enable Kapacitor
@@ -295,8 +295,8 @@ kapacitor:
       memory: 1Gi
       cpu: 1
     limits:
-      memory: 16Gi
-      cpu: 4
+      memory: 2Gi
+      cpu: 2
 
 kafdrop:
   # -- Whether to enable the kafdrop subchart


### PR DESCRIPTION
We review Sasquatch resources requests and limits based on data from Grafana  (Kubernetes / Compute Resources / Pod) for the Summit environment. The general idea is to set more reasonable defaults that are suitable for most environments and then overwrite prod environments accordingly.
