### PR TITLE
DM-51656: Enable Data Origin metadata in SIA

### DIFF
--- a/applications/sia/Chart.yaml
+++ b/applications/sia/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 1.0.1
+appVersion: 1.1.0
 description: Simple Image Access (SIA) IVOA Service using Butler
 name: sia
 sources:


### PR DESCRIPTION
Upgrades SIA to version 1.1.0
This includes upgrades to dax_obscore and fixes to SIA to enable data origin metadata in the query VOTable output.