### PR TITLE
DM-51817: nublado - bump proxy keep-alive timeout

### DIFF
--- a/applications/nublado/README.md
+++ b/applications/nublado/README.md
@@ -157,6 +157,7 @@ JupyterHub and custom spawner for the Rubin Science Platform
 | jupyterhub.ingress.enabled | bool | `false` | Whether to enable the default ingress. Should always be disabled since we install our own `GafaelfawrIngress` to avoid repeating the global hostname and manually configuring authentication |
 | jupyterhub.prePuller.continuous.enabled | bool | `false` | Whether to run the JupyterHub continuous prepuller (the Nublado controller does its own prepulling) |
 | jupyterhub.prePuller.hook.enabled | bool | `false` | Whether to run the JupyterHub hook prepuller (the Nublado controller does its own prepulling) |
+| jupyterhub.proxy.chp.extraCommandLineFlags | list | `["--keep-alive-timeout=61000"]` | Extra CLI options to pass to the proxy. The most up-to-date list is [here](https://github.com/jupyterhub/configurable-http-proxy/blob/main/bin/configurable-http-proxy) (not the docs, unfortunately) |
 | jupyterhub.proxy.chp.networkPolicy.interNamespaceAccessLabels | string | `"accept"` | Enable access to the proxy from other namespaces, since we put each user's lab environment in its own namespace |
 | jupyterhub.proxy.chp.resources | object | See `values.yaml` | Resource limits and requests for proxy pod |
 | jupyterhub.proxy.service.type | string | `"ClusterIP"` | Only expose the proxy to the cluster, overriding the default of exposing the proxy directly to the Internet |

--- a/applications/nublado/values.yaml
+++ b/applications/nublado/values.yaml
@@ -606,6 +606,15 @@ jupyterhub:
         # each user's lab environment in its own namespace
         interNamespaceAccessLabels: "accept"
 
+      # -- Extra CLI options to pass to the proxy. The most up-to-date list is
+      # [here](https://github.com/jupyterhub/configurable-http-proxy/blob/main/bin/configurable-http-proxy)
+      # (not the docs, unfortunately)
+      extraCommandLineFlags:
+        # Keepalive timeout, in milliseconds. This should be longer than any
+        # keepalive timeouts on any downstream proxies. The keepalive timeout
+        # for ingress-nginx connections is 60s.
+        - --keep-alive-timeout=61000
+
       # -- Resource limits and requests for proxy pod
       # @default -- See `values.yaml`
       resources:


### PR DESCRIPTION
Make it longer than `ingress-nginx`'s to avoid a TCP race condition that results in intermittent "connection reset by peer" errors from `ingress-nginx`