### PR TITLE
DM-51704: Support overriding application revisions

### DIFF
--- a/docs/extras/schemas/environment.json
+++ b/docs/extras/schemas/environment.json
@@ -192,6 +192,15 @@
       "description": "Name of the parent Argo CD app-of-apps that manages all of the enabled applications. This is required in the merged values file that includes environment overrides, but the environment override file doesn't need to set it, so it's marked as optional for schema checking purposes to allow the override file to be schema-checked independently.",
       "title": "Argo CD app-of-apps name"
     },
+    "revisions": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "default": {},
+      "description": "Mapping of application names to non-main revisions for the environment. In that environment, the app-of-apps will point these applications at the given revisions instead of at main.",
+      "title": "Revision overrides for applications",
+      "type": "object"
+    },
     "butlerServerRepositories": {
       "anyOf": [
         {

--- a/environments/README.md
+++ b/environments/README.md
@@ -102,8 +102,9 @@
 | controlSystem.topicName | string | `"sal"` | Topic name tag for the control system deployment |
 | fqdn | string | None, must be set | Fully-qualified domain name where the environment is running |
 | name | string | None, must be set | Name of the environment |
-| namespaceLabels | object | `{}` | Add labels for application namespaces. |
+| namespaceLabels | object | `{}` | Add labels for application namespaces |
 | repoUrl | string | `"https://github.com/lsst-sqre/phalanx.git"` | URL of the repository for all applications |
-| targetRevision | string | `"main"` | Revision of repository to use for all applications |
+| revisions | object | `{}` | Mapping of applications to branches to run some applications from revisions other than main |
+| targetRevision | string | `"main"` | Revision of repository to use for all applications unless overridden by branches below |
 | vaultPathPrefix | string | None, must be set | Prefix for Vault secrets for this environment |
 | vaultUrl | string | `"https://vault.lsst.cloud/"` | URL of Vault server for this environment |

--- a/environments/templates/applications/infrastructure/argocd.yaml
+++ b/environments/templates/applications/infrastructure/argocd.yaml
@@ -13,7 +13,7 @@ spec:
   source:
     path: "applications/argocd"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "argocd") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.vaultSecretsPath"

--- a/environments/templates/applications/infrastructure/atlantis.yaml
+++ b/environments/templates/applications/infrastructure/atlantis.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/atlantis"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "atlantis") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/infrastructure/cert-manager.yaml
+++ b/environments/templates/applications/infrastructure/cert-manager.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/cert-manager"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "cert-manager") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.vaultSecretsPath"

--- a/environments/templates/applications/infrastructure/gafaelfawr.yaml
+++ b/environments/templates/applications/infrastructure/gafaelfawr.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/gafaelfawr"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "gafaelfawr") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/infrastructure/ingress-nginx.yaml
+++ b/environments/templates/applications/infrastructure/ingress-nginx.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/ingress-nginx"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "ingress-nginx") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.vaultSecretsPath"

--- a/environments/templates/applications/infrastructure/keda.yaml
+++ b/environments/templates/applications/infrastructure/keda.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/keda"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "keda") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/infrastructure/mobu.yaml
+++ b/environments/templates/applications/infrastructure/mobu.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/mobu"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "mobu") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/infrastructure/vault-secrets-operator.yaml
+++ b/environments/templates/applications/infrastructure/vault-secrets-operator.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/vault-secrets-operator"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "vault-secrets-operator") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "vault-secrets-operator.vault.address"

--- a/environments/templates/applications/monitoring/flink.yaml
+++ b/environments/templates/applications/monitoring/flink.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/flink"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "flink") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/monitoring/google-cloud-observability.yaml
+++ b/environments/templates/applications/monitoring/google-cloud-observability.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/google-cloud-observability"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "google-cloud-observability") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/monitoring/grafana.yaml
+++ b/environments/templates/applications/monitoring/grafana.yaml
@@ -22,7 +22,7 @@ spec:
   source:
     path: "applications/grafana"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "grafana") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/monitoring/sasquatch-backpack.yaml
+++ b/environments/templates/applications/monitoring/sasquatch-backpack.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/sasquatch-backpack"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "sasquatch-backpack") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/monitoring/sasquatch.yaml
+++ b/environments/templates/applications/monitoring/sasquatch.yaml
@@ -23,7 +23,7 @@ spec:
   source:
     path: "applications/sasquatch"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "sasquatch") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/prompt/next-visit-fan-out.yaml
