### PR TITLE
DM-49670: Deploy Butler writer service for prompt processing (standalone variant)

### DIFF
--- a/applications/butler-writer-service/.helmignore
+++ b/applications/butler-writer-service/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/applications/butler-writer-service/Chart.yaml
+++ b/applications/butler-writer-service/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+appVersion: 0.1.0
+description: Write proxy for the Butler that buffers concurrent requests.
+name: butler-writer-service
+sources:
+  - https://github.com/lsst-dm/prompt_processing_butler_writer
+type: application
+version: 1.0.0

--- a/applications/butler-writer-service/README.md
+++ b/applications/butler-writer-service/README.md
@@ -1,0 +1,36 @@
+# butler-writer-service
+
+Write proxy for the Butler that buffers concurrent requests.
+
+## Source Code
+
+* <https://github.com/lsst-dm/prompt_processing_butler_writer>
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Affinity rules for the pod |
+| datasetFilePath | string | `""` | Root path where output dataset files are written pending transfer back to the central repository. |
+| fullnameOverride | string | `""` |  |
+| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
+| global.host | string | Set by Argo CD | Host name for ingress |
+| global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
+| image.pullPolicy | string | `"IfNotPresent"` | When to download an image. `IfNotPresent` uses a cached image if possible, and is the best choice for stable releases. `Always` checks for the latest tag online, and is needed for development builds. |
+| image.repository | string | `"ghcr.io/lsst-dm/prompt_processing_butler_writer"` | Image to use for the Butler writer service |
+| image.tag | string | `""` | Docker container version to use for the Butler writer service |
+| kafka.clusterAddress | string | None, must be set | Address of Kafka broker containing Prompt Processing output events, for consumption by the Butler writer service. |
+| kafka.topic | string | None, must be set | Kafka topic containing Prompt Processing output events, for consumption by the Butler writer service. |
+| kafka.username | string | None, must be set | Username for Kafka broker containing Prompt Processing output events, for consumption by the Butler writer service. |
+| nameOverride | string | `""` |  |
+| nodeSelector | object | `{}` | Node selection rules for the pod |
+| outputRepo | string | None, must be set | URI to the repo the writer should write to. |
+| podAnnotations | object | `{}` | Pod annotations for the writer |
+| resources.cpuLimit | int | `1` | The maximum cpu cores for the Butler writer service. |
+| resources.cpuRequest | float | `0.25` | The cpu cores requested for the Butler writer service. |
+| resources.memoryLimit | string | `"1Gi"` | The maximum memory limit for the Butler writer service. |
+| resources.memoryRequest | string | `"0.5Gi"` | The minimum memory to request for the Butler writer service. |
+| s3.aws_profile | string | `""` | If set, specify a S3 credential profile from the credential file. If empty, the `default` profile is used. |
+| s3.checksum | string | `"WHEN_REQUIRED"` | If set, configure S3 checksum options. |
+| s3.endpointUrl | string | None, must be set | S3 endpoint where datasets are buffered. |
+| tolerations | list | `[]` | Tolerations for the pod |

--- a/applications/butler-writer-service/secrets.yaml
+++ b/applications/butler-writer-service/secrets.yaml
@@ -1,0 +1,9 @@
+butler-writer-password:
+  description: The password for the Kafka account used to read the write requests stream.
+db-auth_file:
+  description: >-
+    A copy of db-auth.yaml for accessing resources through Science Pipelines code,
+    including (but not limited to) Butler registries.
+s3_credentials_file:
+  description:
+    AWS-formatted credentials for accessing S3 resources. May contain multiple profiles.

--- a/applications/butler-writer-service/templates/_helpers.tpl
+++ b/applications/butler-writer-service/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "butler-writer-service.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "butler-writer-service.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "butler-writer-service.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "butler-writer-service.labels" -}}
+helm.sh/chart: {{ include "butler-writer-service.chart" . }}
+{{ include "butler-writer-service.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "butler-writer-service.selectorLabels" -}}
+app.kubernetes.io/name: "butler-writer-service"
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/applications/butler-writer-service/templates/butler-writer-service.yaml
+++ b/applications/butler-writer-service/templates/butler-writer-service.yaml
@@ -1,0 +1,114 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "butler-writer-service.fullname" . }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "butler-writer-service.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "butler-writer-service.selectorLabels" . | nindent 8 }}
+    spec:
+      initContainers:
+        - name: init-db-auth
+          # Make a copy of the read-only secret that's owned by lsst
+          # lsst account is created by main image with id 1000
+          image: busybox
+          imagePullPolicy: IfNotPresent
+          command:
+            [
+            "sh",
+            "-c",
+            "cp -L /app/db-auth-mount/db-auth.yaml /app/dbauth/ && chown 1000:1000 /app/dbauth/db-auth.yaml && chmod u=r,go-rwx /app/dbauth/db-auth.yaml",
+            ]
+          volumeMounts:
+            - mountPath: /app/db-auth-mount
+              name: db-auth-mount
+              readOnly: true
+            - mountPath: /app/dbauth
+              name: db-auth-credentials-file
+      containers:
+        - name: butler-writer
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          env:
+            - name: BUTLER_REPOSITORY
+              value: {{ .Values.outputRepo }}
+            - name: KAFKA_CLUSTER
+              value: {{ .Values.kafka.clusterAddress }}
+            - name: KAFKA_TOPIC
+              value: {{ .Values.kafka.topic }}
+            - name: KAFKA_USERNAME
+              value: {{ .Values.kafka.username }}
+            - name: KAFKA_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "butler-writer-service.fullname" . }}-secret
+                  key: butler-writer-password
+            - name: FILE_STAGING_ROOT_PATH
+              value: {{ .Values.datasetFilePath }}
+            - name: S3_ENDPOINT_URL
+              value: {{ .Values.s3.endpointUrl }}
+            - name: AWS_SHARED_CREDENTIALS_FILE
+              value: /app/s3/credentials
+            {{- with .Values.s3.aws_profile }}
+            - name: AWS_PROFILE
+              value: {{ . }}
+            {{- end }}
+            {{- with .Values.s3.checksum }}
+            - name: AWS_REQUEST_CHECKSUM_CALCULATION
+              value: {{ . }}
+            {{- end }}
+            - name: LSST_DB_AUTH
+              value: /app/lsst-credentials/db-auth.yaml
+          volumeMounts:
+            # /app is defined in Dockerfile
+            - mountPath: /app/lsst-credentials
+              name: db-auth-credentials-file
+              readOnly: true
+            - mountPath: /app/s3/
+              name: s3-credentials-file
+          resources:
+            requests:
+              cpu: {{ .Values.resources.cpuRequest | toString | quote}}
+              memory: {{ .Values.resources.memoryRequest }}
+            limits:
+              cpu: {{ .Values.resources.cpuLimit | toString | quote}}
+              memory: {{ .Values.resources.memoryLimit }}
+      volumes:
+        - name: db-auth-mount
+          # Temporary mount for db-auth.yaml; cannot be read directly because it's owned by root
+          secret:
+            secretName: {{ template "butler-writer-service.fullname" . }}-secret
+            defaultMode: 256
+            items:
+              - key: db-auth_file
+                path: db-auth.yaml
+        - name: db-auth-credentials-file
+          emptyDir:
+            sizeLimit: 10Ki # Just a text file!
+        - name: s3-credentials-file
+          secret:
+            secretName: {{ template "butler-writer-service.fullname" . }}-secret
+            items:
+              - key: s3_credentials_file
+                path: credentials
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 10 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 10 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 10 }}
+      {{- end }}

