### PR TITLE
Review usdfdev resources for Sasquatch

### DIFF
--- a/applications/sasquatch/values-usdfdev.yaml
+++ b/applications/sasquatch/values-usdfdev.yaml
@@ -57,7 +57,13 @@ influxdb:
   config:
     coordinator:
       query-timeout: 300s
-
+  resources:
+    requests:
+      memory: 96Gi
+      cpu: 8
+    limits:
+      memory: 96Gi
+      cpu: 8
 
 customInfluxDBIngress:
   enabled: true

--- a/applications/sasquatch/values-usdfdev.yaml
+++ b/applications/sasquatch/values-usdfdev.yaml
@@ -44,8 +44,10 @@ strimzi-kafka:
     enabled: true
 
 influxdb:
-  livenessProbe:
-    initialDelaySeconds: 360
+  startupProbe:
+    enabled: true
+    failureThreshold: 12
+    periodSeconds: 300
   ingress:
     enabled: false
     hostname: usdf-rsp-dev.slac.stanford.edu

--- a/environments/values-usdfdev.yaml
+++ b/environments/values-usdfdev.yaml
@@ -46,3 +46,6 @@ applications:
   tap: true
   tasso: true
   times-square: true
+
+revisions:
+  strimzi: strimzi-0.45.0


### PR DESCRIPTION
The InfluxDB OSS instance at usdfdev is taking too long to start up because of high cardinality so we need to increase memory resources.
Add a startup probe for InfluxDB OSS to avoid it getting killed by the liveness and readiness probes before it is up and running.
This environment apparently needs Strimzi 0.45.0 as well because an incompatibility issue with Kafka Connect.