### PR TITLE
Bump requests and limits for Nublado proxy

### DIFF
--- a/applications/nublado/values.yaml
+++ b/applications/nublado/values.yaml
@@ -610,10 +610,10 @@ jupyterhub:
       resources:
         limits:
           cpu: "1"
-          memory: "400Mi"
+          memory: "1Gi"
         requests:
-          cpu: "5m"
-          memory: "30Mi"
+          cpu: "250m"
+          memory: "200Mi"
 
   scheduling:
     userScheduler:


### PR DESCRIPTION
The Nublado proxy is being OOM killed in production, so bump the memory limit considerably, increase requests, and increase the CPU request to match usage.