### PR TITLE
DM-51603: Bump Qserv Kafka bridge to 1.2.0

### DIFF
--- a/applications/qserv-kafka/Chart.yaml
+++ b/applications/qserv-kafka/Chart.yaml
@@ -5,7 +5,7 @@ version: 1.0.0
 description: "Qserv Kafka bridge"
 sources:
   - "https://github.com/lsst-sqre/qserv-kafka"
-appVersion: 1.1.0
+appVersion: 1.2.0
 
 dependencies:
   - name: "redis"


### PR DESCRIPTION
Includes support for `unicodeChar` and a partial fix for a memory leak.