### PR TITLE
Rename sasquatch-backup pvc

### DIFF
--- a/applications/sasquatch/charts/backup/templates/backup-cronjob.yaml
+++ b/applications/sasquatch/charts/backup/templates/backup-cronjob.yaml
@@ -28,7 +28,7 @@ spec:
           volumes:
           - name: backup
             persistentVolumeClaim:
-              claimName: sasquatch-backup
+              claimName: sasquatch-backup-artifacts
           containers:
           - name: sasquatch-backup
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/applications/sasquatch/charts/backup/templates/backup-pvc.yaml
+++ b/applications/sasquatch/charts/backup/templates/backup-pvc.yaml
@@ -1,7 +1,7 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: sasquatch-backup
+  name: sasquatch-backup-artifacts
 spec:
   accessModes:
     - ReadWriteOnce

--- a/applications/sasquatch/charts/backup/templates/restore-deployment.yaml
+++ b/applications/sasquatch/charts/backup/templates/restore-deployment.yaml
@@ -28,7 +28,7 @@ spec:
       volumes:
       - name: backup
         persistentVolumeClaim:
-          claimName: sasquatch-backup
+          claimName: sasquatch-backup-artifacts
       containers:
       - name: sasquatch-backup
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
Old versions of vcluster add the `vcluster.loft.sh/fake-pv: "true"` label to PVs and this became  a problem for upgrading the vcluster.
This is affecting two Sasquatch PVs in `sasquatch-backup` at both usdf-rsp-dev and usdf-rsp.

To fix this, we’ll update sasquatch-backup to provision a PV with a different name, run the backup job and when backups are in place we can remove the old PVs.