### PR TITLE
Switch ukidacprod cert-manager to route53

### DIFF
--- a/applications/argocd/values-ukidacprod.yaml
+++ b/applications/argocd/values-ukidacprod.yaml
@@ -8,4 +8,4 @@ argo-cd:
   server:
     ingress:
       hostname: "rsp.lsst.ac.uk"
-      tls: false
+      tls: true

--- a/applications/cert-manager/values-ukidacprod.yaml
+++ b/applications/cert-manager/values-ukidacprod.yaml
@@ -1,2 +1,4 @@
 config:
-  createIssuer: false
+  route53:
+    awsAccessKeyId: "AKIAU52KVHTMUM5LRCMD"
+    hostedZone: "Z06436303FKUL106EU52"

--- a/applications/ingress-nginx/values-ukidacprod.yaml
+++ b/applications/ingress-nginx/values-ukidacprod.yaml
@@ -11,7 +11,3 @@ ingress-nginx:
       annotations:
         kubernetes.io/ingress.class: "openstack"
         loadbalancer.openstack.org/enable-health-monitor: "false"
-    extraArgs:
-      default-ssl-certificate: ingress-nginx/ingress-certificate
-vaultCertificate:
-  enabled: true


### PR DESCRIPTION
Update the ukidacprod environment to use Let's Encrypt DNS and Route53 for TLS instead of using an external certificate.
Changes should be identical to commit 138db33 but for the ukidacprod environment.