### PR TITLE
DM-50087: Preload IERS data in Prompt Processing

### DIFF
--- a/applications/prompt-keda-hsc/README.md
+++ b/applications/prompt-keda-hsc/README.md
@@ -24,6 +24,7 @@ KEDA Prompt Processing instance for HSC
 | prompt-keda.debug.exportOutputs | bool | `true` | Whether or not pipeline outputs should be exported to the central repo. This flag does not turn off APDB writes or alert generation; those must be handled at the pipeline level or by setting up an alternative destination. |
 | prompt-keda.debug.monitorDaxApdb | bool | `false` | Whether `dax_apdb` should run in debug mode and log metrics. |
 | prompt-keda.fullnameOverride | string | `"prompt-keda-hsc"` | Override the full name for resources (includes the release name) |
+| prompt-keda.iers_cache | string | `""` | The URI where IERS data has been pre-downloaded and cached for use by Prompt Processing. If empty, Prompt Processing does not try to update IERS data. |
 | prompt-keda.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
 | prompt-keda.image.repository | string | `"ghcr.io/lsst-dm/prompt-service"` | Image to use in the PP deployment |
 | prompt-keda.image.tag | string | `"latest"` | Overrides the image tag whose default is the chart appVersion. |

--- a/applications/prompt-keda-hsc/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-keda-hsc/values-usdfdev-prompt-processing.yaml
@@ -24,6 +24,8 @@ prompt-keda:
     endpointUrl: https://s3dfrgw.slac.stanford.edu
     aws_profile: prompt-processing-dev
 
+  iers_cache: s3://rubin-pp-dev-users/iers-cache.zip
+
   imageNotifications:
     kafkaClusterAddress: prompt-processing2-kafka-bootstrap.kafka:9092
     topic: prompt-processing-dev

--- a/applications/prompt-keda-hsc/values.yaml
+++ b/applications/prompt-keda-hsc/values.yaml
@@ -85,6 +85,10 @@ prompt-keda:
   # Empty value is allowed, but its handling is undefined.
   mpSky_service: ""
 
+  # -- The URI where IERS data has been pre-downloaded and cached for use by Prompt Processing.
+  # If empty, Prompt Processing does not try to update IERS data.
+  iers_cache: ""
+
   imageNotifications:
     # -- Hostname and port of the Kafka provider
     # @default -- None, must be set

--- a/applications/prompt-keda-latiss/README.md
+++ b/applications/prompt-keda-latiss/README.md
@@ -24,6 +24,7 @@ KEDA Prompt Processing instance for LATISS
 | prompt-keda.debug.exportOutputs | bool | `true` | Whether or not pipeline outputs should be exported to the central repo. This flag does not turn off APDB writes or alert generation; those must be handled at the pipeline level or by setting up an alternative destination. |
 | prompt-keda.debug.monitorDaxApdb | bool | `false` | Whether `dax_apdb` should run in debug mode and log metrics. |
 | prompt-keda.fullnameOverride | string | `"prompt-keda-latiss"` | Override the full name for resources (includes the release name) |
+| prompt-keda.iers_cache | string | `""` | The URI where IERS data has been pre-downloaded and cached for use by Prompt Processing. If empty, Prompt Processing does not try to update IERS data. |
 | prompt-keda.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
 | prompt-keda.image.repository | string | `"ghcr.io/lsst-dm/prompt-service"` | Image to use in the PP deployment |
 | prompt-keda.image.tag | string | `"latest"` | Overrides the image tag whose default is the chart appVersion. |

--- a/applications/prompt-keda-latiss/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-keda-latiss/values-usdfdev-prompt-processing.yaml
@@ -53,6 +53,8 @@ prompt-keda:
     endpointUrl: https://s3dfrgw.slac.stanford.edu
     aws_profile: prompt-processing-dev
 
+  iers_cache: s3://rubin-pp-dev-users/iers-cache.zip
+
   imageNotifications:
     kafkaClusterAddress: prompt-processing2-kafka-bootstrap.kafka:9092
     topic: prompt-processing-dev

--- a/applications/prompt-keda-latiss/values.yaml
+++ b/applications/prompt-keda-latiss/values.yaml
@@ -84,6 +84,10 @@ prompt-keda:
   # Empty value is allowed, but its handling is undefined.
   mpSky_service: ""
 
