### PR TITLE
DM-51899: Update resources for Cloud SQL Proxy

### DIFF
--- a/applications/gafaelfawr/values.yaml
+++ b/applications/gafaelfawr/values.yaml
@@ -338,10 +338,10 @@ cloudsql:
   resources:
     limits:
       cpu: "100m"
-      memory: "20Mi"
+      memory: "30Mi"
     requests:
       cpu: "5m"
-      memory: "7Mi"
+      memory: "15Mi"
 
   # -- Affinity rules for the standalone Cloud SQL Proxy pod
   affinity: {}

--- a/applications/grafana/values.yaml
+++ b/applications/grafana/values.yaml
@@ -46,10 +46,10 @@ cloudsql:
   resources:
     limits:
       cpu: "1"
-      memory: "20Mi"
+      memory: "30Mi"
     requests:
       cpu: "5m"
-      memory: "7Mi"
+      memory: "15Mi"
 
 # -- Config for the grafana-operator, which is a dependency of this chart
 # @default -- [chart values](https://github.com/grafana/grafana-operator/blob/master/deploy/helm/grafana-operator/values.yaml)

--- a/applications/nublado/values.yaml
+++ b/applications/nublado/values.yaml
@@ -646,7 +646,7 @@ cloudsql:
         memory: "64Mi"
       requests:
         cpu: "1m"
-        memory: "10Mi"
+        memory: "15Mi"
 
     # -- Pull policy for Cloud SQL Auth Proxy images
     pullPolicy: "IfNotPresent"

--- a/applications/ook/values.yaml
+++ b/applications/ook/values.yaml
@@ -193,10 +193,10 @@ cloudsql:
     resources:
       limits:
         cpu: "100m"
-        memory: "20Mi"
+        memory: "30Mi"
       requests:
         cpu: "5m"
-        memory: "7Mi"
+        memory: "15Mi"
 
   # -- Instance connection name for a Cloud SQL PostgreSQL instance
   instanceConnectionName: ""

--- a/applications/times-square/README.md
+++ b/applications/times-square/README.md
@@ -18,9 +18,9 @@ An API service for managing and rendering parameterized Jupyter notebooks.
 | cloudsql.enabled | bool | `false` | Enable the Cloud SQL Auth Proxy sidecar, used with Cloud SQL databases on Google Cloud |
 | cloudsql.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for Cloud SQL Auth Proxy images |
 | cloudsql.image.repository | string | `"gcr.io/cloudsql-docker/gce-proxy"` | Cloud SQL Auth Proxy image to use |
-| cloudsql.image.resources | object | See `values.yaml` | Resource requests and limits for Cloud SQL pod |
 | cloudsql.image.tag | string | `"1.37.8"` | Cloud SQL Auth Proxy tag to use |
 | cloudsql.instanceConnectionName | string | `""` | Instance connection name for a Cloud SQL PostgreSQL instance |
+| cloudsql.resources | object | See `values.yaml` | Resource requests and limits for Cloud SQL pod |
 | cloudsql.serviceAccount | string | `""` | The Google service account that has an IAM binding to the `times-square` Kubernetes service accounts and has the `cloudsql.client` role |
 | config.databaseUrl | string | None, must be set | URL for the PostgreSQL database |
 | config.defaultExecutionTimeout | string | `"300"` | Default execution timeout for notebooks in seconds |

--- a/applications/times-square/values.yaml
+++ b/applications/times-square/values.yaml
@@ -188,18 +188,18 @@ cloudsql:
     # -- Pull policy for Cloud SQL Auth Proxy images
     pullPolicy: "IfNotPresent"
 
-    # -- Resource requests and limits for Cloud SQL pod
-    # @default -- See `values.yaml`
-    resources:
-      limits:
-        cpu: "1"
-        memory: "4Gi"
-      requests:
-        cpu: "1m"
-        memory: "512Mi"
-
   # -- Instance connection name for a Cloud SQL PostgreSQL instance
   instanceConnectionName: ""
+
+  # -- Resource requests and limits for Cloud SQL pod
+  # @default -- See `values.yaml`
+  resources:
+    limits:
+      cpu: "1"
+      memory: "30Mi"
+    requests:
+      cpu: "1m"
+      memory: "15Mi"
 
   # -- The Google service account that has an IAM binding to the `times-square`
   # Kubernetes service accounts and has the `cloudsql.client` role

--- a/applications/wobbly/values.yaml
+++ b/applications/wobbly/values.yaml
@@ -119,10 +119,10 @@ cloudsql:
   resources:
     limits:
       cpu: "1"
-      memory: "20Mi"
+      memory: "30Mi"
     requests:
       cpu: "5m"
-      memory: "7Mi"
+      memory: "15Mi"
 
 maintenance:
   # -- Cron schedule string for Wobbly periodic maintenance (in UTC)

--- a/charts/cadc-tap/values.yaml
+++ b/charts/cadc-tap/values.yaml
@@ -301,10 +301,10 @@ cloudsql:
   resources:
     limits:
       cpu: "100m"
-      memory: "20Mi"
+      memory: "30Mi"
     requests:
       cpu: "5m"
-      memory: "7Mi"
+      memory: "15Mi"
 
 # -- The service account will allways be created when cloudsql.enabled is set to true
 # In this case the serviceAccount configuration here is required


### PR DESCRIPTION
The new version of Cloud SQL Proxy uses more memory, enough that we're triggering memory alerts for some services. Increase the requests and limits based on current graphs from idfint.

times-square was not correctly applying resource requests and limits to its Cloud SQL Auth Proxy sidecar because of an indentation error, also fixed in this change.