### PR TITLE
[DM-51746] Add secret for data-transfer-monitoring KafkaUser

### DIFF
--- a/applications/sasquatch/secrets.yaml
+++ b/applications/sasquatch/secrets.yaml
@@ -119,3 +119,9 @@ squadcast-webhook:
   description: >-
     Webhook URL for Squadcast alerts from Kapacitor
   if: kapacitor.squadcast.enabled
+data-transfer-monitoring-password:
+  description: >-
+    Password for the data-transfer-monitoring KafkaUser.
+  generate:
+    type: password
+  if: data-transfer-monitoring.enabled


### PR DESCRIPTION
The data-transfer-monitoring subchart is enabled at both Summit and USDF and create the data-transfer-monitoring KafkaUser.