### PR TITLE
DM-52053: qserv-kafka - periodic arq metrics

### DIFF
--- a/applications/qserv-kafka/Chart.yaml
+++ b/applications/qserv-kafka/Chart.yaml
@@ -5,7 +5,7 @@ version: 1.0.0
 description: "Qserv Kafka bridge"
 sources:
   - "https://github.com/lsst-sqre/qserv-kafka"
-appVersion: 1.2.0
+appVersion: 1.3.0
 
 dependencies:
   - name: "redis"

--- a/applications/qserv-kafka/README.md
+++ b/applications/qserv-kafka/README.md
@@ -50,6 +50,8 @@ Qserv Kafka bridge
 | image.repository | string | `"ghcr.io/lsst-sqre/qserv-kafka"` | Image to use in the qserv-kafka deployment |
 | image.tag | string | The appVersion of the chart | Tag of image to use |
 | ingress.annotations | object | `{}` | Additional annotations for the ingress rule |
+| periodicMetrics.resources | object | See `values.yaml` | Resource limits and requests for the qserv-kafka periodic metrics pods |
+| periodicMetrics.schedule | string | `"* * * * *"` | How often to run the periodic metrics job |
 | redis.config.secretKey | string | `"redis-password"` | Key inside secret from which to get the Redis password (do not change) |
 | redis.config.secretName | string | `"qserv-kafka"` | Name of secret containing Redis password |
 | redis.persistence.accessMode | string | `"ReadWriteOnce"` | Access mode of storage to request |

--- a/applications/qserv-kafka/templates/_helpers.tpl
+++ b/applications/qserv-kafka/templates/_helpers.tpl
@@ -24,3 +24,47 @@ Selector labels
 app.kubernetes.io/name: "qserv-kafka"
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Common environment variables
+*/}}
+{{- define "qserv-kafka.envVars" -}}
+- name: "KAFKA_BOOTSTRAP_SERVERS"
+  valueFrom:
+    secretKeyRef:
+      name: "qserv-kafka-access"
+      key: "bootstrapServers"
+- name: "KAFKA_CLIENT_CERT_PATH"
+  value: "/etc/qserv-kafka/user.crt"
+- name: "KAFKA_CLIENT_KEY_PATH"
+  value: "/etc/qserv-kafka/user.key"
+- name: "KAFKA_CLUSTER_CA_PATH"
+  value: "/etc/qserv-kafka/ca.crt"
+- name: "KAFKA_SECURITY_PROTOCOL"
+  valueFrom:
+    secretKeyRef:
+      name: "qserv-kafka-access"
+      key: "securityProtocol"
+- name: "QSERV_KAFKA_GAFAELFAWR_TOKEN"
+  valueFrom:
+    secretKeyRef:
+      name: "qserv-kafka-token"
+      key: "token"
+- name: "QSERV_KAFKA_QSERV_DATABASE_PASSWORD"
+  valueFrom:
+    secretKeyRef:
+      name: "qserv-kafka"
+      key: "qserv-password"
+- name: "QSERV_KAFKA_REDIS_PASSWORD"
+  valueFrom:
+    secretKeyRef:
+      name: "qserv-kafka"
+      key: "redis-password"
+{{- if .Values.config.qservRestUsername }}
+- name: "QSERV_KAFKA_QSERV_REST_PASSWORD"
+  valueFrom:
+    secretKeyRef:
+      name: "qserv-kafka"
+      key: "qserv-password"
+{{- end }}
+{{- end }}

--- a/applications/qserv-kafka/templates/frontend-deployment.yaml
+++ b/applications/qserv-kafka/templates/frontend-deployment.yaml
@@ -30,51 +30,14 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           env:
-            - name: "KAFKA_BOOTSTRAP_SERVERS"
-              valueFrom:
-                secretKeyRef:
-                  name: "qserv-kafka-access"
-                  key: "bootstrapServers"
-            - name: "KAFKA_CLIENT_CERT_PATH"
-              value: "/etc/qserv-kafka/user.crt"
-            - name: "KAFKA_CLIENT_KEY_PATH"
-              value: "/etc/qserv-kafka/user.key"
-            - name: "KAFKA_CLUSTER_CA_PATH"
-              value: "/etc/qserv-kafka/ca.crt"
-            - name: "KAFKA_SECURITY_PROTOCOL"
-              valueFrom:
-                secretKeyRef:
-                  name: "qserv-kafka-access"
-                  key: "securityProtocol"
-            - name: "QSERV_KAFKA_GAFAELFAWR_TOKEN"
-              valueFrom:
-                secretKeyRef:
-                  name: "qserv-kafka-token"
-                  key: "token"
-            - name: "QSERV_KAFKA_QSERV_DATABASE_PASSWORD"
-              valueFrom:
-                secretKeyRef:
-                  name: "qserv-kafka"
-                  key: "qserv-password"
-            - name: "QSERV_KAFKA_REDIS_PASSWORD"
-              valueFrom:
-                secretKeyRef:
-                  name: "qserv-kafka"
-                  key: "redis-password"
+            {{- include "qserv-kafka.envVars" (dict "Values" .Values) | nindent 12 }}
             {{- if (and .Values.frontend.debug.enabled .Values.frontend.debug.disablePymalloc) }}
             - name: PYTHONMALLOC
               value: malloc
             {{- end }}
