### PR TITLE
[DM-52656] Exclude topic lsst.dm.object from connector configuration

### DIFF
--- a/applications/sasquatch/values-usdfdev.yaml
+++ b/applications/sasquatch/values-usdfdev.yaml
@@ -80,6 +80,7 @@ kafka-connect-manager:
   influxdbSink:
     # Based on the kafka producers configuration for the BTS
     # https://github.com/lsst-ts/argocd-csc/blob/main/apps/kafka-producers/values-base-teststand.yaml
+    excludedTopicsRegex: "lsst.dm.object"
     connectors:
       auxtel:
         enabled: false


### PR DESCRIPTION
After upgrading Kafka Connect at USDF dev cluster to 3.9.0 it is failing to upload the lsst.dm connector with the error

```
appuser@sasquatch-influxdb-sink-lsstdm-dd74f8d4-cs98l:~$ kafkaconnect status influxdb-sink-lsstdm
{
    "connector": {
        "state": "FAILED",
        "trace": "java.lang.IllegalArgumentException: Invalid syntax.failed to parse at line 1 due to extraneous input 'object' expecting SELECT\n\tat com.datamountaineer.kcql.Kcql.parse(Kcql.java:951)\n\tat com.datamountaineer.streamreactor.common.config.Helpers$.$anonfun$checkInputTopics$2(Helpers.scala:102)\n\tat scala.collection.ArrayOps$.map$extension(ArrayOps.scala:924)\n\tat com.datamountaineer.streamreactor.common.config.Helpers$.checkInputTopics(Helpers.scala:102)\n\tat com.datamountaineer.streamreactor.connect.influx.InfluxSinkConnector.start(InfluxSinkConnector.scala:66)\n\tat org.apache.kafka.connect.runtime.WorkerConnector.doStart(WorkerConnector.java:216)\n\tat org.apache.kafka.connect.runtime.WorkerConnector.start(WorkerConnector.java:245)\n\tat org.apache.kafka.connect.runtime.WorkerConnector.doTransitionTo(WorkerConnector.java:404)\n\tat org.apache.kafka.connect.runtime.WorkerConnector.doTransitionTo(WorkerConnector.java:385)\n\tat org.apache.kafka.connect.runtime.WorkerConnector.doRun(WorkerConnector.java:165)\n\tat org.apache.kafka.connect.runtime.WorkerConnector.run(WorkerConnector.java:125)\n\tat org.apache.kafka.connect.runtime.isolation.Plugins.lambda$withClassLoader$1(Plugins.java:238)\n\tat java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)\n\tat java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)\n\tat java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)\n\tat java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)\n\tat java.base/java.lang.Thread.run(Thread.java:840)\nCaused by: java.lang.IllegalStateException: failed to parse at line 1 due to extraneous input 'object' expecting SELECT\n\tat com.datamountaineer.kcql.Kcql$1.syntaxError(Kcql.java:422)\n\tat org.antlr.v4.runtime.ProxyErrorListener.syntaxError(ProxyErrorListener.java:41)\n\tat org.antlr.v4.runtime.Parser.notifyErrorListeners(Parser.java:544)\n\tat org.antlr.v4.runtime.DefaultErrorStrategy.reportUnwantedToken(DefaultErrorStrategy.java:349)\n\tat org.antlr.v4.runtime.DefaultErrorStrategy.singleTokenDeletion(DefaultErrorStrategy.java:513)\n\tat org.antlr.v4.runtime.DefaultErrorStrategy.recoverInline(DefaultErrorStrategy.java:439)\n\tat org.antlr.v4.runtime.Parser.match(Parser.java:206)\n\tat com.datamountaineer.kcql.antlr4.ConnectorParser.select_clause_basic(ConnectorParser.java:1539)\n\tat com.datamountaineer.kcql.antlr4.ConnectorParser.insert_from_clause(ConnectorParser.java:775)\n\tat com.datamountaineer.kcql.antlr4.ConnectorParser.stat(ConnectorParser.java:214)\n\tat com.datamountaineer.kcql.Kcql.parse(Kcql.java:949)\n\t... 16 more\n",
        "worker_id": "sasquatch-connect-0.sasquatch-connect.sasquatch.svc:8083"
    },
    "name": "influxdb-sink-lsstdm",
    "tasks": [],
    "type": "sink"
}
```
`object` is now treated as a reserved word by the KCQL parser. When it sees `lsst.dm.object`topic , it fails parsing the  `connect.influx.kcql` configuration.
I still trying to understand which part of the system is creating that topic and when it was introduced.
Since it is preventing the `lsst.dm` connector from being created I’m excluding that topic from the configuration.