### PR TITLE
DM-52228: Add Repertoire support

### DIFF
--- a/docs/_rst_epilog.rst
+++ b/docs/_rst_epilog.rst
@@ -33,6 +33,7 @@
 .. _Pods:
 .. _Pod: https://kubernetes.io/docs/concepts/workloads/pods/
 .. _pre-commit: https://pre-commit.com
+.. _Repertoire: https://repertoire.lsst.io/
 .. _Roundtable: https://roundtable.lsst.io/
 .. _Ruff: https://docs.astral.sh/ruff/
 .. _Safir: https://safir.lsst.io/

--- a/docs/developers/add-repertoire.rst
+++ b/docs/developers/add-repertoire.rst
@@ -1,0 +1,63 @@
+########################################
+Adding Repertoire to an existing project
+########################################
+
+Repertoire_ is the data and service discovery service for Phalanx.
+All applications created from FastAPI Safir starters after 2025-09-08 are automatically configured to support Repertoire.
+
+When Repertoire support is added to earlier applications, the application Helm chart and Phalanx configuration will have to be updated to inject the configuration information for the Repetoire client.
+This page explains how to do that.
+
+1. Inject the global setting
+============================
+
+Locate the Argo CD ``Application`` resource for your application under :file:`environments/templates/applications`.
+It will be within the directory matching your application's Phalanx project.
+
+Find the ``spec.source.helm.parameters`` setting, where several other parameters such as ``global.host`` are already injected.
+
+Add the rule to inject the new ``global.repertoireUrl`` setting:
+
+.. code-block:: yaml
+
+   - name: "global.repertoireUrl"
+     value: "https://{{ .Values.fqdn }}/repertoire"
+
+Optionally, remove the injection of ``global.baseUrl``, which should no longer be needed or used once an application has been converted to use Repertoire.
+
+2. Pass the base URL to the application
+=======================================
+
+In the values file for the Helm chart for the application, :file:`applications/{name}/values.yaml`, add the documentation for the new injected value under the ``global`` key, which is usually at the bottom of the file.
+
+.. code-block:: yaml
+
+   global:
+     # -- Base URL for Repertoire discovery API
+     # @default -- Set by Argo CD
+     repertoireUrl: null
+
+Remove the documentation for ``global.baseUrl`` if you also removed the injection of that value above.
+
+Then, inject that value into your application so that it knows the base URL of the Repertoire service.
+The recommended default way to do that is to set the environment variable ``REPERTOIRE_BASE_URL``, which will be honored automatically by the `Repertoire client library <https://repertoire.lsst.io/user-guide/initialization.html>`__.
+
+Some applications set environment variables directly in various deployment templates, some in helper functions, and some in ``ConfigMap`` resources, so where to add this injection will vary by application.
+If your application follows the layout of the FastAPI Safir starters, it uses a ``ConfigMap`` defined in :file:`applications/{name}/templates/configmap.yaml`.
+In that case, add a new environment variable to the ``data`` section:
+
+.. code-block:: yaml
+
+   REPERTOIRE_BASE_URL: {{ .Values.global.repertoireUrl | quote }}
+
+3. Test with the new version of your application
+================================================
+
+These Phalanx changes should normally be done in the same PR as the change that updates your application to a new version with Repertoire support.
+Follow the :doc:`normal application testing process <deploy-from-a-branch>` to test these changes together.
+
+.. note::
+
+   Because injecting the Repertoire URL requires changes to the Argo CD ``Application`` resource, you will need to move the app-of-apps to your test branch and sync the application resource in the app-of-apps.
+   If you are not the environment administrator, you will need assistance from the environment administrator to do this.
+   This is very similar to testing a brand new application, as discussed in :doc:`switch-environment-to-branch`.

--- a/docs/developers/index.rst
+++ b/docs/developers/index.rst
@@ -43,6 +43,7 @@ Individual applications are documented in the :doc:`/applications/index` section
    deploy-from-a-branch
    switch-environment-to-branch
    resource-limits
+   add-repertoire
 
 .. toctree::
    :maxdepth: 2

--- a/docs/developers/injected-values.rst
+++ b/docs/developers/injected-values.rst
@@ -21,7 +21,7 @@ Always-injected values
 Injected values must be explicitly listed in the ``Application`` resource template for that application, and therefore a given application may not have any injected values.
 However, by convention and via :command:`phalanx application create`, Phalanx applications always get the following injected values, all of which provide information about the Phalanx environment in which the application is being deployed.
 
-``global.baseUrl``
+``global.baseUrl`` (deprecated)
     The base URL for applications deployed in this Phalanx environment.
     This always uses the ``https://`` schema.
     This value will be retired in favor of service discovery in the future and is therefore not mentioned in :file:`values.yaml` by default, although it is currently always injected.
