### PR TITLE
DM-51735: Stop caching spatial datasets in Prompt Processing

### DIFF
--- a/applications/prompt-keda-hsc/README.md
+++ b/applications/prompt-keda-hsc/README.md
@@ -19,8 +19,6 @@ KEDA Prompt Processing instance for HSC
 | prompt-keda.alerts.username | string | `""` | Username for sending alerts to the alert stream |
 | prompt-keda.apdb.config | string | None, must be set | URL to a serialized APDB configuration, or the "label:" prefix followed by the indexed name of such a config. |
 | prompt-keda.cache.baseSize | int | `3` | The default number of datasets of each type to keep. The pipeline only needs one of most dataset types (one bias, one flat, etc.), so this is roughly the number of visits that fit in the cache. |
-| prompt-keda.cache.patchesPerImage | int | `6` | A factor by which to multiply `baseSize` for templates and other patch-based datasets. |
-| prompt-keda.cache.refcatsPerImage | int | `4` | A factor by which to multiply `baseSize` for refcat datasets. |
 | prompt-keda.debug.exportOutputs | bool | `true` | Whether or not pipeline outputs should be exported to the central repo. This flag does not turn off APDB writes or alert generation; those must be handled at the pipeline level or by setting up an alternative destination. |
 | prompt-keda.debug.monitorDaxApdb | bool | `false` | Whether `dax_apdb` should run in debug mode and log metrics. |
 | prompt-keda.fullnameOverride | string | `"prompt-keda-hsc"` | Override the full name for resources (includes the release name) |

--- a/applications/prompt-keda-hsc/values.yaml
+++ b/applications/prompt-keda-hsc/values.yaml
@@ -52,10 +52,6 @@ prompt-keda:
     # -- The default number of datasets of each type to keep.
     # The pipeline only needs one of most dataset types (one bias, one flat, etc.), so this is roughly the number of visits that fit in the cache.
     baseSize: 3
-    # -- A factor by which to multiply `baseSize` for refcat datasets.
-    refcatsPerImage: 4
-    # -- A factor by which to multiply `baseSize` for templates and other patch-based datasets.
-    patchesPerImage: 6
 
   s3:
     # -- Bucket containing the incoming raw images

--- a/applications/prompt-keda-latiss/README.md
+++ b/applications/prompt-keda-latiss/README.md
@@ -19,8 +19,6 @@ KEDA Prompt Processing instance for LATISS
 | prompt-keda.alerts.username | string | `""` | Username for sending alerts to the alert stream |
 | prompt-keda.apdb.config | string | None, must be set | URL to a serialized APDB configuration, or the "label:" prefix followed by the indexed name of such a config. |
 | prompt-keda.cache.baseSize | int | `3` | The default number of datasets of each type to keep. The pipeline only needs one of most dataset types (one bias, one flat, etc.), so this is roughly the number of visits that fit in the cache. |
-| prompt-keda.cache.patchesPerImage | int | `6` | A factor by which to multiply `baseSize` for templates and other patch-based datasets. |
-| prompt-keda.cache.refcatsPerImage | int | `4` | A factor by which to multiply `baseSize` for refcat datasets. |
 | prompt-keda.debug.exportOutputs | bool | `true` | Whether or not pipeline outputs should be exported to the central repo. This flag does not turn off APDB writes or alert generation; those must be handled at the pipeline level or by setting up an alternative destination. |
 | prompt-keda.debug.monitorDaxApdb | bool | `false` | Whether `dax_apdb` should run in debug mode and log metrics. |
 | prompt-keda.fullnameOverride | string | `"prompt-keda-latiss"` | Override the full name for resources (includes the release name) |

--- a/applications/prompt-keda-latiss/values.yaml
+++ b/applications/prompt-keda-latiss/values.yaml
@@ -52,10 +52,6 @@ prompt-keda:
     # -- The default number of datasets of each type to keep.
     # The pipeline only needs one of most dataset types (one bias, one flat, etc.), so this is roughly the number of visits that fit in the cache.
     baseSize: 3
-    # -- A factor by which to multiply `baseSize` for refcat datasets.
-    refcatsPerImage: 4
-    # -- A factor by which to multiply `baseSize` for templates and other patch-based datasets.
-    patchesPerImage: 6
 
   s3:
     # -- Bucket containing the incoming raw images

--- a/applications/prompt-keda-lsstcam/README.md
+++ b/applications/prompt-keda-lsstcam/README.md
@@ -19,8 +19,6 @@ KEDA Prompt Processing instance for LSSTCam
 | prompt-keda.alerts.username | string | `""` | Username for sending alerts to the alert stream |
 | prompt-keda.apdb.config | string | None, must be set | URL to a serialized APDB configuration, or the "label:" prefix followed by the indexed name of such a config. |
 | prompt-keda.cache.baseSize | int | `3` | The default number of datasets of each type to keep. The pipeline only needs one of most dataset types (one bias, one flat, etc.), so this is roughly the number of visits that fit in the cache. |
