### PR TITLE
DM-51772: Upgrade Qserv TAP service to version 3.4.2

### DIFF
--- a/charts/cadc-tap/README.md
+++ b/charts/cadc-tap/README.md
@@ -47,7 +47,7 @@ IVOA TAP service
 | config.qserv.host | string | `"mock-db:3306"` (the mock QServ) | QServ hostname:port to connect to |
 | config.qserv.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the TAP image |
 | config.qserv.image.repository | string | `"ghcr.io/lsst-sqre/lsst-tap-service"` | TAP image to use |
-| config.qserv.image.tag | string | `"3.4.1"` | Tag of TAP image to use |
+| config.qserv.image.tag | string | `"3.4.2"` | Tag of TAP image to use |
 | config.qserv.jdbcParams | string | `""` | Extra JDBC connection parameters |
 | config.qserv.passwordEnabled | bool | false | Whether the Qserv database is password protected |
 | config.sentryEnabled | bool | `false` | Whether Sentry is enabled in this environment |
@@ -94,7 +94,7 @@ IVOA TAP service
 | uws.affinity | object | `{}` | Affinity rules for the UWS database pod |
 | uws.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the UWS database image |
 | uws.image.repository | string | `"ghcr.io/lsst-sqre/lsst-tap-uws-db"` | UWS database image to use |
-| uws.image.tag | string | `"3.4.1"` | Tag of UWS database image to use |
+| uws.image.tag | string | `"3.4.2"` | Tag of UWS database image to use |
 | uws.nodeSelector | object | `{}` | Node selection rules for the UWS database pod |
 | uws.podAnnotations | object | `{}` | Annotations for the UWS databse pod |
 | uws.resources | object | See `values.yaml` | Resource limits and requests for the UWS database pod |

--- a/charts/cadc-tap/values.yaml
+++ b/charts/cadc-tap/values.yaml
@@ -89,7 +89,7 @@ config:
       pullPolicy: "IfNotPresent"
 
       # -- Tag of TAP image to use
-      tag: "3.4.1"
+      tag: "3.4.2"
 
     # -- Whether the Qserv database is password protected
     # @default -- false
@@ -245,7 +245,7 @@ uws:
     pullPolicy: "IfNotPresent"
 
     # -- Tag of UWS database image to use
-    tag: "3.4.1"
+    tag: "3.4.2"
 
   # -- Resource limits and requests for the UWS database pod
   # @default -- See `values.yaml`


### PR DESCRIPTION
TAP 3.4.2 Changes:
- Includes upgrade of cadc-adql to 1.16.0 which does not allow use of LIMIT in ADQL queries