### PR TITLE
[DM-52373] Set debug false for Sasquatch Telegraf connectors

### DIFF
--- a/applications/sasquatch/values-base.yaml
+++ b/applications/sasquatch/values-base.yaml
@@ -135,43 +135,36 @@ telegraf:
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.ATAOS", "lsst.sal.ATBuilding", "lsst.sal.ATDome", "lsst.sal.ATDomeTrajectory", "lsst.sal.ATHexapod", "lsst.sal.ATPneumatics", "lsst.sal.ATPtg", "lsst.sal.ATMCS" ]
-      debug: true
     maintel:
       enabled: true
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.MTAOS", "lsst.sal.MTDome", "lsst.sal.MTDomeTrajectory", "lsst.sal.MTPtg" ]
-      debug: true
     mtmount:
       enabled: true
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.MTMount" ]
-      debug: true
     envsys:
       enabled: true
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.DIMM", "lsst.sal.DREAM", "lsst.sal.DSM", "lsst.sal.EAS", "lsst.sal.EPM", "lsst.sal.ESS", "lsst.sal.HVAC", "lsst.sal.WeatherForecast" ]
-      debug: true
     latiss:
       enabled: true
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.ATCamera", "lsst.sal.ATHeaderService", "lsst.sal.ATOODS", "lsst.sal.ATSpectrograph" ]
-      debug: true
     m1m3:
       enabled: true
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.MTM1M3.ackcmd", "lsst.sal.MTM1M3.logevent*", "lsst.sal.MTM1M3.command*" ]
-      debug: true
     m1m3-tel1:
       enabled: true
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.MTM1M3.accelerometerData", "lsst.sal.MTM1M3.appliedCylinderForces", "lsst.sal.MTM1M3.appliedForces", "lsst.sal.MTM1M3.gyroData", "lsst.sal.MTM1M3.hardpointActuatorData", "lsst.sal.MTM1M3.hardpointMonitorData" ]
-      debug: true
       resources:
         limits:
           cpu: "6"
@@ -185,7 +178,6 @@ telegraf:
       metric_batch_size: 750
       topicRegexps: |
         [ "lsst.sal.MTM1M3.forceActuatorData", "lsst.sal.MTM1M3.outerLoopData", "lsst.sal.MTM1M3.imsData", "lsst.sal.MTM1M3.inclinometerData", "lsst.sal.MTM1M3.powerSupplyData" ]
-      debug: true
       resources:
         limits:
           cpu: "6"
@@ -198,7 +190,6 @@ telegraf:
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.MTM1M3.appliedAccelerationForces", "lsst.sal.MTM1M3.appliedAzimuthForces", "lsst.sal.MTM1M3.appliedBalanceForces", "lsst.sal.MTM1M3.appliedElevationForces", "lsst.sal.MTM1M3.appliedThermalForces", "lsst.sal.MTM1M3.appliedVelocityForces", "lsst.sal.MTM1M3.forceActuatorPressure", "lsst.sal.MTM1M3.pidData" ]
-      debug: true
       resources:
         limits:
           cpu: "5"
@@ -213,49 +204,41 @@ telegraf:
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.MTM1M3TS" ]
-      debug: true
     m2:
       enabled: true
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.MTHexapod", "lsst.sal.MTM2", "lsst.sal.MTRotator" ]
-      debug: true
     obssys:
       enabled: true
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.Scheduler", "lsst.sal.Script", "lsst.sal.ScriptQueue", "lsst.sal.Watcher" ]
-      debug: true
     ocps:
       enabled: true
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.OCPS" ]
-      debug: true
     test:
       enabled: true
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.Test" ]
-      debug: true
     mtaircompressor:
       enabled: true
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.MTAirCompressor" ]
-      debug: true
     lasertracker:
       enabled: true
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.LaserTracker" ]
-      debug: true
     genericcamera:
       enabled: true
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.GCHeaderService", "lsst.sal.GenericCamera" ]
-      debug: true
     lsstcam:
       enabled: true
       metric_batch_size: 250
