### PR TITLE
Ignore rubin-rag secret differences

### DIFF
--- a/environments/templates/applications/rubin/rubin-rag.yaml
+++ b/environments/templates/applications/rubin/rubin-rag.yaml
@@ -31,4 +31,10 @@ spec:
       valueFiles:
         - "values.yaml"
         - "values-{{ .Values.name }}.yaml"
+  ignoreDifferences:
+    - group: ""
+      kind: "Secret"
+      jsonPointers:
+        - "/data/password"
+        - "/data/username"
 {{- end -}}


### PR DESCRIPTION
rubin-rag modifies its own deployed secret, so ignore those differences in Argo CD.