### PR TITLE
DM-52310: Upgrade vo-cutouts to 4.1.3

### DIFF
--- a/applications/vo-cutouts/Chart.yaml
+++ b/applications/vo-cutouts/Chart.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 description: "Image cutout service complying with IVOA SODA"
 sources:
   - "https://github.com/lsst-sqre/vo-cutouts"
-appVersion: 4.1.2
+appVersion: 4.1.3
 
 dependencies:
   - name: redis


### PR DESCRIPTION
Uses the new Science Pipelines release in the worker backend, which should hopefully fix a memory leak.