### PR TITLE
DM-51768: Support dax_apdb metrics in Prompt Processing

### DIFF
--- a/applications/prompt-keda-hsc/README.md
+++ b/applications/prompt-keda-hsc/README.md
@@ -22,6 +22,7 @@ KEDA Prompt Processing instance for HSC
 | prompt-keda.cache.patchesPerImage | int | `6` | A factor by which to multiply `baseSize` for templates and other patch-based datasets. |
 | prompt-keda.cache.refcatsPerImage | int | `4` | A factor by which to multiply `baseSize` for refcat datasets. |
 | prompt-keda.debug.exportOutputs | bool | `true` | Whether or not pipeline outputs should be exported to the central repo. This flag does not turn off APDB writes or alert generation; those must be handled at the pipeline level or by setting up an alternative destination. |
+| prompt-keda.debug.monitorDaxApdb | bool | `false` | Whether `dax_apdb` should run in debug mode and log metrics. |
 | prompt-keda.fullnameOverride | string | `"prompt-keda-hsc"` | Override the full name for resources (includes the release name) |
 | prompt-keda.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
 | prompt-keda.image.repository | string | `"ghcr.io/lsst-dm/prompt-service"` | Image to use in the PP deployment |

--- a/applications/prompt-keda-hsc/values.yaml
+++ b/applications/prompt-keda-hsc/values.yaml
@@ -119,7 +119,10 @@ prompt-keda:
 
   # -- Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level).
   # @default -- log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING.
-  logLevel: "timer.lsst.activator=DEBUG timer.lsst.daf.butler=DEBUG lsst.associateApdb=VERBOSE lsst.loadDiaCatalogs=VERBOSE lsst.computeReliability=VERBOSE lsst.daf.butler=VERBOSE"
+  logLevel: >-
+    timer.lsst.activator=DEBUG timer.lsst.daf.butler=DEBUG
+    lsst.associateApdb=VERBOSE lsst.loadDiaCatalogs=VERBOSE lsst.computeReliability=VERBOSE
+    lsst.daf.butler=VERBOSE
 
   sasquatch:
     # -- Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload.

--- a/applications/prompt-keda-hsc/values.yaml
+++ b/applications/prompt-keda-hsc/values.yaml
@@ -213,6 +213,8 @@ prompt-keda:
     # -- Whether or not pipeline outputs should be exported to the central repo.
     # This flag does not turn off APDB writes or alert generation; those must be handled at the pipeline level or by setting up an alternative destination.
     exportOutputs: true
+    # -- Whether `dax_apdb` should run in debug mode and log metrics.
+    monitorDaxApdb: false
 
 
   # -- Kubernetes resource requests and limits

--- a/applications/prompt-keda-latiss/README.md
+++ b/applications/prompt-keda-latiss/README.md
@@ -22,6 +22,7 @@ KEDA Prompt Processing instance for LATISS
 | prompt-keda.cache.patchesPerImage | int | `6` | A factor by which to multiply `baseSize` for templates and other patch-based datasets. |
 | prompt-keda.cache.refcatsPerImage | int | `4` | A factor by which to multiply `baseSize` for refcat datasets. |
 | prompt-keda.debug.exportOutputs | bool | `true` | Whether or not pipeline outputs should be exported to the central repo. This flag does not turn off APDB writes or alert generation; those must be handled at the pipeline level or by setting up an alternative destination. |
+| prompt-keda.debug.monitorDaxApdb | bool | `false` | Whether `dax_apdb` should run in debug mode and log metrics. |
 | prompt-keda.fullnameOverride | string | `"prompt-keda-latiss"` | Override the full name for resources (includes the release name) |
 | prompt-keda.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
 | prompt-keda.image.repository | string | `"ghcr.io/lsst-dm/prompt-service"` | Image to use in the PP deployment |

--- a/applications/prompt-keda-latiss/values.yaml
+++ b/applications/prompt-keda-latiss/values.yaml
@@ -211,6 +211,8 @@ prompt-keda:
     # -- Whether or not pipeline outputs should be exported to the central repo.
     # This flag does not turn off APDB writes or alert generation; those must be handled at the pipeline level or by setting up an alternative destination.
     exportOutputs: true
