### PR TITLE
Revert "Update Helm release vault to v0.30.1"

### DIFF
--- a/applications/vault/Chart.yaml
+++ b/applications/vault/Chart.yaml
@@ -4,5 +4,5 @@ version: 1.0.0
 description: Secret Storage
 dependencies:
   - name: vault
-    version: 0.30.1
+    version: 0.30.0
     repository: https://helm.releases.hashicorp.com


### PR DESCRIPTION
This reverts commit fc913d21927beb83d04dbf4869301df9b5767ee5. The bug that prevents Vault from working with GCP still hasn't been fixed in 1.20.1 (or 1.20.2).