### PR TITLE
DM-52622: Add Sentry support for datalinker

### DIFF
--- a/applications/datalinker/Chart.yaml
+++ b/applications/datalinker/Chart.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 description: IVOA DataLink-based service and data discovery
 sources:
   - "https://github.com/lsst-sqre/datalinker"
-appVersion: 4.0.0
+appVersion: 4.1.0
 
 annotations:
   phalanx.lsst.io/docs: |

--- a/applications/datalinker/README.md
+++ b/applications/datalinker/README.md
@@ -14,9 +14,11 @@ IVOA DataLink-based service and data discovery
 | config.linksLifetime | string | `"1h"` | Lifetime of the `{links}` reply. Should be set to match the lifetime of links returned by the Butler server |
 | config.logLevel | string | `"INFO"` | Logging level |
 | config.pathPrefix | string | `"/api/datalink"` | URL path prefix for DataLink and related APIs |
-| config.slackAlerts | bool | `false` | Whether to send certain serious alerts to Slack. If `true`, the `slack-webhook` secret must also be set. |
+| config.sentry.enabled | bool | `false` | Whether to enable the Sentry integration |
+| config.slackAlerts | bool | `false` | Whether to send certain serious alerts to Slack |
 | config.tapMetadataUrl | string | `"https://github.com/lsst/sdm_schemas/releases/download/1.2.0/datalink-columns.zip"` | URL containing TAP schema metadata used to construct queries |
 | global.butlerServerRepositories | string | Set by Argo CD | Butler repositories accessible via Butler server |
+| global.environmentName | string | Set by Argo CD | Name of the Phalanx environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.repertoireUrl | string | Set by Argo CD | Base URL for Repertoire discovery API |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |

--- a/applications/datalinker/templates/deployment.yaml
+++ b/applications/datalinker/templates/deployment.yaml
@@ -37,6 +37,15 @@ spec:
                   name: "datalinker"
                   key: "slack-webhook"
             {{- end }}
+            {{- if .Values.config.sentry.enabled }}
+            - name: "SENTRY_DSN"
+              valueFrom:
+                secretKeyRef:
+                  name: "datalinker"
+                  key: "sentry-dsn"
+            - name: "SENTRY_ENVIRONMENT"
+              value: {{ .Values.global.environmentName | quote }}
+            {{- end }}
             # Uvicorn keepalive timeout, in seconds. This should be longer
             # than any keepalive timeouts on any downstream proxies. The
             # keepalive timeout for ingress-nginx connections is 60s.

--- a/applications/datalinker/values.yaml
+++ b/applications/datalinker/values.yaml
@@ -30,8 +30,11 @@ config:
   # -- URL path prefix for DataLink and related APIs
   pathPrefix: "/api/datalink"
 
-  # -- Whether to send certain serious alerts to Slack. If `true`, the
-  # `slack-webhook` secret must also be set.
+  sentry:
+    # -- Whether to enable the Sentry integration
+    enabled: false
+
+  # -- Whether to send certain serious alerts to Slack
   slackAlerts: false
 
   # -- URL containing TAP schema metadata used to construct queries
@@ -65,6 +68,10 @@ global:
   # -- Butler repositories accessible via Butler server
   # @default -- Set by Argo CD
   butlerServerRepositories: null
+
+  # -- Name of the Phalanx environment
+  # @default -- Set by Argo CD
+  environmentName: null
 
   # -- Host name for ingress
   # @default -- Set by Argo CD

--- a/environments/templates/applications/rsp/datalinker.yaml
+++ b/environments/templates/applications/rsp/datalinker.yaml
@@ -24,6 +24,8 @@ spec:
       parameters:
         - name: "global.butlerServerRepositories"
           value: {{ .Values.butlerServerRepositories | toJson | b64enc }}
+        - name: "global.environmentName"
+          value: {{ .Values.name | quote }}
         - name: "global.host"
           value: {{ .Values.fqdn | quote }}
         - name: "global.repertoireUrl"


### PR DESCRIPTION
Add the Phalanx configuration required to enable Sentry support for datalinker. This is not tested since it's not clear that we want to use it, but at least the basics will be in place.