### PR TITLE
tickets/DM-51675: go to CHP 5

### DIFF
--- a/applications/nublado/values-idfdev.yaml
+++ b/applications/nublado/values-idfdev.yaml
@@ -108,6 +108,7 @@ jupyterhub:
     chp:
       image:
         tag: "5.0.1"
+
 cloudsql:
   enabled: true
   instanceConnectionName: "science-platform-dev-7696:us-central1:science-platform-dev-e9e11de2"

--- a/applications/nublado/values-idfdev.yaml
+++ b/applications/nublado/values-idfdev.yaml
@@ -104,6 +104,10 @@ jupyterhub:
     db:
       upgrade: true
       url: "postgresql://nublado@cloud-sql-proxy.nublado/nublado"
+  proxy:
+    chp:
+      image:
+        tag: "5.0.1"
 cloudsql:
   enabled: true
   instanceConnectionName: "science-platform-dev-7696:us-central1:science-platform-dev-e9e11de2"

--- a/applications/nublado/values-idfint.yaml
+++ b/applications/nublado/values-idfint.yaml
@@ -121,6 +121,11 @@ jupyterhub:
     db:
       url: "postgresql://nublado@cloud-sql-proxy.nublado/nublado"
       upgrade: true
+  proxy:
+    chp:
+      image:
+        tag: "5.0.1"
+
 cronjob:
   tutorials:
     enabled: true

--- a/applications/nublado/values-idfprod.yaml
+++ b/applications/nublado/values-idfprod.yaml
@@ -106,6 +106,10 @@ jupyterhub:
     db:
       url: "postgresql://nublado@cloud-sql-proxy.nublado/nublado"
       upgrade: true
+  proxy:
+    chp:
+      image:
+        tag: "5.0.1"
 
 cronjob:
   tutorials:


### PR DESCRIPTION
Try replacing configurable-hub-proxy with version 5, because it might solve our memory leak problem.