### PR TITLE
Start with four Qserv result workers on idfprod

### DIFF
--- a/applications/qserv-kafka/values-idfprod.yaml
+++ b/applications/qserv-kafka/values-idfprod.yaml
@@ -8,4 +8,5 @@ config:
   qservRestUsername: "qsmaster"
 resultWorker:
   autoscaling:
+    minReplicas: 4
     maxReplicas: 50


### PR DESCRIPTION
We can always reduce this later if we turn out to not need that many result workers.