### PR TITLE
[DM-52612] Upgrade idfdev InfluxDB Enterprise to 1.12.2

### DIFF
--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -162,8 +162,6 @@ Rubin Observatory's telemetry service
 | influxdb-enterprise.data.config.http.flux-enabled | bool | `true` | Whether to enable the Flux query endpoint |
 | influxdb-enterprise.data.config.logging.level | string | `"debug"` | Logging level |
 | influxdb-enterprise.data.env | object | `{}` | Additional environment variables to set in the meta container |
-| influxdb-enterprise.data.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for data images |
-| influxdb-enterprise.data.image.repository | string | `"influxdb"` | Docker repository for data images |
 | influxdb-enterprise.data.ingress.annotations | object | See `values.yaml` | Extra annotations to add to the data ingress |
 | influxdb-enterprise.data.ingress.className | string | `"nginx"` | Ingress class name of the data service |
 | influxdb-enterprise.data.ingress.enabled | bool | `false` | Whether to enable an ingress for the data service |
@@ -192,7 +190,8 @@ Rubin Observatory's telemetry service
 | influxdb-enterprise.data.tolerations | list | `[]` | Tolerations for data pods |
 | influxdb-enterprise.envFromSecret | string | No secret | The name of a secret in the same kubernetes namespace which contain values to be added to the environment |
 | influxdb-enterprise.fullnameOverride | string | `""` | Override the full name for resources (includes the release name) |
-| influxdb-enterprise.image.addsuffix | bool | `false` | Set to true to add a suffix for the type of image to the Docker tag (for example, `-meta`, making an image name of `influxdb:1.8.0-meta`) |
+| influxdb-enterprise.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for images |
+| influxdb-enterprise.image.repository | string | `"influxdb"` | Docker repository for InfluxDB Enterprise images |
 | influxdb-enterprise.image.tag | string | `appVersion` from `Chart.yaml` | Tagged version of the Docker image that you want to run |
 | influxdb-enterprise.imagePullSecrets | list | `[]` | List of pull secrets needed for images. If set, each object in the list should have one attribute, _name_, identifying the pull secret to use |
 | influxdb-enterprise.license.key | string | `""` | License key. You can put your license key here for testing this chart out, but we STRONGLY recommend using a license file stored in a secret when you ship to production. |
@@ -200,8 +199,6 @@ Rubin Observatory's telemetry service
 | influxdb-enterprise.license.secret.name | string | `"influxdb-enterprise-license"` | Name of the secret containing the license |
 | influxdb-enterprise.meta.affinity | object | See `values.yaml` | Affinity rules for meta pods |
 | influxdb-enterprise.meta.env | object | `{}` | Additional environment variables to set in the meta container |
-| influxdb-enterprise.meta.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for meta images |
-| influxdb-enterprise.meta.image.repository | string | `"influxdb"` | Docker repository for meta images |
 | influxdb-enterprise.meta.ingress.annotations | object | See `values.yaml` | Extra annotations to add to the meta ingress |
 | influxdb-enterprise.meta.ingress.className | string | `"nginx"` | Ingress class name of the meta service |
 | influxdb-enterprise.meta.ingress.enabled | bool | `false` | Whether to enable an ingress for the meta service |
@@ -252,8 +249,6 @@ Rubin Observatory's telemetry service
 | influxdb-enterprise-active.data.config.http.flux-enabled | bool | `true` | Whether to enable the Flux query endpoint |
 | influxdb-enterprise-active.data.config.logging.level | string | `"debug"` | Logging level |
 | influxdb-enterprise-active.data.env | object | `{}` | Additional environment variables to set in the meta container |
-| influxdb-enterprise-active.data.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for data images |
-| influxdb-enterprise-active.data.image.repository | string | `"influxdb"` | Docker repository for data images |
 | influxdb-enterprise-active.data.ingress.annotations | object | See `values.yaml` | Extra annotations to add to the data ingress |
 | influxdb-enterprise-active.data.ingress.className | string | `"nginx"` | Ingress class name of the data service |
 | influxdb-enterprise-active.data.ingress.enabled | bool | `false` | Whether to enable an ingress for the data service |
@@ -282,7 +277,8 @@ Rubin Observatory's telemetry service
 | influxdb-enterprise-active.data.tolerations | list | `[]` | Tolerations for data pods |
 | influxdb-enterprise-active.envFromSecret | string | No secret | The name of a secret in the same kubernetes namespace which contain values to be added to the environment |
 | influxdb-enterprise-active.fullnameOverride | string | `""` | Override the full name for resources (includes the release name) |
