### PR TITLE
Update all consdbtap environments to sdm_schemas w.2025.31

### DIFF
--- a/applications/consdbtap/values-usdfdev.yaml
+++ b/applications/consdbtap/values-usdfdev.yaml
@@ -2,7 +2,7 @@ cadc-tap:
   tapSchema:
     image:
       repository: "lsstsqre/tap-schema-usdf-dev-cdb"
-      tag: "w.2025.24"
+      tag: "w.2025.31"
 
   config:
-    datalinkPayloadUrl: "https://github.com/lsst/sdm_schemas/releases/download/w.2025.24/datalink-snippets.zip"
+    datalinkPayloadUrl: "https://github.com/lsst/sdm_schemas/releases/download/w.2025.31/datalink-snippets.zip"

--- a/applications/consdbtap/values-usdfint.yaml
+++ b/applications/consdbtap/values-usdfint.yaml
@@ -2,7 +2,7 @@ cadc-tap:
   tapSchema:
     image:
       repository: "lsstsqre/tap-schema-usdf-prod-cdb"
-      tag: "w.2025.24"
+      tag: "w.2025.31"
 
   config:
-    datalinkPayloadUrl: "https://github.com/lsst/sdm_schemas/releases/download/w.2025.24/datalink-snippets.zip"
+    datalinkPayloadUrl: "https://github.com/lsst/sdm_schemas/releases/download/w.2025.31/datalink-snippets.zip"

--- a/applications/consdbtap/values-usdfprod.yaml
+++ b/applications/consdbtap/values-usdfprod.yaml
@@ -2,7 +2,7 @@ cadc-tap:
   tapSchema:
     image:
       repository: "lsstsqre/tap-schema-usdf-prod-cdb"
-      tag: "w.2025.24"
+      tag: "w.2025.31"
 
   config:
-    datalinkPayloadUrl: "https://github.com/lsst/sdm_schemas/releases/download/w.2025.24/datalink-snippets.zip"
+    datalinkPayloadUrl: "https://github.com/lsst/sdm_schemas/releases/download/w.2025.31/datalink-snippets.zip"


### PR DESCRIPTION
This adds the ConsDB Transformed EFD schemas so they are accessible via the TAP interface.