### PR TITLE
Prompt: Remove Kafka namespace from Strimzi

### DIFF
--- a/applications/strimzi/values-usdfprod-prompt-processing.yaml
+++ b/applications/strimzi/values-usdfprod-prompt-processing.yaml
@@ -5,7 +5,6 @@ strimzi-kafka-operator:
     requests:
       memory: "512Mi"
   watchNamespaces:
-    - "kafka"
     - "prompt-kafka"
     - "s3-file-notifications"
   logLevel: "INFO"


### PR DESCRIPTION
The cluster named Kafka was replaced with S3 File Notifications.  Remove the namespace from Strimzi in Prod.