### PR TITLE
DM-52228: Enable Repertoire for minikube, update for release

### DIFF
--- a/applications/repertoire/values-idfdev.yaml
+++ b/applications/repertoire/values-idfdev.yaml
@@ -1,6 +1,3 @@
-image:
-  tag: "tickets-DM-52228"
-  pullPolicy: "Always"
 config:
   datasets:
     - name: "dp02"

--- a/environments/values-minikube.yaml
+++ b/environments/values-minikube.yaml
@@ -13,3 +13,4 @@ vaultPathPrefix: "secret/phalanx/minikube"
 applications:
   mobu: true
   postgres: true
+  repertoire: true


### PR DESCRIPTION
Add Repertoire to Minikube for additional testing. Remove the image override now that there is a 0.1.0 release.