### PR TITLE
[DM-52396] Investigate write performance degradation in InfluxDB at USDF

### DIFF
--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -117,14 +117,6 @@ influxdb-enterprise-standby:
   data:
     replicas: 1
     affinity:
-      nodeAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-          nodeSelectorTerms:
-            - matchExpressions:
-                - key: kubernetes.io/hostname
-                  operator: In
-                  values:
-                    - sdfk8sn005
       podAntiAffinity:
         preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 1


### PR DESCRIPTION
The active InfluxDB at USDF, in particular the data-1 node is showing significative performance degradation for writes, the hinted handoff queue on data-0 is filling up and the current shard 5436 data is now inconsistent between the two data nodes.
It was identified that most of the CPU usage in data-1 was due querying historical data for the transformed EFD.

We recomend using the standby InfluxDB instance for the transformed EFD use case (single node setup, 16 cpus as limited by the enterprise license backed by a PVC on Weka) 

To connect use this instructions with 
```
INFLUXDB_URL = https://usdf-rsp.slac.stanford.edu/influxdb-enterprise-standby-data
````

In this PR we increase memory limits for the standby instance and further protect the active InfluxDB instance by overwriting the default query limits.