### PR TITLE
DM-51594: Update Qserv Kafka bridge to 1.0.1

### DIFF
--- a/applications/qserv-kafka/Chart.yaml
+++ b/applications/qserv-kafka/Chart.yaml
@@ -5,7 +5,7 @@ version: 1.0.0
 description: "Qserv Kafka bridge"
 sources:
   - "https://github.com/lsst-sqre/qserv-kafka"
-appVersion: 1.0.0
+appVersion: 1.0.1
 
 dependencies:
   - name: "redis"


### PR DESCRIPTION
This release fixes a bug in the query timings reported back to the TAP server.