### PR TITLE
[DM-52665] Fix PodDisruptionBudget for InfluxDB Enterprise

### DIFF
--- a/applications/sasquatch/charts/influxdb-enterprise/templates/data-pdb.yaml
+++ b/applications/sasquatch/charts/influxdb-enterprise/templates/data-pdb.yaml
@@ -6,5 +6,5 @@ spec:
   minAvailable: {{ .Values.data.podDisruptionBudget.minAvailable }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ template "influxdb-enterprise.fullname" . }}
+      app.kubernetes.io/name: {{ template "influxdb-enterprise.name" . }}
       influxdb.influxdata.com/component: data

--- a/applications/sasquatch/charts/influxdb-enterprise/templates/meta-pdb.yaml
+++ b/applications/sasquatch/charts/influxdb-enterprise/templates/meta-pdb.yaml
@@ -6,5 +6,5 @@ spec:
   minAvailable: {{ .Values.meta.podDisruptionBudget.minAvailable }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ template "influxdb-enterprise.fullname" . }}
+      app.kubernetes.io/name: {{ template "influxdb-enterprise.name" . }}
       influxdb.influxdata.com/component: meta


### PR DESCRIPTION
We want both active and standby instances with min availability of 1 and  allowed disruptions of 0 to  block voluntary evictions (node drains). The PodDisruptionBudget was in place but there was a mismatch between Pod and PodDisruptionBudget labels.