@@ -34,6 +34,10 @@ However, by convention and via :command:`phalanx application create`, Phalanx ap
 ``global.host``
     The default hostname used by this Phalanx environment.
     This corresponds to the hostname in the public URLs for the services in this environment.
+
+``global.repertoireUrl``
+    The base URL to the Repertoire REST API for the local environment.
+    Repertoire_ is the data and service discovery service for Phalanx.
 
 ``global.vaultSecretsPath``
     The base path in Vault for secrets for this environment.

--- a/src/phalanx/data/application-template.yaml.jinja
+++ b/src/phalanx/data/application-template.yaml.jinja
@@ -28,6 +28,8 @@ spec:
           value: {{ .Values.name | quote }}
         - name: "global.host"
           value: {{ .Values.fqdn | quote }}
+        - name: "global.repertoireUrl"
+          value: "https://{{ .Values.fqdn }}/repertoire"
         - name: "global.vaultSecretsPath"
           value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:

--- a/src/phalanx/services/application.py
+++ b/src/phalanx/services/application.py
@@ -277,6 +277,7 @@ class ApplicationService:
             "global.host": environment.fqdn,
             "global.baseUrl": f"https://{environment.fqdn}",
             "global.environmentName": environment.name,
+            "global.repertoireUrl": f"https://{environment.fqdn}/repertoire",
             "global.vaultSecretsPath": environment.vault_path_prefix,
         }
         if environment.gcp:

--- a/starters/fastapi-safir-uws/templates/configmap.yaml
+++ b/starters/fastapi-safir-uws/templates/configmap.yaml
@@ -16,3 +16,4 @@ data:
   <CHARTENVPREFIX>_SYNC_TIMEOUT: {{ .Values.config.syncTimeout | quote }}
   <CHARTENVPREFIX>_TIMEOUT: {{ .Values.config.timeout | quote }}
   <CHARTENVPREFIX>_WOBBLY_URL: "{{ .Values.global.baseUrl }}/wobbly"
+  REPERTOIRE_BASE_URL: {{ .Values.global.repertoireUrl | quote }}

--- a/starters/fastapi-safir-uws/values.yaml
+++ b/starters/fastapi-safir-uws/values.yaml
@@ -197,6 +197,10 @@ global:
   # @default -- Set by Argo CD
   host: null
 
+  # -- Base URL for Repertoire discovery API
+  # @default -- Set by Argo CD
+  repertoireUrl: null
+
   # -- Base path for Vault secrets
   # @default -- Set by Argo CD
   vaultSecretsPath: null

--- a/starters/fastapi-safir/templates/configmap.yaml
+++ b/starters/fastapi-safir/templates/configmap.yaml
@@ -8,3 +8,4 @@ data:
   <CHARTENVPREFIX>_LOG_LEVEL: {{ .Values.config.logLevel | quote }}
   <CHARTENVPREFIX>_PATH_PREFIX: {{ .Values.config.pathPrefix | quote }}
   <CHARTENVPREFIX>_PROFILE: {{ .Values.config.logProfile | quote }}
+  REPERTOIRE_BASE_URL: {{ .Values.global.repertoireUrl | quote }}

--- a/starters/fastapi-safir/values.yaml
+++ b/starters/fastapi-safir/values.yaml
@@ -57,6 +57,10 @@ global:
   # @default -- Set by Argo CD
   host: null
 
+  # -- Base URL for Repertoire discovery API
+  # @default -- Set by Argo CD
+  repertoireUrl: null
+
   # -- Base path for Vault secrets
   # @default -- Set by Argo CD
   vaultSecretsPath: null

--- a/tests/data/output/idfdev/lint-all-calls.json
+++ b/tests/data/output/idfdev/lint-all-calls.json
@@ -38,7 +38,7 @@
     "--values",
     "argocd/values-idfdev.yaml",
     "--set",
