### PR TITLE
DM-52601: Enable Repertoire on more environments

### DIFF
--- a/applications/repertoire/secrets-usdfdev.yaml
+++ b/applications/repertoire/secrets-usdfdev.yaml
@@ -1,0 +1,5 @@
+usdfdev_efd-password:
+  description: >-
+    InfluxDB password for the efdreader user for accessing the EFD database on
+    usdf-dev. Clients will cache this secret locally in their client
+    configuration, so changing it may be disruptive.

--- a/applications/repertoire/secrets-usdfprod.yaml
+++ b/applications/repertoire/secrets-usdfprod.yaml
@@ -1,0 +1,5 @@
+usdf_efd-password:
+  description: >-
+    InfluxDB password for the efdreader user for accessing the production EFD
+    database at USDF. Clients will cache this secret locally in their client
+    configuration, so changing it may be disruptive.

--- a/applications/repertoire/values-idfdemo.yaml
+++ b/applications/repertoire/values-idfdemo.yaml
@@ -1,0 +1,2 @@
+config:
+  slackAlerts: true

--- a/applications/repertoire/values-usdfdev.yaml
+++ b/applications/repertoire/values-usdfdev.yaml
@@ -1,0 +1,14 @@
+config:
+  availableDatasets:
+    - "dp02"
+    - "dp03"
+    - "dp1"
+  hips:
+    datasets: {}
+  influxdbDatabases:
+    usdfdev_efd:
+      url: "https://usdf-rsp-dev.slac.stanford.edu/influxdb/"
+      database: "efd"
+      username: "efdreader"
+      passwordKey: "usdfdev_efd-password"
+      schemaRegistry: "http://sasquatch-schema-registry.sasquatch:8081"

--- a/applications/repertoire/values-usdfint.yaml
+++ b/applications/repertoire/values-usdfint.yaml
@@ -1,0 +1,7 @@
+config:
+  availableDatasets:
+    - "dp02"
+    - "dp03"
+    - "dp1"
+  hips:
+    datasets: {}

--- a/applications/repertoire/values-usdfprod.yaml
+++ b/applications/repertoire/values-usdfprod.yaml
@@ -1,0 +1,14 @@
+config:
+  availableDatasets:
+    - "dp02"
+    - "dp03"
+    - "dp1"
+  hips:
+    datasets: {}
+  influxdbDatabases:
+    usdf_efd:
+      url: "https://usdf-rsp.slac.stanford.edu/influxdb-enterprise-data/"
+      database: "efd"
+      username: "efdreader"
+      passwordKey: "usdf_efd-password"
+      schemaRegistry: "http://sasquatch-schema-registry.sasquatch:8081"

--- a/environments/values-idfdemo.yaml
+++ b/environments/values-idfdemo.yaml
@@ -18,6 +18,7 @@ applications:
   fastapi-bootcamp: true
   mobu: true
   nublado: true
+  repertoire: true
   squareone: true
   times-square: true
   vault-secrets-operator: true

--- a/environments/values-idfint.yaml
+++ b/environments/values-idfint.yaml
@@ -27,15 +27,15 @@ applications:
   qserv-kafka: true
   repertoire: true
   rubin-rag: true
-  sasquatch: true
-  sia: true
-  ssotap: true
   sasquatch-backpack: true
+  sasquatch: true
   semaphore: true
+  sia: true
   squareone: true
-  strimzi: true
+  ssotap: true
   strimzi-access-operator: true
   strimzi-registry-operator: true
+  strimzi: true
   tap: true
   times-square: true
   vo-cutouts: true

--- a/environments/values-idfprod.yaml
+++ b/environments/values-idfprod.yaml
@@ -29,10 +29,10 @@ applications:
   semaphore: true
   sia: true
   squareone: true
-  strimzi: true
+  ssotap: true
   strimzi-access-operator: true
   strimzi-registry-operator: true
-  ssotap: true
+  strimzi: true
   tap: true
   times-square: true
   vo-cutouts: true

--- a/environments/values-usdfdev.yaml
+++ b/environments/values-usdfdev.yaml
@@ -13,14 +13,13 @@ applications:
   ingress-nginx: false
 
   butler: true
-  consdb: true
   consdbtap: true
+  consdb: true
   datalinker: true
-  exposurelog: true
   exposure-checker: true
+  exposurelog: true
   fov-quicklook: true
   grafana: false
-  rubin-rag: true
   jira-data-proxy: true
   livetap: true
   mobu: true
@@ -33,20 +32,22 @@ applications:
   obsloctap: true
   plot-navigator: true
   portal: true
-  qserv-kafka: true
   postgres: true
   ppdb-replication: true
+  qserv-kafka: true
+  repertoire: true
+  rubin-rag: true
   rubintv: true
   s3proxy: true
   sasquatch: true
   schedview-snapshot: true
   semaphore: true
   sia: true
-  ssotap: true
   squareone: true
-  strimzi: true
+  ssotap: true
   strimzi-access-operator: true
   strimzi-registry-operator: true
+  strimzi: true
   tap: true
   tasso: true
   times-square: true

--- a/environments/values-usdfint.yaml
+++ b/environments/values-usdfint.yaml
@@ -9,7 +9,6 @@ vaultPathPrefix: "secret/rubin/usdf-rsp-int"
 applications:
   # This environment uses an ingress managed in a separate Kubernetes cluster,
   # despite that configuration not being officially supported by Phalanx.
-  cert-manager: true
   ingress-nginx: false
 
   butler: true
@@ -19,17 +18,18 @@ applications:
   mobu: true
   nublado: true
   plot-navigator: true
-  ppdb-replication: true
   portal: true
   postgres: true
+  ppdb-replication: true
+  repertoire: true
   sasquatch: true
   schedview-snapshot: true
   schedview-static-pages: true
   semaphore: true
   sia: false
-  ssotap: true
   squareone: true
-  strimzi: true
+  ssotap: true
   strimzi-access-operator: true
   strimzi-registry-operator: true
+  strimzi: true
   tap: true

--- a/environments/values-usdfprod.yaml
+++ b/environments/values-usdfprod.yaml
@@ -13,8 +13,8 @@ applications:
   ingress-nginx: false
 
   butler: true
-  consdb: true
   consdbtap: true
+  consdb: true
   datalinker: true
   exposurelog: true
   jira-data-proxy: true
@@ -28,14 +28,15 @@ applications:
   plot-navigator: true
   portal: true
   postgres: true
+  repertoire: true
   rubintv: true
   s3proxy: true
   sasquatch: true
   semaphore: true
-  ssotap: true
   squareone: true
-  strimzi: true
+  ssotap: true
   strimzi-access-operator: true
   strimzi-registry-operator: true
+  strimzi: true
   tap: true
   times-square: true


### PR DESCRIPTION
Enable Repertoire on idfdemo, usdfdev, usdfint, and usdfprod. For usdfdev and usdfprod, add secrets configuration for the InfluxDB databases hosted in those environments. Disable HiPS list support for USDF, since the hips service is not running there.