### PR TITLE
[DM-42378] ArgoCD does not recognize Strimzi PVCs

### DIFF
--- a/applications/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
@@ -22,6 +22,11 @@ spec:
       {{- end}}
       deleteClaim: false
   template:
+    persistentVolumeClaim:
+      metadata:
+        annotations:
+          argocd.argoproj.io/compare-options: IgnoreExtraneous
+          argocd.argoproj.io/sync-options: Prune=false
     pod:
       {{- with .Values.controller.affinity }}
       affinity:
@@ -61,6 +66,11 @@ spec:
       {{- end}}
       deleteClaim: false
   template:
+    persistentVolumeClaim:
+      metadata:
+        annotations:
+          argocd.argoproj.io/compare-options: IgnoreExtraneous
+          argocd.argoproj.io/sync-options: Prune=false
     pod:
       {{- with .Values.broker.affinity }}
       affinity:
@@ -142,12 +152,6 @@ metadata:
     strimzi.io/node-pools: enabled
 spec:
   kafka:
-    template:
-      persistentVolumeClaim:
-        metadata:
-          annotations:
-            argocd.argoproj.io/compare-options: IgnoreExtraneous
-            argocd.argoproj.io/sync-options: Prune=false
     version: {{ .Values.kafka.version | quote }}
     listeners:
     {{- if .Values.kafka.listeners.plain.enabled }}

--- a/applications/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
@@ -148,15 +148,6 @@ spec:
           annotations:
             argocd.argoproj.io/compare-options: IgnoreExtraneous
             argocd.argoproj.io/sync-options: Prune=false
-      pod:
-        {{- with .Values.kafka.affinity }}
-        affinity:
-          {{- toYaml . | nindent 10 }}
-        {{- end }}
-        {{- with .Values.kafka.tolerations }}
-        tolerations:
-          {{- toYaml . | nindent 10 }}
-        {{- end }}
     version: {{ .Values.kafka.version | quote }}
     listeners:
     {{- if .Values.kafka.listeners.plain.enabled }}


### PR DESCRIPTION
We use the following annotations in the Strimzi PVCs

`argocd.argoproj.io/compare-options: IgnoreExtraneous` 
`argocd.argoproj.io/sync-options: Prune=false`

to prevent the parent app (Sasquatch in this case) to show as `OutOfSync` and  to prevent the PVCs from being deleted from the ArgoCD UI.

With KRaft, Strimzi introduced the `KafkaNodePool` resource and these annotations previously in `kafka.spec.template. persistentVolumeClaim` need to be moved under `kafkaNodePool.spec.template.persistentVolumeClaim` for both the controller and broker node pools.