@@ -263,20 +246,17 @@ telegraf:
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.MTCamera", "lsst.sal.MTHeaderService", "lsst.sal.MTOODS" ]
-      debug: true
     calsys:
       enabled: true
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.CBP", "lsst.sal.Electrometer", "lsst.sal.LEDProjector", "lsst.sal.LinearStage", "lsst.sal.MTReflector", "lsst.sal.TunableLaser" ]
-      debug: true
     mtvms:
       enabled: true
       database: "efd"
       timestamp_field: "private_efdStamp"
       topicRegexps: |
         [ "lsst.sal.MTVMS" ]
-      debug: true
     obsenv:
       enabled: true
       database: "lsst.obsenv"
@@ -284,7 +264,6 @@ telegraf:
       timestamp_field: "timestamp"
       topicRegexps: |
         [ "lsst.obsenv" ]
-      debug: true
     scimma:
       enabled: true
       database: "lsst.scimma"
@@ -292,7 +271,6 @@ telegraf:
       timestamp_field: "timestamp"
       topicRegexps: |
         [ "lsst.scimma" ]
-      debug: true
       offset: oldest
   resources:
     limits:

--- a/applications/sasquatch/values-summit.yaml
+++ b/applications/sasquatch/values-summit.yaml
@@ -217,7 +217,6 @@ telegraf:
       timestamp_field: "timestamp"
       topicRegexps: |
         [ "lsst.obsenv" ]
-      debug: true
     scimma:
       enabled: true
       database: "lsst.scimma"
@@ -225,7 +224,6 @@ telegraf:
       timestamp_field: "timestamp"
       topicRegexps: |
         [ "lsst.scimma" ]
-      debug: true
       offset: oldest
     cp:
       enabled: true
@@ -236,7 +234,6 @@ telegraf:
         [ "lsst.cp" ]
       tags: |
         [ "dataset_tag", "band", "instrument", "skymap", "detector", "physical_filter", "tract", "exposure", "patch", "visit", "run", "pipeline" ]
-      debug: true
     backpack:
       enabled: true
       replicaCount: 1
@@ -245,32 +242,27 @@ telegraf:
       timestamp_field: "timestamp"
       topicRegexps: |
         [ "lsst.backpack" ]
-      debug: true
     # CSC connectors
     maintel:
       enabled: true
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.MTAOS", "lsst.sal.MTDome", "lsst.sal.MTDomeTrajectory", "lsst.sal.MTPtg" ]
-      debug: true
     mtmount:
       enabled: true
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.MTMount" ]
-      debug: true
     comcam:
       enabled: true
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.CCCamera", "lsst.sal.CCHeaderService", "lsst.sal.CCOODS" ]
-      debug: true
     envsys:
       enabled: true
       database: "efd"
       topicRegexps: |
          [ "lsst.sal.DIMM", "lsst.sal.DREAM", "lsst.sal.DSM", "lsst.sal.EAS", "lsst.sal.EPM", "lsst.sal.ESS", "lsst.sal.HVAC", "lsst.sal.WeatherForecast" ]
-      debug: true
     m1m3:
       enabled: true
       metric_batch_size: 1500
@@ -278,7 +270,6 @@ telegraf:
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.MTM1M3([^T].*)" ]
-      debug: true
       resources:
         limits:
           cpu: "5"
@@ -293,13 +284,11 @@ telegraf:
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.MTM1M3TS" ]
-      debug: true
     m2:
       enabled: true
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.MTHexapod", "lsst.sal.MTM2", "lsst.sal.MTRotator" ]
-      debug: true
       resources:
         limits:
           cpu: "5"
