### PR TITLE
Rollbackk to 0.21.0

### DIFF
--- a/applications/squareone/Chart.yaml
+++ b/applications/squareone/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
     url: https://github.com/jonathansick
 
 # The default version tag of the squareone docker image
-appVersion: "0.22.0"
+appVersion: "0.21.0"


### PR DESCRIPTION
The Next production build broke with the React/Next.js upgrades.