+    # -- Whether `dax_apdb` should run in debug mode and log metrics.
+    monitorDaxApdb: false
 
 
   # -- Kubernetes resource requests and limits

--- a/applications/prompt-keda-latiss/values.yaml
+++ b/applications/prompt-keda-latiss/values.yaml
@@ -117,7 +117,10 @@ prompt-keda:
 
   # -- Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level).
   # @default -- log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING.
-  logLevel: "timer.lsst.activator=DEBUG timer.lsst.daf.butler=DEBUG lsst.associateApdb=VERBOSE lsst.loadDiaCatalogs=VERBOSE lsst.computeReliability=VERBOSE lsst.daf.butler=VERBOSE"
+  logLevel: >-
+    timer.lsst.activator=DEBUG timer.lsst.daf.butler=DEBUG
+    lsst.associateApdb=VERBOSE lsst.loadDiaCatalogs=VERBOSE lsst.computeReliability=VERBOSE
+    lsst.daf.butler=VERBOSE
 
   sasquatch:
     # -- Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload.

--- a/applications/prompt-keda-lsstcam/README.md
+++ b/applications/prompt-keda-lsstcam/README.md
@@ -22,6 +22,7 @@ KEDA Prompt Processing instance for LSSTCam
 | prompt-keda.cache.patchesPerImage | int | `12` | A factor by which to multiply `baseSize` for templates and other patch-based datasets. |
 | prompt-keda.cache.refcatsPerImage | int | `6` | A factor by which to multiply `baseSize` for refcat datasets. |
 | prompt-keda.debug.exportOutputs | bool | `true` | Whether or not pipeline outputs should be exported to the central repo. This flag does not turn off APDB writes or alert generation; those must be handled at the pipeline level or by setting up an alternative destination. |
+| prompt-keda.debug.monitorDaxApdb | bool | `false` | Whether `dax_apdb` should run in debug mode and log metrics. |
 | prompt-keda.fullnameOverride | string | `"prompt-keda-lsstcam"` | Override the full name for resources (includes the release name) |
 | prompt-keda.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
 | prompt-keda.image.repository | string | `"ghcr.io/lsst-dm/prompt-service"` | Image to use in the PP deployment |

--- a/applications/prompt-keda-lsstcam/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-keda-lsstcam/values-usdfprod-prompt-processing.yaml
@@ -101,6 +101,9 @@ prompt-keda:
     namespace: lsst.prompt.prod
     auth_env: false
 
+  debug:
+    monitorDaxApdb: true
+
   keda:
     minReplicaCount: 3
     maxReplicaCount: 1700

--- a/applications/prompt-keda-lsstcam/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-keda-lsstcam/values-usdfprod-prompt-processing.yaml
@@ -90,7 +90,10 @@ prompt-keda:
   apdb:
     config: s3://rubin-summit-users/apdb_config/cassandra/pp_apdb_lsstcam.yaml
 
-  logLevel: timer.lsst.activator=DEBUG timer.lsst.daf.butler=VERBOSE lsst.associateApdb=VERBOSE lsst.loadDiaCatalogs=VERBOSE lsst.computeReliability=VERBOSE lsst.daf.butler=VERBOSE
+  logLevel: >-
+    timer.lsst.activator=DEBUG timer.lsst.daf.butler=VERBOSE
+    lsst.associateApdb=VERBOSE lsst.loadDiaCatalogs=VERBOSE lsst.computeReliability=VERBOSE
+    lsst.daf.butler=VERBOSE
 
   sasquatch:
     # TODO: production Sasquatch not yet ready

--- a/applications/prompt-keda-lsstcam/values.yaml
+++ b/applications/prompt-keda-lsstcam/values.yaml
@@ -139,6 +139,8 @@ prompt-keda:
     # -- Whether or not pipeline outputs should be exported to the central repo.
     # This flag does not turn off APDB writes or alert generation; those must be handled at the pipeline level or by setting up an alternative destination.
     exportOutputs: true
