### PR TITLE
DM-52601: Add Repertoire rule for logout URL

### DIFF
--- a/applications/repertoire/values.yaml
+++ b/applications/repertoire/values.yaml
@@ -134,6 +134,9 @@ config:
         template: "https://{{base_hostname}}/auth/api/v1"
         openapi: "https://{{base_hostname}}/auth/openapi.json"
       - type: "ui"
+        name: "logout"
+        template: "https://{{base_hostname}}/logout"
+      - type: "ui"
         name: "tokens"
         template: "https://{{base_hostname}}/auth/tokens"
     mobu:


### PR DESCRIPTION
If Gafaelfawr is deployed, advertise a UI service named `logout` with the URL for Gafaelfawr logout. This will be used by Nublado, among other services.