### PR TITLE
DM-52018: Remove unneeded baseUrl references

### DIFF
--- a/applications/alert-stream-broker/charts/alert-database/templates/ingress.yaml
+++ b/applications/alert-stream-broker/charts/alert-database/templates/ingress.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     {{- include "alertDatabase.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   scopes:
     all:
       - "read:alertdb"

--- a/applications/argo-workflows/README.md
+++ b/applications/argo-workflows/README.md
@@ -17,7 +17,6 @@ Kubernetes workflow engine
 | argo-workflows.server.baseHref | string | `"/argo-workflows/"` |  |
 | argo-workflows.server.extraArgs[0] | string | `"--auth-mode=server"` |  |
 | argo-workflows.server.ingress.enabled | bool | `false` |  |
-| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | ingress.annotations."nginx.ingress.kubernetes.io/rewrite-target" | string | `"/$2"` |  |

--- a/applications/argo-workflows/templates/ingress.yaml
+++ b/applications/argo-workflows/templates/ingress.yaml
@@ -3,7 +3,6 @@ kind: GafaelfawrIngress
 metadata:
   name: argo-workflows
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   loginRedirect: true
   scopes:
     all: {{ .Values.ingress.scopes }}

--- a/applications/argo-workflows/values.yaml
+++ b/applications/argo-workflows/values.yaml
@@ -34,10 +34,6 @@ ingress:
 # The following will be set by parameters injected by Argo CD and should
 # not be set in the individual environment values files.
 global:
-  # -- Base URL for the environment
-  # @default -- Set by Argo CD
-  baseUrl: ""
-
   # -- Host name for ingress
   # @default -- Set by Argo CD
   host: ""

--- a/applications/atlantis/templates/ingress-webhooks.yaml
+++ b/applications/atlantis/templates/ingress-webhooks.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "atlantis.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   scopes:
     anonymous: true
 template:

--- a/applications/atlantis/templates/ingress.yaml
+++ b/applications/atlantis/templates/ingress.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "atlantis.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   loginRedirect: true
   scopes:
     all:

--- a/applications/auxtel/README.md
+++ b/applications/auxtel/README.md
@@ -6,7 +6,6 @@ Deployment for the Auxiliary Telescope CSCs
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.controlSystem.appNamespace | string | Set by ArgoCD | Application namespace for the control system deployment |
 | global.controlSystem.imageTag | string | Set by ArgoCD | Image tag for the control system deployment |
 | global.controlSystem.kafkaBrokerAddress | string | Set by ArgoCD | Kafka broker address for the control system deployment |

--- a/applications/auxtel/values.yaml
+++ b/applications/auxtel/values.yaml
@@ -53,10 +53,6 @@ pmd1:
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:
-  # -- Base URL for the environment
-  # @default -- Set by Argo CD
-  baseUrl: ""
-
   # -- Host name for ingress
   # @default -- Set by Argo CD
   host: ""

--- a/applications/butler/templates/ingress-anonymous.yaml
+++ b/applications/butler/templates/ingress-anonymous.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "butler.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   scopes:
     anonymous: true
 template:

--- a/applications/butler/templates/ingress-authenticated.yaml
+++ b/applications/butler/templates/ingress-authenticated.yaml
@@ -8,7 +8,6 @@ config:
   # The Butler server often services large numbers of small requests,
   # so this cache reduces the load on Gafaelfawr.
   authCacheDuration: 5m
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   scopes:
     all:
       - "read:image"

--- a/applications/calsys/README.md
+++ b/applications/calsys/README.md
@@ -18,7 +18,6 @@ Deployment for the Calibration System CSCs
 | electrometer201-sim.enabled | bool | `false` | Enable the Electrometer:201 simulator CSC |
 | electrometer201.enabled | bool | `false` | Enable the Electrometer:201 CSC |
 | gcheaderservice1.enabled | bool | `false` | Enable the GCHeaderService:1 CSC |
-| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.controlSystem.appNamespace | string | Set by ArgoCD | Application namespace for the control system deployment |
 | global.controlSystem.imageTag | string | Set by ArgoCD | Image tag for the control system deployment |
 | global.controlSystem.kafkaBrokerAddress | string | Set by ArgoCD | Kafka broker address for the control system deployment |

--- a/applications/calsys/values.yaml
+++ b/applications/calsys/values.yaml
@@ -109,10 +109,6 @@ atwhitelight:
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:
-  # -- Base URL for the environment
-  # @default -- Set by Argo CD
-  baseUrl: ""
-
   # -- Host name for ingress
   # @default -- Set by Argo CD
   host: ""

--- a/applications/checkerboard/README.md
+++ b/applications/checkerboard/README.md
@@ -16,7 +16,6 @@ Identity mapping service
 | config.profile | string | `"production"` | application Safir profile ("production" or "development") |
 | config.slackProfileField | string | `"GitHub username"` | name of Slack profile field for GitHub username (case-sensitive) |
 | fullnameOverride | string | `""` | Override the full name for resources (includes the release name) |
-| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the checkerboard image |

--- a/applications/checkerboard/templates/ingress-anonymous.yaml
+++ b/applications/checkerboard/templates/ingress-anonymous.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "checkerboard.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   scopes:
     anonymous: true
 template:

--- a/applications/checkerboard/templates/ingress.yaml
+++ b/applications/checkerboard/templates/ingress.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "checkerboard.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   scopes:
     all:
       - "read:checkerboard"

--- a/applications/checkerboard/values.yaml
+++ b/applications/checkerboard/values.yaml
@@ -113,10 +113,6 @@ config:
   slackProfileField: "GitHub username"
 
 global:
-  # -- Base URL for the environment
-  # @default -- Set by Argo CD
-  baseUrl: ""
-
   # -- Host name for ingress
   # @default -- Set by Argo CD
   host: ""

--- a/applications/cm-service/README.md
+++ b/applications/cm-service/README.md
@@ -71,7 +71,6 @@ Campaign Management for Rubin Data Release Production
 | frontend.replicaCount | int | `1` | Number of frontend pods to start |
 | frontend.resources | object | See `values.yaml` | Resource limits and requests for the frontend pods |
 | frontend.tolerations | list | `[]` | Tolerations for the frontend pods |
-| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the frontend image |

--- a/applications/cm-service/templates/ingress.yaml
+++ b/applications/cm-service/templates/ingress.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "application.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   loginRedirect: true
   scopes:
     all:

--- a/applications/cm-service/values.yaml
+++ b/applications/cm-service/values.yaml
@@ -243,10 +243,6 @@ daemon:
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:
-  # -- Base URL for the environment
-  # @default -- Set by Argo CD
-  baseUrl: null
-
   # -- Host name for ingress
   # @default -- Set by Argo CD
   host: null

--- a/applications/consdb/README.md
+++ b/applications/consdb/README.md
@@ -20,7 +20,6 @@ Consolidated Database of Image Metadata
 | db.database | string | `"consdb"` | Database name |
 | db.host | string | `"postgres.postgres"` | Database host |
 | db.user | string | `"consdb"` | Database user |
-| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | hinfo.image.pullPolicy | string | `"Always"` | Pull policy for the consdb-hinfo image |

--- a/applications/consdb/templates/ingress.yaml
+++ b/applications/consdb/templates/ingress.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     {{- include "consdb.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   scopes:
     all:
       - "read:image"

--- a/applications/consdb/values.yaml
+++ b/applications/consdb/values.yaml
@@ -104,10 +104,6 @@ affinity: {}
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:
-  # -- Base URL for the environment
-  # @default -- Set by Argo CD
-  baseUrl: ""
-
   # -- Host name for ingress
   # @default -- Set by Argo CD
   host: ""

--- a/applications/control-system-test/README.md
+++ b/applications/control-system-test/README.md
@@ -6,7 +6,6 @@ Deployment for the Test CSCs and Integration Testing Workflows
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.controlSystem.appNamespace | string | Set by ArgoCD | Application namespace for the control system deployment |
 | global.controlSystem.imageTag | string | Set by ArgoCD | Image tag for the control system deployment |
 | global.controlSystem.kafkaBrokerAddress | string | Set by ArgoCD | Kafka broker address for the control system deployment |

--- a/applications/control-system-test/values.yaml
+++ b/applications/control-system-test/values.yaml
@@ -9,10 +9,6 @@ rumba:
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:
-  # -- Base URL for the environment
-  # @default -- Set by Argo CD
-  baseUrl: ""
-
   # -- Host name for ingress
   # @default -- Set by Argo CD
   host: ""

--- a/applications/csc-versions/README.md
+++ b/applications/csc-versions/README.md
@@ -17,7 +17,6 @@ Dashboard for currently running versions of CSCs
 | config.slackAlerts | bool | `false` | Whether to send Slack alerts for unexpected failures |
 | cyleBranch | string | `nil` | The branch name for the current Cycle revision |
 | envEfd | string | `nil` | The Name of the EFD instance. |
-| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | image.pullPolicy | string | `"Always"` | Pull policy for the csc-versions image |

--- a/applications/csc-versions/templates/ingress.yaml
+++ b/applications/csc-versions/templates/ingress.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "csc-versions.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   loginRedirect: true
   scopes:
     all:

--- a/applications/csc-versions/values.yaml
+++ b/applications/csc-versions/values.yaml
@@ -53,10 +53,6 @@ tolerations: []
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:
-  # -- Base URL for the environment
-  # @default -- Set by Argo CD
-  baseUrl: null
-
   # -- Host name for ingress
   # @default -- Set by Argo CD
   host: null

--- a/applications/datalinker/README.md
+++ b/applications/datalinker/README.md
@@ -12,7 +12,7 @@ IVOA DataLink-based service and data discovery
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules for the datalinker deployment pod |
 | config.hipsDatasets | object | `{}` | HiPS dataset configurations mapping dataset names to their base URLs |
-| config.hipsDefaultDataset | string | `""` | Default dataset for legacy /api/hips endpoints (optional) If not set it will use hips_base_url |
+| config.hipsDefaultDataset | string | `nil` | Default dataset for legacy /api/hips endpoints (optional) If not set it will use hips_base_url |
 | config.hipsPathPrefix | string | `"/api/hips"` | URL path prefix for the HiPS API (must match the configuration of the hips service) |
 | config.hipsV2PathPrefix | string | `"/api/hips/v2"` | URL path prefix for the HiPS v2 API (must match the configuration of the hips service) |
 | config.linksLifetime | string | `"1h"` | Lifetime of the `{links}` reply. Should be set to match the lifetime of links returned by the Butler server |
@@ -26,7 +26,7 @@ IVOA DataLink-based service and data discovery
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the datalinker image |
 | image.repository | string | `"ghcr.io/lsst-sqre/datalinker"` | Image to use in the datalinker deployment |
-| image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
+| image.tag | string | `nil` | Overrides the image tag whose default is the chart appVersion. |
 | ingress.annotations | object | `{}` | Additional annotations for the ingresses |
 | nodeSelector | object | `{}` | Node selection rules for the datalinker deployment pod |
 | podAnnotations | object | `{}` | Annotations for the datalinker deployment pod |

--- a/applications/datalinker/templates/ingress-anonymous.yaml
+++ b/applications/datalinker/templates/ingress-anonymous.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "datalinker.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   scopes:
     anonymous: true
 template:

--- a/applications/datalinker/templates/ingress-image.yaml
+++ b/applications/datalinker/templates/ingress-image.yaml
@@ -6,7 +6,6 @@ metadata:
     {{- include "datalinker.labels" . | nindent 4 }}
 config:
   authType: "basic"
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   scopes:
     all:
       - "read:image"

--- a/applications/datalinker/templates/ingress-tap.yaml
+++ b/applications/datalinker/templates/ingress-tap.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "datalinker.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   scopes:
     all:
       - "read:tap"

--- a/applications/datalinker/values-ccin2p3.yaml
+++ b/applications/datalinker/values-ccin2p3.yaml
@@ -1,2 +1,0 @@
-config:
-  tapMetadataUrl: "https://github.com/gabrimaine/sdm_schemas/releases/download/2.4.1/datalink-columns.zip"

--- a/applications/datalinker/values.yaml
+++ b/applications/datalinker/values.yaml
@@ -13,17 +13,16 @@ image:
   pullPolicy: "IfNotPresent"
 
   # -- Overrides the image tag whose default is the chart appVersion.
-  tag: ""
+  tag: null
 
 ingress:
   # -- Additional annotations for the ingresses
   annotations: {}
 
 config:
-
   # -- Default dataset for legacy /api/hips endpoints (optional)
   # If not set it will use hips_base_url
-  hipsDefaultDataset: ""
+  hipsDefaultDataset: null
 
   # -- HiPS dataset configurations mapping dataset names to their base URLs
   hipsDatasets: {}
@@ -80,16 +79,16 @@ tolerations: []
 global:
   # -- Base URL for the environment
   # @default -- Set by Argo CD
-  baseUrl: ""
+  baseUrl: null
 
   # -- Butler repositories accessible via Butler server
   # @default -- Set by Argo CD
-  butlerServerRepositories: ""
+  butlerServerRepositories: null
 
   # -- Host name for ingress
   # @default -- Set by Argo CD
-  host: ""
+  host: null
 
   # -- Base path for Vault secrets
   # @default -- Set by Argo CD
-  vaultSecretsPath: ""
+  vaultSecretsPath: null

--- a/applications/envsys/README.md
+++ b/applications/envsys/README.md
@@ -39,7 +39,6 @@ Deployment for the Environmental Awareness Systems CSCs
 | epm-generator-ess305.enabled | bool | `false` | Enable the ESS:305 CSC |
 | epm-generator-ess306-sim.enabled | bool | `false` | Enable the ESS:303 simulator CSC |
 | epm-generator-ess306.enabled | bool | `false` | Enable the ESS:306 CSC |
-| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.controlSystem.appNamespace | string | Set by ArgoCD | Application namespace for the control system deployment |
 | global.controlSystem.imageTag | string | Set by ArgoCD | Image tag for the control system deployment |
 | global.controlSystem.kafkaBrokerAddress | string | Set by ArgoCD | Kafka broker address for the control system deployment |

--- a/applications/envsys/values.yaml
+++ b/applications/envsys/values.yaml
@@ -285,10 +285,6 @@ weatherforecast:
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:
-  # -- Base URL for the environment
-  # @default -- Set by Argo CD
-  baseUrl: ""
-
   # -- Host name for ingress
   # @default -- Set by Argo CD
   host: ""

--- a/applications/eups-distributor/README.md
+++ b/applications/eups-distributor/README.md
@@ -11,7 +11,6 @@ Distributes EUPS binaries
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules for the eups-distributor deployment pod |
-| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the eups-distributor image |

--- a/applications/eups-distributor/templates/ingress.yaml
+++ b/applications/eups-distributor/templates/ingress.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "eups-distributor.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   scopes:
     anonymous: true
   service: "eups-distributor"

--- a/applications/eups-distributor/values.yaml
+++ b/applications/eups-distributor/values.yaml
@@ -48,10 +48,6 @@ tolerations: []
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:
-  # -- Base URL for the environment
-  # @default -- Set by Argo CD
-  baseUrl: null
-
   # -- Host name for ingress
   # @default -- Set by Argo CD
   host: null

--- a/applications/exposure-checker/README.md
+++ b/applications/exposure-checker/README.md
@@ -22,7 +22,6 @@ An interface for visually identifying artifacts in Rubin images.
 | config.volume_mounts | list | `[]` | Mount points for additional volumes |
 | config.volumes | list | `[]` | Additional volumes to attach |
 | environment | object | `{}` | Environment variables |
-| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | image.repository | string | `"ghcr.io/lsst-sitcom/rubin_exp_checker"` | rubin_exp_checker image to use |

--- a/applications/exposure-checker/templates/ingress.yaml
+++ b/applications/exposure-checker/templates/ingress.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "application.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   loginRedirect: true
   scopes:
     all:

--- a/applications/exposure-checker/values.yaml
+++ b/applications/exposure-checker/values.yaml
@@ -52,10 +52,6 @@ config:
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:
-  # -- Base URL for the environment
-  # @default -- Set by Argo CD
-  baseUrl: ""
-
   # -- Host name for ingress
   # @default -- Set by Argo CD
   host: ""

--- a/applications/exposurelog/README.md
+++ b/applications/exposurelog/README.md
@@ -34,7 +34,6 @@ Log messages related to an exposure
 | db.user | string | `"exposurelog"` | database user |
 | env | list | `[]` | Environment variables to set in the exposurelog pod |
 | fullnameOverride | string | `""` | Override the full name for resources (includes the release name) |
-| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | image.pullPolicy | string | `"Always"` | Pull policy for the exposurelog image |

--- a/applications/exposurelog/templates/ingress.yaml
+++ b/applications/exposurelog/templates/ingress.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "exposurelog.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   {{- if .Values.ingress.auth.enabled }}
   loginRedirect: false
   scopes:

--- a/applications/exposurelog/values.yaml
+++ b/applications/exposurelog/values.yaml
@@ -148,10 +148,6 @@ affinity: {}
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:
-  # -- Base URL for the environment
-  # @default -- Set by Argo CD
-  baseUrl: ""
-
   # -- Host name for ingress
   # @default -- Set by Argo CD
   host: ""

--- a/applications/fastapi-bootcamp/README.md
+++ b/applications/fastapi-bootcamp/README.md
@@ -15,7 +15,6 @@ FastAPI demonstration application for bootcamp
 | config.logProfile | string | `"production"` | Logging profile (`production` for JSON, `development` for human-friendly) |
 | config.pathPrefix | string | `"/fastapi-bootcamp"` | URL path prefix |
 | config.slackAlerts | bool | `true` | Whether to send alerts and status to Slack. |
-| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the fastapi-bootcamp image |

--- a/applications/fastapi-bootcamp/templates/ingress.yaml
+++ b/applications/fastapi-bootcamp/templates/ingress.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "fastapi-bootcamp.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   scopes:
     all:
       - "read:image"

--- a/applications/fastapi-bootcamp/values.yaml
+++ b/applications/fastapi-bootcamp/values.yaml
@@ -29,7 +29,6 @@ config:
   # -- Whether to send alerts and status to Slack.
   slackAlerts: true
 
-
 ingress:
   # -- Additional annotations for the ingress rule
   annotations: {}
@@ -53,10 +52,6 @@ tolerations: []
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:
-  # -- Base URL for the environment
-  # @default -- Set by Argo CD
-  baseUrl: ""
-
   # -- Host name for ingress
   # @default -- Set by Argo CD
   host: ""

--- a/applications/flink/README.md
+++ b/applications/flink/README.md
@@ -9,6 +9,5 @@ Apache Flink Kubernetes Operator
 | flink.enabled | bool | `true` | Whether to enable the Flink Kubernetes Operator |
 | flink.operatorPod | object | `{"resources":{"limits":{"cpu":"4","memory":"2Gi"},"requests":{"cpu":"1","memory":"512Mi"}}}` | Kubernetes requests and limits for the Flink Job Manager |
 | flink.watchNamespaces | list | `["sasquatch"]` | List of kubernetes namespaces to watch for FlinkDeployment changes |
-| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |

--- a/applications/flink/values.yaml
+++ b/applications/flink/values.yaml
@@ -23,10 +23,6 @@ flink:
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:
-  # -- Base URL for the environment
-  # @default -- Set by Argo CD
-  baseUrl: null
-
   # -- Host name for ingress
   # @default -- Set by Argo CD
   host: null

--- a/applications/gafaelfawr/values.yaml
+++ b/applications/gafaelfawr/values.yaml
@@ -508,12 +508,12 @@ redis:
 global:
   # -- Base URL for the environment
   # @default -- Set by Argo CD
-  baseUrl: ""
+  baseUrl: null
 
   # -- Host name for ingress
   # @default -- Set by Argo CD
-  host: ""
+  host: null
 
   # -- Base path for Vault secrets
   # @default -- Set by Argo CD
-  vaultSecretsPath: ""
+  vaultSecretsPath: null

--- a/applications/ghostwriter/templates/ingress-toplevel.yaml
+++ b/applications/ghostwriter/templates/ingress-toplevel.yaml
@@ -7,7 +7,6 @@ kind: GafaelfawrIngress
 metadata:
   name: "ghostwriter-{{ $res_src }}"
 config:
-  baseUrl: {{ $root.Values.global.baseUrl | quote }}
   scopes:
     all:
       - "read:image"

--- a/applications/ghostwriter/templates/ingress.yaml
+++ b/applications/ghostwriter/templates/ingress.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "ghostwriter.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   scopes:
     all:
       - "read:image"

--- a/applications/google-cloud-observability/README.md
+++ b/applications/google-cloud-observability/README.md
@@ -6,7 +6,6 @@ Google Cloud observability tooling
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | kube-state-metrics | object | See `values.yaml` | Config for kube-state-metrics chart: [values](https://artifacthub.io/packages/helm/prometheus-community/kube-state-metrics/?modal=values) |

--- a/applications/google-cloud-observability/values.yaml
+++ b/applications/google-cloud-observability/values.yaml
@@ -5,10 +5,6 @@
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:
-  # -- Base URL for the environment
-  # @default -- Set by Argo CD
-  baseUrl: null
-
   # -- Host name for ingress
   # @default -- Set by Argo CD
   host: null

--- a/applications/grafana/templates/ingress.yaml
+++ b/applications/grafana/templates/ingress.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "grafana.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   loginRedirect: true
   scopes:
     {{- .Values.grafana.gafaelfawrScopes | toYaml | nindent 4 }}

--- a/applications/hips/README.md
+++ b/applications/hips/README.md
@@ -20,7 +20,6 @@ HiPS tile server backed by Google Cloud Storage
 | config.gcsProject | string | None, must be set | Google Cloud project in which the underlying storage is located |
 | config.logLevel | string | `"INFO"` | Choose from the text form of Python logging levels |
 | config.serviceAccount | string | None, must be set | The Google service account that has an IAM binding to the `hips` Kubernetes service account and has access to the storage bucket |
-| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the hips image |
 | image.repository | string | `"ghcr.io/lsst-sqre/crawlspace"` | Image to use in the hips deployment |

--- a/applications/hips/templates/ingress.yaml
+++ b/applications/hips/templates/ingress.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "hips.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   scopes:
     all:
       - "read:image"

--- a/applications/hips/values.yaml
+++ b/applications/hips/values.yaml
@@ -85,10 +85,6 @@ affinity: {}
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:
-  # -- Base URL for the environment
-  # @default -- Set by Argo CD
-  baseUrl: ""
-
   # -- Host name for ingress
   # @default -- Set by Argo CD
-  host: ""
+  host: null

--- a/applications/hoverdrive/README.md
+++ b/applications/hoverdrive/README.md
@@ -16,7 +16,6 @@ Documentation links for VO.
 | config.ookApiUrl | string | `"https://roundtable.lsst.cloud/ook"` | Ook API URL |
 | config.pathPrefix | string | `"/api/hoverdrive"` | URL path prefix |
 | config.slackAlerts | bool | `false` | Whether to send Slack alerts for unexpected failures |
-| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the hoverdrive image |

--- a/applications/hoverdrive/templates/ingress.yaml
+++ b/applications/hoverdrive/templates/ingress.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "hoverdrive.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   scopes:
     all:
       - "read:image"

--- a/applications/hoverdrive/values.yaml
+++ b/applications/hoverdrive/values.yaml
@@ -56,10 +56,6 @@ tolerations: []
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:
-  # -- Base URL for the environment
-  # @default -- Set by Argo CD
-  baseUrl: null
-
   # -- Host name for ingress
   # @default -- Set by Argo CD
   host: null

--- a/applications/jira-data-proxy/README.md
+++ b/applications/jira-data-proxy/README.md
@@ -17,7 +17,6 @@ Jira API read-only proxy for Times Square users.
 | autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU utilization of jira-data-proxy deployment pods |
 | config.jiraUrl | string | `"https://rubinobs.atlassian.net/"` | Jira base URL |
 | config.logLevel | string | `"info"` | Logging level |
-| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the jira-data-proxy image |

--- a/applications/jira-data-proxy/templates/ingress.yaml
+++ b/applications/jira-data-proxy/templates/ingress.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "jira-data-proxy.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   loginRedirect: false # endpoint is for API use only
   scopes:
     all:

--- a/applications/jira-data-proxy/values.yaml
+++ b/applications/jira-data-proxy/values.yaml
@@ -68,10 +68,6 @@ affinity: {}
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:
-  # -- Base URL for the environment
-  # @default -- Set by Argo CD
-  baseUrl: ""
-
   # -- Host name for ingress
   # @default -- Set by Argo CD
   host: ""

--- a/applications/love/README.md
+++ b/applications/love/README.md
@@ -6,7 +6,6 @@ Deployment for the LSST Operators Visualization Environment
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.controlSystem.appNamespace | string | Set by ArgoCD | Application namespace for the control system deployment |
 | global.controlSystem.imageTag | string | Set by ArgoCD | Image tag for the control system deployment |
 | global.controlSystem.kafkaBrokerAddress | string | Set by ArgoCD | Kafka broker address for the control system deployment |

--- a/applications/love/values.yaml
+++ b/applications/love/values.yaml
@@ -1,10 +1,6 @@
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:
-  # -- Base URL for the environment
-  # @default -- Set by Argo CD
-  baseUrl: ""
-
   # -- Host name for ingress
   # @default -- Set by Argo CD
   host: ""

--- a/applications/mobu/templates/ingress-github-ci.yaml
+++ b/applications/mobu/templates/ingress-github-ci.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     {{- include "mobu.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   scopes:
     anonymous: true
 template:

--- a/applications/mobu/templates/ingress-github-refresh.yaml
+++ b/applications/mobu/templates/ingress-github-refresh.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     {{- include "mobu.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   scopes:
     anonymous: true
 template:

--- a/applications/mobu/templates/ingress.yaml
+++ b/applications/mobu/templates/ingress.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "mobu.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   loginRedirect: true
   scopes:
     all:

--- a/applications/mobu/values.yaml
+++ b/applications/mobu/values.yaml
@@ -125,12 +125,12 @@ tolerations: []
 global:
   # -- Base URL for the environment
   # @default -- Set by Argo CD
-  baseUrl: ""
+  baseUrl: null
 
   # -- Host name for ingress
   # @default -- Set by Argo CD
-  host: ""
+  host: null
 
   # -- Base path for Vault secrets
   # @default -- Set by Argo CD
-  vaultSecretsPath: ""
+  vaultSecretsPath: null

--- a/applications/mpsky/README.md
+++ b/applications/mpsky/README.md
@@ -11,7 +11,6 @@ Solar System Ephemerides
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules for the mpsky deployment pod |
-| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | image.pullPolicy | string | `"Always"` |  |

--- a/applications/mpsky/values.yaml
+++ b/applications/mpsky/values.yaml
@@ -42,10 +42,6 @@ tolerations: []
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:
-  # -- Base URL for the environment
-  # @default -- Set by Argo CD
-  baseUrl: null
-
   # -- Host name for ingress
   # @default -- Set by Argo CD
   host: null

--- a/applications/narrativelog/README.md
+++ b/applications/narrativelog/README.md
@@ -24,7 +24,6 @@ Narrative log service
 | db.port | int | `5432` | database port |
 | db.user | string | `"narrativelog"` | database user |
 | fullnameOverride | string | `""` | Override the full name for resources (includes the release name) |
-| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | image.pullPolicy | string | `"Always"` | Pull policy for the narrativelog image |

--- a/applications/narrativelog/templates/ingress.yaml
+++ b/applications/narrativelog/templates/ingress.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "narrativelog.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   {{- if .Values.ingress.auth.enabled }}
   loginRedirect: false
   scopes:

--- a/applications/narrativelog/values.yaml
+++ b/applications/narrativelog/values.yaml
@@ -87,10 +87,6 @@ affinity: {}
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:
-  # -- Base URL for the environment
-  # @default -- Set by Argo CD
-  baseUrl: ""
-
   # -- Host name for ingress
   # @default -- Set by Argo CD
   host: ""

--- a/applications/next-visit-fan-out/README.md
+++ b/applications/next-visit-fan-out/README.md
@@ -10,7 +10,6 @@ Poll next visit events from Kafka, duplicate them, and send them to all applicat
 | debug | bool | `false` | If set, enable debug logging. |
 | detectorConfig | object | See `values.yaml`. | A mapping, for each instrument, of detector number to whether that detector is "active" (i.e., producing images). |
 | fullnameOverride | string | `""` |  |
-| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/applications/next-visit-fan-out/values.yaml
+++ b/applications/next-visit-fan-out/values.yaml
@@ -73,10 +73,6 @@ affinity: {}
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:
-  # -- Base URL for the environment
-  # @default -- Set by Argo CD
-  baseUrl: ""
-
   # -- Host name for ingress
   # @default -- Set by Argo CD
   host: ""

--- a/applications/nightlydigest/README.md
+++ b/applications/nightlydigest/README.md
@@ -23,8 +23,8 @@ Nightlydigest logging and reporting service
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | nightlydigest-backend.affinity | object | `{}` | Affinity rules applied to the pod. |
 | nightlydigest-backend.annotations | object | `{}` | This allows for the specification of pod annotations. |
-| nightlydigest-backend.env | object | `{}` | This section holds a set of key, value pairs for environmental variables. |
-| nightlydigest-backend.envSecrets | object | `{}` | This section holds a set of key, value pairs for secrets. |
+| nightlydigest-backend.env | list | `[]` | List of Kubernetes environment variable specifiers. |
+| nightlydigest-backend.envSecrets | list | `[]` | List of environment variables that should come from secrets. |
 | nightlydigest-backend.image.pullPolicy | string | `"IfNotPresent"` | The pull policy on the Nightlydigest backend image. |
 | nightlydigest-backend.image.repository | string | `"lsstts/nightlydigest-backend"` | The Nightlydigest backend image to use. |
 | nightlydigest-backend.image.tag | int | `nil` | The cycle revision to add to the image tag. |

--- a/applications/nightlydigest/README.md
+++ b/applications/nightlydigest/README.md
@@ -11,7 +11,6 @@ Nightlydigest logging and reporting service
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.controlSystem.appNamespace | string | Set by ArgoCD | Application namespace for the control system deployment |
 | global.controlSystem.imageTag | string | Set by ArgoCD | Image tag for the control system deployment |
 | global.controlSystem.kafkaBrokerAddress | string | Set by ArgoCD | Kafka broker address for the control system deployment |

--- a/applications/nightlydigest/charts/nightlydigest-backend/README.md
+++ b/applications/nightlydigest/charts/nightlydigest-backend/README.md
@@ -8,8 +8,8 @@ Helm chart for the Nightlydigest FastAPI web server.
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules applied to the pod. |
 | annotations | object | `{}` | This allows for the specification of pod annotations. |
-| env | object | `{}` | This section holds a set of key, value pairs for environmental variables. |
-| envSecrets | object | `{}` | This section holds a set of key, value pairs for secrets. |
+| env | list | `[]` | List of Kubernetes environment variable specifiers. |
+| envSecrets | list | `[]` | List of environment variables that should come from secrets. |
 | image.pullPolicy | string | `"IfNotPresent"` | The pull policy on the Nightlydigest backend image. |
 | image.repository | string | `"lsstts/nightlydigest-backend"` | The Nightlydigest backend image to use. |
 | image.tag | int | `nil` | The cycle revision to add to the image tag. |

--- a/applications/nightlydigest/charts/nightlydigest-backend/values.yaml
+++ b/applications/nightlydigest/charts/nightlydigest-backend/values.yaml
@@ -7,10 +7,10 @@ image:
   tag:
   # -- The pull policy on the Nightlydigest backend image.
   pullPolicy: IfNotPresent
-# -- This section holds a set of key, value pairs for environmental variables.
-env: {}
-# -- This section holds a set of key, value pairs for secrets.
-envSecrets: {}
+# -- List of Kubernetes environment variable specifiers.
+env: []
+# -- List of environment variables that should come from secrets.
+envSecrets: []
 # -- This allows for the specification of pod annotations.
 annotations: {}
 # -- Resource specifications applied to the pod.

--- a/applications/nightlydigest/charts/nightlydigest-nginx/templates/ingress.yaml
+++ b/applications/nightlydigest/charts/nightlydigest-nginx/templates/ingress.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "nightlydigest-nginx.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   loginRedirect: true
   scopes:
     all:

--- a/applications/nightlydigest/values.yaml
+++ b/applications/nightlydigest/values.yaml
@@ -1,10 +1,6 @@
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:
-  # -- Base URL for the environment
-  # @default -- Set by Argo CD
-  baseUrl: ""
-
   # -- Host name for ingress
   # @default -- Set by Argo CD
   host: ""

--- a/applications/nightreport/README.md
+++ b/applications/nightreport/README.md
@@ -24,7 +24,6 @@ Night report log service
 | db.port | int | `5432` | database port |
 | db.user | string | `"nightreport"` | database user |
 | fullnameOverride | string | `""` | Override the full name for resources (includes the release name) |
-| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | image.pullPolicy | string | `"Always"` | Pull policy for the nightreport image |

--- a/applications/nightreport/templates/ingress.yaml
+++ b/applications/nightreport/templates/ingress.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "nightreport.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   {{- if .Values.ingress.auth.enabled }}
   loginRedirect: false
   scopes:

--- a/applications/nightreport/values.yaml
+++ b/applications/nightreport/values.yaml
@@ -97,10 +97,6 @@ affinity: {}
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:
-  # -- Base URL for the environment
-  # @default -- Set by Argo CD
-  baseUrl: ""
-
   # -- Host name for ingress
   # @default -- Set by Argo CD
   host: ""

--- a/applications/noteburst/templates/ingress.yaml
+++ b/applications/noteburst/templates/ingress.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "noteburst.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   loginRedirect: true
   scopes:
     all:

--- a/applications/noteburst/values.yaml
+++ b/applications/noteburst/values.yaml
@@ -7,19 +7,19 @@
 global:
   # -- Base URL for the environment
   # @default -- Set by Argo CD
-  baseUrl: ""
-
-  # -- Host name for ingress
-  # @default -- Set by Argo CD
-  host: ""
-
-  # -- Base path for Vault secrets
-  # @default -- Set by Argo CD
-  vaultSecretsPath: ""
+  baseUrl: null
 
   # -- Name of the Phalanx environment
   # @default -- Set by Argo CD Application
-  environmentName: ""
+  environmentName: null
+
+  # -- Host name for ingress
+  # @default -- Set by Argo CD
+  host: null
+
+  # -- Base path for Vault secrets
+  # @default -- Set by Argo CD
+  vaultSecretsPath: null
 
 # -- Number of API pods to run
 replicaCount: 1

--- a/applications/nublado/templates/controller-ingress-admin.yaml
+++ b/applications/nublado/templates/controller-ingress-admin.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "nublado.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   scopes:
     all:
       - "exec:admin"

--- a/applications/nublado/templates/controller-ingress-anonymous.yaml
+++ b/applications/nublado/templates/controller-ingress-anonymous.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "nublado.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   scopes:
     anonymous: true
 template:

--- a/applications/nublado/templates/controller-ingress-files.yaml
+++ b/applications/nublado/templates/controller-ingress-files.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     {{- include "nublado.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   scopes:
     all:
       - "write:files"

--- a/applications/nublado/templates/controller-ingress-hub.yaml
+++ b/applications/nublado/templates/controller-ingress-hub.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "nublado.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   scopes:
     all:
       - "admin:jupyterlab"

--- a/applications/nublado/templates/controller-ingress-user.yaml
+++ b/applications/nublado/templates/controller-ingress-user.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "nublado.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   scopes:
     all:
       - "exec:notebook"

--- a/applications/nublado/templates/proxy-spawn-ingress.yaml
+++ b/applications/nublado/templates/proxy-spawn-ingress.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     {{- include "nublado.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   loginRedirect: true
   scopes:
     all:

--- a/applications/nvr-control/README.md
+++ b/applications/nvr-control/README.md
@@ -8,7 +8,6 @@ NVR camera illuminator control
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules for the nvr-control deployment pod |
 | config.configVolume.storageClass | string | `nil` | Storage class for configuration persistent volume |
-| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the nvr-control image |

--- a/applications/nvr-control/templates/ingress.yaml
+++ b/applications/nvr-control/templates/ingress.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "nvr-control.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl }}
   loginRedirect: true
   scopes:
     all:

--- a/applications/nvr-control/values.yaml
+++ b/applications/nvr-control/values.yaml
@@ -46,10 +46,6 @@ tolerations: []
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:
-  # -- Base URL for the environment
-  # @default -- Set by Argo CD
-  baseUrl: null
-
   # -- Host name for ingress
   # @default -- Set by Argo CD
   host: null

--- a/applications/obsenv-management/charts/obsenv-ui/templates/ingress.yaml
+++ b/applications/obsenv-management/charts/obsenv-ui/templates/ingress.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "obsenv-ui.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   loginRedirect: true
   scopes:
     all:

--- a/applications/obsloctap/README.md
+++ b/applications/obsloctap/README.md
@@ -17,7 +17,6 @@ Publish observing schedule
 | config.volume_mounts | list | `[]` | Mount points for additional volumes |
 | config.volumes | list | `[]` | Additional volumes to attach |
 | environment | object | `{}` | Environment variables (e.g. butler configuration/auth parms) for panel |
-| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the obsloctap image |

--- a/applications/obsloctap/templates/ingress.yaml
+++ b/applications/obsloctap/templates/ingress.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "obsloctap.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   scopes:
     anonymous: true
 template:

--- a/applications/obsloctap/values.yaml
+++ b/applications/obsloctap/values.yaml
@@ -38,10 +38,6 @@ config:
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:
-  # -- Base URL for the environment
-  # @default -- Set by Argo CD
-  baseUrl: ""
-
   # -- Host name for ingress
   # @default -- Set by Argo CD
   host: ""

--- a/applications/obssys/README.md
+++ b/applications/obssys/README.md
@@ -7,7 +7,6 @@ Deployment for the Observatory System CSCs
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | gis.enabled | bool | `false` | Enable the GIS CSC |
-| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.controlSystem.appNamespace | string | Set by ArgoCD | Application namespace for the control system deployment |
 | global.controlSystem.imageTag | string | Set by ArgoCD | Image tag for the control system deployment |
 | global.controlSystem.kafkaBrokerAddress | string | Set by ArgoCD | Kafka broker address for the control system deployment |

--- a/applications/obssys/values.yaml
+++ b/applications/obssys/values.yaml
@@ -1,13 +1,10 @@
 gis:
   # -- Enable the GIS CSC
   enabled: false
+
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:
-  # -- Base URL for the environment
-  # @default -- Set by Argo CD
-  baseUrl: ""
-
   # -- Host name for ingress
   # @default -- Set by Argo CD
   host: ""

--- a/applications/onepassword-connect/README.md
+++ b/applications/onepassword-connect/README.md
@@ -11,6 +11,5 @@
 | connect.connect.credentialsName | string | `"onepassword-connect-secret"` | Name of secret containing the 1Password credentials |
 | connect.connect.serviceType | string | `"ClusterIP"` | Type of service to create |
 | connect.sync.resources | object | see `values.yaml` | Resource requests and limits for connect-sync pod |
-| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |

--- a/applications/onepassword-connect/values.yaml
+++ b/applications/onepassword-connect/values.yaml
@@ -4,7 +4,6 @@
 
 connect:
   api:
-
     # -- Resource requests and limits for connect-api pod
     # @default -- see `values.yaml`
     resources:
@@ -16,7 +15,6 @@ connect:
         memory: "15Mi"
 
   sync:
-
     # -- Resource requests and limits for connect-sync pod
     # @default -- see `values.yaml`
     resources:
@@ -40,10 +38,6 @@ connect:
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:
-  # -- Base URL for the environment
-  # @default -- Set by Argo CD
-  baseUrl: ""
-
   # -- Host name for ingress
   # @default -- Set by Argo CD
   host: ""

--- a/applications/ook/templates/ingress.yaml
+++ b/applications/ook/templates/ingress.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     {{- include "ook.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   loginRedirect: false
   scopes:
     anonymous: true
@@ -42,7 +41,6 @@ metadata:
   labels:
     {{- include "ook.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   loginRedirect: true
   scopes:
     all:
@@ -77,7 +75,6 @@ metadata:
   labels:
     {{- include "ook.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   loginRedirect: false
   scopes:
     all:

--- a/applications/ook/values.yaml
+++ b/applications/ook/values.yaml
@@ -7,11 +7,11 @@
 global:
   # -- Base URL for the environment
   # @default -- Set by Argo CD
-  baseUrl: ""
+  baseUrl: null
 
   # -- Host name for ingress
   # @default -- Set by Argo CD
-  host: ""
+  host: null
 
 # -- Number of API pods to run
 replicaCount: 1

--- a/applications/plot-navigator/README.md
+++ b/applications/plot-navigator/README.md
@@ -15,7 +15,6 @@ Plot-navigator
 | config.volume_mounts | list | `[]` | Mount points for additional volumes |
 | config.volumes | list | `[]` | Additional volumes to attach |
 | environment | object | `{}` | Environment variables (e.g. butler configuration/auth parms) for the nextjs server |
-| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | image.repository | string | `"ghcr.io/lsst-dm/plot-navigator"` | plot-navigator image to use |

--- a/applications/plot-navigator/templates/ingress.yaml
+++ b/applications/plot-navigator/templates/ingress.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "plot-navigator.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   loginRedirect: true
   scopes:
     all:

--- a/applications/plot-navigator/values.yaml
+++ b/applications/plot-navigator/values.yaml
@@ -29,10 +29,6 @@ config:
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:
-  # -- Base URL for the environment
-  # @default -- Set by Argo CD
-  baseUrl: ""
-
   # -- Host name for ingress
   # @default -- Set by Argo CD
   host: ""

--- a/applications/portal/templates/ingress-admin.yaml
+++ b/applications/portal/templates/ingress-admin.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "portal.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   loginRedirect: true
   scopes:
     all:

--- a/applications/portal/templates/ingress.yaml
+++ b/applications/portal/templates/ingress.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "portal.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   authCacheDuration: "5m"
   loginRedirect: true
   scopes:

--- a/applications/portal/values.yaml
+++ b/applications/portal/values.yaml
@@ -148,12 +148,12 @@ redis:
 global:
   # -- Base URL for the environment
   # @default -- Set by Argo CD
-  baseUrl: ""
+  baseUrl: null
 
   # -- Host name for ingress
   # @default -- Set by Argo CD
-  host: ""
+  host: null
 
   # -- Base path for Vault secrets
   # @default -- Set by Argo CD
-  vaultSecretsPath: ""
+  vaultSecretsPath: null

--- a/applications/ppdb-replication/README.md
+++ b/applications/ppdb-replication/README.md
@@ -34,7 +34,6 @@ Replicates data from the APDB to the PPDB
 | config.updateExisting | bool | `false` | Allow updates to already replicated data |
 | config.uploadInterval | int | `0` | Time to wait between uploader file uploads |
 | config.waitInterval | int | `300` | Time to wait between uploader file scans |
-| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | image.pullPolicy | string | `"Always"` | Pull policy for the ppdb-replication image |

--- a/applications/ppdb-replication/values.yaml
+++ b/applications/ppdb-replication/values.yaml
@@ -48,10 +48,6 @@ tolerations: []
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:
-  # -- Base URL for the environment
-  # @default -- Set by Argo CD
-  baseUrl: null
-
   # -- Host name for ingress
   # @default -- Set by Argo CD
   host: null

--- a/applications/production-tools/README.md
+++ b/applications/production-tools/README.md
@@ -13,7 +13,6 @@ A collection of utility pages for monitoring data processing.
 | affinity | object | `{}` | Affinity rules for the production-tools deployment pod |
 | environment | object | `{}` |  |
 | fullnameOverride | string | `""` | Override the full name for resources (includes the release name) |
-| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the production-tools image |

--- a/applications/production-tools/templates/ingress.yaml
+++ b/applications/production-tools/templates/ingress.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "production-tools.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   loginRedirect: true
   scopes:
     all:

--- a/applications/production-tools/values.yaml
+++ b/applications/production-tools/values.yaml
@@ -47,10 +47,6 @@ affinity: {}
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:
-  # -- Base URL for the environment
-  # @default -- Set by Argo CD
-  baseUrl: ""
-
   # -- Host name for ingress
   # @default -- Set by Argo CD
   host: ""

--- a/applications/prompt-redis/README.md
+++ b/applications/prompt-redis/README.md
@@ -6,7 +6,6 @@ Redis cluster for prompt processing
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | redis.affinity | object | `{}` | Affinity rules for the persistent Redis pod |

--- a/applications/prompt-redis/values.yaml
+++ b/applications/prompt-redis/values.yaml
@@ -47,10 +47,6 @@ redis:
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:
-  # -- Base URL for the environment
-  # @default -- Set by Argo CD
-  baseUrl: ""
-
   # -- Host name for ingress
   # @default -- Set by Argo CD
   host: ""

--- a/applications/rubin-rag/README.md
+++ b/applications/rubin-rag/README.md
@@ -14,7 +14,6 @@ RAG helpers for documentation searches
 | config.logLevel | string | `"INFO"` | Logging level |
 | config.logProfile | string | `"production"` | Logging profile (`production` for JSON, `development` for human-friendly) |
 | config.pathPrefix | string | `"/rubin-rag"` | URL path prefix |
-| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | image.pullPolicy | string | `"Always"` | Pull policy for the rubin-rag image |

--- a/applications/rubin-rag/templates/ingress.yaml
+++ b/applications/rubin-rag/templates/ingress.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "rubin-rag.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   scopes:
     all:
       - "read:image"

--- a/applications/rubin-rag/values.yaml
+++ b/applications/rubin-rag/values.yaml
@@ -50,10 +50,6 @@ tolerations: []
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:
-  # -- Base URL for the environment
-  # @default -- Set by Argo CD
-  baseUrl: null
-
   # -- Host name for ingress
   # @default -- Set by Argo CD
   host: null

--- a/applications/s3proxy/README.md
+++ b/applications/s3proxy/README.md
@@ -16,7 +16,6 @@ Simple application to gateway S3 URLs to HTTPS
 | config.pathPrefix | string | `"/s3proxy"` | URL path prefix |
 | config.profiles | list | `[]` | Profiles using different endpoint URLs and credentials |
 | config.s3EndpointUrl | string | `""` | Default S3 endpoint URL |
-| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the s3proxy image |

--- a/applications/s3proxy/templates/ingress.yaml
+++ b/applications/s3proxy/templates/ingress.yaml
@@ -6,7 +6,6 @@ metadata:
     {{- include "s3proxy.labels" . | nindent 4 }}
 config:
   authCacheDuration: 5m
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   loginRedirect: true
   scopes:
     all:

--- a/applications/s3proxy/values.yaml
+++ b/applications/s3proxy/values.yaml
@@ -56,10 +56,6 @@ tolerations: []
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:
-  # -- Base URL for the environment
-  # @default -- Set by Argo CD
-  baseUrl: null
-
   # -- Host name for ingress
   # @default -- Set by Argo CD
   host: null

--- a/applications/sasquatch-backpack/README.md
+++ b/applications/sasquatch-backpack/README.md
@@ -18,7 +18,6 @@ Collection of APIs that feed into Sasquatch
 | config.logProfile | string | `"production"` | Logging profile (`production` for JSON, `development` for human-friendly) |
 | config.pathPrefix | string | `"/sasquatch-backpack"` | URL path prefix |
 | config.sasquatchRestProxyUrl | string | `""` | Sasquatch REST Proxy URL |
-| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | image.pullPolicy | string | `"Always"` | Pull policy for the sasquatch-backpack image |

--- a/applications/sasquatch-backpack/values.yaml
+++ b/applications/sasquatch-backpack/values.yaml
@@ -58,21 +58,6 @@ resources:
 # -- Tolerations for the sasquatch-backpack deployment pod
 tolerations: []
 
-# The following will be set by parameters injected by Argo CD and should not
-# be set in the individual environment values files.
-global:
-  # -- Base URL for the environment
-  # @default -- Set by Argo CD
-  baseUrl: null
-
-  # -- Host name for ingress
-  # @default -- Set by Argo CD
-  host: null
-
-  # -- Base path for Vault secrets
-  # @default -- Set by Argo CD
-  vaultSecretsPath: null
-
 redis:
   persistence:
     # -- Whether to persist Redis storage.  Setting this to false will use
@@ -110,3 +95,14 @@ redis:
 
   # -- Affinity rules for the Redis pod
   affinity: {}
+
+# The following will be set by parameters injected by Argo CD and should not
+# be set in the individual environment values files.
+global:
+  # -- Host name for ingress
+  # @default -- Set by Argo CD
+  host: null
+
+  # -- Base path for Vault secrets
+  # @default -- Set by Argo CD
+  vaultSecretsPath: null

--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -15,7 +15,6 @@ Rubin Observatory's telemetry service
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | app-metrics.apps | list | `[]` | The apps to create configuration for. |

--- a/applications/sasquatch/values.yaml
+++ b/applications/sasquatch/values.yaml
@@ -346,19 +346,6 @@ data-transfer-monitoring:
   # -- Whether to enable the data-transfer-monitoring subchart
   enabled: false
 
-global:
-  # -- Base URL for the environment
-  # @default -- Set by Argo CD
-  baseUrl: ""
-
-  # -- Host name for ingress
-  # @default -- Set by Argo CD
-  host: ""
-
-  # -- Base path for Vault secrets
-  # @default -- Set by Argo CD
-  vaultSecretsPath: ""
-
 app-metrics:
   # -- Enable the app-metrics subchart with topic, user, and telegraf
   # configurations
@@ -370,3 +357,12 @@ app-metrics:
 grafana:
   # -- Whether to enable the grafana subchart
   enabled: false
+
+global:
+  # -- Host name for ingress
+  # @default -- Set by Argo CD
+  host: null
+
+  # -- Base path for Vault secrets
+  # @default -- Set by Argo CD
+  vaultSecretsPath: null

--- a/applications/schedview-snapshot/README.md
+++ b/applications/schedview-snapshot/README.md
@@ -17,7 +17,6 @@ Dashboard for examination of scheduler snapshots
 | autoscaling.maxReplicas | int | `100` | Maximum number of schedview-snapshot deployment pods |
 | autoscaling.minReplicas | int | `1` | Minimum number of schedview-snapshot deployment pods |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU utilization of schedview-snapshot deployment pods |
-| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | image.pullPolicy | string | `"Always"` | Pull policy for the schedview-snapshot image |

--- a/applications/schedview-snapshot/templates/ingress.yaml
+++ b/applications/schedview-snapshot/templates/ingress.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "schedview-snapshot.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   loginRedirect: true
   scopes:
     all:

--- a/applications/schedview-snapshot/values.yaml
+++ b/applications/schedview-snapshot/values.yaml
@@ -57,10 +57,6 @@ affinity: {}
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:
-  # -- Base URL for the environment
-  # @default -- Set by Argo CD
-  baseUrl: ""
-
   # -- Host name for ingress
   # @default -- Set by Argo CD
   host: ""

--- a/applications/schedview-static-pages/README.md
+++ b/applications/schedview-static-pages/README.md
@@ -13,7 +13,6 @@ Server for static pages from schedview
 | affinity | object | `{}` | Affinity rules for the schedview-static-pages deployment pod |
 | config.persistentVolumeClaims[0].name | string | `"sdf-data-rubin"` |  |
 | config.persistentVolumeClaims[0].storageClassName | string | `"sdf-data-rubin"` |  |
-| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the schedview-static-pages image |

--- a/applications/schedview-static-pages/templates/ingress.yaml
+++ b/applications/schedview-static-pages/templates/ingress.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "schedview-static-pages.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   loginRedirect: true
   scopes:
     all:

--- a/applications/schedview-static-pages/values.yaml
+++ b/applications/schedview-static-pages/values.yaml
@@ -39,10 +39,6 @@ tolerations: []
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:
-  # -- Base URL for the environment
-  # @default -- Set by Argo CD
-  baseUrl: null
-
   # -- Host name for ingress
   # @default -- Set by Argo CD
   host: null

--- a/applications/semaphore/README.md
+++ b/applications/semaphore/README.md
@@ -23,7 +23,6 @@ Semaphore is the user notification and messaging service for the Rubin Science P
 | config.phalanx_env | string | `""` | Name of the Phalanx environment where the application is installed TODO can this be set by a global? |
 | config.profile | string | `"production"` |  |
 | fullnameOverride | string | `""` | Override the full name for resources (includes the release name) |
-| global.baseUrl | string | Set by Argo CD Application | Base URL for the environment |
 | global.host | string | Set by Argo CD Application | Host name for ingress |
 | global.vaultSecretsPathPrefix | string | Set by Argo CD Application | Base path for Vault secrets |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |

--- a/applications/semaphore/values.yaml
+++ b/applications/semaphore/values.yaml
@@ -90,14 +90,10 @@ config:
 # Global parameters will be set by parameters injected by Argo CD and should
 # not be set in the individual environment values files.
 global:
-  # -- Base URL for the environment
-  # @default -- Set by Argo CD Application
-  baseUrl: ""
-
   # -- Host name for ingress
   # @default -- Set by Argo CD Application
-  host: ""
+  host: null
 
   # -- Base path for Vault secrets
   # @default -- Set by Argo CD Application
-  vaultSecretsPathPrefix: ""
+  vaultSecretsPathPrefix: null

--- a/applications/sia/README.md
+++ b/applications/sia/README.md
@@ -26,7 +26,6 @@ Simple Image Access (SIA) IVOA Service using Butler
 | config.sentryTracesSampleRate | float | `0` |  |
 | config.slackAlerts | bool | `false` | Whether to send alerts and status to Slack. |
 | fullnameOverride | string | `""` | Override the full name for resources (includes the release name) |
-| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the sia image |

--- a/applications/sia/templates/ingress-anonymous.yaml
+++ b/applications/sia/templates/ingress-anonymous.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "sia.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   scopes:
     anonymous: true
 template:

--- a/applications/sia/templates/ingress.yaml
+++ b/applications/sia/templates/ingress.yaml
@@ -6,7 +6,6 @@ metadata:
     {{- include "sia.labels" . | nindent 4 }}
 config:
   authType: "basic"
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   scopes:
     all:
       - "read:image"

--- a/applications/sia/values.yaml
+++ b/applications/sia/values.yaml
@@ -109,10 +109,6 @@ tolerations: []
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:
-  # -- Base URL for the environment
-  # @default -- Set by Argo CD
-  baseUrl: null
-
   # -- Host name for ingress
   # @default -- Set by Argo CD
   host: null

--- a/applications/simonyitel/README.md
+++ b/applications/simonyitel/README.md
@@ -8,7 +8,6 @@ Deployment for the Simonyi Survey Telescope CSCs
 |-----|------|---------|-------------|
 | ccheaderservice.enabled | bool | `false` | Enable the CCHeaderService CSC |
 | ccoods.enabled | bool | `false` | Enable the CCOODS CSC |
-| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.controlSystem.appNamespace | string | Set by ArgoCD | Application namespace for the control system deployment |
 | global.controlSystem.imageTag | string | Set by ArgoCD | Image tag for the control system deployment |
 | global.controlSystem.kafkaBrokerAddress | string | Set by ArgoCD | Kafka broker address for the control system deployment |

--- a/applications/simonyitel/values.yaml
+++ b/applications/simonyitel/values.yaml
@@ -109,10 +109,6 @@ mtvms-m1m3-sim:
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:
-  # -- Base URL for the environment
-  # @default -- Set by Argo CD
-  baseUrl: ""
-
   # -- Host name for ingress
   # @default -- Set by Argo CD
   host: ""

--- a/applications/squarebot/templates/ingress-anonymous.yaml
+++ b/applications/squarebot/templates/ingress-anonymous.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "squarebot.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   scopes:
     anonymous: true
 template:

--- a/applications/squareone/templates/ingress-times-square.yaml
+++ b/applications/squareone/templates/ingress-times-square.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "squareone.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   loginRedirect: true
   scopes:
     all:

--- a/applications/squareone/values.yaml
+++ b/applications/squareone/values.yaml
@@ -305,16 +305,16 @@ config:
 global:
   # -- Base URL for the environment
   # @default -- Set by Argo CD Application
-  baseUrl: ""
-
-  # -- Host name for ingress
-  # @default -- Set by Argo CD Application
-  host: ""
-
-  # -- Base path for Vault secrets
-  # @default -- Set by Argo CD Application
-  vaultSecretsPathPrefix: ""
+  baseUrl: null
 
   # -- Name of the Phalanx environment
   # @default -- Set by Argo CD Application
-  environmentName: ""
+  environmentName: null
+
+  # -- Host name for ingress
+  # @default -- Set by Argo CD Application
+  host: null
+
+  # -- Base path for Vault secrets
+  # @default -- Set by Argo CD Application
+  vaultSecretsPathPrefix: null

--- a/applications/tasso/README.md
+++ b/applications/tasso/README.md
@@ -17,7 +17,6 @@ Cutout labeling service
 | config.logProfile | string | `"production"` | Logging profile (`production` for JSON, `development` for human-friendly) |
 | config.pathPrefix | string | `"/tasso-api"` | URL path prefix |
 | config.slackAlerts | bool | `false` | Whether to send Slack alerts for unexpected failures |
-| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the tasso image |

--- a/applications/tasso/templates/ingress.yaml
+++ b/applications/tasso/templates/ingress.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "tasso.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   scopes:
     all:
       - "read:image"

--- a/applications/tasso/values.yaml
+++ b/applications/tasso/values.yaml
@@ -69,10 +69,6 @@ tolerations: []
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:
-  # -- Base URL for the environment
-  # @default -- Set by Argo CD
-  baseUrl: null
-
   # -- Host name for ingress
   # @default -- Set by Argo CD
   host: null

--- a/applications/times-square/templates/ingress-templates.yaml
+++ b/applications/times-square/templates/ingress-templates.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "times-square.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   loginRedirect: true
   scopes:
     all:

--- a/applications/times-square/templates/ingress-webhooks.yaml
+++ b/applications/times-square/templates/ingress-webhooks.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "times-square.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   scopes:
     anonymous: true
 template:

--- a/applications/times-square/templates/ingress.yaml
+++ b/applications/times-square/templates/ingress.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "times-square.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   loginRedirect: true
   scopes:
     all:

--- a/applications/uws/README.md
+++ b/applications/uws/README.md
@@ -6,7 +6,6 @@ Deployment for the UWS and DM OCPS CSCs
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.controlSystem.appNamespace | string | Set by ArgoCD | Application namespace for the control system deployment |
 | global.controlSystem.imageTag | string | Set by ArgoCD | Image tag for the control system deployment |
 | global.controlSystem.kafkaBrokerAddress | string | Set by ArgoCD | Kafka broker address for the control system deployment |

--- a/applications/uws/values.yaml
+++ b/applications/uws/values.yaml
@@ -17,10 +17,6 @@ raocps:
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:
-  # -- Base URL for the environment
-  # @default -- Set by Argo CD
-  baseUrl: ""
-
   # -- Host name for ingress
   # @default -- Set by Argo CD
   host: ""

--- a/applications/vo-cutouts/templates/ingress.yaml
+++ b/applications/vo-cutouts/templates/ingress.yaml
@@ -6,7 +6,6 @@ metadata:
     {{- include "vo-cutouts.labels" . | nindent 4 }}
 config:
   authType: "basic"
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   scopes:
     all:
       - "read:image"

--- a/applications/wobbly/README.md
+++ b/applications/wobbly/README.md
@@ -30,7 +30,6 @@ IVOA UWS database storage
 | config.services | list | See `values.yaml` | Services allowed to use Wobbly for their backend |
 | config.slackAlerts | bool | `true` | Whether to send Slack alerts for unexpected failures |
 | config.updateSchema | bool | `false` | Whether to automatically update the Wobbly database schema |
-| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the wobbly image |

--- a/applications/wobbly/templates/ingress-admin.yaml
+++ b/applications/wobbly/templates/ingress-admin.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "wobbly.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   scopes:
     all:
       - "exec:admin"

--- a/applications/wobbly/values.yaml
+++ b/applications/wobbly/values.yaml
@@ -139,10 +139,6 @@ maintenance:
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:
-  # -- Base URL for the environment
-  # @default -- Set by Argo CD
-  baseUrl: null
-
   # -- Host name for ingress
   # @default -- Set by Argo CD
   host: null

--- a/charts/cadc-tap/templates/tap-ingress-anonymous.yaml
+++ b/charts/cadc-tap/templates/tap-ingress-anonymous.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "cadc-tap.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   scopes:
     anonymous: true
 template:

--- a/charts/cadc-tap/templates/tap-ingress-authenticated.yaml
+++ b/charts/cadc-tap/templates/tap-ingress-authenticated.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "cadc-tap.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   authType: "basic"
   scopes:
     all:

--- a/charts/cadc-tap/values.yaml
+++ b/charts/cadc-tap/values.yaml
@@ -324,12 +324,12 @@ serviceAccount:
 global:
   # -- Base URL for the environment
   # @default -- Set by Argo CD
-  baseUrl: ""
+  baseUrl: null
 
   # -- Host name for ingress
   # @default -- Set by Argo CD
-  host: ""
+  host: null
 
   # -- Base path for Vault secrets
   # @default -- Set by Argo CD
-  vaultSecretsPath: ""
+  vaultSecretsPath: null

--- a/charts/rubintv/templates/ingress.yaml
+++ b/charts/rubintv/templates/ingress.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "rubintv.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   loginRedirect: true
   scopes:
     all:

--- a/docs/developers/injected-values.rst
+++ b/docs/developers/injected-values.rst
@@ -21,16 +21,19 @@ Always-injected values
 Injected values must be explicitly listed in the ``Application`` resource template for that application, and therefore a given application may not have any injected values.
 However, by convention and via :command:`phalanx application create`, Phalanx applications always get the following injected values, all of which provide information about the Phalanx environment in which the application is being deployed.
 
-``global.host``
-    The default hostname used by this Phalanx environment.
-    This corresponds to the hostname in the public URLs for the services in this environment.
-
 ``global.baseUrl``
     The base URL for applications deployed in this Phalanx environment.
     This always uses the ``https://`` schema.
+    This value will be retired in favor of service discovery in the future and is therefore not mentioned in :file:`values.yaml` by default, although it is currently always injected.
+    If you use this value, document it in the :file:`values.yaml` file for your application.
 
 ``global.environmentName``
     The name of this Phalanx environment.
+    If you use this value, document it in the :file:`values.yaml` file for your application.
+
+``global.host``
+    The default hostname used by this Phalanx environment.
+    This corresponds to the hostname in the public URLs for the services in this environment.
 
 ``global.vaultSecretsPath``
     The base path in Vault for secrets for this environment.

--- a/environments/values-ccin2p3.yaml
+++ b/environments/values-ccin2p3.yaml
@@ -3,7 +3,6 @@ fqdn: data-dev.lsst.eu
 vaultPathPrefix: secret/phalanx/ccin2p3
 
 applications:
-  datalinker: true
   nublado: true
   portal: true
   postgres: true
@@ -11,3 +10,7 @@ applications:
   squareone: true
   tap: true
   mobu: false
+
+  # datalinker disabled because it requires the Butler server, which is not
+  # enabled or configured.
+  datalinker: false

--- a/src/phalanx/data/application-template.yaml.jinja
+++ b/src/phalanx/data/application-template.yaml.jinja
@@ -22,12 +22,12 @@ spec:
     targetRevision: {{ or (index .Values "revisions" "[[ name ]]") .Values.targetRevision | quote }}
     helm:
       parameters:
-        - name: "global.host"
-          value: {{ .Values.fqdn | quote }}
         - name: "global.baseUrl"
           value: "https://{{ .Values.fqdn }}"
         - name: "global.environmentName"
           value: {{ .Values.name | quote }}
+        - name: "global.host"
+          value: {{ .Values.fqdn | quote }}
         - name: "global.vaultSecretsPath"
           value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:

--- a/starters/empty/values.yaml
+++ b/starters/empty/values.yaml
@@ -5,10 +5,6 @@
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:
-  # -- Base URL for the environment
-  # @default -- Set by Argo CD
-  baseUrl: null
-
   # -- Host name for ingress
   # @default -- Set by Argo CD
   host: null

--- a/starters/fastapi-safir-uws/templates/ingress.yaml
+++ b/starters/fastapi-safir-uws/templates/ingress.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "<CHARTNAME>.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   scopes:
     all:
       - "read:image"

--- a/starters/fastapi-safir/templates/ingress.yaml
+++ b/starters/fastapi-safir/templates/ingress.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "<CHARTNAME>.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   scopes:
     all:
       - "read:image"

--- a/starters/fastapi-safir/values.yaml
+++ b/starters/fastapi-safir/values.yaml
@@ -53,10 +53,6 @@ tolerations: []
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:
-  # -- Base URL for the environment
-  # @default -- Set by Argo CD
-  baseUrl: null
-
   # -- Host name for ingress
   # @default -- Set by Argo CD
   host: null

--- a/starters/web-service/templates/ingress.yaml
+++ b/starters/web-service/templates/ingress.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "<CHARTNAME>.labels" . | nindent 4 }}
 config:
-  baseUrl: {{ .Values.global.baseUrl | quote }}
   scopes:
     all:
       - "read:image"

--- a/starters/web-service/values.yaml
+++ b/starters/web-service/values.yaml
@@ -39,10 +39,6 @@ tolerations: []
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:
-  # -- Base URL for the environment
-  # @default -- Set by Argo CD
-  baseUrl: null
-
   # -- Host name for ingress
   # @default -- Set by Argo CD
   host: null


### PR DESCRIPTION
We are starting work on service discovery for the Rubin Science Platform. To make it easier to track down every instance where one Phalanx application needs to know about the existence or location of another application, this change removes unnecessary references to `global.baseUrl` across all of the applications. This value is still always injected by Argo CD for now.

Most unnecessary uses were in `GafaelfawrIngress` resources. The `config.baseUrl` parameter there has not been required since the 12.0.0 release (2024-10-18) and ignored entirely since the 13.0.0 release (2025-03-14). Delete it wherever it occurs.

Remove the `values.yaml` description of `global.baseUrl` for those applications that no longer use it to make future searching for remaining references easier.