--- a/applications/butler-writer-service/templates/vault-secret.yaml
+++ b/applications/butler-writer-service/templates/vault-secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: ricoberger.de/v1alpha1
+kind: VaultSecret
+metadata:
+  name: {{ template "butler-writer-service.fullname" . }}-secret
+spec:
+  path: "{{ .Values.global.vaultSecretsPath }}/butler-writer-service"
+  type: Opaque

--- a/applications/butler-writer-service/values-usdfdev-prompt-processing.yaml
+++ b/applications/butler-writer-service/values-usdfdev-prompt-processing.yaml
@@ -1,0 +1,19 @@
+image:
+  pullPolicy: Always
+  # prompt_processing_butler_writer does not have a standard dev tag
+  # release should be good enough if we aren't testing a branch build
+  tag: 1.0.0
+
+outputRepo: s3://rubin-pp-dev-users/central_repo_2
+
+datasetFilePath: s3://rubin-pp-dev-users/central_repo_2/pp-transfer/
+
+kafka:
+  clusterAddress: prompt-kafka-kafka-bootstrap.prompt-kafka:9092
+  username: butler-writer
+  topic: butler-writer
+
+s3:
+  endpointUrl: https://s3dfrgw.slac.stanford.edu
+  # Needed because the profile is hardcoded into butler.yaml!
+  aws_profile: prompt-processing-dev

--- a/applications/butler-writer-service/values-usdfprod-prompt-processing.yaml
+++ b/applications/butler-writer-service/values-usdfprod-prompt-processing.yaml
@@ -1,0 +1,24 @@
+image:
+  pullPolicy: IfNotPresent
+  tag: 1.0.0
+
+outputRepo: s3://embargo@rubin-summit-users/
+
+datasetFilePath: s3://embargo@rubin-summit-users/pp-transfer/
+
+kafka:
+  clusterAddress: prompt-kafka-kafka-bootstrap.prompt-kafka:9092
+  username: butler-writer
+  topic: butler-writer
+
+s3:
+  endpointUrl: https://sdfembs3.sdf.slac.stanford.edu
+  aws_profile: embargo
+
+nameOverride: ""
+fullnameOverride: ""
+
+# Service handles embargoed data
+podAnnotations: {
+  edu.stanford.slac.sdf.project/usdf-embargo: "true"
+}

--- a/applications/butler-writer-service/values.yaml
+++ b/applications/butler-writer-service/values.yaml
@@ -1,0 +1,75 @@
+image:
+  # -- Image to use for the Butler writer service
+  repository: ghcr.io/lsst-dm/prompt_processing_butler_writer
+  # -- When to download an image.
+  # `IfNotPresent` uses a cached image if possible, and is the best choice for stable releases.
+  # `Always` checks for the latest tag online, and is needed for development builds.
+  pullPolicy: IfNotPresent
+  # -- Docker container version to use for the Butler writer service
+  tag: ""
+
+# -- URI to the repo the writer should write to.
+# @default -- None, must be set
+outputRepo: ""
+
+# -- Root path where output dataset files are written pending transfer back to the central repository.
+datasetFilePath: ""
+
+kafka:
+  # -- Address of Kafka broker containing Prompt Processing output events, for consumption by the Butler writer service.
+  # @default -- None, must be set
+  clusterAddress: ""
+  # -- Username for Kafka broker containing Prompt Processing output events, for consumption by the Butler writer service.
+  # @default -- None, must be set
+  username: ""
+  # -- Kafka topic containing Prompt Processing output events, for consumption by the Butler writer service.
+  # @default -- None, must be set
+  topic: ""
+
+s3:
+  # -- S3 endpoint where datasets are buffered.
+  # @default -- None, must be set
+  endpointUrl: ""
+  # -- If set, specify a S3 credential profile from the credential file.
+  # If empty, the `default` profile is used.
+  aws_profile: ""
+  # -- If set, configure S3 checksum options.
+  checksum: WHEN_REQUIRED
+
+nameOverride: ""
+fullnameOverride: ""
+
+# -- Pod annotations for the writer
+podAnnotations: {}
+
+resources:
+  # -- The cpu cores requested for the Butler writer service.
+  cpuRequest: 0.25
+  # -- The maximum cpu cores for the Butler writer service.
+  cpuLimit: 1
+  # -- The minimum memory to request for the Butler writer service.
+  memoryRequest: "0.5Gi"
+  # -- The maximum memory limit for the Butler writer service.
+  memoryLimit: "1Gi"
+
+# -- Node selection rules for the pod
+nodeSelector: {}
+
+# -- Tolerations for the pod
+tolerations: []
+
+# -- Affinity rules for the pod
+affinity: {}
+
+# The following will be set by parameters injected by Argo CD and should not
+# be set in the individual environment values files.
+global:
+  # -- Base URL for the environment
+  # @default -- Set by Argo CD
+  baseUrl: ""
+  # -- Host name for ingress
+  # @default -- Set by Argo CD
+  host: ""
+  # -- Base path for Vault secrets
+  # @default -- Set by Argo CD
+  vaultSecretsPath: ""

