### PR TITLE
DM-52490: Add requests and limits for Repertoire

### DIFF
--- a/applications/repertoire/values.yaml
+++ b/applications/repertoire/values.yaml
@@ -192,7 +192,13 @@ podAnnotations: {}
 
 # -- Resource limits and requests for the repertoire deployment pod
 # @default -- See `values.yaml`
-resources: {}
+resources:
+  limits:
+    cpu: "1"
+    memory: "100Mi"
+  requests:
+    cpu: "10m"
+    memory: "50Mi"
 
 # -- Tolerations for the repertoire deployment pod
 tolerations: []


### PR DESCRIPTION
Based on the GCP metrics for Repertoire running on idfdev. I will never understand why a simple Python program running under uvicorn takes up so much memory.