### PR TITLE
DM-51817: wobbly - graceful shutdown

### DIFF
--- a/applications/wobbly/templates/deployment.yaml
+++ b/applications/wobbly/templates/deployment.yaml
@@ -117,6 +117,23 @@ spec:
               readOnly: true
               subPath: "ssl.keystore.key"
           {{- end }}
+          lifecycle:
+            # Number of seconds k8s should wait before sending SIGTERM on
+            # graceful restarts/deployments/shutdowns. We need this because it
+            # takes ingress-nginx some time to configure itself to stop sending
+            # traffic to the pods scheduled for termination. If Uvicorn gets
+            # the SIGTERM and starts closing connections, we could end up with
+            # a TCP condition if ingress-nginx still tries to send data over
+            # those connections.
+            #
+            # Note that terminationGracePeriodSeconds includes the time that is
+            # spent in the preStop hook. If you’re adding a preStop hook and
+            # your terminationGracePeriodSeconds is super fine-tuned, then you
+            # should update your terminationGracePeriodSeconds to add the
+            # amount of time you’ll be spending in your preStop hook.
+            preStop:
+              sleep:
+                seconds: 10
       {{- if .Values.cloudsql.enabled }}
       initContainers:
         {{- include "wobbly.cloudsqlSidecar" . | nindent 8 }}


### PR DESCRIPTION
We need this because it takes ingress-nginx some time to configure itself to stop sending traffic to the pods scheduled for termination. If Uvicorn gets the SIGTERM and starts closing connections, we could end up with a TCP race condition if ingress-nginx still tries to send data over those connections, which would result in the client getting 502 responses.

Before and after the fix:
<img width="2294" height="167" alt="image" src="https://github.com/user-attachments/assets/e41e1bed-95c8-4fd9-a56b-6abd9c420246" />

