### PR TITLE
DM-52282: Upgrade Qserv Kafka bridge to 3.0.1

### DIFF
--- a/applications/qserv-kafka/Chart.yaml
+++ b/applications/qserv-kafka/Chart.yaml
@@ -5,7 +5,7 @@ version: 1.0.0
 description: "Qserv Kafka bridge"
 sources:
   - "https://github.com/lsst-sqre/qserv-kafka"
-appVersion: 3.0.1
+appVersion: 3.1.0
 
 dependencies:
   - name: "redis"

--- a/applications/qserv-kafka/Chart.yaml
+++ b/applications/qserv-kafka/Chart.yaml
@@ -5,7 +5,7 @@ version: 1.0.0
 description: "Qserv Kafka bridge"
 sources:
   - "https://github.com/lsst-sqre/qserv-kafka"
-appVersion: 3.0.0
+appVersion: 3.0.1
 
 dependencies:
   - name: "redis"

--- a/applications/qserv-kafka/README.md
+++ b/applications/qserv-kafka/README.md
@@ -12,6 +12,7 @@ Qserv Kafka bridge
 |-----|------|---------|-------------|
 | config.consumerGroupId | string | `"qserv"` | Kafka consumer group ID |
 | config.jobCancelTopic | string | `"lsst.tap.job-delete"` | Kafka topic for query cancellation requests |
+| config.jobRunBatchSize | int | `20` | Maximum batch size for query execution requests. This should generally be the same as `qservRestMaxConnections`. |
 | config.jobRunTopic | string | `"lsst.tap.job-run"` | Kafka topic for query execution requests |
 | config.jobStatusTopic | string | `"lsst.tap.job-status"` | Kafka topic for query status |
 | config.logLevel | string | `"INFO"` | Logging level |

--- a/applications/qserv-kafka/README.md
+++ b/applications/qserv-kafka/README.md
@@ -12,7 +12,8 @@ Qserv Kafka bridge
 |-----|------|---------|-------------|
 | config.consumerGroupId | string | `"qserv"` | Kafka consumer group ID |
 | config.jobCancelTopic | string | `"lsst.tap.job-delete"` | Kafka topic for query cancellation requests |
-| config.jobRunBatchSize | int | `20` | Maximum batch size for query execution requests. This should generally be the same as `qservRestMaxConnections`. |
+| config.jobRunBatchSize | int | `10` | Maximum batch size for query execution requests. This should generally be the same as `qservRestMaxConnections`. |
+| config.jobRunMaxBytes | int | 10MiB | Maximum size of a batch read from Kafka in bytes. Wide queries can be up to 500KiB in size, so this should be at least 500KiB * 10. |
 | config.jobRunTopic | string | `"lsst.tap.job-run"` | Kafka topic for query execution requests |
 | config.jobStatusTopic | string | `"lsst.tap.job-status"` | Kafka topic for query status |
 | config.logLevel | string | `"INFO"` | Logging level |
@@ -23,11 +24,11 @@ Qserv Kafka bridge
 | config.metrics.events.topicPrefix | string | `"lsst.square.metrics.events"` | Topic prefix for events. It may sometimes be useful to change this in development environments. |
 | config.metrics.schemaManager.registryUrl | string | Sasquatch in the local cluster | URL of the Confluent-compatible schema registry server |
 | config.metrics.schemaManager.suffix | string | `""` | Suffix to add to all registered subjects. This is sometimes useful for experimentation during development. |
-| config.qservDatabaseOverflow | int | `50` | Extra database connections that may be opened in excess of the pool size to handle surges in load. This is used primarily by the frontend for jobs that complete immediately. |
-| config.qservDatabasePoolSize | int | `2` | Database pool size. This is the number of MySQL connections that will be held open regardless of load. This should generally be set to the same as `maxWorkerJobs`. |
+| config.qservDatabaseOverflow | int | `20` | Extra database connections that may be opened in excess of the pool size to handle surges in load. This is used primarily by the frontend for jobs that complete immediately. |
+| config.qservDatabasePoolSize | int | `10` | Database pool size. This is the number of MySQL connections that will be held open regardless of load. This should generally be set to the same as `maxWorkerJobs`. |
 | config.qservDatabaseUrl | string | None, must be set | URL to the Qserv MySQL interface (must use a scheme of `mysql+asyncmy`) |
 | config.qservPollInterval | string | `"1s"` | Interval at which Qserv is polled for query status in Safir `parse_timedelta` format |
-| config.qservRestMaxConnections | int | `20` | Maximum simultaneous connections to open to the REST API |
+| config.qservRestMaxConnections | int | `15` | Maximum simultaneous connections to open to the REST API. This should be set to `jobRunBatchSize` plus some extra connections for the monitor and cancel jobs. |
 | config.qservRestSendApiVersion | bool | `true` | Whether to send the expected API version in REST API calls to Qserv |
 | config.qservRestTimeout | string | `"30s"` | Timeout for REST API calls in Safir `parse_timedelta` format. This includes time spent waiting for a connection if the maximum number of connections has been reached. |
 | config.qservRestUrl | string | None, must be set | URL to the Qserv REST API |
