### PR TITLE
Use main CILogon for idfdev

### DIFF
--- a/applications/gafaelfawr/values-idfdev.yaml
+++ b/applications/gafaelfawr/values-idfdev.yaml
@@ -11,7 +11,6 @@ config:
   cilogon:
     clientId: "cilogon:/client_id/46f9ae932fd30e9fb1b246972a3c0720"
     enrollmentUrl: "https://id-dev.lsst.cloud/registry/co_petitions/start/coef:6"
-    test: true
 
   ldap:
     url: "ldaps://ldap-test.cilogon.org"


### PR DESCRIPTION
There seems to be a temporary problem with test.cilogon.org. Switch idfdev to the main cilogon.org instance for now until that's fixed.