### PR TITLE
[DM-51572] Increase interval between broker restarts during a Kafka rollout 

### DIFF
--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -603,6 +603,7 @@ Rubin Observatory's telemetry service
 | strimzi-kafka.mirrormaker2.resources | object | `{"limits":{"cpu":1,"memory":"4Gi"},"requests":{"cpu":"500m","memory":"2Gi"}}` | Kubernetes resources for MirrorMaker2 |
 | strimzi-kafka.mirrormaker2.source.bootstrapServer | string | None, must be set if enabled | Source (active) cluster to replicate from |
 | strimzi-kafka.mirrormaker2.source.topicsPattern | string | `"registry-schemas, lsst.sal.*"` | Topic replication from the source cluster defined as a comma-separated list or regular expression pattern |
+| strimzi-kafka.readinessProbe | object | `{}` | Readiness probe configuration for the Kafka brokers. |
 | strimzi-kafka.registry.ingress.annotations | object | `{}` | Annotations that will be added to the Ingress resource |
 | strimzi-kafka.registry.ingress.enabled | bool | `false` | Whether to enable an ingress for the Schema Registry |
 | strimzi-kafka.registry.ingress.hostname | string | None, must be set if ingress is enabled | Hostname for the Schema Registry |

--- a/applications/sasquatch/charts/strimzi-kafka/README.md
+++ b/applications/sasquatch/charts/strimzi-kafka/README.md
@@ -76,6 +76,7 @@ A subchart to deploy Strimzi Kafka components for Sasquatch.
 | mirrormaker2.resources | object | `{"limits":{"cpu":1,"memory":"4Gi"},"requests":{"cpu":"500m","memory":"2Gi"}}` | Kubernetes resources for MirrorMaker2 |
 | mirrormaker2.source.bootstrapServer | string | None, must be set if enabled | Source (active) cluster to replicate from |
 | mirrormaker2.source.topicsPattern | string | `"registry-schemas, lsst.sal.*"` | Topic replication from the source cluster defined as a comma-separated list or regular expression pattern |
+| readinessProbe | object | `{}` | Readiness probe configuration for the Kafka brokers. |
 | registry.ingress.annotations | object | `{}` | Annotations that will be added to the Ingress resource |
 | registry.ingress.enabled | bool | `false` | Whether to enable an ingress for the Schema Registry |
 | registry.ingress.hostname | string | None, must be set if ingress is enabled | Hostname for the Schema Registry |

--- a/applications/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
@@ -142,6 +142,10 @@ metadata:
     strimzi.io/node-pools: enabled
 spec:
   kafka:
+    {{- with .Values.kafka.readinessProbe }}
+    readinessProbe:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     template:
       persistentVolumeClaim:
         metadata:

--- a/applications/sasquatch/charts/strimzi-kafka/values.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/values.yaml
@@ -105,6 +105,9 @@ kafka:
     #     annotations:
     #       metallb.universe.tf/address-pool: sdf-dmz
 
+# -- Readiness probe configuration for the Kafka brokers.
+readinessProbe: {}
+
 controller:
   # -- Enable node pool for the kafka controllers
   enabled: false

--- a/applications/sasquatch/values-base.yaml
+++ b/applications/sasquatch/values-base.yaml
@@ -43,6 +43,8 @@ strimzi-kafka:
           host: sasquatch-base-kafka-2.lsst.codes
     metricsConfig:
       enabled: true
+    readinessProbe:
+      initialDelaySeconds: 600
   kafkaExporter:
     enabled: true
     logging: debug

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -24,6 +24,8 @@ strimzi-kafka:
         - broker: 2
           loadBalancerIP: "34.172.163.125"
           host: sasquatch-dev-kafka-2.lsst.cloud
+    readinessProbe:
+      initialDelaySeconds: 240
   users:
     replicator:
       enabled: true

--- a/applications/strimzi/values-base.yaml
+++ b/applications/strimzi/values-base.yaml
@@ -7,3 +7,4 @@ strimzi-kafka-operator:
   watchNamespaces:
     - "sasquatch"
   logLevel: "INFO"
+  operationTimeoutMs: 900000


### PR DESCRIPTION
The Strimzi operator uses the `readinessProbe` to check whether the brokers are ready to accept connections, and then proceed with restarting the brokers in sequence during a Kafka rollout. 
The interval between broker restarts is too short,  ~30s at BTS.  We found that it takes at least ~6  min for the Kafka brokers to finish rebalancing the leader partitions in the cluster after a broker is removed. That's because of the large number of partitions in these clusters (~1400 per broker) and the large number of consumer groups that need to stabilize.
~6min is longer than the Strimzi Operator default timeout of 5min, so we need to increase both the Strimzi Operator timeout and the `readinessProbe.initialDelaySeconds` to give more time for the brokers to initialize.
This PR is not to be merged yet but will help us to test the Control System stability at BTS during a Kafka rollout.
This was tested on idfdev with an initial delay of 4min which applies to both controllers and brokers because the readinessProbe configuration is done at the Kafka resource level and not at the KafkaNodepool level.


```
sasquatch-controller-3                            1/1     Running     0          9m54s
sasquatch-controller-4                            1/1     Running     0          18m
sasquatch-controller-5                            1/1     Running     0          14m
```

```
sasquatch-kafka-0                                 1/1     Running     0          9m49s
sasquatch-kafka-1                                 1/1     Running     0          5m35s
sasquatch-kafka-2                                 0/1     Running     0          77s
```


