### PR TITLE
Remove the quota for HiPS

### DIFF
--- a/applications/gafaelfawr/values-idfprod.yaml
+++ b/applications/gafaelfawr/values-idfprod.yaml
@@ -46,7 +46,6 @@ config:
   quota:
     default:
       api:
-        hips: 70
         sia: 70
         tap: 200
         vo-cutouts: 35


### PR DESCRIPTION
The HiPS quota when converted to requests per minute was too low, since HiPS browsing may produce bursts of access. Remove the quota for now; we can re-add a higher quota later.