@@ -312,49 +301,41 @@ telegraf:
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.Scheduler", "lsst.sal.Script", "lsst.sal.ScriptQueue", "lsst.sal.Watcher" ]
-      debug: true
     ocps:
       enabled: true
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.OCPS" ]
-      debug: true
     pmd:
       enabled: true
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.PMD" ]
-      debug: true
     calsys:
       enabled: true
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.ATMonochromator", "lsst.sal.ATWhiteLight", "lsst.sal.CBP", "lsst.sal.Electrometer", "lsst.sal.FiberSpectrograph", "lsst.sal.LEDProjector", "lsst.sal.LinearStage", "lsst.sal.MTReflector", "lsst.sal.TunableLaser" ]
-      debug: true
     mtaircompressor:
       enabled: true
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.MTAirCompressor" ]
-      debug: true
     genericcamera:
       enabled: true
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.GCHeaderService", "lsst.sal.GenericCamera" ]
-      debug: true
     gis:
       enabled: true
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.GIS" ]
-      debug: true
     mtvms:
       enabled: true
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.MTVMS" ]
-      debug: true
     lsstcam:
       enabled: true
       metric_batch_size: 250
@@ -362,31 +343,26 @@ telegraf:
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.MTCamera", "lsst.sal.MTHeaderService", "lsst.sal.MTOODS" ]
-      debug: true
     auxtel:
       enabled: true
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.ATAOS", "lsst.sal.ATBuilding", "lsst.sal.ATDome", "lsst.sal.ATDomeTrajectory", "lsst.sal.ATHexapod", "lsst.sal.ATPneumatics", "lsst.sal.ATPtg", "lsst.sal.ATMCS" ]
-      debug: true
     latiss:
       enabled: true
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.ATCamera", "lsst.sal.ATHeaderService", "lsst.sal.ATOODS", "lsst.sal.ATSpectrograph" ]
-      debug: true
     test:
       enabled: true
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.Test" ]
-      debug: true
     lasertracker:
       enabled: true
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.LaserTracker" ]
-      debug: true
     # CCS connectors (experimental) data is being written on separate databases for now
     atcamera:
       enabled: true
@@ -397,7 +373,6 @@ telegraf:
         [ "Agent", "Aspic", "Location", "Raft", "Reb", "Sensor", "Source" ]
       topicRegexps: |
         [ "lsst.ATCamera" ]
-      debug: true
     cccamera:
       enabled: true
       database: "lsst.CCCamera"
@@ -407,7 +382,6 @@ telegraf:
         [ "Agent", "Aspic", "Cold", "Cryo", "Hardware", "Location", "Ps", "RTD", "Raft", "Reb", "Segment", "Sensor", "Source" ]
       topicRegexps: |
         [ "lsst.CCCamera" ]
-      debug: true
     mtcamera:
       enabled: true
       database: "lsst.MTCamera"
@@ -417,7 +391,6 @@ telegraf:
         [ "Agent", "Aspic", "Axis", "Canbus", "Cip", "Clamp", "Cold", "Controller", "Cryo", "Gateway", "Hardware", "Hip", "Hook", "Latch", "Location", "Ps", "RTD", "Raft", "Reb", "Segment", "Sensor", "Socket", "Source", "Truck" ]
       topicRegexps: |
         [ "lsst.MTCamera" ]
-      debug: true
 
 kafdrop:
   ingress:

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -237,7 +237,6 @@ telegraf:
       timestamp_field: "timestamp"
       topicRegexps: |
         [ "lsst.backpack" ]
-      debug: true
     # CSC connectors
     maintel:
       enabled: true
@@ -246,7 +245,6 @@ telegraf:
       timestamp_field: "private_efdStamp"
       topicRegexps: |
         [ "lsst.sal.MTAOS", "lsst.sal.MTDome", "lsst.sal.MTDomeTrajectory", "lsst.sal.MTPtg" ]
-      debug: true
     mtmount:
       enabled: true
       repair: false
@@ -254,7 +252,6 @@ telegraf:
       timestamp_field: "private_efdStamp"
       topicRegexps: |
         [ "lsst.sal.MTMount" ]