-| prompt-keda.cache.patchesPerImage | int | `12` | A factor by which to multiply `baseSize` for templates and other patch-based datasets. |
-| prompt-keda.cache.refcatsPerImage | int | `6` | A factor by which to multiply `baseSize` for refcat datasets. |
 | prompt-keda.debug.exportOutputs | bool | `true` | Whether or not pipeline outputs should be exported to the central repo. This flag does not turn off APDB writes or alert generation; those must be handled at the pipeline level or by setting up an alternative destination. |
 | prompt-keda.debug.monitorDaxApdb | bool | `false` | Whether `dax_apdb` should run in debug mode and log metrics. |
 | prompt-keda.fullnameOverride | string | `"prompt-keda-lsstcam"` | Override the full name for resources (includes the release name) |

--- a/applications/prompt-keda-lsstcam/values.yaml
+++ b/applications/prompt-keda-lsstcam/values.yaml
@@ -52,10 +52,6 @@ prompt-keda:
     # -- The default number of datasets of each type to keep.
     # The pipeline only needs one of most dataset types (one bias, one flat, etc.), so this is roughly the number of visits that fit in the cache.
     baseSize: 3
-    # -- A factor by which to multiply `baseSize` for refcat datasets.
-    refcatsPerImage: 6
-    # -- A factor by which to multiply `baseSize` for templates and other patch-based datasets.
-    patchesPerImage: 12
 
   s3:
     # -- Bucket containing the incoming raw images

--- a/charts/prompt-keda/README.md
+++ b/charts/prompt-keda/README.md
@@ -19,8 +19,6 @@ Event-driven processing of camera images
 | alerts.username | string | `""` | Username for sending alerts to the alert stream |
 | apdb.config | string | None, must be set | URL to a serialized APDB configuration, or the "label:" prefix followed by the indexed name of such a config. |
 | cache.baseSize | int | `3` | The default number of datasets of each type to keep. The pipeline only needs one of most dataset types (one bias, one flat, etc.), so this is roughly the number of visits that fit in the cache. |
-| cache.patchesPerImage | int | `4` | A factor by which to multiply `baseSize` for templates and other patch-based datasets. |
-| cache.refcatsPerImage | int | `4` | A factor by which to multiply `baseSize` for refcat datasets. |
 | debug.exportOutputs | bool | `true` | Whether or not pipeline outputs should be exported to the central repo. This flag does not turn off APDB writes or alert generation; those must be handled at the pipeline level or by setting up an alternative destination. |
 | debug.monitorDaxApdb | bool | `false` | Whether `dax_apdb` should run in debug mode and log metrics. |
 | fullnameOverride | string | `"prompt-keda"` | Override the full name for resources (includes the release name) |

--- a/charts/prompt-keda/templates/scaled-job.yaml
+++ b/charts/prompt-keda/templates/scaled-job.yaml
@@ -165,10 +165,6 @@ spec:
                 value: {{ .Values.logLevel }}
               - name: LOCAL_REPO_CACHE_SIZE
                 value: {{ .Values.cache.baseSize | toString | quote }}
-              - name: REFCATS_PER_IMAGE
-                value: {{ .Values.cache.refcatsPerImage | toString | quote }}
-              - name: PATCHES_PER_IMAGE
-                value: {{ .Values.cache.patchesPerImage | toString | quote }}
               - name: DEBUG_EXPORT_OUTPUTS
                 value: {{ if .Values.debug.exportOutputs }}'1'{{ else }}'0'{{ end }}
               {{- if .Values.debug.monitorDaxApdb }}

--- a/charts/prompt-keda/values.yaml
+++ b/charts/prompt-keda/values.yaml
@@ -56,10 +56,6 @@ cache:
   # -- The default number of datasets of each type to keep.
   # The pipeline only needs one of most dataset types (one bias, one flat, etc.), so this is roughly the number of visits that fit in the cache.
   baseSize: 3
-  # -- A factor by which to multiply `baseSize` for refcat datasets.
-  refcatsPerImage: 4
-  # -- A factor by which to multiply `baseSize` for templates and other patch-based datasets.
-  patchesPerImage: 4
 
 s3:
   # -- Bucket containing the incoming raw images


### PR DESCRIPTION
This PR removes Prompt Processing cache settings associated with spatial datasets, which we will not try to cache in the future.