--- a/applications/prompt-kafka/charts/strimzi-kafka/templates/users.yaml
+++ b/applications/prompt-kafka/charts/strimzi-kafka/templates/users.yaml
@@ -12,7 +12,7 @@ spec:
       valueFrom:
         secretKeyRef:
           name: prompt-kafka
-          key: butler-writer
+          key: butler-writer-password
   authorization:
     type: simple
     acls:

--- a/applications/prompt-kafka/secrets.yaml
+++ b/applications/prompt-kafka/secrets.yaml
@@ -1,6 +1,7 @@
 butler-writer-password:
   description: >-
-    Username for Butler Writer Kafka password.
-kafka-writer-username:
-  description: >-
-    Username for Butler Writer Kafka user.
+    Password to assign to Butler Writer Kafka user.
+kafdrop-kafka-properties:
+  description: Kafdrop properties file for connection with the Kafka broker.
+kafdrop-password:
+  description: Password to assign to Kafdrop Kafka user.

--- a/applications/prompt-keda-hsc/README.md
+++ b/applications/prompt-keda-hsc/README.md
@@ -18,6 +18,11 @@ KEDA Prompt Processing instance for HSC
 | prompt-keda.alerts.topic | string | None, must be set | Topic name where alerts will be sent |
 | prompt-keda.alerts.username | string | `""` | Username for sending alerts to the alert stream |
 | prompt-keda.apdb.config | string | None, must be set | URL to a serialized APDB configuration, or the "label:" prefix followed by the indexed name of such a config. |
+| prompt-keda.butler_writer.enabled | bool | `false` | If false, pipeline outputs will be written directly to the central repo. If true, a Kafka message will be sent to a service to aggregate these writes instead. The init job writes directly to the central repo regardless of this setting. |
+| prompt-keda.butler_writer.kafka_cluster | string | None, must be set | Address of Kafka broker where prompt processing output events will be written, for consumption by the Butler writer service. |
+| prompt-keda.butler_writer.kafka_topic | string | None, must be set | Kafka topic that prompt processing output events will be written to, for consumption by the Butler writer service. |
+| prompt-keda.butler_writer.kafka_username | string | None, must be set | Username for Kafka broker where prompt processing output events will be written, for consumption by the Butler writer service. |
+| prompt-keda.butler_writer.output_file_path | string | None, must be set | Root path where output dataset files will be written when transferring back to the central repository. |
 | prompt-keda.cache.baseSize | int | `3` | The default number of datasets of each type to keep. The pipeline only needs one of most dataset types (one bias, one flat, etc.), so this is roughly the number of visits that fit in the cache. |
 | prompt-keda.debug.exportOutputs | bool | `true` | Whether or not pipeline outputs should be exported to the central repo. This flag does not turn off APDB writes or alert generation; those must be handled at the pipeline level or by setting up an alternative destination. |
 | prompt-keda.debug.monitorDaxApdb | bool | `false` | Whether `dax_apdb` should run in debug mode and log metrics. |

--- a/applications/prompt-keda-hsc/values.yaml
+++ b/applications/prompt-keda-hsc/values.yaml
@@ -207,6 +207,28 @@ prompt-keda:
     # @default -- See the `values.yaml` file.
     podAnnotations: {}
 
+  butler_writer:
+    # -- If false, pipeline outputs will be written directly to the central repo.
+    # If true, a Kafka message will be sent to a service to aggregate these writes instead.
+    # The init job writes directly to the central repo regardless of this setting.
+    enabled: false
+    # -- Address of Kafka broker where prompt processing output events will be
+    # written, for consumption by the Butler writer service.
+    # @default -- None, must be set
+    kafka_cluster: ""
+    # -- Username for Kafka broker where prompt processing output events will be
+    # written, for consumption by the Butler writer service.
+    # @default -- None, must be set
+    kafka_username: ""
+    # -- Kafka topic that prompt processing output events will be written to,
+    # for consumption by the Butler writer service.
+    # @default -- None, must be set
+    kafka_topic: ""
+    # -- Root path where output dataset files will be written when transferring
+    # back to the central repository.
+    # @default -- None, must be set
+    output_file_path: ""
+
   # -- Override the base name for resources
   nameOverride: ""
 

--- a/applications/prompt-keda-latiss/README.md
+++ b/applications/prompt-keda-latiss/README.md
@@ -18,6 +18,11 @@ KEDA Prompt Processing instance for LATISS
 | prompt-keda.alerts.topic | string | `""` | Topic name where alerts will be sent |
 | prompt-keda.alerts.username | string | `""` | Username for sending alerts to the alert stream |
 | prompt-keda.apdb.config | string | None, must be set | URL to a serialized APDB configuration, or the "label:" prefix followed by the indexed name of such a config. |
