### PR TITLE
DM-52103: Add new Gafaelfawr scope for Portal admin page

### DIFF
--- a/applications/gafaelfawr/values-base.yaml
+++ b/applications/gafaelfawr/values-base.yaml
@@ -47,6 +47,9 @@ config:
       - "rsp-bts"
     "exec:portal":
       - "rsp-bts"
+    "exec:portal-admin":
+      - "k8s-manke-admins"
+      - "sqre"
     "read:image":
       - "rsp-bts"
     "read:tap":

--- a/applications/gafaelfawr/values-ccin2p3.yaml
+++ b/applications/gafaelfawr/values-ccin2p3.yaml
@@ -88,6 +88,8 @@ config:
       - "lsst"
     "exec:portal":
       - "lsst"
+    "exec:portal-admin":
+      - "ccin2p3"
     "read:image":
       - "lsst"
     "read:tap":

--- a/applications/gafaelfawr/values-idfdev.yaml
+++ b/applications/gafaelfawr/values-idfdev.yaml
@@ -57,6 +57,8 @@ config:
       - "g_users"
     "exec:portal":
       - "g_users"
+    "exec:portal-admin":
+      - "g_developers"
     "read:image":
       - "g_users"
     "read:tap":

--- a/applications/gafaelfawr/values-idfint.yaml
+++ b/applications/gafaelfawr/values-idfint.yaml
@@ -59,6 +59,8 @@ config:
       - "g_users"
     "exec:portal":
       - "g_users"
+    "exec:portal-admin":
+      - "g_developers"
     "read:image":
       - "g_users"
     "read:tap":

--- a/applications/gafaelfawr/values-idfprod.yaml
+++ b/applications/gafaelfawr/values-idfprod.yaml
@@ -71,6 +71,8 @@ config:
     "exec:portal":
       - "g_rubin"
       - "g_users"
+    "exec:portal-admin":
+      - "g_portal_admins"
     "read:image":
       - "g_rubin"
       - "g_users"

--- a/applications/gafaelfawr/values-summit.yaml
+++ b/applications/gafaelfawr/values-summit.yaml
@@ -45,6 +45,9 @@ config:
       - "rsp-summit"
     "exec:portal":
       - "rsp-summit"
+    "exec:portal-admin":
+      - "k8s-yagan-admins"
+      - "sqre"
     "read:image":
       - "rsp-summit"
     "read:tap":

--- a/applications/gafaelfawr/values-tacc-spherex.yaml
+++ b/applications/gafaelfawr/values-tacc-spherex.yaml
@@ -92,7 +92,7 @@ config:
       #- github:
       #    organization: "lsst-sqre"
       #    team: "tacc-spherex"
-    "read:image":
+    "exec:portal":
       - "G-827698"
       - "G-820288"
       - "TACC-ACI-CIC"
@@ -102,7 +102,16 @@ config:
       #- github:
       #    organization: "lsst-sqre"
       #    team: "tacc-spherex"
-    "exec:portal":
+    "exec:portal-admin":
+      - "G-820288"
+      - "TACC-ACI-CIC"
+      #- github:
+      #    organization: "lsst-sqre"
+      #    team: "square"
+      #- github:
+      #    organization: "lsst-sqre"
+      #    team: "tacc-spherex"
+    "read:image":
       - "G-827698"
       - "G-820288"
       - "TACC-ACI-CIC"

--- a/applications/gafaelfawr/values-tucson-teststand.yaml
+++ b/applications/gafaelfawr/values-tucson-teststand.yaml
@@ -69,6 +69,10 @@ config:
       - github:
           organization: "rubin-summit"
           team: "rsp-access"
+    "exec:portal-admin":
+      - github:
+          organization: "lsst-sqre"
+          team: "square"
     "read:image":
       - github:
           organization: "lsst-sqre"

--- a/applications/gafaelfawr/values-ukidacdev.yaml
+++ b/applications/gafaelfawr/values-ukidacdev.yaml
@@ -34,6 +34,10 @@ config:
       - github:
           organization: "lsp-uk"
           team: "dev"
+    "exec:portal-admin":
+      - github:
+          organization: "lsp-uk"
+          team: "dev"
     "read:image":
       - github:
           organization: "lsp-uk"

--- a/applications/gafaelfawr/values-ukidacprod.yaml
+++ b/applications/gafaelfawr/values-ukidacprod.yaml
@@ -39,6 +39,10 @@ config:
       - github:
           organization: "lsp-uk"
           team: "dev"
+    "exec:portal-admin":
+      - github:
+          organization: "lsp-uk"
+          team: "dev"
     "read:image":
       - github:
           organization: "lsp-uk"

--- a/applications/gafaelfawr/values-usdfdev.yaml
+++ b/applications/gafaelfawr/values-usdfdev.yaml
@@ -153,6 +153,9 @@ config:
       - "rubin_admin_datasets"
       - "rubin_admin_repos"
       - "unix-admin"
+    "exec:portal-admin":
+      - "rubinmgr"
+      - "unix-admin"
     "read:image":
       - "lsst"
       - "lsst-ccs"

