### PR TITLE
DM-51589: Let users onto idfprod

### DIFF
--- a/applications/gafaelfawr/values-idfprod.yaml
+++ b/applications/gafaelfawr/values-idfprod.yaml
@@ -56,14 +56,19 @@ config:
       - "g_admins"
     "exec:notebook":
       - "g_rubin"
+      - "g_users"
     "exec:portal":
       - "g_rubin"
+      - "g_users"
     "read:image":
       - "g_rubin"
+      - "g_users"
     "read:tap":
       - "g_rubin"
+      - "g_users"
     "write:files":
       - "g_rubin"
+      - "g_users"
 
   initialAdmins:
     - "afausti"


### PR DESCRIPTION
Add `g_users` back into the group mapping for idfprod.