### PR TITLE
[DM-49517] Setup a standby InfluxDB Enterprise instance at the Summit

### DIFF
--- a/applications/sasquatch/values-summit.yaml
+++ b/applications/sasquatch/values-summit.yaml
@@ -90,26 +90,7 @@ strimzi-kafka:
       enabled: true
 
 influxdb:
-  image:
-    tag: "1.8.10"
-  persistence:
-    storageClass: rook-ceph-block
-    size: 5Ti
-  ingress:
-    enabled: false
-    hostname: summit-lsp.lsst.codes
-  resources:
-    requests:
-      memory: 128Gi
-      cpu: 16
-    limits:
-      memory: 128Gi
-      cpu: 16
-
-customInfluxDBIngress:
-  enabled: true
-  hostname: summit-lsp.lsst.codes
-  path: "/influxdb-standby(/|$)(.*)"
+  enabled: false
 
 influxdb-enterprise:
   enabled: true

--- a/applications/sasquatch/values-summit.yaml
+++ b/applications/sasquatch/values-summit.yaml
@@ -141,6 +141,57 @@ influxdb-enterprise:
         memory: 256Gi
         cpu: 8
 
+influxdb-enterprise-standby:
+  enabled: true
+  license:
+    secret:
+      name: sasquatch
+      key: influxdb-enterprise-standby-license
+  meta:
+    ingress:
+      enabled: true
+      hostname: summit-lsp.lsst.codes
+      path: "/influxdb-enterprise-standby-meta(/|$)(.*)"
+    persistence:
+      enabled: true
+      accessMode: ReadWriteOnce
+      size: 16Gi
+    sharedSecret:
+      secret:
+        name: sasquatch
+        key: influxdb-enterprise-standby-shared-secret
+  data:
+    replicas: 1
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                  - key: influxdb.influxdata.com/component
+                    operator: In
+                    values:
+                      - data
+              topologyKey: kubernetes.io/hostname
+    ingress:
+      enabled: true
+      hostname: summit-lsp.lsst.codes
+      path: "/influxdb-enterprise-standby-data(/|$)(.*)"
+    persistence:
+      enabled: true
+      accessMode: ReadWriteOnce
+      size: 5Ti
+    resources:
+      requests:
+        memory: 96Gi
+        # The InfluxDB Enterprise license is limited to 16 cpu, the
+        # standby instance uses a 1 node x 16 cpu setup
+        cpu: 16
+      limits:
+        memory: 96Gi
+        cpu: 16
+
 # Dual write to the InfluxDB Enterprise and InfluxDB OSS instances
 telegraf:
   enabled: true

--- a/applications/sasquatch/values-summit.yaml
+++ b/applications/sasquatch/values-summit.yaml
@@ -198,6 +198,7 @@ telegraf:
   influxdb:
     urls:
       - "http://sasquatch-influxdb-enterprise-data.sasquatch:8086"
+      - "http://sasquatch-influxdb-enterprise-standby-data.sasquatch:8086"
   kafkaConsumers:
     # Application connectors
     obsenv:

--- a/applications/sasquatch/values-summit.yaml
+++ b/applications/sasquatch/values-summit.yaml
@@ -147,7 +147,6 @@ telegraf:
   influxdb:
     urls:
       - "http://sasquatch-influxdb-enterprise-data.sasquatch:8086"
-      - "http://sasquatch-influxdb.sasquatch:8086"
   kafkaConsumers:
     # Application connectors
     obsenv:


### PR DESCRIPTION
We are replacing the standby InfluxDB OSS by InfluxDB Enterprise at the Summit