### PR TITLE
DM-52310: Add uvicorn settings for vo-cutouts

### DIFF
--- a/applications/vo-cutouts/templates/deployment.yaml
+++ b/applications/vo-cutouts/templates/deployment.yaml
@@ -33,18 +33,6 @@ spec:
         runAsGroup: 1000
       containers:
         - name: "vo-cutouts"
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - "all"
-            readOnlyRootFilesystem: true
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
-          ports:
-            - containerPort: 8080
-              name: "http"
-              protocol: "TCP"
           env:
             - name: "CUTOUT_ARQ_QUEUE_PASSWORD"
               valueFrom:
@@ -58,9 +46,31 @@ spec:
                   name: "vo-cutouts"
                   key: "slack-webhook"
             {{- end }}
+            # Uvicorn keepalive timeout, in seconds. This should be longer
+            # than any keepalive timeouts on any downstream proxies. The
+            # keepalive timeout for ingress-nginx connections is 60s.
+            - name: "UVICORN_TIMEOUT_KEEP_ALIVE"
+              value: "61"
           envFrom:
             - configMapRef:
                 name: "vo-cutouts"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          lifecycle:
+            # Number of seconds k8s should wait before sending SIGTERM on
+            # graceful restarts/deployments/shutdowns. We need this because it
+            # takes ingress-nginx some time to configure itself to stop
+            # sending traffic to the pods scheduled for termination. If
+            # Uvicorn gets the SIGTERM and starts closing connections, we
+            # could end up with a TCP race condition if ingress-nginx still
+            # tries to send data over those connections.
+            preStop:
+              sleep:
+                seconds: 10
+          ports:
+            - containerPort: 8080
+              name: "http"
+              protocol: "TCP"
           readinessProbe:
             httpGet:
               path: "/api/cutout/availability"
@@ -69,6 +79,12 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+            readOnlyRootFilesystem: true
       {{- with .Values.frontend.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/starters/fastapi-safir-uws/templates/deployment.yaml
+++ b/starters/fastapi-safir-uws/templates/deployment.yaml
@@ -35,9 +35,9 @@ spec:
                 secretKeyRef:
                   name: "<CHARTNAME>"
                   key: "redis-password"
-            # Uvicorn keepalive timeout, in seconds. This should be longer than
-            # any keepalive timeouts on any downstream proxies. The keepalive
-            # timeout for ingress-nginx connections is 60s.
+            # Uvicorn keepalive timeout, in seconds. This should be longer
+            # than any keepalive timeouts on any downstream proxies. The
+            # keepalive timeout for ingress-nginx connections is 60s.
             - name: "UVICORN_TIMEOUT_KEEP_ALIVE"
               value: "61"
             {{- if .Values.config.slackAlerts }}
@@ -52,6 +52,23 @@ spec:
                 name: "<CHARTNAME>"
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          lifecycle:
+            # Number of seconds k8s should wait before sending SIGTERM on
+            # graceful restarts/deployments/shutdowns. We need this because it
+            # takes ingress-nginx some time to configure itself to stop
+            # sending traffic to the pods scheduled for termination. If
+            # Uvicorn gets the SIGTERM and starts closing connections, we
+            # could end up with a TCP race condition if ingress-nginx still
+            # tries to send data over those connections.
+            #
+            # Note that terminationGracePeriodSeconds includes the time that
+            # is spent in the preStop hook. If you’re adding a preStop hook
+            # and your terminationGracePeriodSeconds is super fine-tuned, then
+            # you should update your terminationGracePeriodSeconds to add the
+            # amount of time you’ll be spending in your preStop hook.
+            preStop:
+              sleep:
+                seconds: 10
           ports:
             - containerPort: 8080
               name: "http"
@@ -70,23 +87,6 @@ spec:
               drop:
                 - "all"
             readOnlyRootFilesystem: true
-          lifecycle:
-            # Number of seconds k8s should wait before sending SIGTERM on
-            # graceful restarts/deployments/shutdowns. We need this because it
-            # takes ingress-nginx some time to configure itself to stop sending
-            # traffic to the pods scheduled for termination. If Uvicorn gets
-            # the SIGTERM and starts closing connections, we could end up with
-            # a TCP race condition if ingress-nginx still tries to send data
-            # over those connections.
-            #
-            # Note that terminationGracePeriodSeconds includes the time that is
-            # spent in the preStop hook. If you’re adding a preStop hook and
-            # your terminationGracePeriodSeconds is super fine-tuned, then you
-            # should update your terminationGracePeriodSeconds to add the
-            # amount of time you’ll be spending in your preStop hook.
-            preStop:
-              sleep:
-                seconds: 10
       {{- with .Values.frontend.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/starters/fastapi-safir/templates/deployment.yaml
+++ b/starters/fastapi-safir/templates/deployment.yaml
@@ -33,9 +33,9 @@ spec:
                 secretKeyRef:
                   name: "<CHARTNAME>"
                   key: "slack-webhook"
-            # Uvicorn keepalive timeout, in seconds. This should be longer than
-            # any keepalive timeouts on any downstream proxies. The keepalive
-            # timeout for ingress-nginx connections is 60s.
+            # Uvicorn keepalive timeout, in seconds. This should be longer
+            # than any keepalive timeouts on any downstream proxies. The
+            # keepalive timeout for ingress-nginx connections is 60s.
             - name: "UVICORN_TIMEOUT_KEEP_ALIVE"
               value: "61"
           {{- end }}
@@ -44,6 +44,23 @@ spec:
                 name: "<CHARTNAME>"
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          lifecycle:
+            # Number of seconds k8s should wait before sending SIGTERM on
+            # graceful restarts/deployments/shutdowns. We need this because it
+            # takes ingress-nginx some time to configure itself to stop
+            # sending traffic to the pods scheduled for termination. If
+            # Uvicorn gets the SIGTERM and starts closing connections, we
+            # could end up with a TCP race condition if ingress-nginx still
+            # tries to send data over those connections.
+            #
+            # Note that terminationGracePeriodSeconds includes the time that
+            # is spent in the preStop hook. If you’re adding a preStop hook
+            # and your terminationGracePeriodSeconds is super fine-tuned, then
+            # you should update your terminationGracePeriodSeconds to add the
+            # amount of time you’ll be spending in your preStop hook.
+            preStop:
+              sleep:
+                seconds: 10
           ports:
             - name: "http"
               containerPort: 8080
@@ -60,23 +77,6 @@ spec:
               drop:
                 - "all"
             readOnlyRootFilesystem: true
-          lifecycle:
-            # Number of seconds k8s should wait before sending SIGTERM on
-            # graceful restarts/deployments/shutdowns. We need this because it
-            # takes ingress-nginx some time to configure itself to stop sending
-            # traffic to the pods scheduled for termination. If Uvicorn gets
-            # the SIGTERM and starts closing connections, we could end up with
-            # a TCP race condition if ingress-nginx still tries to send data
-            # over those connections.
-            #
-            # Note that terminationGracePeriodSeconds includes the time that is
-            # spent in the preStop hook. If you’re adding a preStop hook and
-            # your terminationGracePeriodSeconds is super fine-tuned, then you
-            # should update your terminationGracePeriodSeconds to add the
-            # amount of time you’ll be spending in your preStop hook.
-            preStop:
-              sleep:
-                seconds: 10
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
Add the uvicorn keep-alive configuration and the pre-stop wait for vo-cutouts to avoid various issues with ingress-nginx. Alphabetize the settings in the starter templates.