-            {{- if .Values.config.qservRestUsername }}
-            - name: "QSERV_KAFKA_QSERV_REST_PASSWORD"
-              valueFrom:
-                secretKeyRef:
-                  name: "qserv-kafka"
-                  key: "qserv-password"
-            {{- end }}
           envFrom:
-            - configMapRef:
-                name: "qserv-kafka"
+          - configMapRef:
+              name: "qserv-kafka"
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:

--- a/applications/qserv-kafka/templates/metrics-cronjob.yaml
+++ b/applications/qserv-kafka/templates/metrics-cronjob.yaml
@@ -1,0 +1,58 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: periodic-metrics
+  labels:
+    {{- include "qserv-kafka.labels" . | nindent 4 }}
+spec:
+  schedule: {{ .Values.periodicMetrics.schedule | quote }}
+  concurrencyPolicy: "Forbid"
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            {{- include "qserv-kafka.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: "periodic-metrics"
+            qserv-kafka-redis-client: "true"
+        spec:
+          restartPolicy: "Never"
+          containers:
+            - name: periodic-metrics
+              command: ["qserv-kafka", "publish-periodic-metrics"]
+              env:
+              {{- include "qserv-kafka.envVars" (dict "Values" .Values) | nindent 14 }}
+              envFrom:
+              - configMapRef:
+                  name: "qserv-kafka"
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              resources:
+                {{- toYaml .Values.periodicMetrics.resources | nindent 16 }}
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - "all"
+                readOnlyRootFilesystem: true
+              volumeMounts:
+                - name: "kafka"
+                  mountPath: "/etc/qserv-kafka/ca.crt"
+                  readOnly: true
+                  subPath: "ssl.truststore.crt"
+                - name: "kafka"
+                  mountPath: "/etc/qserv-kafka/user.crt"
+                  readOnly: true
+                  subPath: "ssl.keystore.crt"
+                - name: "kafka"
+                  mountPath: "/etc/qserv-kafka/user.key"
+                  readOnly: true
+                  subPath: "ssl.keystore.key"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+          volumes:
+            - name: "kafka"
+              secret:
+                secretName: "qserv-kafka-access"

--- a/applications/qserv-kafka/templates/worker-deployment.yaml
+++ b/applications/qserv-kafka/templates/worker-deployment.yaml
@@ -35,47 +35,10 @@ spec:
             - "arq"
             - "qservkafka.workers.main.WorkerSettings"
           env:
-            - name: "KAFKA_BOOTSTRAP_SERVERS"
-              valueFrom:
-                secretKeyRef:
-                  name: "qserv-kafka-access"
-                  key: "bootstrapServers"
-            - name: "KAFKA_CLIENT_CERT_PATH"
-              value: "/etc/qserv-kafka/user.crt"
-            - name: "KAFKA_CLIENT_KEY_PATH"
-              value: "/etc/qserv-kafka/user.key"
-            - name: "KAFKA_CLUSTER_CA_PATH"
-              value: "/etc/qserv-kafka/ca.crt"
-            - name: "KAFKA_SECURITY_PROTOCOL"
-              valueFrom:
-                secretKeyRef:
-                  name: "qserv-kafka-access"
-                  key: "securityProtocol"
-            - name: "QSERV_KAFKA_GAFAELFAWR_TOKEN"
-              valueFrom:
-                secretKeyRef:
-                  name: "qserv-kafka-token"
-                  key: "token"
-            - name: "QSERV_KAFKA_QSERV_DATABASE_PASSWORD"
-              valueFrom:
-                secretKeyRef:
-                  name: "qserv-kafka"
-                  key: "qserv-password"
-            - name: "QSERV_KAFKA_REDIS_PASSWORD"
-              valueFrom:
-                secretKeyRef:
-                  name: "qserv-kafka"
-                  key: "redis-password"
-            {{- if .Values.config.qservRestUsername }}
-            - name: "QSERV_KAFKA_QSERV_REST_PASSWORD"
-              valueFrom:
-                secretKeyRef:
-                  name: "qserv-kafka"
-                  key: "qserv-password"
-            {{- end }}
+            {{- include "qserv-kafka.envVars" (dict "Values" .Values) | nindent 12 }}
           envFrom:
-            - configMapRef:
-                name: "qserv-kafka"
+          - configMapRef:
+              name: "qserv-kafka"
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           resources:

--- a/applications/qserv-kafka/values.yaml
+++ b/applications/qserv-kafka/values.yaml
@@ -240,6 +240,20 @@ resultWorker:
   # -- Tolerations for the qserv-kafka worker pods
   tolerations: []
 
+periodicMetrics:
+  # -- How often to run the periodic metrics job
+  schedule: "* * * * *"
+
+  # -- Resource limits and requests for the qserv-kafka periodic metrics pods
+  # @default -- See `values.yaml`
+  resources:
+    limits:
+      cpu: "200m"
+      memory: "100Mi"
+    requests:
+      cpu: "100m"
+      memory: "50Mi"
+
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:

--- a/applications/sasquatch/charts/app-metrics/values.yaml
+++ b/applications/sasquatch/charts/app-metrics/values.yaml
@@ -30,6 +30,7 @@ globalAppConfig:
   qservkafka:
     influxTags:
       - "username"
+      - "queue"
   sia:
     influxTags:
       - "username"


### PR DESCRIPTION
Add a `CronJob` to periodically publish arq metrics using the script added in [this qserv-kafka PR](https://github.com/lsst-sqre/qserv-kafka/pull/151).