### PR TITLE
Remove kube-system deny for support

### DIFF
--- a/environments/templates/projects/support.yaml
+++ b/environments/templates/projects/support.yaml
@@ -8,8 +8,6 @@ spec:
     - group: "*"
       kind: "*"
   destinations:
-    - namespace: "!kube-system"
-      server: "*"
     - namespace: "*"
       server: "*"
   namespaceResourceWhitelist:


### PR DESCRIPTION
The support project also contains resources that need to be deployed in the kube-system namespace, such as keda.