+| prompt-keda.butler_writer.enabled | bool | `false` | If false, pipeline outputs will be written directly to the central repo. If true, a Kafka message will be sent to a service to aggregate these writes instead. The init job writes directly to the central repo regardless of this setting. |
+| prompt-keda.butler_writer.kafka_cluster | string | None, must be set | Address of Kafka broker where prompt processing output events will be written, for consumption by the Butler writer service. |
+| prompt-keda.butler_writer.kafka_topic | string | None, must be set | Kafka topic that prompt processing output events will be written to, for consumption by the Butler writer service. |
+| prompt-keda.butler_writer.kafka_username | string | None, must be set | Username for Kafka broker where prompt processing output events will be written, for consumption by the Butler writer service. |
+| prompt-keda.butler_writer.output_file_path | string | None, must be set | Root path where output dataset files will be written when transferring back to the central repository. |
 | prompt-keda.cache.baseSize | int | `3` | The default number of datasets of each type to keep. The pipeline only needs one of most dataset types (one bias, one flat, etc.), so this is roughly the number of visits that fit in the cache. |
 | prompt-keda.debug.exportOutputs | bool | `true` | Whether or not pipeline outputs should be exported to the central repo. This flag does not turn off APDB writes or alert generation; those must be handled at the pipeline level or by setting up an alternative destination. |
 | prompt-keda.debug.monitorDaxApdb | bool | `false` | Whether `dax_apdb` should run in debug mode and log metrics. |

--- a/applications/prompt-keda-latiss/values.yaml
+++ b/applications/prompt-keda-latiss/values.yaml
@@ -205,6 +205,28 @@ prompt-keda:
     # @default -- See the `values.yaml` file.
     podAnnotations: {}
 
+  butler_writer:
+    # -- If false, pipeline outputs will be written directly to the central repo.
+    # If true, a Kafka message will be sent to a service to aggregate these writes instead.
+    # The init job writes directly to the central repo regardless of this setting.
+    enabled: false
+    # -- Address of Kafka broker where prompt processing output events will be
+    # written, for consumption by the Butler writer service.
+    # @default -- None, must be set
+    kafka_cluster: ""
+    # -- Username for Kafka broker where prompt processing output events will be
+    # written, for consumption by the Butler writer service.
+    # @default -- None, must be set
+    kafka_username: ""
+    # -- Kafka topic that prompt processing output events will be written to,
+    # for consumption by the Butler writer service.
+    # @default -- None, must be set
+    kafka_topic: ""
+    # -- Root path where output dataset files will be written when transferring
+    # back to the central repository.
+    # @default -- None, must be set
+    output_file_path: ""
+
   # -- Override the base name for resources
   nameOverride: ""
 

--- a/applications/prompt-keda-lsstcam/README.md
+++ b/applications/prompt-keda-lsstcam/README.md
@@ -18,6 +18,11 @@ KEDA Prompt Processing instance for LSSTCam
 | prompt-keda.alerts.topic | string | None, must be set | Topic name where alerts will be sent |
 | prompt-keda.alerts.username | string | `""` | Username for sending alerts to the alert stream |
 | prompt-keda.apdb.config | string | None, must be set | URL to a serialized APDB configuration, or the "label:" prefix followed by the indexed name of such a config. |
+| prompt-keda.butler_writer.enabled | bool | `false` | If false, pipeline outputs will be written directly to the central repo. If true, a Kafka message will be sent to a service to aggregate these writes instead. The init job writes directly to the central repo regardless of this setting. |
+| prompt-keda.butler_writer.kafka_cluster | string | None, must be set | Address of Kafka broker where prompt processing output events will be written, for consumption by the Butler writer service. |
+| prompt-keda.butler_writer.kafka_topic | string | None, must be set | Kafka topic that prompt processing output events will be written to, for consumption by the Butler writer service. |
+| prompt-keda.butler_writer.kafka_username | string | None, must be set | Username for Kafka broker where prompt processing output events will be written, for consumption by the Butler writer service. |
+| prompt-keda.butler_writer.output_file_path | string | None, must be set | Root path where output dataset files will be written when transferring back to the central repository. |
 | prompt-keda.cache.baseSize | int | `3` | The default number of datasets of each type to keep. The pipeline only needs one of most dataset types (one bias, one flat, etc.), so this is roughly the number of visits that fit in the cache. |
 | prompt-keda.debug.exportOutputs | bool | `true` | Whether or not pipeline outputs should be exported to the central repo. This flag does not turn off APDB writes or alert generation; those must be handled at the pipeline level or by setting up an alternative destination. |
 | prompt-keda.debug.monitorDaxApdb | bool | `false` | Whether `dax_apdb` should run in debug mode and log metrics. |

--- a/applications/prompt-keda-lsstcam/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-keda-lsstcam/values-usdfdev-prompt-processing.yaml
@@ -55,3 +55,9 @@ prompt-keda:
     redisStreams:
       # Dev processes very old images, set to ~20 years
       expiration: 600_000_000.0
+
+  butler_writer:
+    kafka_cluster: prompt-kafka-kafka-bootstrap.prompt-kafka:9092
+    kafka_username: butler-writer
+    kafka_topic: butler-writer
+    output_file_path: s3://rubin-pp-dev-users/central_repo_2/pp-transfer/

--- a/applications/prompt-keda-lsstcam/values-usdfdev-prompt-processing.yaml
+++ b/applications/prompt-keda-lsstcam/values-usdfdev-prompt-processing.yaml
@@ -57,6 +57,7 @@ prompt-keda:
       expiration: 600_000_000.0
 
   butler_writer:
+    enabled: true
     kafka_cluster: prompt-kafka-kafka-bootstrap.prompt-kafka:9092
     kafka_username: butler-writer
     kafka_topic: butler-writer

--- a/applications/prompt-keda-lsstcam/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-keda-lsstcam/values-usdfprod-prompt-processing.yaml
@@ -118,6 +118,12 @@ prompt-keda:
       edu.stanford.slac.sdf.project/usdf-embargo: "true"
     }
 
