### PR TITLE
Upgrade Butler server to 4.1.2

### DIFF
--- a/applications/butler/Chart.yaml
+++ b/applications/butler/Chart.yaml
@@ -4,4 +4,4 @@ version: 1.0.0
 description: Server for Butler data abstraction service
 sources:
   - https://github.com/lsst/daf_butler
-appVersion: server-3.4.0
+appVersion: server-4.1.2


### PR DESCRIPTION
Upgrade Butler server to a version with a fix for a forward-compatibility issue with a new version of the client (from DM-52397) that will be released in a couple weeks.  This also includes minor bugfixes for a few exceptions that should have been propagated to the client but were instead raising 500 server errors.