### PR TITLE
Revert "Update Helm release vault to v0.30.1"

### DIFF
--- a/applications/vault/Chart.yaml
+++ b/applications/vault/Chart.yaml
@@ -4,5 +4,5 @@ version: 1.0.0
 description: Secret Storage
 dependencies:
   - name: vault
-    version: 0.30.1
+    version: 0.30.0
     repository: https://helm.releases.hashicorp.com


### PR DESCRIPTION
This reverts commit d1e67700cd0b41e569d15959ffdbddf1a0527498. This release has a serious bug with GCS storage.