+  butler_writer:
+    kafka_cluster: prompt-kafka-kafka-bootstrap.prompt-kafka:9092
+    kafka_username: butler-writer
+    kafka_topic: butler-writer
+    output_file_path: "s3://embargo@rubin-summit-users/pp-transfer/"
+
   podAnnotations: {
     edu.stanford.slac.sdf.project/usdf-embargo: "true"
   }

--- a/applications/prompt-keda-lsstcam/values.yaml
+++ b/applications/prompt-keda-lsstcam/values.yaml
@@ -208,6 +208,27 @@ prompt-keda:
     # @default -- See the `values.yaml` file.
     podAnnotations: {}
 
+  butler_writer:
+    # -- If false, pipeline outputs will be written directly to the central repo.
+    # If true, a Kafka message will be sent to a service to aggregate these writes instead.
+    # The init job writes directly to the central repo regardless of this setting.
+    enabled: false
+    # -- Address of Kafka broker where prompt processing output events will be
+    # written, for consumption by the Butler writer service.
+    # @default -- None, must be set
+    kafka_cluster: ""
+    # -- Username for Kafka broker where prompt processing output events will be
+    # written, for consumption by the Butler writer service.
+    # @default -- None, must be set
+    kafka_username: ""
+    # -- Kafka topic that prompt processing output events will be written to,
+    # for consumption by the Butler writer service.
+    # @default -- None, must be set
+    kafka_topic: ""
+    # -- Root path where output dataset files will be written when transferring
+    # back to the central repository.
+    # @default -- None, must be set
+    output_file_path: ""
 
   # -- Override the base name for resources
   nameOverride: ""

--- a/charts/prompt-keda/README.md
+++ b/charts/prompt-keda/README.md
@@ -18,6 +18,11 @@ Event-driven processing of camera images
 | alerts.topic | string | `""` | Topic name where alerts will be sent |
 | alerts.username | string | `""` | Username for sending alerts to the alert stream |
 | apdb.config | string | None, must be set | URL to a serialized APDB configuration, or the "label:" prefix followed by the indexed name of such a config. |
+| butler_writer.enabled | bool | `false` | If false, pipeline outputs will be written directly to the central repo. If true, a Kafka message will be sent to a service to aggregate these writes instead. The init job writes directly to the central repo regardless of this setting. |
+| butler_writer.kafka_cluster | string | None, must be set | Address of Kafka broker where prompt processing output events will be written, for consumption by the Butler writer service. |
+| butler_writer.kafka_topic | string | None, must be set | Kafka topic that prompt processing output events will be written to, for consumption by the Butler writer service. |
+| butler_writer.kafka_username | string | None, must be set | Username for Kafka broker where prompt processing output events will be written, for consumption by the Butler writer service. |
+| butler_writer.output_file_path | string | None, must be set | Root path where output dataset files will be written when transferring back to the central repository. |
 | cache.baseSize | int | `3` | The default number of datasets of each type to keep. The pipeline only needs one of most dataset types (one bias, one flat, etc.), so this is roughly the number of visits that fit in the cache. |
 | debug.exportOutputs | bool | `true` | Whether or not pipeline outputs should be exported to the central repo. This flag does not turn off APDB writes or alert generation; those must be handled at the pipeline level or by setting up an alternative destination. |
 | debug.monitorDaxApdb | bool | `false` | Whether `dax_apdb` should run in debug mode and log metrics. |

--- a/charts/prompt-keda/templates/_credentials-config.tpl
+++ b/charts/prompt-keda/templates/_credentials-config.tpl
@@ -1,0 +1,100 @@
+{{/* Shared environment configuration between scaled-job.yaml and_service_init.tpl */}}
+
+{{/* initContainer definition that copies and chowns, and chmods the database
+ auth files so that they are only readable by the container user.  Because of
+ security checks in the code that uses it, this file must not be group or world readable.
+*/}}
+{{- define "prompt-keda.dbauth-initcontainer" -}}
+- name: init-db-auth
+  # Make a copy of the read-only secret that's owned by lsst
+  # lsst account is created by main image with id 1000
+  image: busybox
+  imagePullPolicy: IfNotPresent
+  command:
+    [
+    "sh",
+    "-c",
+    "cp -L /app/db-auth-mount/db-auth.yaml /app/dbauth/ && chown 1000:1000 /app/dbauth/db-auth.yaml && chmod u=r,go-rwx /app/dbauth/db-auth.yaml",
+    ]
+  volumeMounts:
+    - mountPath: /app/db-auth-mount
+      name: db-auth-mount
+      readOnly: true
+    - mountPath: /app/dbauth
+      name: db-auth-credentials-file
+{{- end }}
+
+{{/* volumes containing credential files used by PP and Science Pipelines */}}
+{{- define "prompt-keda.credentials-volumes" -}}
+- name: db-auth-mount
+  # Temporary mount for db-auth.yaml; cannot be read directly because it's owned by root
+  secret:
+    secretName: {{ template "prompt-keda.fullname" . }}-secret
+    defaultMode: 256
+    items:
+      - key: db-auth_file
+        path: db-auth.yaml
+- name: db-auth-credentials-file
+  emptyDir:
+    sizeLimit: 10Ki # Just a text file!
+{{- if .Values.s3.cred_file_auth }}
+- name: s3-credentials-file
+  secret:
+    secretName: {{ template "prompt-keda.fullname" . }}-secret
+    items:
+      - key: s3_credentials_file
+        path: credentials
+{{- end }}
+{{- end }}
+
+{{/* volumeMounts containing credential files used by PP and Science Pipelines */}}
+{{- define "prompt-keda.credentials-volumeMounts" -}}
+- mountPath: /app/lsst-credentials
+  name: db-auth-credentials-file
+  readOnly: true
+{{- if .Values.s3.cred_file_auth }}
+- mountPath: /app/s3/
+  name: s3-credentials-file
+{{- end }}
+{{- end }}
+
+{{/* Environment variables used to configure Science Pipelines credentials */}}
+{{- define "prompt-keda.db-auth-env" -}}
+- name: LSST_DB_AUTH
+  value: /app/lsst-credentials/db-auth.yaml
+{{- end }}
+
+{{/* Environment variables used to configure S3
+     Don't know why the first if needs an extra whitespace chomp.
+ */}}
+{{- define "prompt-keda.s3-env" -}}
+{{- if .Values.s3.cred_file_auth -}}
+- name: AWS_SHARED_CREDENTIALS_FILE
+  value: /app/s3/credentials
+{{- end }}
+- name: S3_ENDPOINT_URL
+  value: {{ .Values.s3.endpointUrl }}
+{{- if .Values.s3.auth_env }}
+- name: AWS_ACCESS_KEY_ID
+  valueFrom:
+    secretKeyRef:
+      name: {{ template "prompt-keda.fullname" . }}-secret
+      key: s3_access_key
+- name: AWS_SECRET_ACCESS_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ template "prompt-keda.fullname" . }}-secret
+      key: s3_secret_key
+{{- end }}
+{{- with .Values.s3.aws_profile }}
+  {{- if not $.Values.s3.cred_file_auth }}
+    {{- fail "When s3.aws_profile is set, s3.cred_file_auth must be true." }}
+  {{- end }}
+- name: AWS_PROFILE
+  value: {{ . }}
+{{- end }}
+{{- with .Values.s3.checksum }}
+- name: AWS_REQUEST_CHECKSUM_CALCULATION
+  value: {{ . }}
+{{- end }}
+{{- end }}

