### PR TITLE
Rollback Squareone to 0.22.0

### DIFF
--- a/applications/squareone/Chart.yaml
+++ b/applications/squareone/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
     url: https://github.com/jonathansick
 
 # The default version tag of the squareone docker image
-appVersion: "0.23.0"
+appVersion: "0.22.0"


### PR DESCRIPTION
This was the migration to Next 13. We're going to hold off on deploying the modernized Squareone to production until we're further along and have done more testing.