-    "global.host=data-dev.lsst.cloud,global.baseUrl=https://data-dev.lsst.cloud,global.environmentName=idfdev,global.vaultSecretsPath=secret/phalanx/idfdev,global.gcpProjectId=science-platform-dev-7696,global.gcpRegion=us-central1"
+    "global.host=data-dev.lsst.cloud,global.baseUrl=https://data-dev.lsst.cloud,global.environmentName=idfdev,global.repertoireUrl=https://data-dev.lsst.cloud/repertoire,global.vaultSecretsPath=secret/phalanx/idfdev,global.gcpProjectId=science-platform-dev-7696,global.gcpRegion=us-central1"
   ],
   [
     "lint",
@@ -49,7 +49,7 @@
     "--values",
     "argocd/values-minikube.yaml",
     "--set",
-    "global.host=minikube.lsst.cloud,global.baseUrl=https://minikube.lsst.cloud,global.environmentName=minikube,global.vaultSecretsPath=secret/phalanx/minikube"
+    "global.host=minikube.lsst.cloud,global.baseUrl=https://minikube.lsst.cloud,global.environmentName=minikube,global.repertoireUrl=https://minikube.lsst.cloud/repertoire,global.vaultSecretsPath=secret/phalanx/minikube"
   ],
   [
     "lint",
@@ -60,7 +60,7 @@
     "--values",
     "argocd/values-usdfdev-prompt-processing.yaml",
     "--set",
-    "global.host=usdf-prompt-processing-dev.slac.stanford.edu,global.baseUrl=https://usdf-prompt-processing-dev.slac.stanford.edu,global.environmentName=usdfdev-prompt-processing,global.vaultSecretsPath=secret/rubin/usdf-prompt-processing-dev"
+    "global.host=usdf-prompt-processing-dev.slac.stanford.edu,global.baseUrl=https://usdf-prompt-processing-dev.slac.stanford.edu,global.environmentName=usdfdev-prompt-processing,global.repertoireUrl=https://usdf-prompt-processing-dev.slac.stanford.edu/repertoire,global.vaultSecretsPath=secret/rubin/usdf-prompt-processing-dev"
   ],
   [
     "dependency",
@@ -76,7 +76,7 @@
     "--values",
     "gafaelfawr/values-idfdev.yaml",
     "--set",
-    "global.host=data-dev.lsst.cloud,global.baseUrl=https://data-dev.lsst.cloud,global.environmentName=idfdev,global.vaultSecretsPath=secret/phalanx/idfdev,global.gcpProjectId=science-platform-dev-7696,global.gcpRegion=us-central1"
+    "global.host=data-dev.lsst.cloud,global.baseUrl=https://data-dev.lsst.cloud,global.environmentName=idfdev,global.repertoireUrl=https://data-dev.lsst.cloud/repertoire,global.vaultSecretsPath=secret/phalanx/idfdev,global.gcpProjectId=science-platform-dev-7696,global.gcpRegion=us-central1"
   ],
   [
     "lint",
@@ -87,7 +87,7 @@
     "--values",
     "gafaelfawr/values-minikube.yaml",
     "--set",
-    "global.host=minikube.lsst.cloud,global.baseUrl=https://minikube.lsst.cloud,global.environmentName=minikube,global.vaultSecretsPath=secret/phalanx/minikube"
+    "global.host=minikube.lsst.cloud,global.baseUrl=https://minikube.lsst.cloud,global.environmentName=minikube,global.repertoireUrl=https://minikube.lsst.cloud/repertoire,global.vaultSecretsPath=secret/phalanx/minikube"
   ],
   [
     "dependency",
@@ -103,7 +103,7 @@
     "--values",
     "nublado/values-idfdev.yaml",
     "--set",
-    "global.host=data-dev.lsst.cloud,global.baseUrl=https://data-dev.lsst.cloud,global.environmentName=idfdev,global.vaultSecretsPath=secret/phalanx/idfdev,global.gcpProjectId=science-platform-dev-7696,global.gcpRegion=us-central1"
+    "global.host=data-dev.lsst.cloud,global.baseUrl=https://data-dev.lsst.cloud,global.environmentName=idfdev,global.repertoireUrl=https://data-dev.lsst.cloud/repertoire,global.vaultSecretsPath=secret/phalanx/idfdev,global.gcpProjectId=science-platform-dev-7696,global.gcpRegion=us-central1"
   ],
   [
     "dependency",
@@ -119,7 +119,7 @@
     "--values",
     "portal/values-idfdev.yaml",
     "--set",
-    "global.host=data-dev.lsst.cloud,global.baseUrl=https://data-dev.lsst.cloud,global.environmentName=idfdev,global.vaultSecretsPath=secret/phalanx/idfdev,global.gcpProjectId=science-platform-dev-7696,global.gcpRegion=us-central1"
+    "global.host=data-dev.lsst.cloud,global.baseUrl=https://data-dev.lsst.cloud,global.environmentName=idfdev,global.repertoireUrl=https://data-dev.lsst.cloud/repertoire,global.vaultSecretsPath=secret/phalanx/idfdev,global.gcpProjectId=science-platform-dev-7696,global.gcpRegion=us-central1"
   ],
   [
     "dependency",
@@ -135,7 +135,7 @@
     "--values",
     "postgres/values-idfdev.yaml",
     "--set",
-    "global.host=data-dev.lsst.cloud,global.baseUrl=https://data-dev.lsst.cloud,global.environmentName=idfdev,global.vaultSecretsPath=secret/phalanx/idfdev,global.gcpProjectId=science-platform-dev-7696,global.gcpRegion=us-central1"
+    "global.host=data-dev.lsst.cloud,global.baseUrl=https://data-dev.lsst.cloud,global.environmentName=idfdev,global.repertoireUrl=https://data-dev.lsst.cloud/repertoire,global.vaultSecretsPath=secret/phalanx/idfdev,global.gcpProjectId=science-platform-dev-7696,global.gcpRegion=us-central1"
   ],
   [
     "lint",
@@ -146,6 +146,6 @@
     "--values",
     "postgres/values-minikube.yaml",
     "--set",
-    "global.host=minikube.lsst.cloud,global.baseUrl=https://minikube.lsst.cloud,global.environmentName=minikube,global.vaultSecretsPath=secret/phalanx/minikube"
+    "global.host=minikube.lsst.cloud,global.baseUrl=https://minikube.lsst.cloud,global.environmentName=minikube,global.repertoireUrl=https://minikube.lsst.cloud/repertoire,global.vaultSecretsPath=secret/phalanx/minikube"
   ]
 ]