+++ b/environments/templates/applications/prompt/next-visit-fan-out.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/next-visit-fan-out"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "next-visit-fan-out") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/prompt/prompt-kafka.yaml
+++ b/environments/templates/applications/prompt/prompt-kafka.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/prompt-kafka"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "prompt-kafka") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/prompt/prompt-keda-hsc.yaml
+++ b/environments/templates/applications/prompt/prompt-keda-hsc.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/prompt-keda-hsc"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "prompt-keda-hsc") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/prompt/prompt-keda-latiss.yaml
+++ b/environments/templates/applications/prompt/prompt-keda-latiss.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/prompt-keda-latiss"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "prompt-keda-latiss") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/prompt/prompt-keda-lsstcam.yaml
+++ b/environments/templates/applications/prompt/prompt-keda-lsstcam.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/prompt-keda-lsstcam"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "prompt-keda-lsstcam") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/prompt/prompt-keda-lsstcamimsim.yaml
+++ b/environments/templates/applications/prompt/prompt-keda-lsstcamimsim.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/prompt-keda-lsstcamimsim"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "prompt-keda-lsstcamimsim") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/prompt/prompt-keda-lsstcomcam.yaml
+++ b/environments/templates/applications/prompt/prompt-keda-lsstcomcam.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/prompt-keda-lsstcomcam"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "prompt-keda-lsstcomcam") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/prompt/prompt-keda-lsstcomcamsim.yaml
+++ b/environments/templates/applications/prompt/prompt-keda-lsstcomcamsim.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/prompt-keda-lsstcomcamsim"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "prompt-keda-lsstcomcamsim") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/prompt/prompt-redis.yaml
+++ b/environments/templates/applications/prompt/prompt-redis.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/prompt-redis"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "prompt-redis") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/roundtable/checkerboard.yaml
+++ b/environments/templates/applications/roundtable/checkerboard.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/checkerboard"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "checkerboard") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/roundtable/eups-distributor.yaml
+++ b/environments/templates/applications/roundtable/eups-distributor.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/eups-distributor"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "eups-distributor") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/roundtable/giftless.yaml
+++ b/environments/templates/applications/roundtable/giftless.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/giftless"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "giftless") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/roundtable/monitoring.yaml
+++ b/environments/templates/applications/roundtable/monitoring.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/monitoring"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "monitoring") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/roundtable/onepassword-connect.yaml
+++ b/environments/templates/applications/roundtable/onepassword-connect.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/onepassword-connect"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "onepassword-connect") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/roundtable/ook.yaml
+++ b/environments/templates/applications/roundtable/ook.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/ook"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "ook") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/roundtable/squarebot.yaml
+++ b/environments/templates/applications/roundtable/squarebot.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/squarebot"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "squarebot") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/roundtable/templatebot.yaml
+++ b/environments/templates/applications/roundtable/templatebot.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/templatebot"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "templatebot") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/roundtable/unfurlbot.yaml
+++ b/environments/templates/applications/roundtable/unfurlbot.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/unfurlbot"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "unfurlbot") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/roundtable/vault.yaml
+++ b/environments/templates/applications/roundtable/vault.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/vault"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "vault") .Values.targetRevision | quote }}
     helm:
       valueFiles:
         - "values.yaml"

--- a/environments/templates/applications/rsp/butler.yaml
+++ b/environments/templates/applications/rsp/butler.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/butler"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "butler") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/rsp/consdbtap.yaml
+++ b/environments/templates/applications/rsp/consdbtap.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/consdbtap"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "consdbtap") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/rsp/datalinker.yaml
+++ b/environments/templates/applications/rsp/datalinker.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/datalinker"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "datalinker") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.baseUrl"

--- a/environments/templates/applications/rsp/fspurger.yaml
+++ b/environments/templates/applications/rsp/fspurger.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/fspurger"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "fspurger") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/rsp/hips.yaml
+++ b/environments/templates/applications/rsp/hips.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/hips"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "hips") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/rsp/hoverdrive.yaml
+++ b/environments/templates/applications/rsp/hoverdrive.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/hoverdrive"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "hoverdrive") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/rsp/jira-data-proxy.yaml
+++ b/environments/templates/applications/rsp/jira-data-proxy.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/jira-data-proxy"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "jira-data-proxy") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/rsp/livetap.yaml
+++ b/environments/templates/applications/rsp/livetap.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/livetap"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "livetap") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/rsp/noteburst.yaml
+++ b/environments/templates/applications/rsp/noteburst.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/noteburst"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "noteburst") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/rsp/nublado-fileservers.yaml
+++ b/environments/templates/applications/rsp/nublado-fileservers.yaml
@@ -24,5 +24,5 @@ spec:
   source:
     path: "applications/nublado-fileservers"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "nublado-fileservers") .Values.targetRevision | quote }}
 {{- end -}}

