### PR TITLE
DM-52103: Add g_admins to exec:portal-admin scope

### DIFF
--- a/applications/gafaelfawr/values-idfdev.yaml
+++ b/applications/gafaelfawr/values-idfdev.yaml
@@ -58,6 +58,7 @@ config:
     "exec:portal":
       - "g_users"
     "exec:portal-admin":
+      - "g_admins"
       - "g_developers"
     "read:image":
       - "g_users"

--- a/applications/gafaelfawr/values-idfint.yaml
+++ b/applications/gafaelfawr/values-idfint.yaml
@@ -60,6 +60,7 @@ config:
     "exec:portal":
       - "g_users"
     "exec:portal-admin":
+      - "g_admins"
       - "g_developers"
     "read:image":
       - "g_users"

--- a/applications/gafaelfawr/values-idfprod.yaml
+++ b/applications/gafaelfawr/values-idfprod.yaml
@@ -72,6 +72,7 @@ config:
       - "g_rubin"
       - "g_users"
     "exec:portal-admin":
+      - "g_admins"
       - "g_portal_admins"
     "read:image":
       - "g_rubin"


### PR DESCRIPTION
On idfdev and idfint, add `g_admins` to the list of groups that get `exec:portal-admin` scope.