-| influxdb-enterprise-active.image.addsuffix | bool | `false` | Set to true to add a suffix for the type of image to the Docker tag (for example, `-meta`, making an image name of `influxdb:1.8.0-meta`) |
+| influxdb-enterprise-active.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for images |
+| influxdb-enterprise-active.image.repository | string | `"influxdb"` | Docker repository for InfluxDB Enterprise images |
 | influxdb-enterprise-active.image.tag | string | `appVersion` from `Chart.yaml` | Tagged version of the Docker image that you want to run |
 | influxdb-enterprise-active.imagePullSecrets | list | `[]` | List of pull secrets needed for images. If set, each object in the list should have one attribute, _name_, identifying the pull secret to use |
 | influxdb-enterprise-active.license.key | string | `""` | License key. You can put your license key here for testing this chart out, but we STRONGLY recommend using a license file stored in a secret when you ship to production. |
@@ -290,8 +286,6 @@ Rubin Observatory's telemetry service
 | influxdb-enterprise-active.license.secret.name | string | `"influxdb-enterprise-license"` | Name of the secret containing the license |
 | influxdb-enterprise-active.meta.affinity | object | See `values.yaml` | Affinity rules for meta pods |
 | influxdb-enterprise-active.meta.env | object | `{}` | Additional environment variables to set in the meta container |
-| influxdb-enterprise-active.meta.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for meta images |
-| influxdb-enterprise-active.meta.image.repository | string | `"influxdb"` | Docker repository for meta images |
 | influxdb-enterprise-active.meta.ingress.annotations | object | See `values.yaml` | Extra annotations to add to the meta ingress |
 | influxdb-enterprise-active.meta.ingress.className | string | `"nginx"` | Ingress class name of the meta service |
 | influxdb-enterprise-active.meta.ingress.enabled | bool | `false` | Whether to enable an ingress for the meta service |
@@ -342,8 +336,6 @@ Rubin Observatory's telemetry service
 | influxdb-enterprise-standby.data.config.http.flux-enabled | bool | `true` | Whether to enable the Flux query endpoint |
 | influxdb-enterprise-standby.data.config.logging.level | string | `"debug"` | Logging level |
 | influxdb-enterprise-standby.data.env | object | `{}` | Additional environment variables to set in the meta container |
-| influxdb-enterprise-standby.data.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for data images |
-| influxdb-enterprise-standby.data.image.repository | string | `"influxdb"` | Docker repository for data images |
 | influxdb-enterprise-standby.data.ingress.annotations | object | See `values.yaml` | Extra annotations to add to the data ingress |
 | influxdb-enterprise-standby.data.ingress.className | string | `"nginx"` | Ingress class name of the data service |
 | influxdb-enterprise-standby.data.ingress.enabled | bool | `false` | Whether to enable an ingress for the data service |
@@ -372,7 +364,8 @@ Rubin Observatory's telemetry service
 | influxdb-enterprise-standby.data.tolerations | list | `[]` | Tolerations for data pods |
 | influxdb-enterprise-standby.envFromSecret | string | No secret | The name of a secret in the same kubernetes namespace which contain values to be added to the environment |
 | influxdb-enterprise-standby.fullnameOverride | string | `""` | Override the full name for resources (includes the release name) |
-| influxdb-enterprise-standby.image.addsuffix | bool | `false` | Set to true to add a suffix for the type of image to the Docker tag (for example, `-meta`, making an image name of `influxdb:1.8.0-meta`) |
+| influxdb-enterprise-standby.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for images |
+| influxdb-enterprise-standby.image.repository | string | `"influxdb"` | Docker repository for InfluxDB Enterprise images |
 | influxdb-enterprise-standby.image.tag | string | `appVersion` from `Chart.yaml` | Tagged version of the Docker image that you want to run |
 | influxdb-enterprise-standby.imagePullSecrets | list | `[]` | List of pull secrets needed for images. If set, each object in the list should have one attribute, _name_, identifying the pull secret to use |
 | influxdb-enterprise-standby.license.key | string | `""` | License key. You can put your license key here for testing this chart out, but we STRONGLY recommend using a license file stored in a secret when you ship to production. |
@@ -380,8 +373,6 @@ Rubin Observatory's telemetry service
 | influxdb-enterprise-standby.license.secret.name | string | `"influxdb-enterprise-license"` | Name of the secret containing the license |
 | influxdb-enterprise-standby.meta.affinity | object | See `values.yaml` | Affinity rules for meta pods |
 | influxdb-enterprise-standby.meta.env | object | `{}` | Additional environment variables to set in the meta container |
-| influxdb-enterprise-standby.meta.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for meta images |
-| influxdb-enterprise-standby.meta.image.repository | string | `"influxdb"` | Docker repository for meta images |
 | influxdb-enterprise-standby.meta.ingress.annotations | object | See `values.yaml` | Extra annotations to add to the meta ingress |
 | influxdb-enterprise-standby.meta.ingress.className | string | `"nginx"` | Ingress class name of the meta service |
 | influxdb-enterprise-standby.meta.ingress.enabled | bool | `false` | Whether to enable an ingress for the meta service |

