### PR TITLE
Advertise HTTP Basic Auth for vo-cutouts

### DIFF
--- a/applications/vo-cutouts/templates/ingress.yaml
+++ b/applications/vo-cutouts/templates/ingress.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "vo-cutouts.labels" . | nindent 4 }}
 config:
+  authType: "basic"
   baseUrl: {{ .Values.global.baseUrl | quote }}
   scopes:
     all:


### PR DESCRIPTION
Similar to datalinker, advertise HTTP Basic Auth so that TOPCAT will work correctly, since it thinks it doesn't support bearer token authentication.