--- a/charts/prompt-keda/templates/_service-init.tpl
+++ b/charts/prompt-keda/templates/_service-init.tpl
@@ -9,17 +9,7 @@ spec:
       {{- end }}
     spec:
       initContainers:
-      - name: init-db-auth
-        # Make a copy of the read-only secret that's owned by lsst
-        # lsst account is created by main image with id 1000
-        image: busybox
-        command: ["sh", "-c", "cp -L /app/db-auth-mount/db-auth.yaml /app/dbauth/ && chown 1000:1000 /app/dbauth/db-auth.yaml && chmod u=r,go-rwx /app/dbauth/db-auth.yaml"]
-        volumeMounts:
-        - mountPath: /app/db-auth-mount
-          name: db-auth-mount
-          readOnly: true
-        - mountPath: /app/dbauth
-          name: db-auth-credentials-file
+      {{- include "prompt-keda.dbauth-initcontainer" . | nindent 6 }}
       containers:
       - image: "{{ .Values.initializer.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
@@ -64,37 +54,8 @@ spec:
         {{- end }}
         - name: DAF_BUTLER_SASQUATCH_NAMESPACE
           value: {{ .Values.sasquatch.namespace }}
-        - name: S3_ENDPOINT_URL
-          value: {{ .Values.s3.endpointUrl }}
-        {{- if .Values.s3.auth_env }}
-        - name: AWS_ACCESS_KEY_ID
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "prompt-keda.fullname" . }}-secret
-              key: s3_access_key
-        - name: AWS_SECRET_ACCESS_KEY
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "prompt-keda.fullname" . }}-secret
-              key: s3_secret_key
-        {{- end }}
-        {{- if .Values.s3.cred_file_auth }}
-        - name: AWS_SHARED_CREDENTIALS_FILE
-          value: /app/s3/credentials
-        {{- end }}
-        {{- with .Values.s3.aws_profile }}
-          {{- if not $.Values.s3.cred_file_auth }}
-            {{- fail "When s3.aws_profile is set, s3.cred_file_auth must be true." }}
-          {{- end }}
-        - name: AWS_PROFILE
-          value: {{ . }}
-        {{- end }}
-        {{- with .Values.s3.checksum }}
-        - name: AWS_REQUEST_CHECKSUM_CALCULATION
-          value: {{ . }}
-        {{- end }}
-        - name: LSST_DB_AUTH
-          value: /app/lsst-credentials/db-auth.yaml
+        {{- include "prompt-keda.s3-env" . | nindent 8 }}
+        {{- include "prompt-keda.db-auth-env" . | nindent 8 }}
         {{- /* Job does not produce alerts, but PackageAlertsTask may ping the server. */}}
         - name: AP_KAFKA_PRODUCER_PASSWORD
           valueFrom:
@@ -110,13 +71,7 @@ spec:
         - name: SERVICE_LOG_LEVELS
           value: {{ .Values.logLevel }}
         volumeMounts:
-        - mountPath: /app/lsst-credentials
-          name: db-auth-credentials-file
-          readOnly: true
-        {{- if .Values.s3.cred_file_auth }}
-        - mountPath: /app/s3/
-          name: s3-credentials-file
-        {{- end }}
+        {{- include "prompt-keda.credentials-volumeMounts" . | nindent 8 }}
         {{- if .Values.registry.centralRepoFile }}
         - mountPath: {{ .Values.instrument.centralRepo }}
           name: central-repo-file
@@ -132,25 +87,7 @@ spec:
             cpu: {{ .Values.initializer.resources.cpuLimit | toString | quote}}
             memory: {{ .Values.initializer.resources.memoryLimit }}
       volumes:
-      - name: db-auth-mount
-        # Temporary mount for db-auth.yaml; cannot be read directly because it's owned by root
-        secret:
-          secretName: {{ template "prompt-keda.fullname" . }}-secret
-          defaultMode: 256
-          items:
-            - key: db-auth_file
-              path: db-auth.yaml
-      - name: db-auth-credentials-file
-        emptyDir:
-          sizeLimit: 10Ki  # Just a text file!
-      {{- if .Values.s3.cred_file_auth }}
-      - name: s3-credentials-file
-        secret:
-          secretName: {{ template "prompt-keda.fullname" . }}-secret
-          items:
-           - key: s3_credentials_file
-             path: credentials
-      {{- end }}
+      {{- include "prompt-keda.credentials-volumes" . | nindent 6 }}
       {{- if .Values.registry.centralRepoFile }}
       - name: central-repo-file
         secret:

