### PR TITLE
DM-52588: Add timeseries support using `visit` and `detector` as join columns for DP1 schema

### DIFF
--- a/applications/datalinker/README.md
+++ b/applications/datalinker/README.md
@@ -16,7 +16,7 @@ IVOA DataLink-based service and data discovery
 | config.pathPrefix | string | `"/api/datalink"` | URL path prefix for DataLink and related APIs |
 | config.sentry.enabled | bool | `false` | Whether to enable the Sentry integration |
 | config.slackAlerts | bool | `false` | Whether to send certain serious alerts to Slack |
-| config.tapMetadataUrl | string | `"https://github.com/lsst/sdm_schemas/releases/download/1.2.0/datalink-columns.zip"` | URL containing TAP schema metadata used to construct queries |
+| config.tapMetadataUrl | string | `"https://github.com/lsst/sdm_schemas/releases/download/DP1-v1.2.0/datalink-columns.zip"` | URL containing TAP schema metadata used to construct queries |
 | global.butlerServerRepositories | string | Set by Argo CD | Butler repositories accessible via Butler server |
 | global.environmentName | string | Set by Argo CD | Name of the Phalanx environment |
 | global.host | string | Set by Argo CD | Host name for ingress |

--- a/applications/datalinker/values.yaml
+++ b/applications/datalinker/values.yaml
@@ -38,7 +38,7 @@ config:
   slackAlerts: false
 
   # -- URL containing TAP schema metadata used to construct queries
-  tapMetadataUrl: "https://github.com/lsst/sdm_schemas/releases/download/1.2.0/datalink-columns.zip"
+  tapMetadataUrl: "https://github.com/lsst/sdm_schemas/releases/download/DP1-v1.2.0/datalink-columns.zip"
 
 # -- Affinity rules for the datalinker deployment pod
 affinity: {}

--- a/charts/cadc-tap/README.md
+++ b/charts/cadc-tap/README.md
@@ -23,7 +23,7 @@ IVOA TAP service
 | cloudsql.serviceAccount | string | None, must be set | The Google service account that has an IAM binding to the `cadc-tap` Kubernetes service accounts and has the `cloudsql.client` role, access |
 | config.backend | string | None, must be set to `pg` or `qserv` | What type of backend are we connecting to? |
 | config.database | string | `"dp02"` | Data Database name |
-| config.datalinkPayloadUrl | string | `"https://github.com/lsst/sdm_schemas/releases/download/DP1-v1.1.4-rc1/datalink-snippets.zip"` | Datalink payload URL |
+| config.datalinkPayloadUrl | string | `"https://github.com/lsst/sdm_schemas/releases/download/DP1-v1.2.0/datalink-snippets.zip"` | Datalink payload URL |
 | config.gcsBucket | string | `"async-results.lsst.codes"` | Name of GCS bucket in which to store results |
 | config.gcsBucketType | string | `"GCS"` | GCS bucket type (GCS or S3) |
 | config.gcsBucketUrl | string | `"https://storage.googleapis.com"` | Base URL for results stored in GCS bucket |

--- a/charts/cadc-tap/values.yaml
+++ b/charts/cadc-tap/values.yaml
@@ -99,7 +99,7 @@ config:
   tapSchemaAddress: "cadc-tap-schema-db:3306"
 
   # -- Datalink payload URL
-  datalinkPayloadUrl: "https://github.com/lsst/sdm_schemas/releases/download/DP1-v1.1.4-rc1/datalink-snippets.zip"
+  datalinkPayloadUrl: "https://github.com/lsst/sdm_schemas/releases/download/DP1-v1.2.0/datalink-snippets.zip"
 
   # -- Name of GCS bucket in which to store results
   gcsBucket: "async-results.lsst.codes"


### PR DESCRIPTION
This adds support for using the `visit` and `detector` columns as a compound key for showing the timeseries which displays automatically when displaying the search results in the RSP portal.

See also [DM-51416](https://rubinobs.atlassian.net/browse/DM-51416) for related sdm_schemas branch and [DM-52588](https://rubinobs.atlassian.net/browse/DM-52588) for the datalinker changes. I have put the Phalanx changes related to both on this ticket branch for convenience.

**Changes**

- The `datalinkPayloadUrl` was changed in the `cadc-tap` chart to point to the sdm_schemas `DP1-v1.2.0-rc1` release.
- The analogous `tapMetadataUrl` setting in `datalinker` was updated to use this as well.
- The `datalinker` image tag was changed to `tickets-DM-52588` which adds support for the new join scheme.

If the `datalinker` PR is merged, then its image tag in this PR can be set back to `null` so that it uses `main` instead.

[DM-51416]: https://rubinobs.atlassian.net/browse/DM-51416?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DM-52588]: https://rubinobs.atlassian.net/browse/DM-52588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