### PR TITLE
DM-51686: Update Nublado to 8.9.2

### DIFF
--- a/applications/nublado/Chart.yaml
+++ b/applications/nublado/Chart.yaml
@@ -5,7 +5,7 @@ description: JupyterHub and custom spawner for the Rubin Science Platform
 sources:
   - https://github.com/lsst-sqre/nublado
 home: https://nublado.lsst.io/
-appVersion: 8.9.0
+appVersion: 8.9.2
 
 dependencies:
   - name: jupyterhub

--- a/applications/nublado/README.md
+++ b/applications/nublado/README.md
@@ -152,7 +152,7 @@ JupyterHub and custom spawner for the Rubin Science Platform
 | jupyterhub.hub.extraVolumeMounts | list | `hub-config` and the Gafaelfawr token | Additional volume mounts for JupyterHub |
 | jupyterhub.hub.extraVolumes | list | The `hub-config` `ConfigMap` and the Gafaelfawr token | Additional volumes to make available to JupyterHub |
 | jupyterhub.hub.image.name | string | `"ghcr.io/lsst-sqre/nublado-jupyterhub"` | Image to use for JupyterHub |
-| jupyterhub.hub.image.tag | string | `"8.9.0"` | Tag of image to use for JupyterHub |
+| jupyterhub.hub.image.tag | string | `"8.9.2"` | Tag of image to use for JupyterHub |
 | jupyterhub.hub.loadRoles.server.scopes | list | See `values.yaml` | Default scopes for the user's lab, overridden to allow the lab to delete itself (which we use for our added menu items) |
 | jupyterhub.hub.networkPolicy.enabled | bool | `false` | Whether to enable the default `NetworkPolicy` (currently, the upstream one does not work correctly) |
 | jupyterhub.hub.resources | object | See `values.yaml` | Resource limits and requests |

--- a/applications/nublado/values-base.yaml
+++ b/applications/nublado/values-base.yaml
@@ -30,7 +30,7 @@ controller:
         - name: "inithome"
           image:
             repository: "ghcr.io/lsst-sqre/nublado-inithome"
-            tag: "8.9.0"
+            tag: "8.9.2"
           privileged: true
           volumeMounts:
             - containerPath: "/home"

--- a/applications/nublado/values-idfdemo.yaml
+++ b/applications/nublado/values-idfdemo.yaml
@@ -23,7 +23,7 @@ controller:
         - name: "inithome"
           image:
             repository: "us-central1-docker.pkg.dev/rubin-shared-services-71ec/sciplat/inithome"
-            tag: "8.9.0"
+            tag: "8.9.2"
           privileged: true
           volumeMounts:
             - containerPath: "/home"

--- a/applications/nublado/values-idfdev.yaml
+++ b/applications/nublado/values-idfdev.yaml
@@ -42,7 +42,7 @@ controller:
         - name: "inithome"
           image:
             repository: "us-central1-docker.pkg.dev/rubin-shared-services-71ec/sciplat/inithome"
-            tag: "8.9.0"
+            tag: "8.9.2"
           privileged: true
           volumeMounts:
             - containerPath: "/home"

--- a/applications/nublado/values-idfint.yaml
+++ b/applications/nublado/values-idfint.yaml
@@ -51,7 +51,7 @@ controller:
         - name: "inithome"
           image:
             repository: "us-central1-docker.pkg.dev/rubin-shared-services-71ec/sciplat/inithome"
-            tag: "8.9.0"
+            tag: "8.9.2"
           privileged: true
           volumeMounts:
             - containerPath: "/home"

--- a/applications/nublado/values-idfprod.yaml
+++ b/applications/nublado/values-idfprod.yaml
@@ -35,7 +35,7 @@ controller:
         - name: "inithome"
           image:
             repository: "us-central1-docker.pkg.dev/rubin-shared-services-71ec/sciplat/inithome"
-            tag: "8.9.0"
+            tag: "8.9.2"
           privileged: true
           volumeMounts:
             - containerPath: "/home"

--- a/applications/nublado/values-summit.yaml
+++ b/applications/nublado/values-summit.yaml
@@ -29,7 +29,7 @@ controller:
         - name: "inithome"
           image:
             repository: "ghcr.io/lsst-sqre/nublado-inithome"
-            tag: "8.9.0"
+            tag: "8.9.2"
           privileged: true
           volumeMounts:
             - containerPath: "/home"

--- a/applications/nublado/values-tucson-teststand.yaml
+++ b/applications/nublado/values-tucson-teststand.yaml
@@ -33,7 +33,7 @@ controller:
         - name: "inithome"
           image:
             repository: "ghcr.io/lsst-sqre/nublado-inithome"
-            tag: "8.9.0"
+            tag: "8.9.2"
           privileged: true
           volumeMounts:
             - containerPath: "/home"

--- a/applications/nublado/values-ukidacdev.yaml
+++ b/applications/nublado/values-ukidacdev.yaml
@@ -14,7 +14,7 @@ controller:
         - name: "inithome"
           image:
             repository: "ghcr.io/lsst-sqre/nublado-inithome"
-            tag: "8.9.0"
+            tag: "8.9.2"
           privileged: true
           volumeMounts:
             - containerPath: "/home"

--- a/applications/nublado/values-ukidacprod.yaml
+++ b/applications/nublado/values-ukidacprod.yaml
@@ -14,7 +14,7 @@ controller:
         - name: "inithome"
           image:
             repository: "ghcr.io/lsst-sqre/nublado-inithome"
-            tag: "8.9.0"
+            tag: "8.9.2"
           privileged: true
           volumeMounts:
             - containerPath: "/home"

--- a/applications/nublado/values.yaml
+++ b/applications/nublado/values.yaml
@@ -494,7 +494,7 @@ jupyterhub:
       name: "ghcr.io/lsst-sqre/nublado-jupyterhub"
 
       # -- Tag of image to use for JupyterHub
-      tag: "8.9.0"
+      tag: "8.9.2"
 
     # -- Resource limits and requests
     # @default -- See `values.yaml`


### PR DESCRIPTION
Fixes handling of groups starting with a number, such as user-private groups for usernames starting with a number.