--- a/environments/templates/applications/rsp/nublado-users.yaml
+++ b/environments/templates/applications/rsp/nublado-users.yaml
@@ -14,5 +14,5 @@ spec:
   source:
     path: "applications/nublado-users"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "nublado-users") .Values.targetRevision | quote }}
 {{- end -}}

--- a/environments/templates/applications/rsp/nublado.yaml
+++ b/environments/templates/applications/rsp/nublado.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/nublado"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "nublado") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/rsp/portal.yaml
+++ b/environments/templates/applications/rsp/portal.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/portal"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "portal") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/rsp/qserv-kafka.yaml
+++ b/environments/templates/applications/rsp/qserv-kafka.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/qserv-kafka"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "qserv-kafka") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/rsp/semaphore.yaml
+++ b/environments/templates/applications/rsp/semaphore.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/semaphore"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "semaphore") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/rsp/sia.yaml
+++ b/environments/templates/applications/rsp/sia.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/sia"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "sia") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/rsp/squareone.yaml
+++ b/environments/templates/applications/rsp/squareone.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/squareone"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "squareone") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/rsp/ssotap.yaml
+++ b/environments/templates/applications/rsp/ssotap.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/ssotap"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "ssotap") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/rsp/tap.yaml
+++ b/environments/templates/applications/rsp/tap.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/tap"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "tap") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/rsp/times-square.yaml
+++ b/environments/templates/applications/rsp/times-square.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/times-square"
     repoURL: {{ .Values.repoUrl |quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "times-square") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/rsp/vo-cutouts.yaml
+++ b/environments/templates/applications/rsp/vo-cutouts.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/vo-cutouts"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "vo-cutouts") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.baseUrl"

--- a/environments/templates/applications/rsp/wobbly.yaml
+++ b/environments/templates/applications/rsp/wobbly.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/wobbly"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "wobbly") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/rubin/alert-stream-broker.yaml
+++ b/environments/templates/applications/rubin/alert-stream-broker.yaml
@@ -23,7 +23,7 @@ spec:
   source:
     path: "applications/alert-stream-broker"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "alert-stream-broker") .Values.targetRevision | quote }}
     helm:
       valueFiles:
         - "values.yaml"