--- a/tests/data/output/idfdev/lint-git-calls.json
+++ b/tests/data/output/idfdev/lint-git-calls.json
@@ -31,7 +31,7 @@
     "--values",
     "argocd/values-idfdev.yaml",
     "--set",
-    "global.host=data-dev.lsst.cloud,global.baseUrl=https://data-dev.lsst.cloud,global.environmentName=idfdev,global.vaultSecretsPath=secret/phalanx/idfdev,global.gcpProjectId=science-platform-dev-7696,global.gcpRegion=us-central1"
+    "global.host=data-dev.lsst.cloud,global.baseUrl=https://data-dev.lsst.cloud,global.environmentName=idfdev,global.repertoireUrl=https://data-dev.lsst.cloud/repertoire,global.vaultSecretsPath=secret/phalanx/idfdev,global.gcpProjectId=science-platform-dev-7696,global.gcpRegion=us-central1"
   ],
   [
     "dependency",
@@ -47,7 +47,7 @@
     "--values",
     "gafaelfawr/values-idfdev.yaml",
     "--set",
-    "global.host=data-dev.lsst.cloud,global.baseUrl=https://data-dev.lsst.cloud,global.environmentName=idfdev,global.vaultSecretsPath=secret/phalanx/idfdev,global.gcpProjectId=science-platform-dev-7696,global.gcpRegion=us-central1"
+    "global.host=data-dev.lsst.cloud,global.baseUrl=https://data-dev.lsst.cloud,global.environmentName=idfdev,global.repertoireUrl=https://data-dev.lsst.cloud/repertoire,global.vaultSecretsPath=secret/phalanx/idfdev,global.gcpProjectId=science-platform-dev-7696,global.gcpRegion=us-central1"
   ],
   [
     "lint",
@@ -58,7 +58,7 @@
     "--values",
     "gafaelfawr/values-minikube.yaml",
     "--set",
-    "global.host=minikube.lsst.cloud,global.baseUrl=https://minikube.lsst.cloud,global.environmentName=minikube,global.vaultSecretsPath=secret/phalanx/minikube"
+    "global.host=minikube.lsst.cloud,global.baseUrl=https://minikube.lsst.cloud,global.environmentName=minikube,global.repertoireUrl=https://minikube.lsst.cloud/repertoire,global.vaultSecretsPath=secret/phalanx/minikube"
   ],
   [
     "dependency",
@@ -74,6 +74,6 @@
     "--values",
     "portal/values-idfdev.yaml",
     "--set",
-    "global.host=data-dev.lsst.cloud,global.baseUrl=https://data-dev.lsst.cloud,global.environmentName=idfdev,global.vaultSecretsPath=secret/phalanx/idfdev,global.gcpProjectId=science-platform-dev-7696,global.gcpRegion=us-central1"
+    "global.host=data-dev.lsst.cloud,global.baseUrl=https://data-dev.lsst.cloud,global.environmentName=idfdev,global.repertoireUrl=https://data-dev.lsst.cloud/repertoire,global.vaultSecretsPath=secret/phalanx/idfdev,global.gcpProjectId=science-platform-dev-7696,global.gcpRegion=us-central1"
   ]
 ]

--- a/tests/data/output/idfdev/lint-set-values.json
+++ b/tests/data/output/idfdev/lint-set-values.json
@@ -2,6 +2,7 @@
   "global.host=data-dev.lsst.cloud",
   "global.baseUrl=https://data-dev.lsst.cloud",
   "global.environmentName=idfdev",
+  "global.repertoireUrl=https://data-dev.lsst.cloud/repertoire",
   "global.vaultSecretsPath=secret/phalanx/idfdev",
   "global.gcpProjectId=science-platform-dev-7696",
   "global.gcpRegion=us-central1"


### PR DESCRIPTION
Add Repertoire to the FastAPI Safir starters. Add the new `global.repertoireUrl` setting to the template for the `Application` resource and also inject it during Phalanx CLI operations.