### PR TITLE
DM-51589: Disable idfprod access to non-Rubin users

### DIFF
--- a/applications/gafaelfawr/values-idfprod.yaml
+++ b/applications/gafaelfawr/values-idfprod.yaml
@@ -36,6 +36,7 @@ config:
       g_users:
         - "dp0.2"
         - "dp0.3"
+        - "dp1"
 
   # Enable metrics reporting.
   metrics:
@@ -54,15 +55,15 @@ config:
     "exec:admin":
       - "g_admins"
     "exec:notebook":
-      - "g_users"
+      - "g_rubin"
     "exec:portal":
-      - "g_users"
+      - "g_rubin"
     "read:image":
-      - "g_users"
+      - "g_rubin"
     "read:tap":
-      - "g_users"
+      - "g_rubin"
     "write:files":
-      - "g_users"
+      - "g_rubin"
 
   initialAdmins:
     - "afausti"
@@ -74,9 +75,8 @@ config:
     - "svoutsin"
 
   errorFooter: |
-    To report problems or ask for help, please open an issue in the
-    <a href="https://github.com/rubin-dp0/Support/issues">GitHub
-    rubin-dp0/Support project</a>.
+    To report problems or ask for help, see the instructions at
+    <a href="https://rsp.lsst.io/support/index.html">Getting Help</a>.
 
 cloudsql:
   enabled: true

--- a/applications/gafaelfawr/values-roundtable-dev.yaml
+++ b/applications/gafaelfawr/values-roundtable-dev.yaml
@@ -54,7 +54,8 @@ config:
     - "stvoutsin"
 
   errorFooter: |
-    To report problems or ask for help, contact #dm-square on the LSSTC Slack.
+    To report problems or ask for help, contact #square-team on the Rubin
+    Observatory Slack.
 
 ingress:
   additionalHosts:

--- a/applications/gafaelfawr/values-roundtable-prod.yaml
+++ b/applications/gafaelfawr/values-roundtable-prod.yaml
@@ -55,7 +55,8 @@ config:
     - "stvoutsin"
 
   errorFooter: |
-    To report problems or ask for help, contact #dm-square on the LSSTC Slack.
+    To report problems or ask for help, contact #square-team on the Rubin
+    Observatory Slack.
 
 ingress:
   additionalHosts:


### PR DESCRIPTION
Temporarily cut off idfprod access to non-Rubin users. Add `dp1` to the list of data releases to which users have data rights. Update the error footers for idfprod, roundtable-dev, and roundtable-prod.