### PR TITLE
DM-51571: Deploy DP1 HiPS to production

### DIFF
--- a/applications/datalinker/values-idfprod.yaml
+++ b/applications/datalinker/values-idfprod.yaml
@@ -14,3 +14,17 @@ config:
         - "images/band_z"
         - "images/band_y"
         - "images/2MASS/Color"
+    dp1:
+      url: "https://data.lsst.cloud/api/hips/v2/dp1"
+      paths:
+        - "deep_coadd/color_ugri"
+        - "deep_coadd/color_gri"
+        - "deep_coadd/color_izy"
+        - "deep_coadd/color_riz"
+        - "deep_coadd/color_ugr"
+        - "deep_coadd/band_u"
+        - "deep_coadd/band_g"
+        - "deep_coadd/band_r"
+        - "deep_coadd/band_i"
+        - "deep_coadd/band_z"
+        - "deep_coadd/band_y"

--- a/applications/hips/values-idfprod.yaml
+++ b/applications/hips/values-idfprod.yaml
@@ -5,5 +5,8 @@ config:
   buckets:
     dp02:
       bucketName: "static-us-central1-dp02-hips"
+    dp1:
+      bucketName: "static-us-central1-dp1-hips"
+      objectPrefix: "DM-51494"
   defaultBucketKey: "dp02"
   serviceAccount: "crawlspace-hips@science-platform-stable-6994.iam.gserviceaccount.com"


### PR DESCRIPTION
Configure datalinker and crawlspace to serve the DP1 HiPS maps at `idfprod`.