### PR TITLE
Make the Kafka-based TAP (3.3.1) the default and pin other envs to 2.13.1

### DIFF
--- a/applications/tap/values-idfdev.yaml
+++ b/applications/tap/values-idfdev.yaml
@@ -8,8 +8,6 @@ cadc-tap:
       host: "qserv-int.slac.stanford.edu:4090"
       jdbcParams: "?enabledTLSProtocols=TLSv1.3"
       passwordEnabled: true
-      image:
-        tag: "3.3.1"
 
     kafka:
       bootstrapServer: "sasquatch-dev-kafka-bootstrap.lsst.cloud:9094"

--- a/applications/tap/values-idfint.yaml
+++ b/applications/tap/values-idfint.yaml
@@ -10,8 +10,6 @@ cadc-tap:
       host: "qserv-int.slac.stanford.edu:4090"
       jdbcParams: "?enabledTLSProtocols=TLSv1.3"
       passwordEnabled: true
-      image:
-        tag: "3.3.1"
 
     sentryEnabled: true
     sentryTracesSampleRate: "0.1"

--- a/applications/tap/values-idfprod.yaml
+++ b/applications/tap/values-idfprod.yaml
@@ -10,8 +10,6 @@ cadc-tap:
       host: "qserv-prod.slac.stanford.edu:4040"
       jdbcParams: "?enabledTLSProtocols=TLSv1.3"
       passwordEnabled: true
-      image:
-        tag: "3.3.1"
 
     kafka:
       bootstrapServer: "sasquatch-kafka-bootstrap.lsst.cloud:9094"

--- a/applications/tap/values-ukidacdev.yaml
+++ b/applications/tap/values-ukidacdev.yaml
@@ -12,3 +12,5 @@ cadc-tap:
 
     qserv:
       host: "192.41.122.85:30040"
+      image:
+        tag: "2.13.1"

--- a/applications/tap/values-ukidacprod.yaml
+++ b/applications/tap/values-ukidacprod.yaml
@@ -12,3 +12,5 @@ cadc-tap:
 
     qserv:
       host: "192.41.122.85:30040"
+      image:
+        tag: "2.13.1"

--- a/applications/tap/values-usdfdev.yaml
+++ b/applications/tap/values-usdfdev.yaml
@@ -8,6 +8,8 @@ cadc-tap:
       host: "sdfqserv001.sdf.slac.stanford.edu:4090"
       jdbcParams: "?enabledTLSProtocols=TLSv1.3"
       passwordEnabled: true
+      image:
+        tag: "2.13.1"
 
     gcsBucket: "rubin:rubin-qserv"
     gcsBucketUrl: "https://s3dfrgw.slac.stanford.edu"

--- a/applications/tap/values-usdfint.yaml
+++ b/applications/tap/values-usdfint.yaml
@@ -8,6 +8,8 @@ cadc-tap:
       host: "sdfqserv001.sdf.slac.stanford.edu:4090"
       jdbcParams: "?enabledTLSProtocols=TLSv1.3"
       passwordEnabled: true
+      image:
+        tag: "2.13.1"
 
     gcsBucket: "rubin:rubin-qserv"
     gcsBucketUrl: "https://s3dfrgw.slac.stanford.edu"

--- a/applications/tap/values-usdfprod.yaml
+++ b/applications/tap/values-usdfprod.yaml
@@ -8,6 +8,8 @@ cadc-tap:
       host: "sdfqserv001.sdf.slac.stanford.edu:4040"
       jdbcParams: "?enabledTLSProtocols=TLSv1.3"
       passwordEnabled: true
+      image:
+        tag: "2.13.1"
 
     gcsBucket: "rubin:rubin-qserv"
     gcsBucketUrl: "https://s3dfrgw.slac.stanford.edu"

--- a/charts/cadc-tap/README.md
+++ b/charts/cadc-tap/README.md
@@ -47,7 +47,7 @@ IVOA TAP service
 | config.qserv.host | string | `"mock-db:3306"` (the mock QServ) | QServ hostname:port to connect to |
 | config.qserv.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the TAP image |
 | config.qserv.image.repository | string | `"ghcr.io/lsst-sqre/lsst-tap-service"` | TAP image to use |
-| config.qserv.image.tag | string | `"2.13.1"` | Tag of TAP image to use |
+| config.qserv.image.tag | string | `"3.3.1"` | Tag of TAP image to use |
 | config.qserv.jdbcParams | string | `""` | Extra JDBC connection parameters |
 | config.qserv.passwordEnabled | bool | false | Whether the Qserv database is password protected |
 | config.sentryEnabled | bool | `false` | Whether Sentry is enabled in this environment |
@@ -94,7 +94,7 @@ IVOA TAP service
 | uws.affinity | object | `{}` | Affinity rules for the UWS database pod |
 | uws.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the UWS database image |
 | uws.image.repository | string | `"ghcr.io/lsst-sqre/lsst-tap-uws-db"` | UWS database image to use |
-| uws.image.tag | string | `"2.13.1"` | Tag of UWS database image to use |
+| uws.image.tag | string | `"3.3.1"` | Tag of UWS database image to use |
 | uws.nodeSelector | object | `{}` | Node selection rules for the UWS database pod |
 | uws.podAnnotations | object | `{}` | Annotations for the UWS databse pod |
 | uws.resources | object | See `values.yaml` | Resource limits and requests for the UWS database pod |

--- a/charts/cadc-tap/values.yaml
+++ b/charts/cadc-tap/values.yaml
@@ -89,7 +89,7 @@ config:
       pullPolicy: "IfNotPresent"
 
       # -- Tag of TAP image to use
-      tag: "2.13.1"
+      tag: "3.3.1"
 
     # -- Whether the Qserv database is password protected
     # @default -- false
@@ -245,7 +245,7 @@ uws:
     pullPolicy: "IfNotPresent"
 
     # -- Tag of UWS database image to use
-    tag: "2.13.1"
+    tag: "3.3.1"
 
   # -- Resource limits and requests for the UWS database pod
   # @default -- See `values.yaml`


### PR DESCRIPTION
We've moved the idfs to use a Kafka (qserv-bridge) based approach so this PR sets the cadc-tap chart to use the latest version of that as the default. For other envs that do not support this yet, pin their version to the latest release of the legacy TAP service.