### PR TITLE
DM-52011: Upgrade QServ TAP service to version 3.5.0

### DIFF
--- a/charts/cadc-tap/README.md
+++ b/charts/cadc-tap/README.md
@@ -47,7 +47,7 @@ IVOA TAP service
 | config.qserv.host | string | `"mock-db:3306"` (the mock QServ) | QServ hostname:port to connect to |
 | config.qserv.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the TAP image |
 | config.qserv.image.repository | string | `"ghcr.io/lsst-sqre/lsst-tap-service"` | TAP image to use |
-| config.qserv.image.tag | string | `"3.4.3"` | Tag of TAP image to use |
+| config.qserv.image.tag | string | `"3.5.0"` | Tag of TAP image to use |
 | config.qserv.jdbcParams | string | `""` | Extra JDBC connection parameters |
 | config.qserv.passwordEnabled | bool | false | Whether the Qserv database is password protected |
 | config.sentryEnabled | bool | `false` | Whether Sentry is enabled in this environment |
@@ -94,7 +94,7 @@ IVOA TAP service
 | uws.affinity | object | `{}` | Affinity rules for the UWS database pod |
 | uws.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the UWS database image |
 | uws.image.repository | string | `"ghcr.io/lsst-sqre/lsst-tap-uws-db"` | UWS database image to use |
-| uws.image.tag | string | `"3.4.3"` | Tag of UWS database image to use |
+| uws.image.tag | string | `"3.5.0"` | Tag of UWS database image to use |
 | uws.nodeSelector | object | `{}` | Node selection rules for the UWS database pod |
 | uws.podAnnotations | object | `{}` | Annotations for the UWS databse pod |
 | uws.resources | object | See `values.yaml` | Resource limits and requests for the UWS database pod |

--- a/charts/cadc-tap/values.yaml
+++ b/charts/cadc-tap/values.yaml
@@ -89,7 +89,7 @@ config:
       pullPolicy: "IfNotPresent"
 
       # -- Tag of TAP image to use
-      tag: "3.4.3"
+      tag: "3.5.0"
 
     # -- Whether the Qserv database is password protected
     # @default -- false
@@ -245,7 +245,7 @@ uws:
     pullPolicy: "IfNotPresent"
 
     # -- Tag of UWS database image to use
-    tag: "3.4.3"
+    tag: "3.5.0"
 
   # -- Resource limits and requests for the UWS database pod
   # @default -- See `values.yaml`


### PR DESCRIPTION
Changes to TAP service include:

- DM-51834: Add support for unicodeChar for uploaded tables by @stvoutsin in https://github.com/lsst-sqre/lsst-tap-service/pull/164
- DM-52011: Upgrade cadc-gms library to 1.0.17 by @stvoutsin in https://github.com/lsst-sqre/lsst-tap-service/pull/165
- DM-51730: Enable setting the availability via a system property by @stvoutsin in https://github.com/lsst-sqre/lsst-tap-service/pull/158
- DM-51595: Use jobPersist instead of jobUpdater.setPhase to update job by @stvoutsin in https://github.com/lsst-sqre/lsst-tap-service/pull/153
