### PR TITLE
Set quota of 12 on idfprod Qserv queries

### DIFF
--- a/applications/gafaelfawr/values-idfprod.yaml
+++ b/applications/gafaelfawr/values-idfprod.yaml
@@ -53,6 +53,9 @@ config:
       notebook:
         cpu: 4.0
         memory: 16
+      tap:
+        qserv:
+          concurrent: 12
 
   groupMapping:
     "admin:jupyterlab":


### PR DESCRIPTION
Set a quota of 12 concurrent queries per user to Qserv on idfprod. This uses the new quota mechanism imposed by the Qserv Kafka bridge.