+    # -- Whether `dax_apdb` should run in debug mode and log metrics.
+    monitorDaxApdb: false
 
   keda:
     # -- Minimum number of replicas to start with.

--- a/applications/prompt-keda-lsstcam/values.yaml
+++ b/applications/prompt-keda-lsstcam/values.yaml
@@ -119,7 +119,10 @@ prompt-keda:
 
   # -- Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level).
   # @default -- log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING.
-  logLevel: "timer.lsst.activator=DEBUG timer.lsst.daf.butler=DEBUG lsst.associateApdb=VERBOSE lsst.loadDiaCatalogs=VERBOSE lsst.computeReliability=VERBOSE lsst.daf.butler=VERBOSE"
+  logLevel: >-
+    timer.lsst.activator=DEBUG timer.lsst.daf.butler=DEBUG
+    lsst.associateApdb=VERBOSE lsst.loadDiaCatalogs=VERBOSE lsst.computeReliability=VERBOSE
+    lsst.daf.butler=VERBOSE
 
   sasquatch:
     # -- Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload.

--- a/applications/prompt-keda-lsstcamimsim/README.md
+++ b/applications/prompt-keda-lsstcamimsim/README.md
@@ -22,6 +22,7 @@ KEDA Prompt Processing instance for LSSTCam-imSim.
 | prompt-keda.cache.patchesPerImage | int | `12` | A factor by which to multiply `baseSize` for templates and other patch-based datasets. |
 | prompt-keda.cache.refcatsPerImage | int | `6` | A factor by which to multiply `baseSize` for refcat datasets. |
 | prompt-keda.debug.exportOutputs | bool | `true` | Whether or not pipeline outputs should be exported to the central repo. This flag does not turn off APDB writes or alert generation; those must be handled at the pipeline level or by setting up an alternative destination. |
+| prompt-keda.debug.monitorDaxApdb | bool | `false` | Whether `dax_apdb` should run in debug mode and log metrics. |
 | prompt-keda.fullnameOverride | string | `"prompt-keda-lsstcamimsim"` | Override the full name for resources (includes the release name) |
 | prompt-keda.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
 | prompt-keda.image.repository | string | `"ghcr.io/lsst-dm/prompt-service"` | Image to use in the PP deployment |

--- a/applications/prompt-keda-lsstcamimsim/values.yaml
+++ b/applications/prompt-keda-lsstcamimsim/values.yaml
@@ -139,6 +139,8 @@ prompt-keda:
     # -- Whether or not pipeline outputs should be exported to the central repo.
     # This flag does not turn off APDB writes or alert generation; those must be handled at the pipeline level or by setting up an alternative destination.
     exportOutputs: true
+    # -- Whether `dax_apdb` should run in debug mode and log metrics.
+    monitorDaxApdb: false
 
   keda:
     # -- Minimum number of replicas to start with.

--- a/applications/prompt-keda-lsstcamimsim/values.yaml
+++ b/applications/prompt-keda-lsstcamimsim/values.yaml
@@ -119,7 +119,10 @@ prompt-keda:
 
   # -- Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level).
   # @default -- log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING.
-  logLevel: "timer.lsst.activator=DEBUG timer.lsst.daf.butler=DEBUG lsst.associateApdb=VERBOSE lsst.loadDiaCatalogs=VERBOSE lsst.computeReliability=VERBOSE lsst.daf.butler=VERBOSE"
+  logLevel: >-
+    timer.lsst.activator=DEBUG timer.lsst.daf.butler=DEBUG
+    lsst.associateApdb=VERBOSE lsst.loadDiaCatalogs=VERBOSE lsst.computeReliability=VERBOSE
+    lsst.daf.butler=VERBOSE
 
   sasquatch:
     # -- Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload.

--- a/applications/prompt-keda-lsstcomcam/README.md
+++ b/applications/prompt-keda-lsstcomcam/README.md
@@ -21,6 +21,8 @@ KEDA Prompt Processing instance for LSSTComCam.
 | prompt-keda.cache.baseSize | int | `3` | The default number of datasets of each type to keep. The pipeline only needs one of most dataset types (one bias, one flat, etc.), so this is roughly the number of visits that fit in the cache. |
 | prompt-keda.cache.patchesPerImage | int | `16` | A factor by which to multiply `baseSize` for templates and other patch-based datasets. |
 | prompt-keda.cache.refcatsPerImage | int | `6` | A factor by which to multiply `baseSize` for refcat datasets. |
