### PR TITLE
Change projects for keda and atlantis

### DIFF
--- a/docs/applications/infrastructure.rst
+++ b/docs/applications/infrastructure.rst
@@ -11,10 +11,8 @@ Argo CD project: ``infrastructure``
    :maxdepth: 1
 
    argocd/index
-   atlantis/index
    cert-manager/index
    ingress-nginx/index
    gafaelfawr/index
-   keda/index
    mobu/index
    vault-secrets-operator/index

--- a/docs/applications/roundtable.rst
+++ b/docs/applications/roundtable.rst
@@ -12,6 +12,7 @@ Argo CD project: ``roundtable``
    :maxdepth: 1
    :caption: Roundtable
 
+   atlantis/index
    checkerboard/index
    eups-distributor/index
    giftless/index

--- a/docs/applications/support.rst
+++ b/docs/applications/support.rst
@@ -11,6 +11,7 @@ Argo CD project: ``support``
    :maxdepth: 1
 
    ghostwriter/index
+   keda/index
    postgres/index
    strimzi/index
    strimzi-access-operator/index

--- a/environments/templates/applications/roundtable/atlantis.yaml
+++ b/environments/templates/applications/roundtable/atlantis.yaml
@@ -1,25 +1,25 @@
-{{- if (index .Values "applications" "keda") -}}
+{{- if (index .Values "applications" "atlantis") -}}
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: "keda"
+  name: "atlantis"
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: "keda"
+  name: "atlantis"
   namespace: "argocd"
   finalizers:
     - "resources-finalizer.argocd.argoproj.io"
 spec:
   destination:
-    namespace: "keda"
+    namespace: "atlantis"
     server: "https://kubernetes.default.svc"
-  project: "infrastructure"
+  project: "roundtable"
   source:
-    path: "applications/keda"
+    path: "applications/atlantis"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ or (index .Values "revisions" "keda") .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "atlantis") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"
@@ -31,7 +31,4 @@ spec:
       valueFiles:
         - "values.yaml"
         - "values-{{ .Values.name }}.yaml"
-  syncPolicy:
-    syncOptions:
-      - ServerSideApply=true
 {{- end -}}

--- a/environments/templates/applications/support/keda.yaml
+++ b/environments/templates/applications/support/keda.yaml
@@ -1,25 +1,25 @@
-{{- if (index .Values "applications" "atlantis") -}}
+{{- if (index .Values "applications" "keda") -}}
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: "atlantis"
+  name: "keda"
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: "atlantis"
+  name: "keda"
   namespace: "argocd"
   finalizers:
     - "resources-finalizer.argocd.argoproj.io"
 spec:
   destination:
-    namespace: "atlantis"
+    namespace: "keda"
     server: "https://kubernetes.default.svc"
-  project: "infrastructure"
+  project: "support"
   source:
-    path: "applications/atlantis"
+    path: "applications/keda"
     repoURL: {{ .Values.repoUrl | quote }}
-    targetRevision: {{ or (index .Values "revisions" "atlantis") .Values.targetRevision | quote }}
+    targetRevision: {{ or (index .Values "revisions" "keda") .Values.targetRevision | quote }}
     helm:
       parameters:
         - name: "global.host"
@@ -31,4 +31,7 @@ spec:
       valueFiles:
         - "values.yaml"
         - "values-{{ .Values.name }}.yaml"
+  syncPolicy:
+    syncOptions:
+      - ServerSideApply=true
 {{- end -}}


### PR DESCRIPTION
keda is only needed for some environments and therefore should be in support. atlantis is only deployed on Roundtable and therefore should be in roundtable.