--- a/applications/sasquatch/charts/influxdb-enterprise/README.md
+++ b/applications/sasquatch/charts/influxdb-enterprise/README.md
@@ -27,8 +27,6 @@ Run InfluxDB Enterprise on Kubernetes
 | data.config.http.flux-enabled | bool | `true` | Whether to enable the Flux query endpoint |
 | data.config.logging.level | string | `"debug"` | Logging level |
 | data.env | object | `{}` | Additional environment variables to set in the meta container |
-| data.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for data images |
-| data.image.repository | string | `"influxdb"` | Docker repository for data images |
 | data.ingress.annotations | object | See `values.yaml` | Extra annotations to add to the data ingress |
 | data.ingress.className | string | `"nginx"` | Ingress class name of the data service |
 | data.ingress.enabled | bool | `false` | Whether to enable an ingress for the data service |
@@ -57,7 +55,8 @@ Run InfluxDB Enterprise on Kubernetes
 | data.tolerations | list | `[]` | Tolerations for data pods |
 | envFromSecret | string | No secret | The name of a secret in the same kubernetes namespace which contain values to be added to the environment |
 | fullnameOverride | string | `""` | Override the full name for resources (includes the release name) |
-| image.addsuffix | bool | `false` | Set to true to add a suffix for the type of image to the Docker tag (for example, `-meta`, making an image name of `influxdb:1.8.0-meta`) |
+| image.pullPolicy | string | `"IfNotPresent"` | Pull policy for images |
+| image.repository | string | `"influxdb"` | Docker repository for InfluxDB Enterprise images |
 | image.tag | string | `appVersion` from `Chart.yaml` | Tagged version of the Docker image that you want to run |
 | imagePullSecrets | list | `[]` | List of pull secrets needed for images. If set, each object in the list should have one attribute, _name_, identifying the pull secret to use |
 | license.key | string | `""` | License key. You can put your license key here for testing this chart out, but we STRONGLY recommend using a license file stored in a secret when you ship to production. |
@@ -65,8 +64,6 @@ Run InfluxDB Enterprise on Kubernetes
 | license.secret.name | string | `"influxdb-enterprise-license"` | Name of the secret containing the license |
 | meta.affinity | object | See `values.yaml` | Affinity rules for meta pods |
 | meta.env | object | `{}` | Additional environment variables to set in the meta container |
-| meta.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for meta images |
-| meta.image.repository | string | `"influxdb"` | Docker repository for meta images |
 | meta.ingress.annotations | object | See `values.yaml` | Extra annotations to add to the meta ingress |
 | meta.ingress.className | string | `"nginx"` | Ingress class name of the meta service |
 | meta.ingress.enabled | bool | `false` | Whether to enable an ingress for the meta service |

--- a/applications/sasquatch/charts/influxdb-enterprise/templates/_helpers.tpl
+++ b/applications/sasquatch/charts/influxdb-enterprise/templates/_helpers.tpl
@@ -38,7 +38,7 @@ Common labels
 helm.sh/chart: {{ include "influxdb-enterprise.chart" . }}
 {{ include "influxdb-enterprise.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
@@ -61,16 +61,3 @@ Create the name of the service account
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
-
-{{- define "influxdb-enterprise.image" -}}
-{{- $dataTagName := (printf "%s-%s" .chart.AppVersion .podtype) -}}
-{{- if (.imageroot) }}
-{{- if (.imageroot.tag) -}}
-{{- $dataTagName = .imageroot.tag -}}
-{{- end -}}
-{{- if (.imageroot.addsuffix) -}}
-{{- $dataTagName = printf "%s-%s" $dataTagName .podtype -}}
-{{- end -}}
-{{- end }}
-image: "{{ .podvals.image.repository | default "influxdb" }}:{{ $dataTagName }}"
-{{- end }}

--- a/applications/sasquatch/charts/influxdb-enterprise/templates/bootstrap-job.yaml
+++ b/applications/sasquatch/charts/influxdb-enterprise/templates/bootstrap-job.yaml
@@ -30,8 +30,8 @@ spec:
       initContainers:
       {{- if .Values.bootstrap.auth.secretName }}
       - name: auth
-        {{- include "influxdb-enterprise.image" (dict "chart" .Chart "imageroot" .Values.image "podvals" .Values.data "podtype" "data") | indent 8 }}
-        imagePullPolicy: {{ .Values.data.image.pullPolicy }}
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}-data
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
         # Exposing these environment variables makes this command idempotent
         # as even if the authentication has been setup, we can still execute the command
         # and it won't error as nothing has changed
@@ -63,8 +63,8 @@ spec:
       {{ end }}
       {{- if .Values.bootstrap.ddldml.configMap }}
       - name: ddl
-        {{- include "influxdb-enterprise.image" (dict "chart" .Chart "imageroot" .Values.image "podvals" .Values.data "podtype" "data") | indent 8 }}
-        imagePullPolicy: {{ .Values.data.image.pullPolicy }}
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}-data
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- if .Values.bootstrap.auth.secretName }}
         env:
         - name: INFLUX_USERNAME
