### PR TITLE
DM-52437: Change kafka authentication for tap to use certs

### DIFF
--- a/applications/sasquatch/charts/tap/templates/kafka-users.yaml
+++ b/applications/sasquatch/charts/tap/templates/kafka-users.yaml
@@ -34,6 +34,33 @@ spec:
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaUser
 metadata:
+  name: tap-tls
+  labels:
+    strimzi.io/cluster: {{ .Values.cluster.name }}
+spec:
+  authentication:
+    type: tls
+  authorization:
+    type: simple
+    acls:
+      - resource:
+          type: group
+          name: "*"
+          patternType: literal
+        operations:
+          - All
+      - resource:
+          type: topic
+          name: "lsst.tap"
+          patternType: prefix
+        type: allow
+        host: "*"
+        operations:
+          - All
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaUser
+metadata:
   name: qserv
   labels:
     strimzi.io/cluster: {{ .Values.cluster.name }}

--- a/applications/tap/values-idfdev.yaml
+++ b/applications/tap/values-idfdev.yaml
@@ -10,7 +10,7 @@ cadc-tap:
       passwordEnabled: true
 
     kafka:
-      bootstrapServer: "sasquatch-dev-kafka-bootstrap.lsst.cloud:9094"
+      bootstrapServer: "sasquatch-kafka-bootstrap.sasquatch.svc:9093"
       schemaRegistry:
         url: "https://data-dev.lsst.cloud/schema-registry/"
       auth:

--- a/charts/cadc-tap/README.md
+++ b/charts/cadc-tap/README.md
@@ -28,10 +28,10 @@ IVOA TAP service
 | config.gcsBucketType | string | `"GCS"` | GCS bucket type (GCS or S3) |
 | config.gcsBucketUrl | string | `"https://tap-files.lsst.codes"` | Base URL for results stored in GCS bucket |
 | config.jvmMaxHeapSize | string | `"31G"` | Java heap size, which will set the maximum size of the heap. Otherwise Java would determine it based on how much memory is available and black maths. |
-| config.kafka | object | `{"auth":{"enabled":false},"bootstrapServer":"sasquatch-dev-kafka-bootstrap.lsst.cloud:9094","schemaRegistry":{"url":""},"topics":{"jobDelete":"lsst.tap.job-delete","jobRun":"lsst.tap.job-run","jobStatus":"lsst.tap.job-status"}}` | Kafka configuration |
+| config.kafka | object | `{"auth":{"enabled":false},"bootstrapServer":"sasquatch-kafka-bootstrap.sasquatch.svc:9093","schemaRegistry":{"url":""},"topics":{"jobDelete":"lsst.tap.job-delete","jobRun":"lsst.tap.job-run","jobStatus":"lsst.tap.job-status"}}` | Kafka configuration |
 | config.kafka.auth | object | `{"enabled":false}` | Authentication configuration |
 | config.kafka.auth.enabled | bool | `false` | Whether auth is enabled |
-| config.kafka.bootstrapServer | string | `"sasquatch-dev-kafka-bootstrap.lsst.cloud:9094"` | Bootstrap Server |
+| config.kafka.bootstrapServer | string | `"sasquatch-kafka-bootstrap.sasquatch.svc:9093"` | Bootstrap Server |
 | config.kafka.schemaRegistry | object | `{"url":""}` | Schema Registry Configuration |
 | config.kafka.schemaRegistry.url | string | `""` | URL |
 | config.kafka.topics | object | `{"jobDelete":"lsst.tap.job-delete","jobRun":"lsst.tap.job-run","jobStatus":"lsst.tap.job-status"}` | Kafka topics |
@@ -47,7 +47,7 @@ IVOA TAP service
 | config.qserv.host | string | `"mock-db:3306"` (the mock QServ) | QServ hostname:port to connect to |
 | config.qserv.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the TAP image |
 | config.qserv.image.repository | string | `"ghcr.io/lsst-sqre/lsst-tap-service"` | TAP image to use |
-| config.qserv.image.tag | string | `"3.6.0"` | Tag of TAP image to use |
+| config.qserv.image.tag | string | `"3.8.0"` | Tag of TAP image to use |
 | config.qserv.jdbcParams | string | `""` | Extra JDBC connection parameters |
 | config.qserv.passwordEnabled | bool | false | Whether the Qserv database is password protected |
 | config.sentryEnabled | bool | `false` | Whether Sentry is enabled in this environment |
@@ -94,7 +94,7 @@ IVOA TAP service
 | uws.affinity | object | `{}` | Affinity rules for the UWS database pod |
 | uws.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the UWS database image |
 | uws.image.repository | string | `"ghcr.io/lsst-sqre/lsst-tap-uws-db"` | UWS database image to use |
-| uws.image.tag | string | `"3.6.0"` | Tag of UWS database image to use |
+| uws.image.tag | string | `"3.8.0"` | Tag of UWS database image to use |
 | uws.nodeSelector | object | `{}` | Node selection rules for the UWS database pod |
 | uws.podAnnotations | object | `{}` | Annotations for the UWS databse pod |
 | uws.resources | object | See `values.yaml` | Resource limits and requests for the UWS database pod |

