### PR TITLE
Add exec:internal-tools scope to idfprod

### DIFF
--- a/applications/gafaelfawr/values-idfprod.yaml
+++ b/applications/gafaelfawr/values-idfprod.yaml
@@ -59,6 +59,8 @@ config:
       - "g_admins"
     "exec:admin":
       - "g_admins"
+    "exec:internal-tools":
+      - "g_rubin"
     "exec:notebook":
       - "g_rubin"
       - "g_users"


### PR DESCRIPTION
We want to use `exec:internal-tools` for Chronograf and related services. Grant that scope on idfprod to `g_rubin`.