@@ -94,8 +94,8 @@ spec:
       {{ end }}
       {{- if .Values.bootstrap.ddldml.configMap }}
       - name: dml
-        {{- include "influxdb-enterprise.image" (dict "chart" .Chart "imageroot" .Values.image "podvals" .Values.data "podtype" "data") | indent 8 }}
-        imagePullPolicy: {{ .Values.data.image.pullPolicy }}
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}-data
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- if .Values.bootstrap.auth.secretName }}
         env:
         - name: INFLUX_USERNAME
@@ -125,8 +125,8 @@ spec:
       {{ end }}
       containers:
       - name: success
-        {{- include "influxdb-enterprise.image" (dict "chart" .Chart "imageroot" .Values.image "podvals" .Values.data "podtype" "data") | indent 8 }}
-        imagePullPolicy: {{ .Values.data.image.pullPolicy }}
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}-data
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
           - echo
         args:

--- a/applications/sasquatch/charts/influxdb-enterprise/templates/data-statefulset.yaml
+++ b/applications/sasquatch/charts/influxdb-enterprise/templates/data-statefulset.yaml
@@ -53,8 +53,8 @@ spec:
           - "/etc/influxdb/entrypoint.pl"
           securityContext:
             {{- toYaml .Values.data.securityContext | nindent 12 }}
-          {{- include "influxdb-enterprise.image" (dict "chart" .Chart "imageroot" .Values.image "podvals" .Values.data "podtype" "data") | indent 10 }}
-          imagePullPolicy: {{ .Values.data.image.pullPolicy }}
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}-data
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
           - name: RELEASE_NAME
             value: {{ include "influxdb-enterprise.fullname" . }}

--- a/applications/sasquatch/charts/influxdb-enterprise/templates/meta-statefulset.yaml
+++ b/applications/sasquatch/charts/influxdb-enterprise/templates/meta-statefulset.yaml
@@ -53,8 +53,8 @@ spec:
           - "/etc/influxdb/entrypoint.pl"
           securityContext:
             {{- toYaml .Values.meta.securityContext | nindent 12 }}
-          {{- include "influxdb-enterprise.image" (dict "chart" .Chart "imageroot" .Values.image "podvals" .Values.meta "podtype" "meta") | indent 10 }}
-          imagePullPolicy: {{ .Values.meta.image.pullPolicy }}
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}-meta
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: INFLUXDB_META_INTERNAL_SHARED_SECRET
               valueFrom:

--- a/applications/sasquatch/charts/influxdb-enterprise/values.yaml
+++ b/applications/sasquatch/charts/influxdb-enterprise/values.yaml
@@ -64,24 +64,17 @@ bootstrap:
     resources: {}
 
 image:
+  # -- Docker repository for InfluxDB Enterprise images
+  repository: "influxdb"
   # -- Tagged version of the Docker image that you want to run
   # @default -- `appVersion` from `Chart.yaml`
   tag: ""
-
-  # -- Set to true to add a suffix for the type of image to the Docker tag
-  # (for example, `-meta`, making an image name of `influxdb:1.8.0-meta`)
-  addsuffix: false
+  # -- Pull policy for images
+  pullPolicy: "IfNotPresent"
 
 meta:
   # -- Number of meta pods to run
   replicas: 3
-
-  image:
-    # -- Docker repository for meta images
-    repository: "influxdb"
-
-    # -- Pull policy for meta images
-    pullPolicy: "IfNotPresent"
 
   # -- Node selection rules for meta pods
   nodeSelector: {}
@@ -230,13 +223,6 @@ meta:
 data:
   # -- Number of data replicas to run
   replicas: 1
-
-  image:
-    # -- Docker repository for data images
-    repository: "influxdb"
-
-    # -- Pull policy for data images
-    pullPolicy: "IfNotPresent"
 
   # -- Node selection rules for data pods
   nodeSelector: {}

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -57,6 +57,8 @@ customInfluxDBIngress:
 
 influxdb-enterprise:
   enabled: true
+  image:
+    tag: "1.12.2"
   license:
     secret:
       name: sasquatch


### PR DESCRIPTION
Trying InfluxDB Enterprise version 1.12.2 to see if this version help us with the datbase compaction issues. 
Improve how image configuration is done in the influxdb-enterprise subchart.