### PR TITLE
DM-52647: gafaelfawr - fix update-schema job

### DIFF
--- a/applications/gafaelfawr/templates/job-schema-update.yaml
+++ b/applications/gafaelfawr/templates/job-schema-update.yaml
@@ -35,6 +35,14 @@ spec:
             - "update-schema"
           env:
             {{- include "gafaelfawr.envVars" (dict "Chart" .Chart "Release" .Release "Values" .Values) | nindent 12 }}
+            {{- if .Values.config.metrics.enabled }}
+            - name: "KAFKA_CLIENT_CERT_PATH"
+              value: "/etc/gafaelfawr-kafka/user.crt"
+            - name: "KAFKA_CLIENT_KEY_PATH"
+              value: "/etc/gafaelfawr-kafka/user.key"
+            - name: "KAFKA_CLUSTER_CA_PATH"
+              value: "/etc/gafaelfawr-kafka/ca.crt"
+            {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
           {{- with .Values.resources }}
@@ -51,6 +59,20 @@ spec:
             - name: "config"
               mountPath: "/etc/gafaelfawr"
               readOnly: true
+            {{- if .Values.config.metrics.enabled }}
+            - name: "kafka"
+              mountPath: "/etc/gafaelfawr-kafka/ca.crt"
+              readOnly: true
+              subPath: "ssl.truststore.crt"
+            - name: "kafka"
+              mountPath: "/etc/gafaelfawr-kafka/user.crt"
+              readOnly: true
+              subPath: "ssl.keystore.crt"
+            - name: "kafka"
+              mountPath: "/etc/gafaelfawr-kafka/user.key"
+              readOnly: true
+              subPath: "ssl.keystore.key"
+            {{- end }}
       {{- if .Values.cloudsql.enabled }}
       initContainers:
         {{- include "gafaelfawr.cloudsqlSidecar" . | nindent 8 }}
@@ -64,6 +86,11 @@ spec:
         - name: "config"
           configMap:
             name: "gafaelfawr"
+        {{- if .Values.config.metrics.enabled }}
+        - name: "kafka"
+          secret:
+            secretName: "gafaelfawr-kafka"
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
Add the necessary env vars and volume mounts to the Gafaelfawr update schema job so that it works in environments with metrics enabled.