### PR TITLE
DM-52423: Enable SIA metrics on idfprod

### DIFF
--- a/applications/sia/values-idfprod.yaml
+++ b/applications/sia/values-idfprod.yaml
@@ -16,3 +16,6 @@ config:
       butler_type: "REMOTE"
       repository: "https://data.lsst.cloud/api/butler/repo/dp1/butler.yaml"
       datalink_url: "https://data.lsst.cloud/api/datalink/links?ID=ivo%3A%2F%2Forg.rubinobs%2Flsst-dp1%3Frepo%3Ddp1%26id%3D{id}"
+
+  enableSentry: true
+  sentryTracesSampleRate: 1


### PR DESCRIPTION
NOTE: This needs a 1pass secret (and secrets sync) before we can deploy it