### PR TITLE
tickets/OSW-669-3

### DIFF
--- a/applications/sasquatch/values-base.yaml
+++ b/applications/sasquatch/values-base.yaml
@@ -54,7 +54,7 @@ strimzi-kafka:
         cpu: 2
       limits:
         memory: 1Gi
-        cpu: 2
+        cpu: 4
   controller:
     enabled: true
   broker:


### PR DESCRIPTION
BTS: Bump CPU limit for kafka-exporter.