### PR TITLE
DM-52568: Remove Dockerfile override from Prompt Processing template.

### DIFF
--- a/charts/prompt-keda/templates/scaled-job.yaml
+++ b/charts/prompt-keda/templates/scaled-job.yaml
@@ -25,13 +25,6 @@ spec:
           - name: {{ include "prompt-keda.fullname" . | trimPrefix "prompt-keda-" }}
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
             imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
-            command:
-              - /bin/sh
-              - -c
-              - |
-                source /opt/lsst/software/stack/loadLSST.bash
-                setup lsst_distrib
-                python3 -m activator.activator
             env:
               - name: PLATFORM
                 value: keda


### PR DESCRIPTION
This PR removes a test patch in the Prompt Processing Keda implementation that ended up becoming permanent. It should not be merged until all active Prompt Processing builds include lsst-dm/prompt_processing#349.