### PR TITLE
DM-51817: butler - add Uvicorn keepalive and preStop timeouts

### DIFF
--- a/applications/butler/templates/deployment.yaml
+++ b/applications/butler/templates/deployment.yaml
@@ -45,6 +45,11 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:
+            # Uvicorn keepalive timeout, in seconds. This should be longer than
+            # any keepalive timeouts on any downstream proxies. The keepalive
+            # timeout for ingress-nginx connections is 60s.
+            - name: "UVICORN_TIMEOUT_KEEP_ALIVE"
+              value: "61"
             - name: AWS_SHARED_CREDENTIALS_FILE
               value: "/opt/lsst/butler/secrets/aws-credentials.ini"
             - name: PGPASSFILE
@@ -94,6 +99,24 @@ spec:
             - name: config-private
               mountPath: "/opt/lsst/butler/config"
               readOnly: true
+
+          lifecycle:
+            # Number of seconds k8s should wait before sending SIGTERM on
+            # graceful restarts/deployments/shutdowns. We need this because it
+            # takes ingress-nginx some time to configure itself to stop sending
+            # traffic to the pods scheduled for termination. If Uvicorn gets
+            # the SIGTERM and starts closing connections, we could end up with
+            # a TCP race condition if ingress-nginx still tries to send data
+            # over those connections.
+            #
+            # Note that terminationGracePeriodSeconds includes the time that is
+            # spent in the preStop hook. If you’re adding a preStop hook and
+            # your terminationGracePeriodSeconds is super fine-tuned, then you
+            # should update your terminationGracePeriodSeconds to add the
+            # amount of time you’ll be spending in your preStop hook.
+            preStop:
+              sleep:
+                seconds: 10
       volumes:
         # butler-secrets-raw pulls in the secrets from the vault as files.
         # These files are owned by root and group/world readable.


### PR DESCRIPTION
We noticed sporatic 502s and "Connection reset by peer" errors coming from `ingress-nginx` for requests to [wobbly](https://github.com/lsst-sqre/wobbly) when load was high. We think these came from a TCP race condition where the upstream wobbly Uvicorn closed keepalive TCP conections opened by the ingress-nginx connection pool, but ingress-nginx tried to send data over those connections before they were fully closed.

I'm noticing several "Connection reset by peer" error in the ingress-nginx logs for [requests to Butler too](https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22science-platform-stable-6994%22%0Aresource.labels.location%3D%22us-central1%22%0Aresource.labels.cluster_name%3D%22science-platform-stable%22%0Aresource.labels.namespace_name%3D%22ingress-nginx%22%0Alabels.k8s-pod%2Fapp_kubernetes_io%2Fcomponent%3D%22controller%22%0Alabels.k8s-pod%2Fapp_kubernetes_io%2Finstance%3D%22ingress-nginx%22%0Alabels.k8s-pod%2Fapp_kubernetes_io%2Fname%3D%22ingress-nginx%22%20severity%3E%3DDEFAULT%0A%22by%20peer%22%0A%22butler%22;storageScope=project;cursorTimestamp=2025-07-21T17:33:19.917221102Z;duration=P5D?inv=1&invt=Ab3Xqw&project=science-platform-stable-6994), maybe this will prevent them.

We rolled out these changes to Wobbly on Thursday, and haven't seen any of these 502s since, though that's not necessarily a guarantee that this fixes them.

More details [here](https://rubinobs.atlassian.net/browse/DM-51817)