### PR TITLE
[DM-52379] Add k8sup labels to backup Sasquatch kafka PVCs

### DIFF
--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -559,6 +559,7 @@ Rubin Observatory's telemetry service
 | scimma.cluster.name | string | `"sasquatch"` | Name of the Strimzi cluster. Synchronize this with the cluster name in the parent Sasquatch chart. |
 | square-events.cluster.name | string | `"sasquatch"` |  |
 | strimzi-kafka.broker.affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchExpressions":[{"key":"app.kubernetes.io/name","operator":"In","values":["kafka"]}]},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for broker pod assignment |
+| strimzi-kafka.broker.backup | bool | `false` | Whether to label the broker PVCs for backup by k8up, enabled on the summit and base environments |
 | strimzi-kafka.broker.enabled | bool | `false` | Enable node pool for the kafka brokers |
 | strimzi-kafka.broker.name | string | `"kafka"` | Node pool name |
 | strimzi-kafka.broker.nodeIds | string | `"[0,1,2]"` | IDs to assign to the brokers |
@@ -588,6 +589,7 @@ Rubin Observatory's telemetry service
 | strimzi-kafka.connect.replicas | int | `3` | Number of Kafka Connect replicas to run |
 | strimzi-kafka.connect.resources | object | See `values.yaml` | Kubernetes requests and limits for Kafka Connect |
 | strimzi-kafka.controller.affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchExpressions":[{"key":"app.kubernetes.io/name","operator":"In","values":["kafka"]}]},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for controller pod assignment |
+| strimzi-kafka.controller.backup | bool | `false` | Whether to label the controller PVCs for backup by k8up, enabled on the summit and base environments |
 | strimzi-kafka.controller.enabled | bool | `false` | Enable node pool for the kafka controllers |
 | strimzi-kafka.controller.nodeIds | string | `"[3,4,5]"` | IDs to assign to the controllers |
 | strimzi-kafka.controller.resources | object | `{"limits":{"cpu":"1","memory":"4Gi"},"requests":{"cpu":"500m","memory":"2Gi"}}` | Kubernetes resources for the controllers |

--- a/applications/sasquatch/charts/strimzi-kafka/README.md
+++ b/applications/sasquatch/charts/strimzi-kafka/README.md
@@ -7,6 +7,7 @@ A subchart to deploy Strimzi Kafka components for Sasquatch.
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | broker.affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchExpressions":[{"key":"app.kubernetes.io/name","operator":"In","values":["kafka"]}]},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for broker pod assignment |
+| broker.backup | bool | `false` | Whether to label the broker PVCs for backup by k8up, enabled on the summit and base environments |
 | broker.enabled | bool | `false` | Enable node pool for the kafka brokers |
 | broker.name | string | `"kafka"` | Node pool name |
 | broker.nodeIds | string | `"[0,1,2]"` | IDs to assign to the brokers |
@@ -36,6 +37,7 @@ A subchart to deploy Strimzi Kafka components for Sasquatch.
 | connect.replicas | int | `3` | Number of Kafka Connect replicas to run |
 | connect.resources | object | See `values.yaml` | Kubernetes requests and limits for Kafka Connect |
 | controller.affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchExpressions":[{"key":"app.kubernetes.io/name","operator":"In","values":["kafka"]}]},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for controller pod assignment |
+| controller.backup | bool | `false` | Whether to label the controller PVCs for backup by k8up, enabled on the summit and base environments |
 | controller.enabled | bool | `false` | Enable node pool for the kafka controllers |
 | controller.nodeIds | string | `"[3,4,5]"` | IDs to assign to the controllers |
 | controller.resources | object | `{"limits":{"cpu":"1","memory":"4Gi"},"requests":{"cpu":"500m","memory":"2Gi"}}` | Kubernetes resources for the controllers |

--- a/applications/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
@@ -27,6 +27,10 @@ spec:
         annotations:
           argocd.argoproj.io/compare-options: IgnoreExtraneous
           argocd.argoproj.io/sync-options: Prune=false
+        {{- if .Values.controller.backup }}
+        labels:
+          k8up.io/backup-target: "true"
+        {{- end }}
     pod:
       {{- with .Values.controller.affinity }}
       affinity:
@@ -71,6 +75,10 @@ spec:
         annotations:
           argocd.argoproj.io/compare-options: IgnoreExtraneous
           argocd.argoproj.io/sync-options: Prune=false
+        {{- if .Values.broker.backup }}
+        labels:
+          k8up.io/backup-target: "true"
+        {{- end }}
     pod:
       {{- with .Values.broker.affinity }}
       affinity:

--- a/applications/sasquatch/charts/strimzi-kafka/values.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/values.yaml
@@ -120,6 +120,10 @@ controller:
     # @default -- None, use the default storage class
     storageClassName: ""
 
+  # -- Whether to label the controller PVCs for backup by k8up,
+  # enabled on the summit and base environments
+  backup: false
+
   # -- Affinity for controller pod assignment
   affinity:
     podAntiAffinity:
@@ -161,6 +165,10 @@ broker:
     # -- Storage class to use when requesting persistent volumes
     # @default -- None, use the default storage class
     storageClassName: ""
+
+  # -- Whether to label the broker PVCs for backup by k8up,
+  # enabled on the summit and base environments
+  backup: false
 
   # -- Affinity for broker pod assignment
   affinity:

--- a/applications/sasquatch/values-base.yaml
+++ b/applications/sasquatch/values-base.yaml
@@ -57,6 +57,7 @@ strimzi-kafka:
         cpu: 4
   controller:
     enabled: true
+    backup: true
   broker:
     enabled: true
     name: "kafka-local-storage"
@@ -64,6 +65,7 @@ strimzi-kafka:
     storage:
       size: 1.5Ti
       storageClassName: localdrive
+    backup: true
     affinity:
       nodeAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -31,10 +31,12 @@ strimzi-kafka:
       enabled: true
   controller:
     enabled: true
+    backup: true
   broker:
     enabled: true
     storage:
       size: 500Gi
+    backup: true
 
 schema-registry:
   enabled: true

--- a/applications/sasquatch/values-summit.yaml
+++ b/applications/sasquatch/values-summit.yaml
@@ -48,6 +48,7 @@ strimzi-kafka:
         cpu: 4
   controller:
     enabled: true
+    backup: true
   broker:
     enabled: true
     name: "kafka-local-storage"
@@ -55,6 +56,7 @@ strimzi-kafka:
     storage:
       size: 15Ti
       storageClassName: localdrive
+    backup: true
     affinity:
       nodeAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
Add the  `k8up.io/backup-target: true` label to Sasquatch Kafka PVCs, this needs to be done via the `KafkaNodePool` template, so the labels are added by the Strimzi operator to the corresponding PVCs. 

This is enable at summit and base environments only, where we run k8up backup tool.