--- a/environments/templates/applications/rubin/cm-service.yaml
+++ b/environments/templates/applications/rubin/cm-service.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/cm-service"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "cm-service") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/rubin/consdb.yaml
+++ b/environments/templates/applications/rubin/consdb.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/consdb"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "consdb") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/rubin/exposure-checker.yaml
+++ b/environments/templates/applications/rubin/exposure-checker.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/exposure-checker"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "exposure-checker") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/rubin/exposurelog.yaml
+++ b/environments/templates/applications/rubin/exposurelog.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/exposurelog"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "exposurelog") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/rubin/fastapi-bootcamp.yaml
+++ b/environments/templates/applications/rubin/fastapi-bootcamp.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/fastapi-bootcamp"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "fastapi-bootcamp") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/rubin/narrativelog.yaml
+++ b/environments/templates/applications/rubin/narrativelog.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/narrativelog"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "narrativelog") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/rubin/nightlydigest.yaml
+++ b/environments/templates/applications/rubin/nightlydigest.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/nightlydigest"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "nightlydigest") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/rubin/nightreport.yaml
+++ b/environments/templates/applications/rubin/nightreport.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/nightreport"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "nightreport") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/rubin/nvr-control.yaml
+++ b/environments/templates/applications/rubin/nvr-control.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/nvr-control"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "nvr-control") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/rubin/obsloctap.yaml
+++ b/environments/templates/applications/rubin/obsloctap.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/obsloctap"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "obsloctap") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/rubin/plot-navigator.yaml
+++ b/environments/templates/applications/rubin/plot-navigator.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/plot-navigator"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "plot-navigator") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/rubin/ppdb-replication.yaml
+++ b/environments/templates/applications/rubin/ppdb-replication.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/ppdb-replication"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "ppdb-replication") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/rubin/production-tools.yaml
+++ b/environments/templates/applications/rubin/production-tools.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/production-tools"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "production-tools") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/rubin/rapid-analysis.yaml
+++ b/environments/templates/applications/rubin/rapid-analysis.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/rapid-analysis"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "rapid-analysis") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/rubin/rubin-rag.yaml
+++ b/environments/templates/applications/rubin/rubin-rag.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/rubin-rag"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "rubin-rag") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/rubin/rubintv-dev.yaml
+++ b/environments/templates/applications/rubin/rubintv-dev.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/rubintv-dev"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "rubintv-dev") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/rubin/rubintv.yaml
+++ b/environments/templates/applications/rubin/rubintv.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/rubintv"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "rubintv") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/rubin/s3proxy.yaml
+++ b/environments/templates/applications/rubin/s3proxy.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/s3proxy"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "s3proxy") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/rubin/schedview-snapshot.yaml
+++ b/environments/templates/applications/rubin/schedview-snapshot.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/schedview-snapshot"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "schedview-snapshot") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/rubin/schedview-static-pages.yaml
+++ b/environments/templates/applications/rubin/schedview-static-pages.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/schedview-static-pages"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "schedview-static-pages") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/rubin/tasso.yaml
+++ b/environments/templates/applications/rubin/tasso.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/tasso"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "tasso") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/support/ghostwriter.yaml
+++ b/environments/templates/applications/support/ghostwriter.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/ghostwriter"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "ghostwriter") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/support/postgres.yaml
+++ b/environments/templates/applications/support/postgres.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/postgres"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "postgres") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.vaultSecretsPath"

--- a/environments/templates/applications/support/strimzi-access-operator.yaml
+++ b/environments/templates/applications/support/strimzi-access-operator.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/strimzi-access-operator"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "strimzi-access-operator") .Values.targetRevision | quote }}
     helm:
       valueFiles:
         - "values.yaml"

--- a/environments/templates/applications/support/strimzi.yaml
+++ b/environments/templates/applications/support/strimzi.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/strimzi"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "strimzi") .Values.targetRevision | quote }}
     helm:
       valueFiles:
         - "values-{{ .Values.name }}.yaml"

--- a/environments/templates/applications/telescope/argo-workflows.yaml
+++ b/environments/templates/applications/telescope/argo-workflows.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/argo-workflows"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "argo-workflows") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/telescope/auxtel.yaml
+++ b/environments/templates/applications/telescope/auxtel.yaml
@@ -22,7 +22,7 @@ spec:
   source:
     path: "applications/auxtel"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "auxtel") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/telescope/calsys.yaml
+++ b/environments/templates/applications/telescope/calsys.yaml
@@ -22,7 +22,7 @@ spec:
   source:
     path: "applications/calsys"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "calsys") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/telescope/control-system-test.yaml
+++ b/environments/templates/applications/telescope/control-system-test.yaml
@@ -22,7 +22,7 @@ spec:
   source:
     path: "applications/control-system-test"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "control-system-test") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/telescope/csc-versions.yaml
+++ b/environments/templates/applications/telescope/csc-versions.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/csc-versions"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "csc-versions") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/telescope/envsys.yaml
+++ b/environments/templates/applications/telescope/envsys.yaml
@@ -22,7 +22,7 @@ spec:
   source:
     path: "applications/envsys"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "envsys") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/telescope/love.yaml
+++ b/environments/templates/applications/telescope/love.yaml
@@ -22,7 +22,7 @@ spec:
   source:
     path: "applications/love"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "love") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/telescope/obsenv-management.yaml
+++ b/environments/templates/applications/telescope/obsenv-management.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/obsenv-management"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "obsenv-management") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/telescope/obssys.yaml
+++ b/environments/templates/applications/telescope/obssys.yaml
@@ -22,7 +22,7 @@ spec:
   source:
     path: "applications/obssys"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "obssys") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/telescope/ocps-uws-job.yaml
+++ b/environments/templates/applications/telescope/ocps-uws-job.yaml
@@ -14,5 +14,5 @@ spec:
   source:
     path: "applications/ocps-uws-job"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "ocps-uws-job") .Values.targetRevision | quote }}
 {{- end -}}

