### PR TITLE
DM-51504: Update vo-cutouts to 4.1.2

### DIFF
--- a/applications/vo-cutouts/Chart.yaml
+++ b/applications/vo-cutouts/Chart.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 description: "Image cutout service complying with IVOA SODA"
 sources:
   - "https://github.com/lsst-sqre/vo-cutouts"
-appVersion: 4.1.1
+appVersion: 4.1.2
 
 dependencies:
   - name: redis

--- a/applications/vo-cutouts/values-idfdev.yaml
+++ b/applications/vo-cutouts/values-idfdev.yaml
@@ -1,3 +1,5 @@
 config:
   serviceAccount: "vo-cutouts@science-platform-dev-7696.iam.gserviceaccount.com"
   storageBucketUrl: "gs://rubin-cutouts-dev-us-central1-output/"
+cutoutWorker:
+  replicaCount: 1

--- a/applications/vo-cutouts/values-idfprod.yaml
+++ b/applications/vo-cutouts/values-idfprod.yaml
@@ -1,3 +1,5 @@
 config:
   serviceAccount: "vo-cutouts@science-platform-stable-6994.iam.gserviceaccount.com"
   storageBucketUrl: "gs://rubin-cutouts-stable-us-central1-output/"
+cutoutWorker:
+  replicaCount: 4


### PR DESCRIPTION
Update the vo-cutouts backend worker to v21.1.1. Increase the default number of workers for idfprod to four, and reduce the workers to one on idfdev.