### PR TITLE
Fix link check errors and tweak GitHub CI job

### DIFF
--- a/.github/workflows/linkcheck.yaml
+++ b/.github/workflows/linkcheck.yaml
@@ -1,4 +1,4 @@
-# This is a separate documentation build just to check links.  We don't check
+# This is a separate documentation build just to check links. We don't check
 # links as part of the normal documentation build since, unlike Sphinx errors
 # and warnings, we don't want broken links to block a merge. (Sometimes they
 # will be fixed by the same merge, sometimes they're temporary rate limit
@@ -22,7 +22,7 @@ env:
     branches-ignore:
       # These should always correspond to pull requests, so ignore them for
       # the push trigger and let them be triggered by the pull_request
-      # trigger, avoiding running the workflow twice.  This is a minor
+      # trigger, avoiding running the workflow twice. This is a minor
       # optimization so there's no need to ensure this is comprehensive.
       - "dependabot/**"
       - "gh-readonly-queue/**"
@@ -32,11 +32,10 @@ env:
     tags:
       - "*"
     paths:
+      # Only check links on changes that are likely to include links that
+      # might break with the change. Rely on the weekly check to pick up other
+      # bad links.
       - "docs/**"
-      - "applications/*/Chart.yaml"
-      - "applications/*/values.yaml"
-      - "applications/gafaelfawr/values-*.yaml"
-      - "environments/values-*.yaml"
   schedule:
     - cron: "0 12 * * 1"
   workflow_dispatch: {}
@@ -44,6 +43,9 @@ env:
 jobs:
   linkcheck:
     runs-on: ubuntu-latest
+
+    # Takes about 35m to run with rate limiting from GitHub as of 2025-07-14.
+    timeout-minutes: 60
 
     steps:
       - name: Checkout

--- a/docs/developers/helm-chart/add-application.rst
+++ b/docs/developers/helm-chart/add-application.rst
@@ -32,8 +32,6 @@ Configure other Phalanx applications
 If the application needs to listen on hostnames other than the normal cluster-wide hostname, you will need to configure :px-app:`cert-manager` so that it can generate a TLS certificate for that hostname.
 See :doc:`/applications/cert-manager/add-new-hostname` for more details.
 
-If your application exposes Prometheus endpoints, you will want to configure these in the `telegraf application's prometheus_config <https://github.com/lsst-sqre/phalanx/blob/main/applications/telegraf/values.yaml>`__.
-
 Enable the application for some environment
 ===========================================
 

--- a/src/phalanx/github.py
+++ b/src/phalanx/github.py
@@ -6,7 +6,7 @@ Actions and, if so, add additional GitHub-specific markers to the output to
 improve display in GitHub Actions logs.
 
 See `GitHub's documentation
-<https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions>`__
+<https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions>`__
 for other possibly useful commands that could be added.
 """
 


### PR DESCRIPTION
Trigger the GitHub linkcheck CI job only on documentation changes, since it's expensive and triggering it on every `values.yaml` and `Chart.yaml` change feels like a bit too much. Fix a couple of broken links, and add a timeout on the link check that's about twice the current runtime.