### PR TITLE
DM-51647: Upgrade mobu, add g_users to idfdev monkeys

### DIFF
--- a/applications/mobu/Chart.yaml
+++ b/applications/mobu/Chart.yaml
@@ -5,4 +5,4 @@ description: "Continuous integration testing"
 home: https://mobu.lsst.io/
 sources:
   - "https://github.com/lsst-sqre/mobu"
-appVersion: 15.3.1
+appVersion: 15.4.0

--- a/applications/mobu/values-idfdev.yaml
+++ b/applications/mobu/values-idfdev.yaml
@@ -71,6 +71,9 @@ config:
       count: 1
       users:
         - username: "bot-mobu-tutorial"
+          groups:
+            - name: "g_users"
+              id: 2000003
       scopes:
         - "exec:notebook"
         - "exec:portal"
@@ -98,6 +101,9 @@ config:
       count: 1
       users:
         - username: "bot-mobu-sia"
+          groups:
+            - name: "g_users"
+              id: 2000003
       scopes: ["read:image"]
       business:
         type: "SIAQuerySetRunner"


### PR DESCRIPTION
Butler in idfdev is starting to use groups to restrict access to particular data sets. Upgrade mobu to a version that supports adding groups to user tokens and add the `g_users` group to the tutorial and sia monkey users.