### PR TITLE
[DM-52494] Adjust query limits further in the Standby InfluxDB instance at USDF

### DIFF
--- a/applications/sasquatch/charts/influxdb-enterprise/templates/data-statefulset.yaml
+++ b/applications/sasquatch/charts/influxdb-enterprise/templates/data-statefulset.yaml
@@ -87,7 +87,7 @@ spec:
               protocol: UDP
           startupProbe:
             failureThreshold: 6
-            periodSeconds: 30
+            periodSeconds: 60
             httpGet:
               path: /ping
               port: http

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -143,12 +143,12 @@ influxdb-enterprise-standby:
       size: 100Ti
     resources:
       requests:
-        memory: 192Gi
+        memory: 128Gi
         # The InfluxDB Enterprise license is limited to 16 cpu, the
         # standby instance uses a 1 node x 16 cpu setup
         cpu: 16
       limits:
-        memory: 192Gi
+        memory: 128Gi
         cpu: 16
 
 influxdb-enterprise-active:

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -116,6 +116,10 @@ influxdb-enterprise-standby:
         key: influxdb-enterprise-standby-shared-secret
   data:
     replicas: 1
+    config:
+      cluster:
+        max-concurrent-queries: 150
+        query-timeout: "90s"
     affinity:
       podAntiAffinity:
         preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
Using the following limits to alleviate the query load on the standby InfluxDB instance at USDF
```
max-concurrent-queries: 150
query-timeout: "90s"
```
this helps up to certain point because the EFD transformation service is retrying killed queries. 
I have asked the users to pause their queries until we fix the compaction problems, otherwise this won't hold. 