+| prompt-keda.debug.exportOutputs | bool | `true` | Whether or not pipeline outputs should be exported to the central repo. This flag does not turn off APDB writes or alert generation; those must be handled at the pipeline level or by setting up an alternative destination. |
+| prompt-keda.debug.monitorDaxApdb | bool | `false` | Whether `dax_apdb` should run in debug mode and log metrics. |
 | prompt-keda.fullnameOverride | string | `"prompt-keda-lsstcomcam"` | Override the full name for resources (includes the release name) |
 | prompt-keda.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
 | prompt-keda.image.repository | string | `"ghcr.io/lsst-dm/prompt-service"` | Image to use in the PP deployment |

--- a/applications/prompt-keda-lsstcomcam/values.yaml
+++ b/applications/prompt-keda-lsstcomcam/values.yaml
@@ -204,6 +204,13 @@ prompt-keda:
   # -- Override the full name for resources (includes the release name)
   fullnameOverride: "prompt-keda-lsstcomcam"
 
+  debug:
+    # -- Whether or not pipeline outputs should be exported to the central repo.
+    # This flag does not turn off APDB writes or alert generation; those must be handled at the pipeline level or by setting up an alternative destination.
+    exportOutputs: true
+    # -- Whether `dax_apdb` should run in debug mode and log metrics.
+    monitorDaxApdb: false
+
   # -- Kubernetes resource requests and limits
   # @default -- See `values.yaml`
   resources:

--- a/applications/prompt-keda-lsstcomcam/values.yaml
+++ b/applications/prompt-keda-lsstcomcam/values.yaml
@@ -118,7 +118,10 @@ prompt-keda:
 
   # -- Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level).
   # @default -- log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING.
-  logLevel: "timer.lsst.activator=DEBUG timer.lsst.daf.butler=DEBUG lsst.associateApdb=VERBOSE lsst.loadDiaCatalogs=VERBOSE lsst.computeReliability=VERBOSE lsst.daf.butler=VERBOSE"
+  logLevel: >-
+    timer.lsst.activator=DEBUG timer.lsst.daf.butler=DEBUG
+    lsst.associateApdb=VERBOSE lsst.loadDiaCatalogs=VERBOSE lsst.computeReliability=VERBOSE
+    lsst.daf.butler=VERBOSE
 
   sasquatch:
     # -- Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload.

--- a/applications/prompt-keda-lsstcomcamsim/README.md
+++ b/applications/prompt-keda-lsstcomcamsim/README.md
@@ -22,6 +22,7 @@ KEDA Prompt Processing instance for LSSTComCamSim
 | prompt-keda.cache.patchesPerImage | int | `16` | A factor by which to multiply `baseSize` for templates and other patch-based datasets. |
 | prompt-keda.cache.refcatsPerImage | int | `6` | A factor by which to multiply `baseSize` for refcat datasets. |
 | prompt-keda.debug.exportOutputs | bool | `true` | Whether or not pipeline outputs should be exported to the central repo. This flag does not turn off APDB writes or alert generation; those must be handled at the pipeline level or by setting up an alternative destination. |
+| prompt-keda.debug.monitorDaxApdb | bool | `false` | Whether `dax_apdb` should run in debug mode and log metrics. |
 | prompt-keda.fullnameOverride | string | `"prompt-keda-lsstcomcamsim"` | Override the full name for resources (includes the release name) |
 | prompt-keda.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev | Pull policy for the PP image |
 | prompt-keda.image.repository | string | `"ghcr.io/lsst-dm/prompt-service"` | Image to use in the PP deployment |

