### PR TITLE
DM-51899: Fix resources for Nublado Cloud SQL Proxy

### DIFF
--- a/applications/nublado/README.md
+++ b/applications/nublado/README.md
@@ -16,7 +16,6 @@ JupyterHub and custom spawner for the Rubin Science Platform
 | cloudsql.enabled | bool | `false` | Enable the Cloud SQL Auth Proxy, used with Cloud SQL databases on Google Cloud |
 | cloudsql.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for Cloud SQL Auth Proxy images |
 | cloudsql.image.repository | string | `"gcr.io/cloudsql-docker/gce-proxy"` | Cloud SQL Auth Proxy image to use |
-| cloudsql.image.resources | object | See `values.yaml` | Resource requests and limits for Cloud SQL pod |
 | cloudsql.image.tag | string | `"1.37.8"` | Cloud SQL Auth Proxy tag to use |
 | cloudsql.instanceConnectionName | string | None, must be set if Cloud SQL Auth Proxy is enabled | Instance connection name for a Cloud SQL PostgreSQL instance |
 | cloudsql.nodeSelector | object | `{}` | Node selection rules for the Cloud SQL Auth Proxy pod |

--- a/applications/nublado/values.yaml
+++ b/applications/nublado/values.yaml
@@ -638,16 +638,6 @@ cloudsql:
     # -- Cloud SQL Auth Proxy image to use
     repository: "gcr.io/cloudsql-docker/gce-proxy"
 
-    # -- Resource requests and limits for Cloud SQL pod
-    # @default -- See `values.yaml`
-    resources:
-      limits:
-        cpu: "50m"
-        memory: "64Mi"
-      requests:
-        cpu: "1m"
-        memory: "15Mi"
-
     # -- Pull policy for Cloud SQL Auth Proxy images
     pullPolicy: "IfNotPresent"
 
@@ -663,10 +653,10 @@ cloudsql:
   resources:
     limits:
       cpu: "100m"
-      memory: "20Mi"
+      memory: "30Mi"
     requests:
       cpu: "5m"
-      memory: "7Mi"
+      memory: "15Mi"
 
   # -- Annotations for the Cloud SQL Auth Proxy pod
   podAnnotations: {}


### PR DESCRIPTION
There were two copies of the resources stanza, one of which was not used.