--- a/applications/gafaelfawr/values-usdfint.yaml
+++ b/applications/gafaelfawr/values-usdfint.yaml
@@ -146,7 +146,10 @@ config:
       - "rubin_admin_datasets"
       - "rubin_admin_repos"
       - "unix-admin"
-    "read:tap":
+    "exec:portal-admin":
+      - "rubinmgr"
+      - "unix-admin"
+    "read:image":
       - "lsst"
       - "lsst-ccs"
       - "rubin_users"
@@ -179,7 +182,7 @@ config:
       - "rubin_admin_datasets"
       - "rubin_admin_repos"
       - "unix-admin"
-    "read:image":
+    "read:tap":
       - "lsst"
       - "lsst-ccs"
       - "rubin_users"

--- a/applications/gafaelfawr/values-usdfprod.yaml
+++ b/applications/gafaelfawr/values-usdfprod.yaml
@@ -146,6 +146,9 @@ config:
       - "rubin_admin_datasets"
       - "rubin_admin_repos"
       - "unix-admin"
+    "exec:portal-admin":
+      - "rubinmgr"
+      - "unix-admin"
     "read:image":
       - "lsst"
       - "lsst-ccs"

--- a/applications/gafaelfawr/values.yaml
+++ b/applications/gafaelfawr/values.yaml
@@ -288,6 +288,8 @@ config:
       Retrieve alert packets and schemas from the alert archive database
     "read:image": >-
       Retrieve images from project datasets
+    "exec:portal-admin": >-
+      Read access to the Portal admin page
     "read:tap": >-
       Execute SELECT queries in the TAP interface on project datasets
     "write:files": >-

--- a/applications/portal/templates/ingress-admin.yaml
+++ b/applications/portal/templates/ingress-admin.yaml
@@ -8,7 +8,7 @@ config:
   loginRedirect: true
   scopes:
     all:
-      - "exec:admin"
+      - "exec:portal-admin"
   service: "portal"
 template:
   metadata:

--- a/docs/applications/gafaelfawr/add-scope.rst
+++ b/docs/applications/gafaelfawr/add-scope.rst
@@ -1,0 +1,36 @@
+##########################
+Add a new Gafaelfawr scope
+##########################
+
+In order for Gafaelfawr to apply authorization rules, there has to be a scope that matches the granularity of access to be granted.
+Rarely, it may be necessary to add a new scope to avoid granting too much access.
+
+.. warning::
+
+   Avoid adding new scopes whenever possible, since a large number of scopes becomes unwieldy.
+   Most group-based access control decisions should be made inside applications rather than by using Gafaelfawr scopes.
+   Read the cautions in :dmtn:`235` before proceeding.
+
+Adding a new scope requires the following steps:
+
+#. Add the new scope and its description to ``config.knownScopes`` in :file:`applications/gafaelfawr/values.yaml`.
+   It is possible to add the scope only in specific environments, but we prefer to keep the list of scopes the same in all environments since it makes writing Phalanx Helm charts easier.
+
+#. If necessary (if there is no existing group that can be used for this purpose), create a new group containing the specific people who will be granted the new scope.
+   How to do this will depend on the source of groups for every affected environment.
+   For example, for environments that use COmanage, do this in the corresponding COmanage instance for each environment.
+   For environments that use GitHub, add people to an appropriate team.
+
+#. By default, no one will receive the new scope.
+   For every environment where the application using the new scope will be deployed, add a group mapping rule to ``config.groupMappings`` in :file:`applications/gafaelfawr/values-{environment}.yaml`.
+   Yes, this is tedious and requires modifying lots of environments in the common case.
+   This helps discourage you from adding new scopes unnecessarily.
+
+#. Update the ``GafaelfawrIngress`` resource in the applications that will use the new scope to require it instead of whatever scope they were using before.
+
+#. Update :dmtn:`235` to document the new scope in more detail.
+
+#. When syncing applications in each environment to apply this change, sync the ``gafaelfawr`` application first before syncing any application that wants to start using the scope for access control.
+
+Be aware that, after Gafaelfawr has been synced, users will have to log out and log back in to get their new scope.
+Users with existing sessions will not have that scope, even if they are eligible for it based on their group memberships, and thus will be denied access to ingresses that require it until they log out and back in.

--- a/docs/applications/gafaelfawr/github-organizations.rst
+++ b/docs/applications/gafaelfawr/github-organizations.rst
@@ -6,8 +6,8 @@ This applies only to Science Platform environments that use GitHub for authentic
 
 When the user is sent to GitHub to perform an OAuth 2.0 authentication, they are told what information about their account the application is requesting, and are prompted for which organizational information to release.
 Since we're using GitHub for group information, all organizations that should contribute to group information (via team membership) must have their data released.
-GitHub supports two ways of doing this: make the organization membership public, or grant the OAuth App access to that organization's data explicitly.
 
+GitHub supports two ways of doing this: make the organization membership public, or grant the OAuth App access to that organization's data explicitly.
 GitHub allows the user to do the latter in the authorization screen during OAuth 2.0 authentication.
 
 .. figure:: github-oauth.png