+  # -- The URI where IERS data has been pre-downloaded and cached for use by Prompt Processing.
+  # If empty, Prompt Processing does not try to update IERS data.
+  iers_cache: ""
+
   imageNotifications:
     # -- Hostname and port of the Kafka provider
     # @default -- None, must be set

--- a/applications/prompt-keda-lsstcam/README.md
+++ b/applications/prompt-keda-lsstcam/README.md
@@ -24,6 +24,7 @@ KEDA Prompt Processing instance for LSSTCam
 | prompt-keda.debug.exportOutputs | bool | `true` | Whether or not pipeline outputs should be exported to the central repo. This flag does not turn off APDB writes or alert generation; those must be handled at the pipeline level or by setting up an alternative destination. |
 | prompt-keda.debug.monitorDaxApdb | bool | `false` | Whether `dax_apdb` should run in debug mode and log metrics. |
 | prompt-keda.fullnameOverride | string | `"prompt-keda-lsstcam"` | Override the full name for resources (includes the release name) |
+| prompt-keda.iers_cache | string | `""` | The URI where IERS data has been pre-downloaded and cached for use by Prompt Processing. If empty, Prompt Processing does not try to update IERS data. |
 | prompt-keda.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
 | prompt-keda.image.repository | string | `"ghcr.io/lsst-dm/prompt-service"` | Image to use in the PP deployment |
 | prompt-keda.image.tag | string | `"latest"` | Overrides the image tag whose default is the chart appVersion. |

--- a/applications/prompt-keda-lsstcam/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-keda-lsstcam/values-usdfdev-prompt-processing.yaml
@@ -29,6 +29,8 @@ prompt-keda:
     endpointUrl: https://s3dfrgw.slac.stanford.edu
     aws_profile: prompt-processing-dev
 
+  iers_cache: s3://rubin-pp-dev-users/iers-cache.zip
+
   imageNotifications:
     kafkaClusterAddress: prompt-processing2-kafka-bootstrap.kafka:9092
     topic: prompt-processing-dev

--- a/applications/prompt-keda-lsstcam/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-keda-lsstcam/values-usdfprod-prompt-processing.yaml
@@ -80,6 +80,8 @@ prompt-keda:
   # TODO: replace with permanent service once it's up
   mpSky_service: http://sdfiana014.sdf.slac.stanford.edu:3666/ephemerides/
 
+  iers_cache: s3://rubin-summit-users/iers-cache.zip
+
   imageNotifications:
     kafkaClusterAddress: prompt-processing-2-kafka-bootstrap.kafka:9092
     topic: rubin-summit-notification

--- a/applications/prompt-keda-lsstcam/values.yaml
+++ b/applications/prompt-keda-lsstcam/values.yaml
@@ -85,6 +85,10 @@ prompt-keda:
   # Empty value is allowed, but its handling is undefined.
   mpSky_service: ""
 
+  # -- The URI where IERS data has been pre-downloaded and cached for use by Prompt Processing.
+  # If empty, Prompt Processing does not try to update IERS data.
+  iers_cache: ""
+
   imageNotifications:
     # -- Hostname and port of the Kafka provider
     # @default -- None, must be set

--- a/applications/prompt-keda-lsstcamimsim/README.md
+++ b/applications/prompt-keda-lsstcamimsim/README.md
@@ -24,6 +24,7 @@ KEDA Prompt Processing instance for LSSTCam-imSim.
 | prompt-keda.debug.exportOutputs | bool | `true` | Whether or not pipeline outputs should be exported to the central repo. This flag does not turn off APDB writes or alert generation; those must be handled at the pipeline level or by setting up an alternative destination. |
 | prompt-keda.debug.monitorDaxApdb | bool | `false` | Whether `dax_apdb` should run in debug mode and log metrics. |
 | prompt-keda.fullnameOverride | string | `"prompt-keda-lsstcamimsim"` | Override the full name for resources (includes the release name) |
+| prompt-keda.iers_cache | string | `""` | The URI where IERS data has been pre-downloaded and cached for use by Prompt Processing. If empty, Prompt Processing does not try to update IERS data. |
 | prompt-keda.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
 | prompt-keda.image.repository | string | `"ghcr.io/lsst-dm/prompt-service"` | Image to use in the PP deployment |
 | prompt-keda.image.tag | string | `"latest"` | Overrides the image tag whose default is the chart appVersion. |

