### PR TITLE
[DM-52637] Change InfluxDB logging format to JSON

### DIFF
--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -59,6 +59,7 @@ Rubin Observatory's telemetry service
 | influxdb.config.http.enabled | bool | `true` | Whether to enable the HTTP endpoints |
 | influxdb.config.http.flux-enabled | bool | `true` | Whether to enable the Flux query endpoint |
 | influxdb.config.http.max-row-limit | int | `0` | Maximum number of rows the system can return from a non-chunked query (0 is unlimited) |
+| influxdb.config.logging.format | string | `"json"` | Format to use for log messages |
 | influxdb.config.logging.level | string | `"debug"` | Logging level |
 | influxdb.enabled | bool | `true` | Whether InfluxDB is enabled |
 | influxdb.image.tag | string | `"1.11.8"` | InfluxDB image tag |
@@ -160,6 +161,7 @@ Rubin Observatory's telemetry service
 | influxdb-enterprise.data.config.hintedHandoff.max-size | int | `107374182400` | Maximum size of the hinted-handoff queue in bytes |
 | influxdb-enterprise.data.config.http.auth-enabled | bool | `true` | Whether authentication is required |
 | influxdb-enterprise.data.config.http.flux-enabled | bool | `true` | Whether to enable the Flux query endpoint |
+| influxdb-enterprise.data.config.logging.format | string | `"json"` | Format to use for log messages |
 | influxdb-enterprise.data.config.logging.level | string | `"debug"` | Logging level |
 | influxdb-enterprise.data.env | object | `{}` | Additional environment variables to set in the meta container |
 | influxdb-enterprise.data.ingress.annotations | object | See `values.yaml` | Extra annotations to add to the data ingress |
@@ -247,6 +249,7 @@ Rubin Observatory's telemetry service
 | influxdb-enterprise-active.data.config.hintedHandoff.max-size | int | `107374182400` | Maximum size of the hinted-handoff queue in bytes |
 | influxdb-enterprise-active.data.config.http.auth-enabled | bool | `true` | Whether authentication is required |
 | influxdb-enterprise-active.data.config.http.flux-enabled | bool | `true` | Whether to enable the Flux query endpoint |
+| influxdb-enterprise-active.data.config.logging.format | string | `"json"` | Format to use for log messages |
 | influxdb-enterprise-active.data.config.logging.level | string | `"debug"` | Logging level |
 | influxdb-enterprise-active.data.env | object | `{}` | Additional environment variables to set in the meta container |
 | influxdb-enterprise-active.data.ingress.annotations | object | See `values.yaml` | Extra annotations to add to the data ingress |
@@ -334,6 +337,7 @@ Rubin Observatory's telemetry service
 | influxdb-enterprise-standby.data.config.hintedHandoff.max-size | int | `107374182400` | Maximum size of the hinted-handoff queue in bytes |
 | influxdb-enterprise-standby.data.config.http.auth-enabled | bool | `true` | Whether authentication is required |
 | influxdb-enterprise-standby.data.config.http.flux-enabled | bool | `true` | Whether to enable the Flux query endpoint |
+| influxdb-enterprise-standby.data.config.logging.format | string | `"json"` | Format to use for log messages |
 | influxdb-enterprise-standby.data.config.logging.level | string | `"debug"` | Logging level |
 | influxdb-enterprise-standby.data.env | object | `{}` | Additional environment variables to set in the meta container |
 | influxdb-enterprise-standby.data.ingress.annotations | object | See `values.yaml` | Extra annotations to add to the data ingress |

--- a/applications/sasquatch/charts/influxdb-enterprise/README.md
+++ b/applications/sasquatch/charts/influxdb-enterprise/README.md
@@ -25,6 +25,7 @@ Run InfluxDB Enterprise on Kubernetes
 | data.config.hintedHandoff.max-size | int | `107374182400` | Maximum size of the hinted-handoff queue in bytes |
 | data.config.http.auth-enabled | bool | `true` | Whether authentication is required |
 | data.config.http.flux-enabled | bool | `true` | Whether to enable the Flux query endpoint |
+| data.config.logging.format | string | `"json"` | Format to use for log messages |
 | data.config.logging.level | string | `"debug"` | Logging level |
 | data.env | object | `{}` | Additional environment variables to set in the meta container |
 | data.ingress.annotations | object | See `values.yaml` | Extra annotations to add to the data ingress |

--- a/applications/sasquatch/charts/influxdb-enterprise/values.yaml
+++ b/applications/sasquatch/charts/influxdb-enterprise/values.yaml
@@ -388,6 +388,8 @@ data:
     logging:
       # -- Logging level
       level: "debug"
+      # -- Format to use for log messages
+      format: "json"
 
   podDisruptionBudget:
     # -- Minimum available pods to maintain

--- a/applications/sasquatch/values.yaml
+++ b/applications/sasquatch/values.yaml
@@ -127,6 +127,8 @@ influxdb:
     logging:
       # -- Logging level
       level: "debug"
+      # -- Format to use for log messages
+      format: "json"
 
   initScripts:
     # -- Whether to enable the InfluxDB custom initialization script


### PR DESCRIPTION
For a better monitoring experience, I need to use Grafana Loki at USDF and Summit. 
Loki requires the logging format to be JSON.
This PR changes the InfluxDB OSS and Enterprise logging format to JSON
[Configure InfluxDB Enterprise clusters | InfluxDB Enterprise Documentation](https://docs.influxdata.com/enterprise_influxdb/v1/administration/configure/configuration/)