--- a/environments/templates/applications/telescope/rubin-too-producer.yaml
+++ b/environments/templates/applications/telescope/rubin-too-producer.yaml
@@ -23,7 +23,7 @@ spec:
   source:
     path: "applications/rubin-too-producer"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "rubin-too-producer") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/telescope/simonyitel.yaml
+++ b/environments/templates/applications/telescope/simonyitel.yaml
@@ -22,7 +22,7 @@ spec:
   source:
     path: "applications/simonyitel"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "simonyitel") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/templates/applications/telescope/uws.yaml
+++ b/environments/templates/applications/telescope/uws.yaml
@@ -22,7 +22,7 @@ spec:
   source:
     path: "applications/uws"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "uws") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/environments/values-idfdev.yaml
+++ b/environments/values-idfdev.yaml
@@ -42,3 +42,6 @@ applications:
   vault-secrets-operator: true
   vo-cutouts: true
   wobbly: true
+
+revisions:
+  strimzi: renovate/strimzi-kafka-operator-0.x

--- a/environments/values-idfint.yaml
+++ b/environments/values-idfint.yaml
@@ -39,3 +39,6 @@ applications:
   times-square: true
   vo-cutouts: true
   wobbly: true
+
+revisions:
+  strimzi: renovate/strimzi-kafka-operator-0.x

--- a/environments/values-idfprod.yaml
+++ b/environments/values-idfprod.yaml
@@ -36,3 +36,6 @@ applications:
   times-square: true
   vo-cutouts: true
   wobbly: true
+
+revisions:
+  strimzi: renovate/strimzi-kafka-operator-0.x

--- a/environments/values.yaml
+++ b/environments/values.yaml
@@ -20,7 +20,8 @@ butlerServerRepositories: {}
 # -- URL of the repository for all applications
 repoUrl: https://github.com/lsst-sqre/phalanx.git
 
-# -- Revision of repository to use for all applications
+# -- Revision of repository to use for all applications unless overridden by
+# branches below
 targetRevision: "main"
 
 # -- URL of Vault server for this environment
@@ -302,7 +303,11 @@ applications:
   # running any Safir-based UWS services
   wobbly: false
 
-# -- Add labels for application namespaces.
+# -- Mapping of applications to branches to run some applications from
+# revisions other than main
+revisions: {}
+
+# -- Add labels for application namespaces
 namespaceLabels: {}
 
 # The following settings are used for the control system

--- a/src/phalanx/data/application-template.yaml.jinja
+++ b/src/phalanx/data/application-template.yaml.jinja
@@ -19,7 +19,7 @@ spec:
   source:
     path: "applications/[[ name ]]"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "[[ name ]]") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"

--- a/src/phalanx/models/environments.py
+++ b/src/phalanx/models/environments.py
@@ -196,6 +196,16 @@ class EnvironmentBaseConfig(BaseModel):
         ),
     )
 
+    revisions: dict[str, str] = Field(
+        {},
+        title="Revision overrides for applications",
+        description=(
+            "Mapping of application names to non-main revisions for the"
+            " environment. In that environment, the app-of-apps will point"
+            " these applications at the given revisions instead of at main."
+        ),
+    )
+
     butler_server_repositories: dict[str, AnyUrl] | None = Field(
         None,
         title="Butler repositories accessible via Butler server",

--- a/tests/cli/application_test.py
+++ b/tests/cli/application_test.py
@@ -126,6 +126,12 @@ def test_create(tmp_path: Path) -> None:
     env_values = (config_path / "environments" / "values.yaml").read_text()
     assert env_values == read_output_data("minikube", "values-after-add.yaml")
 
+    # Check that the Argo CD application templates were created.
+    argo_path = config_path / "environments" / "templates" / "applications"
+    assert (argo_path / "infrastructure" / "aaa-new-app.yaml").exists()
+    assert (argo_path / "rsp" / "hips.yaml").exists()
+    assert (argo_path / "rsp" / "zzz-other-app.yaml").exists()
+
     # Check that the documentation files were created.
     assert (app_docs_path / "aaa-new-app" / "index.rst").exists()
     assert (app_docs_path / "aaa-new-app" / "values.md").exists()


### PR DESCRIPTION
Add a `revisions` setting for environments that allows persistently overriding the target revision for specific applications, allowing them to be run long-term from a branch. We will need this to run Strimzi on T&S deployments from a stable branch while upgrading Strimzi elsewhere.