--- a/charts/cadc-tap/templates/kafka-access.yaml
+++ b/charts/cadc-tap/templates/kafka-access.yaml
@@ -1,0 +1,16 @@
+apiVersion: access.strimzi.io/v1alpha1
+kind: KafkaAccess
+metadata:
+  name: "cadc-tap-kafka-access"
+  labels:
+    {{- include "cadc-tap.labels" . | nindent 4 }}
+spec:
+  kafka:
+    name: "sasquatch"
+    namespace: "sasquatch"
+    listener: "tls"
+  user:
+    kind: "KafkaUser"
+    apiGroup: "kafka.strimzi.io"
+    name: "tap-tls"
+    namespace: "sasquatch"

--- a/charts/cadc-tap/templates/tap-deployment.yaml
+++ b/charts/cadc-tap/templates/tap-deployment.yaml
@@ -72,8 +72,9 @@ spec:
                 -Dgcs_bucket_type={{ .Values.config.gcsBucketType }}
                 -Ddatabase={{ .Values.config.database }}
                  {{- if .Values.config.kafka.auth.enabled }}
-                -Dkafka.username=tap
-                -Dkafka.password=$KAFKA_PASSWORD
+                -Dkafka.ssl.truststore=/etc/cadc-tap/kafka/ca.crt
+                -Dkafka.ssl.keystore=/etc/cadc-tap/kafka/user.crt
+                -Dkafka.ssl.key=/etc/cadc-tap/kafka/user.key
                 -Dkafka.bootstrap.server={{ .Values.config.kafka.bootstrapServer }}
                 -Dkafka.query.topic={{ .Values.config.kafka.topics.jobRun }}
                 -Dkafka.status.topic={{ .Values.config.kafka.topics.jobStatus }}
@@ -86,13 +87,6 @@ spec:
                 -Durl.rewrite.enabled={{ .Values.config.urlRewrite.enabled | default true }}
                 -Durl.rewrite.rules="{{ .Values.config.urlRewrite.rules | default "ivoa.ObsCore:access_url" }}"
                 -Xmx{{ .Values.config.jvmMaxHeapSize }}
-            {{- if .Values.config.kafka.auth.enabled }}
-            - name: "KAFKA_PASSWORD"
-              valueFrom:
-                secretKeyRef:
-                  name: "cadc-tap"
-                  key: "kafka-password"
-            {{- end }}
             {{- if (and (eq .Values.config.backend "qserv") .Values.config.qserv.passwordEnabled) }}
             - name: "QSERV_DB_PASSWORD"
               valueFrom:
@@ -163,6 +157,20 @@ spec:
               mountPath: "/tmp"
             - name: "config-volume"
               mountPath: "/config"
+          {{- if .Values.config.kafka.auth.enabled }}
+            - name: "kafka-certs"
+              mountPath: "/etc/cadc-tap/kafka/ca.crt"
+              readOnly: true
+              subPath: "ssl.truststore.crt"
+            - name: "kafka-certs"
+              mountPath: "/etc/cadc-tap/kafka/user.crt"
+              readOnly: true
+              subPath: "ssl.keystore.crt"
+            - name: "kafka-certs"
+              mountPath: "/etc/cadc-tap/kafka/user.key"
+              readOnly: true
+              subPath: "ssl.keystore.key"
+          {{- end }}
           livenessProbe:
             failureThreshold: 3
             httpGet:
@@ -208,6 +216,11 @@ spec:
         - name: "config-volume"
           configMap:
             name: "cadc-tap-config"
+        {{- if .Values.config.kafka.auth.enabled }}
+        - name: "kafka-certs"
+          secret:
+            secretName: "cadc-tap-kafka-access"
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/cadc-tap/values.yaml
+++ b/charts/cadc-tap/values.yaml
@@ -89,7 +89,7 @@ config:
       pullPolicy: "IfNotPresent"
 
       # -- Tag of TAP image to use
-      tag: "3.6.0"
+      tag: "3.8.0"
 
     # -- Whether the Qserv database is password protected
     # @default -- false
@@ -134,7 +134,7 @@ config:
   kafka:
 
     # -- Bootstrap Server
-    bootstrapServer: "sasquatch-dev-kafka-bootstrap.lsst.cloud:9094"
+    bootstrapServer: "sasquatch-kafka-bootstrap.sasquatch.svc:9093"
 
     # -- Schema Registry Configuration
     schemaRegistry:
@@ -245,7 +245,7 @@ uws:
     pullPolicy: "IfNotPresent"
 
     # -- Tag of UWS database image to use
-    tag: "3.6.0"
+    tag: "3.8.0"
 
   # -- Resource limits and requests for the UWS database pod
   # @default -- See `values.yaml`


### PR DESCRIPTION
This PR changes how TAP authenticates to kafka from user/pass to using certificates (strimzi).
The specific changes include:
- Change bootstrap server to `sasquatch-kafka-bootstrap.sasquatch.svc:9093`
- Upgrade TAP to version 3.8.0 (includes changes required for this to work)
- Adds `tap-tls` user to Sasquatch - I'm adding a new user rather than changing tap, so that we can still have both ways of authenticating until we are sure we want to switch to tls, and this allows us to fallback if something goes wrong.
- Adds KafkaAccess resource to enable TLS certificate setup
- Changes tap-deployment.yaml to use certificates instead of user/password