--- a/applications/prompt-keda-lsstcamimsim/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-keda-lsstcamimsim/values-usdfdev-prompt-processing.yaml
@@ -26,6 +26,8 @@ prompt-keda:
     endpointUrl: https://s3dfrgw.slac.stanford.edu
     aws_profile: prompt-processing-dev
 
+  iers_cache: s3://rubin-pp-dev-users/iers-cache.zip
+
   imageNotifications:
     kafkaClusterAddress: prompt-processing2-kafka-bootstrap.kafka:9092
     topic: prompt-processing-dev

--- a/applications/prompt-keda-lsstcamimsim/values.yaml
+++ b/applications/prompt-keda-lsstcamimsim/values.yaml
@@ -85,6 +85,10 @@ prompt-keda:
   # Empty value is allowed, but its handling is undefined.
   mpSky_service: ""
 
+  # -- The URI where IERS data has been pre-downloaded and cached for use by Prompt Processing.
+  # If empty, Prompt Processing does not try to update IERS data.
+  iers_cache: ""
+
   imageNotifications:
     # -- Hostname and port of the Kafka provider
     # @default -- None, must be set

--- a/applications/prompt-keda-lsstcomcam/README.md
+++ b/applications/prompt-keda-lsstcomcam/README.md
@@ -24,6 +24,7 @@ KEDA Prompt Processing instance for LSSTComCam.
 | prompt-keda.debug.exportOutputs | bool | `true` | Whether or not pipeline outputs should be exported to the central repo. This flag does not turn off APDB writes or alert generation; those must be handled at the pipeline level or by setting up an alternative destination. |
 | prompt-keda.debug.monitorDaxApdb | bool | `false` | Whether `dax_apdb` should run in debug mode and log metrics. |
 | prompt-keda.fullnameOverride | string | `"prompt-keda-lsstcomcam"` | Override the full name for resources (includes the release name) |
+| prompt-keda.iers_cache | string | `""` | The URI where IERS data has been pre-downloaded and cached for use by Prompt Processing. If empty, Prompt Processing does not try to update IERS data. |
 | prompt-keda.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
 | prompt-keda.image.repository | string | `"ghcr.io/lsst-dm/prompt-service"` | Image to use in the PP deployment |
 | prompt-keda.image.tag | string | `"latest"` | Overrides the image tag whose default is the chart appVersion. |

--- a/applications/prompt-keda-lsstcomcam/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-keda-lsstcomcam/values-usdfdev-prompt-processing.yaml
@@ -25,6 +25,8 @@ prompt-keda:
     endpointUrl: https://s3dfrgw.slac.stanford.edu
     aws_profile: prompt-processing-dev
 
+  iers_cache: s3://rubin-pp-dev-users/iers-cache.zip
+
   imageNotifications:
     kafkaClusterAddress: prompt-processing2-kafka-bootstrap.kafka:9092
     topic: prompt-processing-dev

--- a/applications/prompt-keda-lsstcomcam/values.yaml
+++ b/applications/prompt-keda-lsstcomcam/values.yaml
@@ -85,6 +85,10 @@ prompt-keda:
   # Empty value is allowed, but its handling is undefined.
   mpSky_service: ""
 
+  # -- The URI where IERS data has been pre-downloaded and cached for use by Prompt Processing.
+  # If empty, Prompt Processing does not try to update IERS data.
+  iers_cache: ""
+
   imageNotifications:
     # -- Hostname and port of the Kafka provider
     # @default -- None, must be set

--- a/applications/prompt-keda-lsstcomcamsim/README.md
+++ b/applications/prompt-keda-lsstcomcamsim/README.md
@@ -24,6 +24,7 @@ KEDA Prompt Processing instance for LSSTComCamSim
 | prompt-keda.debug.exportOutputs | bool | `true` | Whether or not pipeline outputs should be exported to the central repo. This flag does not turn off APDB writes or alert generation; those must be handled at the pipeline level or by setting up an alternative destination. |
 | prompt-keda.debug.monitorDaxApdb | bool | `false` | Whether `dax_apdb` should run in debug mode and log metrics. |
 | prompt-keda.fullnameOverride | string | `"prompt-keda-lsstcomcamsim"` | Override the full name for resources (includes the release name) |
+| prompt-keda.iers_cache | string | `""` | The URI where IERS data has been pre-downloaded and cached for use by Prompt Processing. If empty, Prompt Processing does not try to update IERS data. |
 | prompt-keda.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
 | prompt-keda.image.repository | string | `"ghcr.io/lsst-dm/prompt-service"` | Image to use in the PP deployment |
 | prompt-keda.image.tag | string | `"latest"` | Overrides the image tag whose default is the chart appVersion. |