-      debug: true
     comcam:
       enabled: true
       repair: false
@@ -262,7 +259,6 @@ telegraf:
       timestamp_field: "private_efdStamp"
       topicRegexps: |
         [ "lsst.sal.CCCamera", "lsst.sal.CCHeaderService", "lsst.sal.CCOODS" ]
-      debug: true
     envsys:
       enabled: true
       repair: false
@@ -270,7 +266,6 @@ telegraf:
       timestamp_field: "private_efdStamp"
       topicRegexps: |
         [ "lsst.sal.DIMM", "lsst.sal.DREAM", "lsst.sal.EAS", "lsst.sal.ESS", "lsst.sal.DSM", "lsst.sal.EPM", "lsst.sal.HVAC", "lsst.sal.WeatherForecast" ]
-      debug: true
     m1m3:
       enabled: true
       metric_batch_size: 1500
@@ -278,7 +273,6 @@ telegraf:
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.MTM1M3([^T].*)" ]
-      debug: true
     m1m3ts:
       enabled: true
       metric_batch_size: 1500
@@ -286,7 +280,6 @@ telegraf:
       database: "efd"
       topicRegexps: |
         [ "lsst.sal.MTM1M3TS" ]
-      debug: true
     m2:
       enabled: true
       repair: false
@@ -294,7 +287,6 @@ telegraf:
       timestamp_field: "private_efdStamp"
       topicRegexps: |
         [ "lsst.sal.MTHexapod", "lsst.sal.MTM2", "lsst.sal.MTRotator" ]
-      debug: true
     obssys:
       enabled: true
       repair: false
@@ -302,7 +294,6 @@ telegraf:
       timestamp_field: "private_efdStamp"
       topicRegexps: |
         [ "lsst.sal.Scheduler", "lsst.sal.Script", "lsst.sal.ScriptQueue", "lsst.sal.Watcher" ]
-      debug: true
     ocps:
       enabled: true
       repair: false
@@ -310,7 +301,6 @@ telegraf:
       timestamp_field: "private_efdStamp"
       topicRegexps: |
         [ "lsst.sal.OCPS" ]
-      debug: true
     pmd:
       enabled: true
       repair: false
@@ -318,7 +308,6 @@ telegraf:
       timestamp_field: "private_efdStamp"
       topicRegexps: |
         [ "lsst.sal.PMD" ]
-      debug: true
     calsys:
       enabled: true
       repair: false
@@ -326,7 +315,6 @@ telegraf:
       timestamp_field: "private_efdStamp"
       topicRegexps: |
         [ "lsst.sal.ATMonochromator", "lsst.sal.ATWhiteLight", "lsst.sal.CBP", "lsst.sal.Electrometer", "lsst.sal.FiberSpectrograph", "lsst.sal.LEDProjector", "lsst.sal.LinearStage", "lsst.sal.MTReflector", "lsst.sal.TunableLaser" ]
-      debug: true
     mtaircompressor:
       enabled: true
       repair: false
@@ -334,7 +322,6 @@ telegraf:
       timestamp_field: "private_efdStamp"
       topicRegexps: |
         [ "lsst.sal.MTAirCompressor" ]
-      debug: true
     genericcamera:
       enabled: true
       repair: false
@@ -342,7 +329,6 @@ telegraf:
       timestamp_field: "private_efdStamp"
       topicRegexps: |
         [ "lsst.sal.GCHeaderService", "lsst.sal.GenericCamera" ]
-      debug: true
     gis:
       enabled: true
       repair: false
@@ -350,7 +336,6 @@ telegraf:
       timestamp_field: "private_efdStamp"
       topicRegexps: |
         [ "lsst.sal.GIS" ]
-      debug: true
     mtvms:
       enabled: true
       repair: false
@@ -358,7 +343,6 @@ telegraf:
       timestamp_field: "private_efdStamp"
       topicRegexps: |
         [ "lsst.sal.MTVMS" ]
