### PR TITLE
Rename PROFILE to LOG_PROFILE in Safir starters

### DIFF
--- a/starters/fastapi-safir-uws/templates/configmap.yaml
+++ b/starters/fastapi-safir-uws/templates/configmap.yaml
@@ -9,8 +9,8 @@ data:
   <CHARTENVPREFIX>_GRACE_PERIOD: {{ .Values.config.gracePeriod | quote }}
   <CHARTENVPREFIX>_LIFETIME: {{ .Values.config.lifetime | quote }}
   <CHARTENVPREFIX>_LOG_LEVEL: {{ .Values.config.loglevel | quote }}
+  <CHARTENVPREFIX>_LOG_PROFILE: {{ .Values.config.logProfile | quote }}
   <CHARTENVPREFIX>_PATH_PREFIX: {{ .Values.config.pathPrefix | quote }}
-  <CHARTENVPREFIX>_PROFILE: {{ .Values.config.logProfile | quote }}
   <CHARTENVPREFIX>_SERVICE_ACCOUNT: {{ required "config.serviceAccount must be set" .Values.config.serviceAccount | quote }}
   <CHARTENVPREFIX>_STORAGE_URL: {{ required "config.storageBucketUrl must be set" .Values.config.storageBucketUrl | quote }}
   <CHARTENVPREFIX>_SYNC_TIMEOUT: {{ .Values.config.syncTimeout | quote }}

--- a/starters/fastapi-safir/templates/configmap.yaml
+++ b/starters/fastapi-safir/templates/configmap.yaml
@@ -6,6 +6,6 @@ metadata:
     {{- include "<CHARTNAME>.labels" . | nindent 4 }}
 data:
   <CHARTENVPREFIX>_LOG_LEVEL: {{ .Values.config.logLevel | quote }}
+  <CHARTENVPREFIX>_LOG_PROFILE: {{ .Values.config.logProfile | quote }}
   <CHARTENVPREFIX>_PATH_PREFIX: {{ .Values.config.pathPrefix | quote }}
-  <CHARTENVPREFIX>_PROFILE: {{ .Values.config.logProfile | quote }}
   REPERTOIRE_BASE_URL: {{ .Values.global.repertoireUrl | quote }}


### PR DESCRIPTION
The FastAPI Safir app template was changed to name the field `log_profile` instead of `profile`. Update the starter to match.