--- a/charts/prompt-keda/templates/scaled-job.yaml
+++ b/charts/prompt-keda/templates/scaled-job.yaml
@@ -19,23 +19,7 @@ spec:
       {{- end }}
       spec:
         initContainers:
-          - name: init-db-auth
-            # Make a copy of the read-only secret that's owned by lsst
-            # lsst account is created by main image with id 1000
-            image: busybox
-            imagePullPolicy: IfNotPresent
-            command:
-              [
-                "sh",
-                "-c",
-                "cp -L /app/db-auth-mount/db-auth.yaml /app/dbauth/ && chown 1000:1000 /app/dbauth/db-auth.yaml && chmod u=r,go-rwx /app/dbauth/db-auth.yaml",
-              ]
-            volumeMounts:
-              - mountPath: /app/db-auth-mount
-                name: db-auth-mount
-                readOnly: true
-              - mountPath: /app/dbauth
-                name: db-auth-credentials-file
+          {{- include "prompt-keda.dbauth-initcontainer" . | nindent 10 }}
         restartPolicy: Never
         containers:
           - name: {{ include "prompt-keda.fullname" . | trimPrefix "prompt-keda-" }}
@@ -117,37 +101,8 @@ spec:
               {{- end }}
               - name: DAF_BUTLER_SASQUATCH_NAMESPACE
                 value: {{ .Values.sasquatch.namespace }}
-              - name: S3_ENDPOINT_URL
-                value: {{ .Values.s3.endpointUrl }}
-              {{- if .Values.s3.auth_env }}
-              - name: AWS_ACCESS_KEY_ID
-                valueFrom:
-                  secretKeyRef:
-                    name: {{ template "prompt-keda.fullname" . }}-secret
-                    key: s3_access_key
-              - name: AWS_SECRET_ACCESS_KEY
-                valueFrom:
-                  secretKeyRef:
-                    name: {{ template "prompt-keda.fullname" . }}-secret
-                    key: s3_secret_key
-              {{- end }}
-              {{- if .Values.s3.cred_file_auth }}
-              - name: AWS_SHARED_CREDENTIALS_FILE
-                value: /app/s3/credentials
-              {{- end }}
-              {{- if .Values.s3.aws_profile }}
-                {{- if not $.Values.s3.cred_file_auth }}
-                  {{- fail "When s3.aws_profile is set, s3.cred_file_auth must be true." }}
-                {{- end }}
-              - name: AWS_PROFILE
-                value: {{.Values.s3.aws_profile }}
-              {{- end }}
-              {{- if .Values.s3.checksum }}
-              - name: AWS_REQUEST_CHECKSUM_CALCULATION
-                value: {{.Values.s3.checksum}}
-              {{- end }}
-              - name: LSST_DB_AUTH
-                value: /app/lsst-credentials/db-auth.yaml
+              {{- include "prompt-keda.s3-env" . | nindent 14 }}
+              {{- include "prompt-keda.db-auth-env" . | nindent 14 }}
               - name: AP_KAFKA_PRODUCER_PASSWORD
                 valueFrom:
                   secretKeyRef:
@@ -184,13 +139,7 @@ spec:
             volumeMounts:
               - mountPath: /tmp-butler
                 name: ephemeral
-              - mountPath: /app/lsst-credentials
-                name: db-auth-credentials-file
-                readOnly: true
-              {{- if .Values.s3.cred_file_auth }}
-              - mountPath: /app/s3/
-                name: s3-credentials-file
-              {{- end }}
+              {{- include "prompt-keda.credentials-volumeMounts" . | nindent 14 }}
               {{- if .Values.registry.centralRepoFile }}
               - mountPath: {{ .Values.instrument.centralRepo }}
                 name: central-repo-file
@@ -210,25 +159,7 @@ spec:
           - name: ephemeral
             emptyDir:
               sizeLimit: {{ .Values.keda.ephemeralStorageLimit }}
-          - name: db-auth-mount
-            # Temporary mount for db-auth.yaml; cannot be read directly because it's owned by root
-            secret:
-              secretName: {{ template "prompt-keda.fullname" . }}-secret
-              defaultMode: 256
-              items:
-                - key: db-auth_file
-                  path: db-auth.yaml
-          - name: db-auth-credentials-file
-            emptyDir:
-              sizeLimit: 10Ki # Just a text file!
-          {{- if .Values.s3.cred_file_auth }}
-          - name: s3-credentials-file
-            secret:
-              secretName: {{ template "prompt-keda.fullname" . }}-secret
-              items:
-                - key: s3_credentials_file
-                  path: credentials
-          {{- end }}
+          {{- include "prompt-keda.credentials-volumes" . | nindent 10 }}
           {{- if .Values.registry.centralRepoFile }}
           - name: central-repo-file
             secret:

--- a/charts/prompt-keda/templates/scaled-job.yaml
+++ b/charts/prompt-keda/templates/scaled-job.yaml
@@ -57,6 +57,23 @@ spec:
                 value: {{ .Values.s3.imageBucket }}
               - name: BUCKET_TOPIC
                 value: {{ .Values.imageNotifications.topic }}
+              {{- if .Values.butler_writer.enabled }}
+              - name: USE_KAFKA_BUTLER_WRITER
+                value: "1"
+              - name: BUTLER_WRITER_KAFKA_CLUSTER
+                value: {{ .Values.butler_writer.kafka_cluster }}
+              - name: BUTLER_WRITER_KAFKA_USERNAME
+                value: {{ .Values.butler_writer.kafka_username }}
+              - name: BUTLER_WRITER_KAFKA_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ template "prompt-keda.fullname" . }}-secret
+                    key: butler-writer-password
+              - name: BUTLER_WRITER_KAFKA_TOPIC
+                value: {{ .Values.butler_writer.kafka_topic }}
+              - name: BUTLER_WRITER_FILE_OUTPUT_PATH
+                value: {{ .Values.butler_writer.output_file_path }}
+              {{- end}}
               - name: BUCKET_NOTIFICATION_KAFKA_OFFSET_RESET
                 value: {{ .Values.imageNotifications.consumerOffsetReset }}
               - name: IMAGE_TIMEOUT

