### PR TITLE
DM-52453: Add InfluxDB support to Repertoire

### DIFF
--- a/applications/gafaelfawr/templates/deployment.yaml
+++ b/applications/gafaelfawr/templates/deployment.yaml
@@ -40,8 +40,30 @@ spec:
             - name: "KAFKA_CLUSTER_CA_PATH"
               value: "/etc/gafaelfawr-kafka/ca.crt"
             {{- end }}
+            # Uvicorn keepalive timeout, in seconds. This should be longer
+            # than any keepalive timeouts on any downstream proxies. The
+            # keepalive timeout for ingress-nginx connections is 60s.
+            - name: "UVICORN_TIMEOUT_KEEP_ALIVE"
+              value: "61"
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          lifecycle:
+            # Number of seconds k8s should wait before sending SIGTERM on
+            # graceful restarts/deployments/shutdowns. We need this because it
+            # takes ingress-nginx some time to configure itself to stop
+            # sending traffic to the pods scheduled for termination. If
+            # Uvicorn gets the SIGTERM and starts closing connections, we
+            # could end up with a TCP race condition if ingress-nginx still
+            # tries to send data over those connections.
+            #
+            # Note that terminationGracePeriodSeconds includes the time that
+            # is spent in the preStop hook. If you’re adding a preStop hook
+            # and your terminationGracePeriodSeconds is super fine-tuned, then
+            # you should update your terminationGracePeriodSeconds to add the
+            # amount of time you’ll be spending in your preStop hook.
+            preStop:
+              sleep:
+                seconds: 10
           livenessProbe:
             httpGet:
               path: "/health"

--- a/applications/gafaelfawr/values-idfdev.yaml
+++ b/applications/gafaelfawr/values-idfdev.yaml
@@ -62,6 +62,8 @@ config:
       - "g_developers"
     "read:image":
       - "g_users"
+    "read:sasquatch":
+      - "g_users"
     "read:tap":
       - "g_users"
     "write:files":

--- a/applications/gafaelfawr/values.yaml
+++ b/applications/gafaelfawr/values.yaml
@@ -284,12 +284,14 @@ config:
       Use the Notebook Aspect
     "exec:portal": >-
       Use the Portal Aspect
+    "exec:portal-admin": >-
+      Read access to the Portal admin page
     "read:alertdb": >-
       Retrieve alert packets and schemas from the alert archive database
     "read:image": >-
       Retrieve images from project datasets
-    "exec:portal-admin": >-
-      Read access to the Portal admin page
+    "read:sasquatch": >-
+      Retrieve Sasquatch InfluxDB connection credentials
     "read:tap": >-
       Execute SELECT queries in the TAP interface on project datasets
     "write:files": >-

--- a/applications/repertoire/Chart.yaml
+++ b/applications/repertoire/Chart.yaml
@@ -6,7 +6,7 @@ description: Service discovery
 home: "https://repertoire.lsst.io/"
 sources:
   - "https://github.com/lsst-sqre/repertoire"
-appVersion: 0.1.0
+appVersion: 0.2.0
 
 annotations:
   phalanx.lsst.io/docs: |

--- a/applications/repertoire/README.md
+++ b/applications/repertoire/README.md
@@ -14,9 +14,10 @@ Service discovery
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules for the repertoire deployment pod |
 | config.applications | list | Set by Argo CD | List of applications deployed in this Phalanx environment (do not set) |
+| config.availableDatasets | list | `[]` | Datasets available in the Phalanx environment. This should be overridden by environments to list the datasets they provide. |
 | config.baseHostname | string | Set by Argo CD | Base hostname of the Phalanx environment (do not set) |
 | config.butlerConfigs | object | Set by Argo CD | Butler configuration mapping (do not set) |
-| config.datasets | list | `[]` | List of datasets served by this environment. Each member of the list is a dictionary with key `name` (human-readable short name of dataset like `dp1`). |
+| config.datasets | object | See `values.yaml` | Known datasets. Each member of the list is a dictionary with key `description`. Datasets are only shown if also listed in `availableDatasets`. |
 | config.influxdbDatabases | object | `{}` | Dictionary of InfluxDB database names to connection information for that database, with keys `url`, `database`, `username`, `passwordKey`, and `schemaRegistry`. `passwordKey` must match an entry in `secrets.yaml`. |
 | config.logLevel | string | `"INFO"` | Logging level |
 | config.logProfile | string | `"production"` | Logging profile (`production` for JSON, `development` for human-friendly) |

--- a/applications/repertoire/README.md
+++ b/applications/repertoire/README.md
@@ -17,13 +17,14 @@ Service discovery
 | config.baseHostname | string | Set by Argo CD | Base hostname of the Phalanx environment (do not set) |
 | config.butlerConfigs | object | Set by Argo CD | Butler configuration mapping (do not set) |
 | config.datasets | list | `[]` | List of datasets served by this environment. Each member of the list is a dictionary with key `name` (human-readable short name of dataset like `dp1`). |
