### PR TITLE
DM-52277: Bump Qserv Kafka bridge to 3.0.0

### DIFF
--- a/applications/qserv-kafka/Chart.yaml
+++ b/applications/qserv-kafka/Chart.yaml
@@ -5,7 +5,7 @@ version: 1.0.0
 description: "Qserv Kafka bridge"
 sources:
   - "https://github.com/lsst-sqre/qserv-kafka"
-appVersion: 2.0.0
+appVersion: 3.0.0
 
 dependencies:
   - name: "redis"


### PR DESCRIPTION
This version sends the collation name on table upload, which is a new parameter with the new release of Qserv and is now effectively required if a UTF-8 character set is used. It also switches the character set to support the full UTF-8 range.