### PR TITLE
DM-50987: Fix inconsistent use of SATTLE_URI_BASE in Prompt Processing

### DIFF
--- a/charts/prompt-keda/templates/_service-init.tpl
+++ b/charts/prompt-keda/templates/_service-init.tpl
@@ -52,7 +52,7 @@ spec:
         {{- with .Values.sattle.uri_base }}
         - name: SATTLE_URI_BASE
           value: {{ . }}
-	{{- end }}
+        {{- end }}
         - name: SASQUATCH_URL
           value: {{ .Values.sasquatch.endpointUrl }}
         {{- if and .Values.sasquatch.endpointUrl .Values.sasquatch.auth_env }}

--- a/charts/prompt-keda/templates/scaled-job.yaml
+++ b/charts/prompt-keda/templates/scaled-job.yaml
@@ -102,6 +102,10 @@ spec:
               - name: CENTRAL_IERS_CACHE
                 value: {{ . }}
               {{- end }}
+              {{- with .Values.sattle.uri_base }}
+              - name: SATTLE_URI_BASE
+                value: {{ . }}
+              {{- end }}
               - name: SASQUATCH_URL
                 value: {{ .Values.sasquatch.endpointUrl }}
               {{- if and .Values.sasquatch.endpointUrl .Values.sasquatch.auth_env }}


### PR DESCRIPTION
This PR fixes a bug introduced in #5162 where the init job used `SATTLE_URI_BASE` but the main service did not.