### PR TITLE
Add link to community forum for support

### DIFF
--- a/applications/squareone/values-idfint.yaml
+++ b/applications/squareone/values-idfint.yaml
@@ -7,17 +7,6 @@ config:
   semaphoreUrl: "https://data-int.lsst.cloud/semaphore"
   timesSquareUrl: "https://data-int.lsst.cloud/times-square/api"
   coManageRegistryUrl: "https://id-int.lsst.cloud"
-  supportPageMdx: |
-    # Get help with the Rubin Science Platform on idf-int.lsst.cloud
-
-    For user-oriented questions, contact us on the LSSTC Slack in the
-    [#dm-rsp-support channel](https://lsstc.slack.com/archives/CAS7Y9ADS).
-
-    If you're a developer working on an RSP application, join us in the
-    [#dm-rsp-team channel](https://lsstc.slack.com/archives/C8EEUGDSA).
-
-    Don't forget to check the <Link href="/docs">documentation</Link>.
-
   enableSentry: true
   sentryTracesSampleRate: 1.0
   sentryReplaysOnErrorSampleRate: 1.0

--- a/applications/squareone/values.yaml
+++ b/applications/squareone/values.yaml
@@ -205,25 +205,15 @@ config:
     from Rubin Observatory staff. Here are the ways to ask for help.</Lede>
 
     <Section>
-      ## Data Preview 0 science questions
+      ## Community forum
 
-      For questions about the Data Preview dataset (DESC DC2) and analyzing
-      that data (such as with the LSST Science Pipelines), create a new
-      topic in the [Data Preview 0 Support category](https://community.lsst.org/c/support/dp0/49)
-      of the Community forum.
+      Ask questions and solve problems with the help of Rubin Observatory staff and other users:
 
-      <CtaLink href="http://community.lsst.org/new-topic?category=support/dp0">Create a science support topic in the forum</CtaLink>
-    </Section>
+      - [RSP service issues category](https://community.lsst.org/c/support/rsp-issues/52) for issues with the Rubin Science Platform including Portal, Notebooks, API services.
+      - [Data Products category](https://community.lsst.org/c/support/data/34) for questions about the LSST data products.
+      - [Data Preview 0 category](https://community.lsst.org/c/support/dp0/49) for questions about the Data Preview 0 datasets (pre DP1).
+      - [Rubin Science Platform category](https://community.lsst.org/c/support/lsp/39) for discussions about the Rubin Science Platform.
 
-    <Section>
-      ## Rubin Science Platform technical support and feature requests
-
-      For technical issues or feature requests related to the Rubin Science
-      Platform itself (the Portal, Notebooks, and API services such as TAP)
-      create a GitHub issue in the
-      [rubin-dp0/Support](https://github.com/rubin-dp0/Support) repository.
-
-      <CtaLink href="https://github.com/rubin-dp0/Support/issues/new/choose">Create a GitHub issue</CtaLink>
     </Section>
 
   # -- MDX content for the `/enrollment/thanks-for-signing-up` page

--- a/applications/squareone/values.yaml
+++ b/applications/squareone/values.yaml
@@ -214,6 +214,11 @@ config:
       - [Data Preview 0 category](https://community.lsst.org/c/support/dp0/49) for questions about the Data Preview 0 datasets (pre DP1).
       - [Rubin Science Platform category](https://community.lsst.org/c/support/lsp/39) for discussions about the Rubin Science Platform.
 
+      ## Keeping up to date
+
+      The Rubin Science Platform is constantly improving with exciting new features and bug fixes.
+      [*Staying up to date*](https://rsp.lsst.io/guides/life/updates.html) provides tips for following the latest developments to make the most of the platform.
+
     </Section>
 
   # -- MDX content for the `/enrollment/thanks-for-signing-up` page


### PR DESCRIPTION
DP0 used different categories and GitHub issues for support. This updates the /support page to point to Community forum categories. Not eprfect, but more useful at this moment.