@@ -35,6 +36,7 @@ Qserv Kafka bridge
 | config.qservRetryCount | int | `3` | How many times to retry after a Qserv API network failure |
 | config.qservRetryDelay | string | `"1s"` | How long to wait between retries after a Qserv API network failure in Safir `parse_timedelta` format |
 | config.qservUploadTimeout | string | `"5m"` | How long to allow for user table upload before timing out in Safir `parse_timedelta` format. |
+| config.redisMaxConnections | int | `15` | Size of the Redis connection pool. This should be set to `jobRunBatchSize` plus some extra connections for the monitor, cancel jobs. |
 | config.resultTimeout | int | 3600 (1 hour) | How long to wait for result processing (retrieval and upload) before timing out, in seconds. This doubles as the timeout forcibly terminating result worker pods. |
 | config.tapService | string | `"qserv"` | Name of the TAP service for which this Qserv Kafka instance is managing queries. This must match the name of the TAP service for the corresponding query quota in the Gafaelfawr configuration. |
 | frontend.affinity | object | `{}` | Affinity rules for the qserv-kafka frontend pod |

--- a/applications/qserv-kafka/templates/configmap.yaml
+++ b/applications/qserv-kafka/templates/configmap.yaml
@@ -12,7 +12,7 @@ data:
   QSERV_KAFKA_GAFAELFAWR_BASE_URL: {{ .Values.global.baseUrl | quote }}
   QSERV_KAFKA_JOB_CANCEL_TOPIC: {{ .Values.config.jobCancelTopic | quote }}
   QSERV_KAFKA_JOB_RUN_BATCH_SIZE: {{ .Values.config.jobRunBatchSize | quote }}
-  QSERV_KAFKA_JOB_RUN_MAX_BYTES: {{ .Values.config.jobRunMaxBytes | quote }}
+  QSERV_KAFKA_JOB_RUN_MAX_BYTES: {{ int64 .Values.config.jobRunMaxBytes | quote }}
   QSERV_KAFKA_JOB_RUN_TOPIC: {{ .Values.config.jobRunTopic | quote }}
   QSERV_KAFKA_JOB_STATUS_TOPIC: {{ .Values.config.jobStatusTopic | quote }}
   QSERV_KAFKA_LOG_LEVEL: {{ .Values.config.logLevel | quote }}

--- a/applications/qserv-kafka/templates/configmap.yaml
+++ b/applications/qserv-kafka/templates/configmap.yaml
@@ -11,6 +11,7 @@ data:
   QSERV_KAFKA_CONSUMER_GROUP_ID: {{ .Values.config.consumerGroupId | quote }}
   QSERV_KAFKA_GAFAELFAWR_BASE_URL: {{ .Values.global.baseUrl | quote }}
   QSERV_KAFKA_JOB_CANCEL_TOPIC: {{ .Values.config.jobCancelTopic | quote }}
+  QSERV_KAFKA_JOB_RUN_BATCH_SIZE: {{ .Values.config.jobRunBatchSize | quote }}
   QSERV_KAFKA_JOB_RUN_TOPIC: {{ .Values.config.jobRunTopic | quote }}
   QSERV_KAFKA_JOB_STATUS_TOPIC: {{ .Values.config.jobStatusTopic | quote }}
   QSERV_KAFKA_LOG_LEVEL: {{ .Values.config.logLevel | quote }}

--- a/applications/qserv-kafka/templates/configmap.yaml
+++ b/applications/qserv-kafka/templates/configmap.yaml
@@ -12,6 +12,7 @@ data:
   QSERV_KAFKA_GAFAELFAWR_BASE_URL: {{ .Values.global.baseUrl | quote }}
   QSERV_KAFKA_JOB_CANCEL_TOPIC: {{ .Values.config.jobCancelTopic | quote }}
   QSERV_KAFKA_JOB_RUN_BATCH_SIZE: {{ .Values.config.jobRunBatchSize | quote }}
+  QSERV_KAFKA_JOB_RUN_MAX_BYTES: {{ .Values.config.jobRunMaxBytes | quote }}
   QSERV_KAFKA_JOB_RUN_TOPIC: {{ .Values.config.jobRunTopic | quote }}
   QSERV_KAFKA_JOB_STATUS_TOPIC: {{ .Values.config.jobStatusTopic | quote }}
   QSERV_KAFKA_LOG_LEVEL: {{ .Values.config.logLevel | quote }}