--- a/docs/applications/gafaelfawr/index.rst
+++ b/docs/applications/gafaelfawr/index.rst
@@ -25,6 +25,7 @@ Guides
    manage-schema
    quotas
    recreate-token
+   add-scope
    add-oidc-client
    github-organizations
    troubleshoot

--- a/docs/applications/gafaelfawr/recreate-token.rst
+++ b/docs/applications/gafaelfawr/recreate-token.rst
@@ -8,20 +8,20 @@ However, if that persistent storage is deleted for some reason, or if Gafaelfawr
 When this happens, depending on the order of restart, the ``gafaelfawr-tokens`` pod that is responsible for maintaining service tokens in the cluster may take up to 30 minutes to realize those tokens are no longer valid.
 This will primarily affect the Notebook Aspect, which will be unable to authenticate to the Nublado controller and thus will not be able to spawn pods.
 
-Gafaelfawr will automatically fix this problem after 30 minutes, but unfortunately the JupyterHub component of ``nublado`` currently loads its token on startup and doesn't pick up changes.
+Gafaelfawr will automatically fix this problem after 30 minutes, but unfortunately the JupyterHub component of Nublado currently loads its token on startup and doesn't pick up changes.
 
 The easiest way to fix this problem is to force revalidation of all of the Gafaelfawr service tokens.
 To do that:
 
-#. Force a restart of the ``gafaelfawr-tokens`` deployment in the ``gafaelfawr`` namespace.
+#. Force a restart of the ``gafaelfawr-tokens`` deployment in the ``gafaelfawr`` application.
    This will recreate any token secrets that are not valid.
 
-#. Force a restart of the ``hub`` deployment in ``nublado``.
+#. Force a restart of the ``hub`` deployment in the ``nublado`` application.
    This will restart the hub with the new, correct token.
 
 Be aware that when the Redis storage is wipoed, all user tokens will also be invalidated.
 Users will be prompted to log in again the next time they go to the Science Platform.
 
 Invalidating the Redis storage will also result in inconsistencies between Redis and SQL that will produce nightly alerts if Gafaelfawr is configured to send Slack alerts.
-To fix the inconsistencies, run ``gafaelfawr audit --fix`` inside the Gafaelfawr pod using ``kubectl exec``.
+To fix the inconsistencies, run :command:`gafaelfawr audit --fix` inside the Gafaelfawr pod using :command:`kubectl exec`.
 This will locate all the tokens that are no longer valid and mark them as expired in the database as well.

--- a/docs/applications/gafaelfawr/troubleshoot.rst
+++ b/docs/applications/gafaelfawr/troubleshoot.rst
@@ -9,21 +9,32 @@ Troubleshooting
 User has no access to services
 ==============================
 
-If a user successfully authenticates through the Gafaelfawr ``/login`` route but then cannot access an application such as the Notebook or Portal, or if Gafaelfawr tells them that they are not a member of any authorized groups, start by determining what groups the user is a member of.
+If a user successfully authenticates through the Gafaelfawr ``/login`` route but then cannot access an application such as the Notebook or Portal, or if Gafaelfawr tells them that they are not a member of any authorized groups, the problem is likely the user's group memberships.
 
-Have the user go to ``/auth/api/v1/user-info``, which will provide a JSON dump of their authentication information.
-There is nothing secret in this information, so they can safely cut and paste it into a help ticket, Slack, etc.
+GitHub
+------
 
+If the environment is using GitHub, there is no simple way to see Gafaelfawr's view of their group memberships other than finding the log message for their failed login.
+However, one thing to check is if the organizational membership is private and the user didn't release it.
+See :doc:`github-organizations` for more details about that problem.
+
+If not, check that the user is indeed a member of the organizations and teams that should be granted access.
+Sometimes the user forgot to accept the invitation to the group or team.
+
+LDAP
+----
+
+For environments using LDAP, you can see the user's group information directly as an environment administrator.
+
+As someone with ``admin:userinfo`` scope, go to :samp:`/auth/api/v1/users/{username}` in the corresponding Phalanx environment.
+This will display the user's metadata from LDAP.
 The important information is in the ``groups`` portion of the JSON document.
 This shows the group membership as seen by Gafaelfawr.
+
 Scopes are then assigned based on the ``config.groupMapping`` configuration in the ``values-*.yaml`` file for that environment.
 Chances are good that the user is not a member of a group that conveys the appropriate scopes.
 
 From there, the next step is usually to determine why the user is not a member of the appropriate group.
-Usually this means they weren't added or (in the case of groups from GitHub teams) didn't accept the invitation.
-
-For a new GitHub configuration, it's possible that the organizational membership is private and the user didn't release it.
-See :doc:`github-organizations` for more details about that problem.
 
 COmanage enrollment fails after prompting for attributes
 ========================================================


### PR DESCRIPTION
Add a new `exec:portal-admin` scope that controls read access to the Portal admin page so that we can grant access to Portal administrators without giving them `exec:admin`.

Document how to add a new Gafaelfawr scope and make some minor edits to the other Gafaelfawr documentation.