### PR TITLE
DM-52257 (hotfix): Revert "Merge pull request #5269"

### DIFF
--- a/applications/livetap/values.yaml
+++ b/applications/livetap/values.yaml
@@ -16,7 +16,7 @@ cadc-tap:
     pg:
       # -- Postgres hostname:port to connect to
       # @default -- `"mock-pg:5432"` (the mock pg)
-      host: "usdf-butler-main-transaction.slac.stanford.edu:5432"
+      host: "usdf-butler.slac.stanford.edu:5432"
 
       # -- Postgres database to connect to
       database: "lsstdb1"


### PR DESCRIPTION
The database hostname is desirable, but this causes mismatches with the database credentials file, so we are reverting the hostname change.

This reverts commit 94b39243c3b388ce04940a9c8f0728c569821e46, reversing changes made to fa7f89f4f3a396605d128ee20282323a3807cc2d.