### PR TITLE
DM-52623: Add read:sasquatch rules for base and TTS

### DIFF
--- a/applications/gafaelfawr/values-base.yaml
+++ b/applications/gafaelfawr/values-base.yaml
@@ -52,6 +52,8 @@ config:
       - "sqre"
     "read:image":
       - "rsp-bts"
+    "read:sasquatch":
+      - "rsp-bts"
     "read:tap":
       - "rsp-bts"
     "write:sasquatch":

--- a/applications/gafaelfawr/values-tucson-teststand.yaml
+++ b/applications/gafaelfawr/values-tucson-teststand.yaml
@@ -86,6 +86,19 @@ config:
       - github:
           organization: "rubin-summit"
           team: "rsp-access"
+    "read:sasquatch":
+      - github:
+          organization: "lsst-sqre"
+          team: "square"
+      - github:
+          organization: "lsst-sqre"
+          team: "friends"
+      - github:
+          organization: "lsst-ts"
+          team: "tts-access"
+      - github:
+          organization: "rubin-summit"
+          team: "rsp-access"
     "read:tap":
       - github:
           organization: "lsst-sqre"


### PR DESCRIPTION
Add Gafaelfawr authorization rules for the `read:sasquatch` scope to base and tuscon-teststand. This scope will be used for Repertoire access.