### PR TITLE
Add alert message support for the Portal

### DIFF
--- a/applications/portal/README.md
+++ b/applications/portal/README.md
@@ -12,11 +12,12 @@ Rubin Science Platform Portal Aspect
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules for the Portal pod |
+| config.alertMessage | string | `nil` | If not null, display this alert to all users in a banner |
 | config.cleanupInterval | string | `"36h"` | How long results should be retained before being deleted |
 | config.debug | string | `"FALSE"` | Set to `TRUE` to enable service debugging |
 | config.hipsUrl | string | `/api/hips/images/color_gri` in the local Science Platform | URL for default HiPS service |
 | config.livetap | string | `""` | Endpoint under `/api/` for the live TAP service on the instance, if present |
-| config.showUserInfo | string | `"true"` |  |
+| config.showUserInfo | string | `"true"` | Whether to show information about the logged-in user |
 | config.ssotap | string | `""` | Endpoint under `/api/` for the DP0.3 SSO TAP service on the instance, if present |
 | config.tapHistoryLimit | string | `"50"` | Maximum number of recent TAP queries to show in history |
 | config.visualizeFitsSearchPath | string | `"/datasets"` | Search path for FITS files |

--- a/applications/portal/templates/alert-configmap.yaml
+++ b/applications/portal/templates/alert-configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "portal-alerts"
+  labels:
+    {{- include "portal.labels" . | nindent 4 }}
+data:
+  {{- if .Values.config.alertMessage }}
+  message.txt: {{ .Values.config.alertMessage | quote }}
+  {{- end }}

--- a/applications/portal/templates/statefulset.yaml
+++ b/applications/portal/templates/statefulset.yaml
@@ -227,6 +227,9 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
+            - mountPath: "/firefly/alerts"
+              name: "alerts"
+              readOnly: true
             - mountPath: "/firefly/shared-workarea"
               name: "firefly-shared-workarea"
             - mountPath: "/firefly/config"
@@ -241,6 +244,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
+        - name: "alerts"
+          configMap:
+            name: "portal-alerts"
         - name: "firefly-shared-workarea"
           {{- if .Values.config.volumes.sharedWorkarea.hostPath }}
           hostPath:

--- a/applications/portal/values-idfdev.yaml
+++ b/applications/portal/values-idfdev.yaml
@@ -1,6 +1,9 @@
 replicaCount: 2
 
 config:
+  alertMessage: |
+    This is a test alert message.
+    It should be shown to all users.
   volumes:
     cleanupInterval: "1h"
     sharedWorkarea:

--- a/applications/portal/values.yaml
+++ b/applications/portal/values.yaml
@@ -57,6 +57,9 @@ securityContext:
   fsGroup: 91
 
 config:
+  # -- If not null, display this alert to all users in a banner
+  alertMessage: null
+
   # -- Set to `TRUE` to enable service debugging
   debug: "FALSE"
 
@@ -67,6 +70,7 @@ config:
   # @default -- `/api/hips/images/color_gri` in the local Science Platform
   hipsUrl: ""
 
+  # -- Whether to show information about the logged-in user
   showUserInfo: "true"
 
   # -- Search path for FITS files


### PR DESCRIPTION
Mount a `ConfigMap` in the Portal so that we can drop alerts into the place where Firefly looks for them. The outage banner can be added and removed by changing `values-<env>.yaml` to add or remove `config.alertMessage` and syncing the Portal. Syncing should not restart the Portal if all you changed is the `ConfigMap`.