### PR TITLE
Skip minikube on dependabot changes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -144,8 +144,10 @@ jobs:
 
     needs: [test, helm, changes]
     if: >-
-      (needs.changes.outputs.minikube == 'true' && github.event_name != 'push')
-      || (github.event_name == 'workflow_dispatch')
+      (github.event_name == 'workflow_dispatch')
+      || (needs.changes.outputs.minikube == 'true'
+          && github.event_name != 'push'
+          && !startsWith(github.head_ref, 'dependabot/'))
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/rebasecheck.yaml
+++ b/.github/workflows/rebasecheck.yaml
@@ -1,11 +1,8 @@
----
 name: Git
 
 "on":
-  merge_group: {}
   pull_request: {}
 
 jobs:
   call-workflow:
-    if: github.event_name == 'pull_request'
     uses: lsst/rubin_workflows/.github/workflows/rebase_checker.yaml@main


### PR DESCRIPTION
Don't run the minikube test if the head reference starts with dependabot, since GitHub dependabot doesn't have access to the repository secrets.