@@ -33,6 +34,7 @@ data:
   QSERV_KAFKA_QSERV_RETRY_COUNT: {{ .Values.config.qservRetryCount | quote }}
   QSERV_KAFKA_QSERV_RETRY_DELAY: {{ .Values.config.qservRetryDelay | quote }}
   QSERV_KAFKA_QSERV_UPLOAD_TIMEOUT: {{ .Values.config.qservUploadTimeout | quote }}
+  QSERV_KAFKA_REDIS_MAX_CONNECTIONS: {{ .Values.config.redisMaxConnections | quote }}
   QSERV_KAFKA_REDIS_URL: "redis://qserv-kafka-redis.{{ .Release.Namespace }}:6379/0"
   QSERV_KAFKA_RESULT_TIMEOUT: {{ .Values.config.resultTimeout | quote }}
   QSERV_KAFKA_REWRITE_BASE_URL: {{ .Values.global.baseUrl | quote }}

--- a/applications/qserv-kafka/values-idfdev.yaml
+++ b/applications/qserv-kafka/values-idfdev.yaml
@@ -4,7 +4,7 @@ config:
     enabled: true
   qservDatabaseUrl: "mysql+asyncmy://qsmaster@qserv-int.slac.stanford.edu:4090/"
   qservRestSendApiVersion: false
-  qservRestUrl: "https://134.79.23.197:4098/"
+  qservRestUrl: "https://qserv-int-https.slac.stanford.edu:4098/"
   qservRestUsername: "qsmaster"
 resultWorker:
   allowRootDebug: true

--- a/applications/qserv-kafka/values.yaml
+++ b/applications/qserv-kafka/values.yaml
@@ -11,7 +11,12 @@ config:
 
   # -- Maximum batch size for query execution requests. This should generally
   # be the same as `qservRestMaxConnections`.
-  jobRunBatchSize: 20
+  jobRunBatchSize: 10
+
+  # -- Maximum size of a batch read from Kafka in bytes. Wide queries can be
+  # up to 500KiB in size, so this should be at least 500KiB * 10.
+  # @default -- 10MiB
+  jobRunMaxBytes: 10485760
 
   # -- Kafka topic for query execution requests
   jobRunTopic: "lsst.tap.job-run"
@@ -54,12 +59,12 @@ config:
   # -- Extra database connections that may be opened in excess of the pool
   # size to handle surges in load. This is used primarily by the frontend for
   # jobs that complete immediately.
-  qservDatabaseOverflow: 50
+  qservDatabaseOverflow: 20
 
   # -- Database pool size. This is the number of MySQL connections that will
   # be held open regardless of load. This should generally be set to the same
   # as `maxWorkerJobs`.
-  qservDatabasePoolSize: 2
+  qservDatabasePoolSize: 10
 
   # -- URL to the Qserv MySQL interface (must use a scheme of `mysql+asyncmy`)
   # @default -- None, must be set
@@ -69,8 +74,10 @@ config:
   # `parse_timedelta` format
   qservPollInterval: "1s"
 
-  # -- Maximum simultaneous connections to open to the REST API
-  qservRestMaxConnections: 20
+  # -- Maximum simultaneous connections to open to the REST API. This should
+  # be set to `jobRunBatchSize` plus some extra connections for the monitor
+  # and cancel jobs.
+  qservRestMaxConnections: 15
 
   # -- Whether to send the expected API version in REST API calls to Qserv
   qservRestSendApiVersion: true
@@ -99,6 +106,11 @@ config:
   # -- How long to wait between retries after a Qserv API network failure in
   # Safir `parse_timedelta` format
   qservRetryDelay: "1s"
+
+  # -- Size of the Redis connection pool. This should be set to
+  # `jobRunBatchSize` plus some extra connections for the monitor, cancel
+  # jobs.
+  redisMaxConnections: 15
 
   # -- How long to wait for result processing (retrieval and upload) before
   # timing out, in seconds. This doubles as the timeout forcibly terminating

--- a/applications/qserv-kafka/values.yaml
+++ b/applications/qserv-kafka/values.yaml
@@ -9,6 +9,10 @@ config:
   # -- Kafka topic for query cancellation requests
   jobCancelTopic: "lsst.tap.job-delete"
 
+  # -- Maximum batch size for query execution requests. This should generally
+  # be the same as `qservRestMaxConnections`.
+  jobRunBatchSize: 20
+
   # -- Kafka topic for query execution requests
   jobRunTopic: "lsst.tap.job-run"
 

--- a/applications/qserv-kafka/values.yaml
+++ b/applications/qserv-kafka/values.yaml
@@ -164,7 +164,7 @@ frontend:
   resources:
     limits:
       cpu: "1"
-      memory: "300Mi"
+      memory: "450Mi"
     requests:
       cpu: "100m"
       memory: "145Mi"


### PR DESCRIPTION
Parallelize query processing to make better use of the CPU of the frontend under heavy query load.