+| config.influxdbDatabases | object | `{}` | Dictionary of InfluxDB database names to connection information for that database, with keys `url`, `database`, `username`, `passwordKey`, and `schemaRegistry`. `passwordKey` must match an entry in `secrets.yaml`. |
 | config.logLevel | string | `"INFO"` | Logging level |
 | config.logProfile | string | `"production"` | Logging profile (`production` for JSON, `development` for human-friendly) |
 | config.pathPrefix | string | `"/repertoire"` | URL path prefix |
 | config.rules | object | See `values.yaml` | Rules for determining the expected URLs of deployed services that use the main hostname. See the [Repertoire documentation](https://repertoire.lsst.io/) for more information. |
 | config.slackAlerts | bool | `false` | Whether to send Slack alerts for unexpected failures |
 | config.subdomainRules | object | See `values.yaml` | Rules for determining the expected URLs of deployed services that use a subdomain. See the [Repertoire documentation](https://repertoire.lsst.io/) for more information. |
-| config.useSubdomains | list | `["nublado"]` | List of services that use subdomains instead of the main hostname. See the [Repertoire documentation](https://repertoire.lsst.io/) for more information. |
+| config.useSubdomains | list | `[]` | List of services that use subdomains instead of the main hostname. See the [Repertoire documentation](https://repertoire.lsst.io/) for more information. |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the repertoire image |

--- a/applications/repertoire/secrets-idfdev.yaml
+++ b/applications/repertoire/secrets-idfdev.yaml
@@ -1,0 +1,5 @@
+idfdev_efd-password:
+  description: >-
+    InfluxDB password for the efdreader user for accessing the efd database on
+    idfdev. Clients will cache this secret locally in their client
+    configuration, so changing it may be disruptive.

--- a/applications/repertoire/templates/deployment.yaml
+++ b/applications/repertoire/templates/deployment.yaml
@@ -81,6 +81,9 @@ spec:
             - name: "config"
               mountPath: "/etc/repertoire"
               readOnly: true
+            - name: "secrets"
+              mountPath: "/etc/repertoire/secrets"
+              readOnly: true
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -97,3 +100,6 @@ spec:
         - name: "config"
           configMap:
             name: "repertoire"
+        - name: "secrets"
+          secret:
+            secretName: "repertoire"

--- a/applications/repertoire/templates/ingress-influxdb.yaml
+++ b/applications/repertoire/templates/ingress-influxdb.yaml
@@ -1,0 +1,30 @@
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
+metadata:
+  name: "repertoire-influxdb"
+  labels:
+    {{- include "repertoire.labels" . | nindent 4 }}
+config:
+  scopes:
+    all:
+      - "read:sasquatch"
+  service: "repertoire"
+template:
+  metadata:
+    name: "repertoire-influxdb"
+    {{- with .Values.ingress.annotations }}
+    annotations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  spec:
+    rules:
+      - host: {{ required "global.host must be set" .Values.global.host | quote }}
+        http:
+          paths:
+            - path: "{{ .Values.config.pathPrefix }}/discovery/influxdb"
+              pathType: "Prefix"
+              backend:
+                service:
+                  name: "repertoire"
+                  port:
+                    number: 8080

--- a/applications/repertoire/templates/vault-secrets.yaml
+++ b/applications/repertoire/templates/vault-secrets.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.config.slackAlerts -}}
 apiVersion: ricoberger.de/v1alpha1
 kind: VaultSecret
 metadata:
@@ -8,4 +7,3 @@ metadata:
 spec:
   path: "{{ .Values.global.vaultSecretsPath }}/repertoire"
   type: Opaque
-{{- end }}

--- a/applications/repertoire/values-idfdev.yaml
+++ b/applications/repertoire/values-idfdev.yaml
@@ -3,4 +3,13 @@ config:
     - name: "dp02"
     - name: "dp03"
     - name: "dp1"
+  influxdbDatabases:
+    idfdev_efd:
+      url: "https://data-dev.lsst.cloud/influxdb/"
+      database: "efd"
+      username: "efdreader"
+      passwordKey: "idfdev_efd-password"
+      schemaRegistry: "http://sasquatch-schema-registry.sasquatch:8081"
   slackAlerts: true
+  useSubdomains:
+    - "nublado"

--- a/applications/repertoire/values-idfdev.yaml
+++ b/applications/repertoire/values-idfdev.yaml
@@ -1,8 +1,8 @@
 config:
-  datasets:
-    - name: "dp02"
-    - name: "dp03"
-    - name: "dp1"
+  availableDatasets:
+    - "dp02"
+    - "dp03"
+    - "dp1"
   influxdbDatabases:
     idfdev_efd:
       url: "https://data-dev.lsst.cloud/influxdb/"

--- a/applications/repertoire/values.yaml
+++ b/applications/repertoire/values.yaml
@@ -84,6 +84,7 @@ config:
       - type: "internal"
         name: "gafaelfawr"
         template: "https://{{base_hostname}}/auth/api/v1"
+        openapi: "https://{{base_hostname}}/auth/openapi.json"
       - type: "ui"
         name: "tokens"
         template: "https://{{base_hostname}}/auth/tokens"
@@ -98,10 +99,12 @@ config:
       - type: "internal"
         name: "mobu"
         template: "https://{{base_hostname}}/mobu"
+        openapi: "https://{{base_hostname}}/mobu/openapi.json"
     noteburst:
       - type: "internal"
         name: "noteburst"
         template: "https://{{base_hostname}}/noteburst/v1"
+        openapi: "https://{{base_hostname}}/noteburst/openapi.json"
     nublado:
       - type: "ui"
         name: "nublado"
@@ -117,6 +120,7 @@ config:
       - type: "internal"
         name: "semaphore"
         template: "https://{{base_hostname}}/semaphore"
+        openapi: "https://{{base_hostname}}/semaphore/openapi.json"
     sia:
       - type: "data"
         name: "sia"
@@ -124,6 +128,7 @@ config:
           - "dp02"
           - "dp1"
         template: "https://{{base_hostname}}/api/sia/{{dataset}}"
+        openapi: "https://{{base_hostname}}/api/sia/openapi.json"
     ssotap:
       - type: "data"
         name: "tap"
@@ -144,10 +149,12 @@ config:
           - "dp02"
           - "dp1"
         template: "https://{{base_hostname}}/api/cutout"
+        openapi: "https://{{base_hostname}}/api/cutout/openapi.json"
     wobbly:
       - type: "internal"
         name: "wobbly"
         template: "https://{{base_hostname}}/wobbly"
+        openapi: "https://{{base_hostname}}/wobbly/openapi.json"
 
   # -- Whether to send Slack alerts for unexpected failures
   slackAlerts: false

--- a/applications/repertoire/values.yaml
+++ b/applications/repertoire/values.yaml
@@ -34,6 +34,11 @@ config:
   # `dp1`).
   datasets: []
 
+  # -- Dictionary of InfluxDB database names to connection information for
+  # that database, with keys `url`, `database`, `username`, `passwordKey`, and
+  # `schemaRegistry`. `passwordKey` must match an entry in `secrets.yaml`.
+  influxdbDatabases: {}
+
   # -- Logging level
   logLevel: "INFO"
 
@@ -141,8 +146,7 @@ config:
   # -- List of services that use subdomains instead of the main hostname. See
   # the [Repertoire documentation](https://repertoire.lsst.io/) for more
   # information.
-  useSubdomains:
-    - "nublado"
+  useSubdomains: []
 
 ingress:
   # -- Additional annotations for the ingress rule

--- a/applications/repertoire/values.yaml
+++ b/applications/repertoire/values.yaml
@@ -21,6 +21,10 @@ config:
   # @default -- Set by Argo CD
   applications: []
 
+  # -- Datasets available in the Phalanx environment. This should be
+  # overridden by environments to list the datasets they provide.
+  availableDatasets: []
+
   # -- Base hostname of the Phalanx environment (do not set)
   # @default -- Set by Argo CD
   baseHostname: null
@@ -29,10 +33,28 @@ config:
   # @default -- Set by Argo CD
   butlerConfigs: {}
 
-  # -- List of datasets served by this environment. Each member of the list is
-  # a dictionary with key `name` (human-readable short name of dataset like
-  # `dp1`).
-  datasets: []
+  # -- Known datasets. Each member of the list is a dictionary with key
+  # `description`. Datasets are only shown if also listed in
+  # `availableDatasets`.
+  # @default -- See `values.yaml`
+  datasets:
+    dp02:
+      description: >-
+        Data Preview 0.2 contains the image and catalog products of the Rubin
+        Science Pipelines v23 processing of the DESC Data Challenge 2
+        simulation, which covered 300 square degrees of the wide-fast-deep
+        LSST survey region over 5 years.
+    dp03:
+      description: >-
+        Data Preview 0.3 contains the catalog products of a Solar System
+        Science Collaboration simulation of the results of SSO analysis of the
+        wide-fast-deep data from the LSST dataset.
+    dp1:
+      description: >-
+        Data Preview 1 contains image and catalog products from the Rubin
+        Science Pipelines v29 processing of observations obtained with the
+        LSST Commissioning Camera of seven ~1 square degree fields, over seven
+        weeks in late 2024.
 
   # -- Dictionary of InfluxDB database names to connection information for
   # that database, with keys `url`, `database`, `username`, `passwordKey`, and


### PR DESCRIPTION
Add a new scope, `read:sasquatch`, that controls the top-level ability to retrieve any InfluxDB connection information with credentials. More fine-grained access control in the future will probably use groups.

Update Repertoire to 0.2.0 and add idfdev InfluxDB configuration information and a secret for the `idfdev_efd` Sasquatch InfluxDB database. Add an authenticated ingress for retrieving InfluxDB connection information with credentials.