### PR TITLE
Generalising Butler paths

### DIFF
--- a/applications/nublado/values-ukidacdev.yaml
+++ b/applications/nublado/values-ukidacdev.yaml
@@ -10,6 +10,7 @@ controller:
         AUTO_REPO_URLS: "https://github.com/lsst-uk/rsp-uk-notebooks"
         AUTO_REPO_BRANCH: "main"
         AUTO_REPO_SPECS: "https://github.com/lsst-uk/rsp-uk-notebooks@main"
+        DAF_BUTLER_REPOSITORY_INDEX: "/data/butler/data-repos.yaml"
       initContainers:
         - name: "inithome"
           image:
@@ -36,6 +37,11 @@ controller:
             serverPath: "/datasets"
             server: "192.41.122.94"
             type: "nfs"
+        - name: "lsdb-data"
+          source:
+            serverPath: "/data/butler/lsdb_data"
+            server: "192.41.122.94"
+            type: "nfs"
       volumeMounts:
         - containerPath: "/data"
           volumeName: "data"
@@ -43,6 +49,8 @@ controller:
           volumeName: "home"
         - containerPath: "/datasets"
           volumeName: "datasets"
+        - containerPath: "/rubin/lsdb_data"
+          volumeName: "lsdb-data"
 
 proxy:
   ingress:

--- a/applications/nublado/values-ukidacprod.yaml
+++ b/applications/nublado/values-ukidacprod.yaml
@@ -10,6 +10,7 @@ controller:
         AUTO_REPO_URLS: "https://github.com/lsst-uk/rsp-uk-notebooks"
         AUTO_REPO_BRANCH: "main"
         AUTO_REPO_SPECS: "https://github.com/lsst-uk/rsp-uk-notebooks@main"
+        DAF_BUTLER_REPOSITORY_INDEX: "/data/butler/data-repos.yaml"
       initContainers:
         - name: "inithome"
           image:
@@ -36,6 +37,11 @@ controller:
             serverPath: "/datasets"
             server: "192.41.122.33"
             type: "nfs"
+        - name: "lsdb-data"
+          source:
+            serverPath: "/data/butler/lsdb_data"
+            server: "192.41.122.94"
+            type: "nfs"
       volumeMounts:
         - containerPath: "/data"
           volumeName: "data"
@@ -43,6 +49,8 @@ controller:
           volumeName: "home"
         - containerPath: "/datasets"
           volumeName: "datasets"
+         - containerPath: "/rubin/lsdb_data"
+          volumeName: "lsdb-data"
 
 proxy:
   ingress:


### PR DESCRIPTION
This PR makes changes to the Nublado values YAMLs for ukidacdev and ukidacprod.

It adds:

- an environment variable, `DAF_BUTLER_REPOSITORY_INDEX` with the path to a local YAML file describing Butler repos;
- and additional volume and volumeMount to map LSDB data to `/rubin/lsdb_data`.

Both of these changes help compatibility of Rubin Tutorial Notebooks, LSDB Notebooks and UK RSP Tutorial Notebooks with the folder structure on the UK IDAC without changes to paths.