### PR TITLE
Include chart name in container names

### DIFF
--- a/applications/vo-cutouts/templates/db-worker-deployment.yaml
+++ b/applications/vo-cutouts/templates/db-worker-deployment.yaml
@@ -28,7 +28,7 @@ spec:
       {{- end }}
       automountServiceAccountToken: false
       containers:
-        - name: "db-worker"
+        - name: "vo-cutouts-db-worker"
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/applications/vo-cutouts/templates/worker-deployment.yaml
+++ b/applications/vo-cutouts/templates/worker-deployment.yaml
@@ -28,7 +28,7 @@ spec:
       {{- end }}
       serviceAccountName: "vo-cutouts"
       containers:
-        - name: "worker"
+        - name: "vo-cutouts-worker"
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/starters/fastapi-safir-uws/templates/db-worker-deployment.yaml
+++ b/starters/fastapi-safir-uws/templates/db-worker-deployment.yaml
@@ -28,7 +28,7 @@ spec:
       {{- end }}
       automountServiceAccountToken: false
       containers:
-        - name: "db-worker"
+        - name: "<CHARTNAME>-db-worker"
           command:
             - "arq"
             - "<CHARTNAME>.workers.uws.WorkerSettings"

--- a/starters/fastapi-safir-uws/templates/worker-deployment.yaml
+++ b/starters/fastapi-safir-uws/templates/worker-deployment.yaml
@@ -28,7 +28,7 @@ spec:
       {{- end }}
       serviceAccountName: "<CHARTNAME>"
       containers:
-        - name: "worker"
+        - name: "<CHARTNAME>-worker"
           env:
             # Password for Redis for the job queue.
             - name: "<CHARTENVPREFIX>_ARQ_QUEUE_PASSWORD"


### PR DESCRIPTION
In the UWS starter pattern and in vo-cutouts, include the chart name as a prefix of the container name for the worker and database worker. This makes reading logs in Google Log Explorer easier since they're prefixed with the container name in isolation without the pod name or namespace.