### PR TITLE
[DM-52404] Upgrade Kafka to version 4.0.0

### DIFF
--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -118,6 +118,7 @@ Rubin Observatory's telemetry service
 | app-metrics.image.tag | string | `"1.34.0-alpine"` | Telegraf image tag |
 | app-metrics.imagePullSecrets | list | `[]` | Secret names to use for Docker pulls |
 | app-metrics.influxdb.url | string | `"http://sasquatch-influxdb.sasquatch:8086"` | URL of the InfluxDB v1 instance to write to |
+| app-metrics.kafkaVersion | string | null, use the Sarama library default. | Set the minimal supported Kafka version for the Sarama Go client library. |
 | app-metrics.nodeSelector | object | `{}` | Node labels for pod assignment |
 | app-metrics.podAnnotations | object | `{}` | Annotations for the Telegraf pods |
 | app-metrics.podLabels | object | `{}` | Labels for the Telegraf pods |

--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -672,7 +672,7 @@ Rubin Observatory's telemetry service
 | telegraf.kafkaConsumers.test.topicRegexps | string | `"[ \".*Test\" ]\n"` | List of regular expressions to specify the Kafka topics consumed by this agent. |
 | telegraf.kafkaConsumers.test.union_field_separator | string | `""` | Union field separator: if a single Avro field is flattened into more than one InfluxDB field (e.g. an array `a`, with four members, would yield `a0`, `a1`, `a2`, `a3`; if the field separator were `_`, these would be `a_0`...`a_3`. |
 | telegraf.kafkaConsumers.test.union_mode | string | `"nullable"` | Union mode: this can be one of `flatten`, `nullable`, or `any`. See `values.yaml` for extensive discussion. |
-| telegraf.kafkaVersion | string | `nil` |  |
+| telegraf.kafkaVersion | string | null, use the Sarama library default. | Set the minimal supported Kafka version for the Sarama Go client library. |
 | telegraf.nodeSelector | object | `{}` | Node labels for pod assignment |
 | telegraf.podAnnotations | object | `{}` | Annotations for the Telegraf pods |
 | telegraf.podLabels | object | `{}` | Labels for the Telegraf pods |
@@ -711,7 +711,7 @@ Rubin Observatory's telemetry service
 | telegraf-oss.kafkaConsumers.test.topicRegexps | string | `"[ \".*Test\" ]\n"` | List of regular expressions to specify the Kafka topics consumed by this agent. |
 | telegraf-oss.kafkaConsumers.test.union_field_separator | string | `""` | Union field separator: if a single Avro field is flattened into more than one InfluxDB field (e.g. an array `a`, with four members, would yield `a0`, `a1`, `a2`, `a3`; if the field separator were `_`, these would be `a_0`...`a_3`. |
 | telegraf-oss.kafkaConsumers.test.union_mode | string | `"nullable"` | Union mode: this can be one of `flatten`, `nullable`, or `any`. See `values.yaml` for extensive discussion. |
-| telegraf-oss.kafkaVersion | string | `nil` |  |
+| telegraf-oss.kafkaVersion | string | null, use the Sarama library default. | Set the minimal supported Kafka version for the Sarama Go client library. |
 | telegraf-oss.nodeSelector | object | `{}` | Node labels for pod assignment |
 | telegraf-oss.podAnnotations | object | `{}` | Annotations for the Telegraf pods |
 | telegraf-oss.podLabels | object | `{}` | Labels for the Telegraf pods |

--- a/applications/sasquatch/charts/app-metrics/README.md
+++ b/applications/sasquatch/charts/app-metrics/README.md
@@ -20,6 +20,7 @@ Kafka topics, users, and a telegraf connector for metrics events.
 | image.tag | string | `"1.34.0-alpine"` | Telegraf image tag |
 | imagePullSecrets | list | `[]` | Secret names to use for Docker pulls |
 | influxdb.url | string | `"http://sasquatch-influxdb.sasquatch:8086"` | URL of the InfluxDB v1 instance to write to |
+| kafkaVersion | string | null, use the Sarama library default. | Set the minimal supported Kafka version for the Sarama Go client library. |
 | nodeSelector | object | `{}` | Node labels for pod assignment |
 | podAnnotations | object | `{}` | Annotations for the Telegraf pods |
 | podLabels | object | `{}` | Labels for the Telegraf pods |

--- a/applications/sasquatch/charts/app-metrics/templates/telegraf-configmap.yaml
+++ b/applications/sasquatch/charts/app-metrics/templates/telegraf-configmap.yaml
@@ -44,6 +44,9 @@ data:
       brokers = [
         "sasquatch-kafka-brokers.sasquatch:9092"
       ]
+      {{- if $.Values.kafkaVersion }}
+      kafka_version = "{{ $.Values.kafkaVersion }}"
+      {{- end }}
       consumer_group = "telegraf-kafka-consumer-app-metrics"
       sasl_mechanism = "SCRAM-SHA-512"
       sasl_password = "$TELEGRAF_PASSWORD"

--- a/applications/sasquatch/charts/app-metrics/values.yaml
+++ b/applications/sasquatch/charts/app-metrics/values.yaml
@@ -105,6 +105,10 @@ envFromSecret: ""
 # @default -- false
 debug: false
 
+# -- Set the minimal supported Kafka version for the Sarama Go client library.
+# @default -- null, use the Sarama library default.
+kafkaVersion: null
+
 influxdb:
   # -- URL of the InfluxDB v1 instance to write to
   url: "http://sasquatch-influxdb.sasquatch:8086"

--- a/applications/sasquatch/charts/telegraf/README.md
+++ b/applications/sasquatch/charts/telegraf/README.md
@@ -38,7 +38,7 @@ Telegraf is an agent for collecting, processing, aggregating, and writing metric
 | kafkaConsumers.test.topicRegexps | string | `"[ \".*Test\" ]\n"` | List of regular expressions to specify the Kafka topics consumed by this agent. |
 | kafkaConsumers.test.union_field_separator | string | `""` | Union field separator: if a single Avro field is flattened into more than one InfluxDB field (e.g. an array `a`, with four members, would yield `a0`, `a1`, `a2`, `a3`; if the field separator were `_`, these would be `a_0`...`a_3`. |
 | kafkaConsumers.test.union_mode | string | `"nullable"` | Union mode: this can be one of `flatten`, `nullable`, or `any`. See `values.yaml` for extensive discussion. |
-| kafkaVersion | string | `nil` |  |
+| kafkaVersion | string | null, use the Sarama library default. | Set the minimal supported Kafka version for the Sarama Go client library. |
 | nodeSelector | object | `{}` | Node labels for pod assignment |
 | podAnnotations | object | `{}` | Annotations for the Telegraf pods |
 | podLabels | object | `{}` | Labels for the Telegraf pods |

--- a/applications/sasquatch/charts/telegraf/values.yaml
+++ b/applications/sasquatch/charts/telegraf/values.yaml
@@ -184,7 +184,10 @@ kafkaConsumers:
     # @default -- 3
     compression_codec: 3
 
-kafkaVersion:
+
+# -- Set the minimal supported Kafka version for the Sarama Go client library.
+# @default -- null, use the Sarama library default.
+kafkaVersion: null
 
 influxdb:
   # -- URL of the InfluxDB v1 instance to write to

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -1,6 +1,6 @@
 strimzi-kafka:
   kafka:
-    version: "3.9.0"
+    version: "4.0.0"
     listeners:
       tls:
         enabled: true

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -88,6 +88,7 @@ influxdb-enterprise:
 
 telegraf:
   enabled: true
+  kafkaVersion: "4.0.0"
   influxdb:
     urls:
       - "http://sasquatch-influxdb-enterprise-data.sasquatch:8086"

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -147,6 +147,7 @@ chronograf:
 
 app-metrics:
   enabled: true
+  kafkaVersion: "4.0.0"
   apps:
     - gafaelfawr
     - mobu

--- a/applications/sasquatch/values-idfint.yaml
+++ b/applications/sasquatch/values-idfint.yaml
@@ -1,6 +1,6 @@
 strimzi-kafka:
   kafka:
-    version: "3.9.0"
+    version: "4.0.0"
     listeners:
       tls:
         enabled: true

--- a/applications/sasquatch/values-idfint.yaml
+++ b/applications/sasquatch/values-idfint.yaml
@@ -109,6 +109,7 @@ chronograf:
 
 app-metrics:
   enabled: true
+  kafkaVersion: "4.0.0"
   apps:
     - gafaelfawr
     - mobu

--- a/applications/sasquatch/values-idfint.yaml
+++ b/applications/sasquatch/values-idfint.yaml
@@ -55,6 +55,7 @@ customInfluxDBIngress:
 
 telegraf:
   enabled: true
+  kafkaVersion: "4.0.0"
   kafkaConsumers:
     example:
       enabled: true


### PR DESCRIPTION
Upgrade Kafka to version 4.0.0 on idfdev and idfint environments.
Telegraf config also requires setting kafka_version for the Sarama Go client library.