### PR TITLE
Increase rest proxy JVM heap size and Pod memory resources

### DIFF
--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -514,7 +514,7 @@ Rubin Observatory's telemetry service
 | rest-proxy.affinity | object | `{}` | Affinity configuration |
 | rest-proxy.configurationOverrides | object | See `values.yaml` | Kafka REST configuration options |
 | rest-proxy.customEnv | object | `{}` | Kafka REST additional env variables |
-| rest-proxy.heapOptions | string | `"-Xms512M -Xmx512M"` | Kafka REST proxy JVM Heap Option |
+| rest-proxy.heapOptions | string | `"-Xms1024M -Xmx1024M"` | Kafka REST proxy JVM Heap Option |
 | rest-proxy.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | rest-proxy.image.repository | string | `"confluentinc/cp-kafka-rest"` | Kafka REST proxy image repository |
 | rest-proxy.image.tag | string | `"8.0.0"` | Kafka REST proxy image tag |

--- a/applications/sasquatch/charts/rest-proxy/README.md
+++ b/applications/sasquatch/charts/rest-proxy/README.md
@@ -13,7 +13,7 @@ A subchart to deploy Confluent REST proxy for Sasquatch.
 | affinity | object | `{}` | Affinity configuration |
 | configurationOverrides | object | See `values.yaml` | Kafka REST configuration options |
 | customEnv | object | `{}` | Kafka REST additional env variables |
-| heapOptions | string | `"-Xms512M -Xmx512M"` | Kafka REST proxy JVM Heap Option |
+| heapOptions | string | `"-Xms1024M -Xmx1024M"` | Kafka REST proxy JVM Heap Option |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | image.repository | string | `"confluentinc/cp-kafka-rest"` | Kafka REST proxy image repository |
 | image.tag | string | `"8.0.0"` | Kafka REST proxy image tag |

--- a/applications/sasquatch/charts/rest-proxy/values.yaml
+++ b/applications/sasquatch/charts/rest-proxy/values.yaml
@@ -35,7 +35,7 @@ ingress:
   path: "/sasquatch-rest-proxy(/|$)(.*)"
 
 # -- Kafka REST proxy JVM Heap Option
-heapOptions: "-Xms512M -Xmx512M"
+heapOptions: "-Xms1024M -Xmx1024M"
 
 # -- Kafka REST configuration options
 # @default -- See `values.yaml`
@@ -73,10 +73,10 @@ kafka:
 # @default -- See `values.yaml`
 resources:
   requests:
-    memory: 500Mi
+    memory: 1Gi
     cpu: 200m
   limits:
-    memory: 1Gi
+    memory: 2Gi
     cpu: 1
 
 # -- Node selector configuration


### PR DESCRIPTION
From the rest-rpxy logs, the Pods are running out of memory. I've increased the rest proxy JVM heap size and Pod memory resources.