-      debug: true
     lsstcam:
       enabled: true
       repair: false
@@ -368,7 +352,6 @@ telegraf:
       timestamp_field: "private_efdStamp"
       topicRegexps: |
         [ "lsst.sal.MTCamera", "lsst.sal.MTHeaderService", "lsst.sal.MTOODS" ]
-      debug: true
     auxtel:
       enabled: true
       repair: false
@@ -376,7 +359,6 @@ telegraf:
       timestamp_field: "private_efdStamp"
       topicRegexps: |
         [ "lsst.sal.ATAOS", "lsst.sal.ATBuilding", "lsst.sal.ATDome", "lsst.sal.ATDomeTrajectory", "lsst.sal.ATHexapod", "lsst.sal.ATPneumatics", "lsst.sal.ATPtg", "lsst.sal.ATMCS" ]
-      debug: true
     latiss:
       enabled: true
       repair: false
@@ -384,7 +366,6 @@ telegraf:
       timestamp_field: "private_efdStamp"
       topicRegexps: |
         [ "lsst.sal.ATCamera", "lsst.sal.ATHeaderService", "lsst.sal.ATOODS", "lsst.sal.ATSpectrograph" ]
-      debug: true
     test:
       enabled: true
       repair: false
@@ -392,7 +373,6 @@ telegraf:
       timestamp_field: "private_efdStamp"
       topicRegexps: |
         [ "lsst.sal.Test" ]
-      debug: true
     lasertracker:
       enabled: true
       repair: false
@@ -400,7 +380,6 @@ telegraf:
       timestamp_field: "private_efdStamp"
       topicRegexps: |
         [ "lsst.sal.LaserTracker" ]
-      debug: true
     # CCS connectors (experimental) data is being written on separate databases for now
     atcamera:
       enabled: true
@@ -411,7 +390,6 @@ telegraf:
         [ "Agent", "Aspic", "Location", "Raft", "Reb", "Sensor", "Source" ]
       topicRegexps: |
         [ "lsst.ATCamera" ]
-      debug: true
     cccamera:
       enabled: true
       database: "lsst.CCCamera"
@@ -421,7 +399,6 @@ telegraf:
         [ "Agent", "Aspic", "Cold", "Cryo", "Hardware", "Location", "Ps", "RTD", "Raft", "Reb", "Segment", "Sensor", "Source" ]
       topicRegexps: |
         [ "lsst.CCCamera" ]
-      debug: true
     mtcamera:
       enabled: true
       database: "lsst.MTCamera"
@@ -431,7 +408,6 @@ telegraf:
         [ "Agent", "Aspic", "Axis", "Canbus", "Cip", "Clamp", "Cold", "Controller", "Cryo", "Gateway", "Hardware", "Hip", "Hook", "Latch", "Location", "Ps", "RTD", "Raft", "Reb", "Segment", "Sensor", "Socket", "Source", "Truck" ]
       topicRegexps: |
         [ "lsst.MTCamera" ]
-      debug: true
     obsenv:
       enabled: true
       database: "lsst.obsenv"
@@ -439,7 +415,6 @@ telegraf:
       timestamp_field: "timestamp"
       topicRegexps: |
         [ "lsst.obsenv" ]
-      debug: true
     cp:
       enabled: true
       database: "lsst.cp"
@@ -449,7 +424,6 @@ telegraf:
         [ "lsst.cp" ]
       tags: |
         [ "dataset_tag", "band", "instrument", "skymap", "detector", "physical_filter", "tract", "exposure", "patch", "visit", "run", "pipeline" ]
-      debug: true
 
 kafdrop:
   ingress:


### PR DESCRIPTION
We have been running the Telegraf connectors with `debug: true` for some time. Set it to `false` at the production environments, specially at the Summit and BTS.
Cristian noted that some Telegraf pods are spamming, which is causing problems with Loki.