### PR TITLE
DM-52140: Bump Gafaelfawr to 14.0.1

### DIFF
--- a/applications/gafaelfawr/Chart.yaml
+++ b/applications/gafaelfawr/Chart.yaml
@@ -5,7 +5,7 @@ description: "Authentication and identity system"
 home: "https://gafaelfawr.lsst.io/"
 sources:
   - "https://github.com/lsst-sqre/gafaelfawr"
-appVersion: 14.0.0
+appVersion: 14.0.1
 
 dependencies:
   - name: "redis"


### PR DESCRIPTION
Fixes a group name validation regression that broke TACC.