### PR TITLE
[DM-51848] Add signout redirect URL for Grafana

### DIFF
--- a/applications/grafana/templates/grafana.yaml
+++ b/applications/grafana/templates/grafana.yaml
@@ -63,6 +63,7 @@ spec:
     auth:
       # We'll assume that Gafaelfawr has already auth'd any requests that come in
       disable_login_form: {{ if .Values.grafana.authProxy.enabled }}"true"{{ else }}"false"{{ end }}
+      signout_redirect_url: {{ .Values.global.baseUrl }}
     auth.proxy:
       enabled: {{ if .Values.grafana.authProxy.enabled }}"true"{{ else }}"false"{{ end }}
       # HTTP Header name that will contain the username or email


### PR DESCRIPTION
Set [signout_redirect_url](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#signout_redirect_url ) to `global.baseUrl` so when users sign out from Grafana they are redirected to Squareone.

