### PR TITLE
Fix Butler signed URLs on prod

### DIFF
--- a/applications/butler/templates/configmap-private.yaml
+++ b/applications/butler/templates/configmap-private.yaml
@@ -8,7 +8,7 @@ data:
       cls: lsst.daf.butler.datastores.fileDatastore.FileDatastore
       records:
         table: file_datastore_records
-      root: s3://gcs@butler-us-central1-dp1/DM-51372/
+      root: s3://butler-us-central1-dp1/DM-51372/
     registry:
       db: {{ .Values.config.dp1PostgresUri }}
       temporary_tables: false


### PR DESCRIPTION
Removed 'gcs' profile from DP1 datastore root.  This is now the default profile, and the secret on production does not contain a separate 'gcs' profile.