### PR TITLE
DM-52453: Add Repertoire to more environments

### DIFF
--- a/applications/repertoire/secrets-base.yaml
+++ b/applications/repertoire/secrets-base.yaml
@@ -1,0 +1,5 @@
+base_efd-password:
+  description: >-
+    InfluxDB password for the efdreader user for accessing the EFD database on
+    the base teststand. Clients will cache this secret locally in their client
+    configuration, so changing it may be disruptive.

--- a/applications/repertoire/secrets-tucson-teststand.yaml
+++ b/applications/repertoire/secrets-tucson-teststand.yaml
@@ -1,0 +1,5 @@
+tucson_teststand_efd-password:
+  description: >-
+    InfluxDB password for the efdreader user for accessing the EFD database on
+    the Tucson teststand. Clients will cache this secret locally in their
+    client configuration, so changing it may be disruptive.

--- a/applications/repertoire/values-base.yaml
+++ b/applications/repertoire/values-base.yaml
@@ -1,0 +1,9 @@
+config:
+  influxdbDatabases:
+    base_efd:
+      url: "https://base.lsst.codes/influxdb/"
+      database: "efd"
+      username: "efdreader"
+      passwordKey: "idfdev_efd-password"
+      schemaRegistry: "http://sasquatch-schema-registry.sasquatch:8081"
+  slackAlerts: true

--- a/applications/repertoire/values-idfint.yaml
+++ b/applications/repertoire/values-idfint.yaml
@@ -1,0 +1,8 @@
+config:
+  availableDatasets:
+    - "dp02"
+    - "dp03"
+    - "dp1"
+  slackAlerts: true
+  useSubdomains:
+    - "nublado"

--- a/applications/repertoire/values-idfprod.yaml
+++ b/applications/repertoire/values-idfprod.yaml
@@ -1,0 +1,8 @@
+config:
+  availableDatasets:
+    - "dp02"
+    - "dp03"
+    - "dp1"
+  slackAlerts: true
+  useSubdomains:
+    - "nublado"

--- a/applications/repertoire/values-roundtable-dev.yaml
+++ b/applications/repertoire/values-roundtable-dev.yaml
@@ -1,0 +1,2 @@
+config:
+  slackAlerts: true

--- a/applications/repertoire/values-roundtable-prod.yaml
+++ b/applications/repertoire/values-roundtable-prod.yaml
@@ -1,0 +1,2 @@
+config:
+  slackAlerts: true

--- a/applications/repertoire/values-tucson-teststand.yaml
+++ b/applications/repertoire/values-tucson-teststand.yaml
@@ -1,0 +1,9 @@
+config:
+  influxdbDatabases:
+    tucson_teststand_efd:
+      url: "https://tucson-teststand.lsst.codes/influxdb/"
+      database: "efd"
+      username: "efdreader"
+      passwordKey: "idfdev_efd-password"
+      schemaRegistry: "http://sasquatch-schema-registry.sasquatch:8081"
+  slackAlerts: true

--- a/environments/values-base.yaml
+++ b/environments/values-base.yaml
@@ -29,6 +29,7 @@ applications:
   obssys: true
   portal: true
   rapid-analysis: true
+  repertoire: true
   rubintv: true
   sasquatch: true
   simonyitel: true

--- a/environments/values-idfint.yaml
+++ b/environments/values-idfint.yaml
@@ -25,6 +25,7 @@ applications:
   nublado: true
   portal: true
   qserv-kafka: true
+  repertoire: true
   rubin-rag: true
   sasquatch: true
   sia: true

--- a/environments/values-idfprod.yaml
+++ b/environments/values-idfprod.yaml
@@ -24,6 +24,7 @@ applications:
   nublado: true
   portal: true
   qserv-kafka: true
+  repertoire: true
   sasquatch: true
   semaphore: true
   sia: true

--- a/environments/values-roundtable-dev.yaml
+++ b/environments/values-roundtable-dev.yaml
@@ -19,6 +19,7 @@ applications:
   mobu: true
   onepassword-connect: true
   ook: true
+  repertoire: true
   sasquatch: true
   squarebot: true
   squareone: true

--- a/environments/values-roundtable-prod.yaml
+++ b/environments/values-roundtable-prod.yaml
@@ -20,6 +20,7 @@ applications:
   mobu: true
   onepassword-connect: true
   ook: true
+  repertoire: true
   sasquatch: true
   squareone: true
   strimzi: true

--- a/environments/values-tucson-teststand.yaml
+++ b/environments/values-tucson-teststand.yaml
@@ -27,6 +27,7 @@ applications:
   obssys: true
   portal: true
   rapid-analysis: true
+  repertoire: true
   rubintv: true
   sasquatch: true
   simonyitel: true


### PR DESCRIPTION
Enable Repertoire on idfint, idfprod, roundtable-dev, roundtable-prod, tucson-teststand, and base with appropriate configuration. Include the InfluxDB EFD databases for tucson-teststand and base.