### PR TITLE
Switch idfdev back to test CILogon

### DIFF
--- a/applications/gafaelfawr/values-idfdev.yaml
+++ b/applications/gafaelfawr/values-idfdev.yaml
@@ -11,6 +11,7 @@ config:
   cilogon:
     clientId: "cilogon:/client_id/46f9ae932fd30e9fb1b246972a3c0720"
     enrollmentUrl: "https://id-dev.lsst.cloud/registry/co_petitions/start/coef:6"
+    test: true
 
   ldap:
     url: "ldaps://ldap-test.cilogon.org"


### PR DESCRIPTION
In theory, the problem with test CILogon for that environment has been fixed.