### PR TITLE
Ignore spurious Flink differences

### DIFF
--- a/environments/templates/applications/monitoring/flink.yaml
+++ b/environments/templates/applications/monitoring/flink.yaml
@@ -31,4 +31,9 @@ spec:
       valueFiles:
         - "values.yaml"
         - "values-{{ .Values.name }}.yaml"
+  ignoreDifferences:
+    - group: "apiextensions.k8s.io"
+      kind: "CustomResourceDefinition"
+      jqPathExpressions:
+        - ".spec.versions.[].additionalPrinterColumns.[].priority"
 {{- end -}}


### PR DESCRIPTION
Configure Argo CD to ignore the priority field in the Flink CRDs, since it's not present upstream but is added automatically by Kubernetes, resulting in spurious differences.