### PR TITLE
DM-52127: Update squareone to 0.22.0

### DIFF
--- a/applications/squareone/Chart.yaml
+++ b/applications/squareone/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
     url: https://github.com/jonathansick
 
 # The default version tag of the squareone docker image
-appVersion: "0.21.0"
+appVersion: "0.22.0"


### PR DESCRIPTION
https://github.com/lsst-sqre/squareone/releases/tag/squareone%400.22.0