### PR TITLE
Advertise HTTP Basic Auth for datalinker images

### DIFF
--- a/applications/datalinker/templates/ingress-image.yaml
+++ b/applications/datalinker/templates/ingress-image.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "datalinker.labels" . | nindent 4 }}
 config:
+  authType: "basic"
   baseUrl: {{ .Values.global.baseUrl | quote }}
   scopes:
     all:


### PR DESCRIPTION
This will allow TOPCAT to be able to retrieve the image link from an SIA response, since it refuses to do authentication other than HTTP Basic Auth (apparently).