### PR TITLE
[DM-51517] Update sasquatch backup to version 1.3.1

### DIFF
--- a/applications/sasquatch/charts/backup/values.yaml
+++ b/applications/sasquatch/charts/backup/values.yaml
@@ -10,7 +10,7 @@ image:
 
   # -- Tag of image to use
   # @default -- The appVersion of the chart
-  tag: "1.3.0"
+  tag: "1.3.1"
 
 # -- Schedule for executing the sasquatch backup script
 # @default -- "0 3 * * *"


### PR DESCRIPTION
The sasquatch backup Job fails intermittently and eventually hits the backoffLimit and k8s gives up retrying.
Since the backup script uses set -e, any command that exits with a non-zero status will immediately terminate the script, causing the container to exit with failure triggering the Kubernetes retries.
This version removes `set -e` and improve error handling to help identify in which step the backup script is failing.