--- a/applications/prompt-keda-lsstcomcamsim/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-keda-lsstcomcamsim/values-usdfdev-prompt-processing.yaml
@@ -27,6 +27,8 @@ prompt-keda:
     endpointUrl: https://s3dfrgw.slac.stanford.edu
     aws_profile: prompt-processing-dev
 
+  iers_cache: s3://rubin-pp-dev-users/iers-cache.zip
+
   imageNotifications:
     kafkaClusterAddress: prompt-processing2-kafka-bootstrap.kafka:9092
     topic: prompt-processing-dev

--- a/applications/prompt-keda-lsstcomcamsim/values.yaml
+++ b/applications/prompt-keda-lsstcomcamsim/values.yaml
@@ -86,6 +86,10 @@ prompt-keda:
   # Empty value is allowed, but its handling is undefined.
   mpSky_service: ""
 
+  # -- The URI where IERS data has been pre-downloaded and cached for use by Prompt Processing.
+  # If empty, Prompt Processing does not try to update IERS data.
+  iers_cache: ""
+
   imageNotifications:
     # -- Hostname and port of the Kafka provider
     # @default -- None, must be set

--- a/charts/prompt-keda/README.md
+++ b/charts/prompt-keda/README.md
@@ -24,6 +24,7 @@ Event-driven processing of camera images
 | debug.exportOutputs | bool | `true` | Whether or not pipeline outputs should be exported to the central repo. This flag does not turn off APDB writes or alert generation; those must be handled at the pipeline level or by setting up an alternative destination. |
 | debug.monitorDaxApdb | bool | `false` | Whether `dax_apdb` should run in debug mode and log metrics. |
 | fullnameOverride | string | `"prompt-keda"` | Override the full name for resources (includes the release name) |
+| iers_cache | string | `""` | The URI where IERS data has been pre-downloaded and cached for use by Prompt Processing. If empty, Prompt Processing does not try to update IERS data. |
 | image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev.  Set to `IfNotPresent` for scale testing in dev. | Pull policy for the Prompt Processing image |
 | image.repository | string | `"ghcr.io/lsst-dm/prompt-service"` | Image to use in the Prompt Processing deployment |
 | image.tag | string | `"latest"` | Overrides the image tag whose default is the chart appVersion. |

--- a/charts/prompt-keda/templates/_service-init.tpl
+++ b/charts/prompt-keda/templates/_service-init.tpl
@@ -45,6 +45,10 @@ spec:
           value: {{ .Values.s3.disableBucketValidation | toString | quote }}
         - name: CONFIG_APDB
           value: {{ .Values.apdb.config }}
+        {{- with .Values.iers_cache }}
+        - name: CENTRAL_IERS_CACHE
+          value: {{ . }}
+        {{- end }}
         - name: SASQUATCH_URL
           value: {{ .Values.sasquatch.endpointUrl }}
         {{- if and .Values.sasquatch.endpointUrl .Values.sasquatch.auth_env }}

--- a/charts/prompt-keda/templates/scaled-job.yaml
+++ b/charts/prompt-keda/templates/scaled-job.yaml
@@ -98,6 +98,10 @@ spec:
               - name: MP_SKY_URL
                 value: {{ . }}
               {{- end }}
+              {{- with .Values.iers_cache }}
+              - name: CENTRAL_IERS_CACHE
+                value: {{ . }}
+              {{- end }}
               - name: SASQUATCH_URL
                 value: {{ .Values.sasquatch.endpointUrl }}
               {{- if and .Values.sasquatch.endpointUrl .Values.sasquatch.auth_env }}

--- a/charts/prompt-keda/values.yaml
+++ b/charts/prompt-keda/values.yaml
@@ -89,6 +89,10 @@ raw_microservice: ""
 # Empty value is allowed, but its handling is undefined.
 mpSky_service: ""
 
+# -- The URI where IERS data has been pre-downloaded and cached for use by Prompt Processing.
+# If empty, Prompt Processing does not try to update IERS data.
+iers_cache: ""
+
 imageNotifications:
   # -- Hostname and port of the Kafka provider
   # @default -- None, must be set


### PR DESCRIPTION
This PR configures manual IERS downloads from a USDF-local cache. This is much faster than downloading directly from the public services.