### PR TITLE
DM-51494: Switch default DP1 HiPs coverage map to r band

### DIFF
--- a/applications/portal/values-idfdev.yaml
+++ b/applications/portal/values-idfdev.yaml
@@ -12,7 +12,7 @@ config:
         size: "20Gi"
         storageClass: "standard-rwo"
   ssotap: "ssotap"
-  hipsUrl: "https://data-dev.lsst.cloud/api/hips/v2/dp1/deep_coadd/color_gri"
+  hipsUrl: "https://data-dev.lsst.cloud/api/hips/v2/dp1/deep_coadd/band_r"
 
 redis:
   persistence:

--- a/applications/portal/values-idfint.yaml
+++ b/applications/portal/values-idfint.yaml
@@ -12,7 +12,7 @@ config:
         size: "20Gi"
         storageClass: "standard-rwo"
   ssotap: "ssotap"
-  hipsUrl: "https://data-int.lsst.cloud/api/hips/v2/dp1/deep_coadd/color_gri"
+  hipsUrl: "https://data-int.lsst.cloud/api/hips/v2/dp1/deep_coadd/band_r"
 
 redis:
   persistence:

--- a/applications/portal/values-idfprod.yaml
+++ b/applications/portal/values-idfprod.yaml
@@ -12,7 +12,7 @@ config:
         size: "40Gi"
         storageClass: "standard-rwo"
   ssotap: "ssotap"
-  hipsUrl: "https://data.lsst.cloud/api/hips/v2/dp1/deep_coadd/color_gri"
+  hipsUrl: "https://data.lsst.cloud/api/hips/v2/dp1/deep_coadd/band_r"
 
 redis:
   persistence:


### PR DESCRIPTION
We now have single-channel HiPS for DP1.  Frossie made an executive decision to switch to the r band for the default coverage map.  The r band is better than the colors we were using before, because it has fewer edge artifacts and is less confusing as a background for other things.