--- a/applications/prompt-keda-lsstcomcamsim/values.yaml
+++ b/applications/prompt-keda-lsstcomcamsim/values.yaml
@@ -214,6 +214,8 @@ prompt-keda:
     # -- Whether or not pipeline outputs should be exported to the central repo.
     # This flag does not turn off APDB writes or alert generation; those must be handled at the pipeline level or by setting up an alternative destination.
     exportOutputs: true
+    # -- Whether `dax_apdb` should run in debug mode and log metrics.
+    monitorDaxApdb: false
 
   # -- Kubernetes resource requests and limits
   # @default -- See `values.yaml`

--- a/applications/prompt-keda-lsstcomcamsim/values.yaml
+++ b/applications/prompt-keda-lsstcomcamsim/values.yaml
@@ -120,7 +120,10 @@ prompt-keda:
 
   # -- Requested logging levels in the format of [Middleware's \-\-log-level argument](https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level).
   # @default -- log prompt_processing at DEBUG, other LSST code at INFO, and third-party code at WARNING.
-  logLevel: "timer.lsst.activator=DEBUG timer.lsst.daf.butler=DEBUG lsst.associateApdb=VERBOSE lsst.loadDiaCatalogs=VERBOSE lsst.computeReliability=VERBOSE lsst.daf.butler=VERBOSE"
+  logLevel: >-
+    timer.lsst.activator=DEBUG timer.lsst.daf.butler=DEBUG
+    lsst.associateApdb=VERBOSE lsst.loadDiaCatalogs=VERBOSE lsst.computeReliability=VERBOSE
+    lsst.daf.butler=VERBOSE
 
   sasquatch:
     # -- Url of the Sasquatch proxy server to upload metrics to. Leave blank to disable upload.

--- a/charts/prompt-keda/README.md
+++ b/charts/prompt-keda/README.md
@@ -22,6 +22,7 @@ Event-driven processing of camera images
 | cache.patchesPerImage | int | `4` | A factor by which to multiply `baseSize` for templates and other patch-based datasets. |
 | cache.refcatsPerImage | int | `4` | A factor by which to multiply `baseSize` for refcat datasets. |
 | debug.exportOutputs | bool | `true` | Whether or not pipeline outputs should be exported to the central repo. This flag does not turn off APDB writes or alert generation; those must be handled at the pipeline level or by setting up an alternative destination. |
+| debug.monitorDaxApdb | bool | `false` | Whether `dax_apdb` should run in debug mode and log metrics. |
 | fullnameOverride | string | `"prompt-keda"` | Override the full name for resources (includes the release name) |
 | image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev.  Set to `IfNotPresent` for scale testing in dev. | Pull policy for the Prompt Processing image |
 | image.repository | string | `"ghcr.io/lsst-dm/prompt-service"` | Image to use in the Prompt Processing deployment |

--- a/charts/prompt-keda/templates/scaled-job.yaml
+++ b/charts/prompt-keda/templates/scaled-job.yaml
@@ -163,6 +163,10 @@ spec:
                 value: {{ .Values.cache.patchesPerImage | toString | quote }}
               - name: DEBUG_EXPORT_OUTPUTS
                 value: {{ if .Values.debug.exportOutputs }}'1'{{ else }}'0'{{ end }}
+              {{- if .Values.debug.monitorDaxApdb }}
+              - name: DAX_APDB_MONITOR_CONFIG
+                value: 'logging:lsst.dax.apdb.monitor'
+              {{- end }}
               - name: REDIS_STREAM_HOST
                 value: {{ .Values.keda.redisStreams.host}}
               - name: REDIS_STREAM_NAME

--- a/charts/prompt-keda/values.yaml
+++ b/charts/prompt-keda/values.yaml
@@ -213,6 +213,8 @@ debug:
   # -- Whether or not pipeline outputs should be exported to the central repo.
   # This flag does not turn off APDB writes or alert generation; those must be handled at the pipeline level or by setting up an alternative destination.
   exportOutputs: true
+  # -- Whether `dax_apdb` should run in debug mode and log metrics.
+  monitorDaxApdb: false
 
 
 # -- Kubernetes resource requests and limits


### PR DESCRIPTION
This PR adds a `dax_apdb` metrics configuration flag to Prompt Processing, and turns it on for the production instance.