### PR TITLE
Set proxy-busy-buffers-size in ingress-nginx

### DIFF
--- a/applications/ingress-nginx/README.md
+++ b/applications/ingress-nginx/README.md
@@ -19,6 +19,7 @@ Ingress controller
 | ingress-nginx.controller.config.large-client-header-buffers | string | `"4 64k"` | Size and number of the buffers used to read HTTP headers from clients. Increase this from its default size in case clients send large cookies. |
 | ingress-nginx.controller.config.proxy-body-size | string | `"100m"` | Maximum size of the client request body (needs to be large enough to allow table uploads) |
 | ingress-nginx.controller.config.proxy-buffer-size | string | `"64k"` | Maximum size of the buffer used to read HTTP headers from the backend or auth subrequest handler. This needs to be larger than the default because Gafaelfawr reflects all of the user's cookies other than the Gafaelfawr one. |
+| ingress-nginx.controller.config.proxy-busy-buffers-size | string | `"64k"` | Maximum size of the buffers that can be busy sending a response to the client. This must be at least as large as proxy-buffer-size. |
 | ingress-nginx.controller.config.server-snippet | string | See `values.yaml` | Add additional per-server configuration used by Gafaelfawr to report errors from the authorization layer |
 | ingress-nginx.controller.config.ssl-redirect | string | `"true"` | Redirect all non-SSL access to SSL |
 | ingress-nginx.controller.config.use-forwarded-headers | string | `"true"` | Enable the `X-Forwarded-For` processing |

--- a/applications/ingress-nginx/values.yaml
+++ b/applications/ingress-nginx/values.yaml
@@ -30,6 +30,10 @@ ingress-nginx:
       # than the Gafaelfawr one.
       proxy-buffer-size: "64k"
 
+      # -- Maximum size of the buffers that can be busy sending a response
+      # to the client. This must be at least as large as proxy-buffer-size.
+      proxy-busy-buffers-size: "64k"
+
       # -- Redirect all non-SSL access to SSL
       ssl-redirect: "true"
 


### PR DESCRIPTION
This now must be at least as large as proxy-buffer-size, which we increase to 64KB.