### PR TITLE
portal for ops DP1

### DIFF
--- a/applications/portal/Chart.yaml
+++ b/applications/portal/Chart.yaml
@@ -5,7 +5,7 @@ description: Rubin Science Platform Portal Aspect
 sources:
   - https://github.com/lsst/suit
   - https://github.com/Caltech-IPAC/firefly
-appVersion: "portal-2025.2.3"
+appVersion: "portal-2025.3.0-build2"
 
 dependencies:
   - name: redis

--- a/applications/portal/templates/statefulset.yaml
+++ b/applications/portal/templates/statefulset.yaml
@@ -69,6 +69,8 @@ spec:
               value: lsstObsCoreTapTable
             - name: PROPS_OP_searchActionsCmdMask_10
               value: lsstTruthSummaryRadiusTable
+            - name: PROPS_OP_searchActionsCmdMask_11
+              value: showDatalinkTable
             - name: PROPS_OP_hips_defHipsSources_label
               value: "'Rubin Featured'"
             - name: PROPS_OP_hips_adhocMocSource_label
@@ -90,20 +92,22 @@ spec:
             - name: PROPS_OP_hips_adhocMocSource_sources_7
               value: ivo://CDS/P/2MASS/color
             - name: PROPS_inventory.serverURLAry
-              value: "[\"https://raw.githubusercontent.com/lsst-sqre/portal-config/refs/heads/tickets/DM-43947/dce-searchPage-idf.xml\"]"
+              value: "[\"https://raw.githubusercontent.com/lsst-sqre/portal-config/refs/heads/main/dce-searchPage-idf.xml\"]"
+            - name: PROPS_uws.history.svcs
+              value: {{ .Values.global.baseUrl }}/api/tap/async|DP02_DC|TAP
             - name: "PROPS_OP_coverage_hipsSourceURL"
               value: >-
                 {{- if .Values.config.hipsUrl }}
-                       "{{ .Values.config.hipsUrl }}"
+                       {{ .Values.config.hipsUrl }}
                 {{- else }}
-                       "{{ .Values.global.baseUrl }}/api/hips/images/color_gri"
+                       {{ .Values.global.baseUrl }}/api/hips/images/color_gri
                 {{- end }}
             - name: "PROPS_OP_coverage_hipsSource360URL"
               value: >-
                 {{- if .Values.config.hipsUrl }}
-                       "{{ .Values.config.hipsUrl }}"
+                       {{ .Values.config.hipsUrl }}
                 {{- else }}
-                       "{{ .Values.global.baseUrl }}/api/hips/images/color_gri"
+                       {{ .Values.global.baseUrl }}/api/hips/images/color_gri
                 {{- end }}
             - name: "PROPS_FIREFLY_OPTIONS"
               value: >-
@@ -112,7 +116,19 @@ spec:
                       "additional": {
                           "services": [
                             {
-                               "label": "LSST SIAV2 DP0.2 DC2",
+                               "label": "DP1 Images SIAv2",
+                               "serviceId": "DP1 Images SIAv2",
+                               "value": "{{ .Values.global.baseUrl }}/api/sia/dp1/query",
+                               {{- if .Values.config.hipsUrl }}
+                               "hipsUrl": "{{ .Values.config.hipsUrl }}",
+                               {{- else }}
+                               "hipsUrl": "{{ .Values.global.baseUrl }}/api/hips/images/color_gri",
+                               {{- end }}
+                               "centerWP": "62;-37;EQ_J2000",
+                               "fovDeg": 10
+                            },
+                            {
+                               "label": "DP0 Images SIAv2",
                                "serviceId": "RubinSiaDp02Dc2",
                                "value": "{{ .Values.global.baseUrl }}/api/sia/dp02/query",
                                {{- if .Values.config.hipsUrl }}
@@ -130,8 +146,8 @@ spec:
                       "additional": {
                           "services": [
                             {
-                               "label": "LSST DP0.2 DC2",
-                               "serviceId": "RubinDp02Dc2",
+                               "label": "Rubin TAP",
+                               "serviceId": "RubinPrimaryTAPID",
                                "value": "{{ .Values.global.baseUrl }}/api/tap",
                                {{- if .Values.config.hipsUrl }}
                                "hipsUrl": "{{ .Values.config.hipsUrl }}",

--- a/applications/portal/values-idfdev.yaml
+++ b/applications/portal/values-idfdev.yaml
@@ -12,6 +12,7 @@ config:
         size: "20Gi"
         storageClass: "standard-rwo"
   ssotap: "ssotap"
+  hipsUrl: "https://data-dev.lsst.cloud/api/hips/v2/dp1/deep_coadd/band_r"
 
 redis:
   persistence:

--- a/applications/portal/values-idfint.yaml
+++ b/applications/portal/values-idfint.yaml
@@ -12,6 +12,7 @@ config:
         size: "20Gi"
         storageClass: "standard-rwo"
   ssotap: "ssotap"
+  hipsUrl: "https://data-int.lsst.cloud/api/hips/v2/dp1/deep_coadd/band_r"
 
 redis:
   persistence:

--- a/applications/portal/values-idfprod.yaml
+++ b/applications/portal/values-idfprod.yaml
@@ -12,6 +12,7 @@ config:
         size: "40Gi"
         storageClass: "standard-rwo"
   ssotap: "ssotap"
+  hipsUrl: "https://data.lsst.cloud/api/hips/v2/dp1/deep_coadd/band_r"
 
 redis:
   persistence:


### PR DESCRIPTION
#### portal for ops DP1
 - tags:
    - appVersion: "portal-2025.3.0-build2"
    - firefly: release-3.4
    - portal: portal-2025.3.0
 - clean and fixed statefulset.yaml for ops
 - update uws.history.svcs
 - expose showDatalinkTable
 - Add global override of base HiPS map for data-int
 - Hard-code base URL - no templates in values files
 - Queue DP1 HiPS background for dev and prod as well
 - Switch default DP1 HiPs coverage map to r band
 - We now have single-channel HiPS for DP1.  Frossie made an executive decision to switch to the r band for the default coverage map.  The r band is better than the colors we were using before, because it has fewer edge artifacts and is less confusing as a background for other things.