--- a/charts/prompt-keda/values.yaml
+++ b/charts/prompt-keda/values.yaml
@@ -207,6 +207,28 @@ initializer:
   # @default -- See the `values.yaml` file.
   podAnnotations: {}
 
+butler_writer:
+  # -- If false, pipeline outputs will be written directly to the central repo.
+  # If true, a Kafka message will be sent to a service to aggregate these writes instead.
+  # The init job writes directly to the central repo regardless of this setting.
+  enabled: false
+  # -- Address of Kafka broker where prompt processing output events will be
+  # written, for consumption by the Butler writer service.
+  # @default -- None, must be set
+  kafka_cluster: ""
+  # -- Username for Kafka broker where prompt processing output events will be
+  # written, for consumption by the Butler writer service.
+  # @default -- None, must be set
+  kafka_username: ""
+  # -- Kafka topic that prompt processing output events will be written to,
+  # for consumption by the Butler writer service.
+  # @default -- None, must be set
+  kafka_topic: ""
+  # -- Root path where output dataset files will be written when transferring
+  # back to the central repository.
+  # @default -- None, must be set
+  output_file_path: ""
+
 # -- Override the base name for resources
 nameOverride: ""
 

--- a/docs/applications/butler-writer-service/index.rst
+++ b/docs/applications/butler-writer-service/index.rst
@@ -1,0 +1,18 @@
+.. px-app:: butler-writer-service
+
+##############################################################################
+butler-writer-service — Proxy service for concurrent writes to a shared Butler
+##############################################################################
+
+The Butler writer service takes concurrent write requests from Prompt Processing and forwards them at a sustainable pace to the repository.
+
+.. jinja:: butler-writer-service
+   :file: applications/_summary.rst.jinja
+
+Guides
+======
+
+.. toctree::
+   :maxdepth: 1
+
+   values

--- a/docs/applications/butler-writer-service/values.md
+++ b/docs/applications/butler-writer-service/values.md
@@ -1,0 +1,12 @@
+```{px-app-values} butler-writer-service
+```
+
+# butler-writer-service Helm values reference
+
+Helm values reference table for the {px-app}`butler-writer-service` application.
+
+```{include} ../../../applications/butler-writer-service/README.md
+---
+start-after: "## Values"
+---
+```

--- a/docs/applications/prompt.rst
+++ b/docs/applications/prompt.rst
@@ -9,6 +9,7 @@ Argo CD project: ``prompt``
 .. toctree::
    :maxdepth: 1
 
+   butler-writer-service/index
    next-visit-fan-out/index
    prompt-keda-hsc/index
    prompt-keda-latiss/index

--- a/environments/README.md
+++ b/environments/README.md
@@ -11,6 +11,7 @@
 | applications.atlantis | bool | `false` | Enable the atlantis application |
 | applications.auxtel | bool | `false` | Enable the auxtel control system application |
 | applications.butler | bool | `false` | Enable the butler application |
+| applications.butler-writer-service | bool | `false` | Enable the Butler writer application |
 | applications.calsys | bool | `false` | Enable the calsys control system application |
 | applications.cert-manager | bool | `true` | Enable the cert-manager application, required unless the environment makes separate arrangements to inject a current TLS certificate |
 | applications.checkerboard | bool | `false` | Enable the checkerboard application |

--- a/environments/templates/applications/prompt/butler-writer-service.yaml
+++ b/environments/templates/applications/prompt/butler-writer-service.yaml
@@ -1,0 +1,34 @@
+{{- if (index .Values "applications" "butler-writer-service") -}}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "butler-writer-service"
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: "butler-writer-service"
+  namespace: "argocd"
+  finalizers:
+    - "resources-finalizer.argocd.argoproj.io"
+spec:
+  destination:
+    namespace: "butler-writer-service"
+    server: "https://kubernetes.default.svc"
+  project: "prompt"
+  source:
+    path: "applications/butler-writer-service"
+    repoURL: {{ .Values.repoUrl | quote }}
+    targetRevision: {{ .Values.targetRevision | quote }}
+    helm:
+      parameters:
+        - name: "global.host"
+          value: {{ .Values.fqdn | quote }}
+        - name: "global.baseUrl"
+          value: "https://{{ .Values.fqdn }}"
+        - name: "global.vaultSecretsPath"
+          value: {{ .Values.vaultPathPrefix | quote }}
+      valueFiles:
+        - "values.yaml"
+        - "values-{{ .Values.name }}.yaml"
+{{- end -}}

--- a/environments/values-usdfdev-prompt-processing.yaml
+++ b/environments/values-usdfdev-prompt-processing.yaml
@@ -4,6 +4,7 @@ vaultUrl: "https://vault.slac.stanford.edu"
 vaultPathPrefix: secret/rubin/usdf-prompt-processing-dev
 
 applications:
+  butler-writer-service: true
   cert-manager: false
   gafaelfawr: false
   ingress-nginx: false

--- a/environments/values.yaml
+++ b/environments/values.yaml
@@ -51,6 +51,9 @@ applications:
   # -- Enable the butler application
   butler: false
 
+  # -- Enable the Butler writer application
+  butler-writer-service: false
+
   # -- Enable the calsys control system application
   calsys: false
 


### PR DESCRIPTION
This PR adds a Butler writer service for Prompt Processing in an alternative architecture to #5079 . The service is enabled in `dev` but used only by LSSTCam-dev.