### PR TITLE
[DM-52671] Configure Kafdrop logging level

### DIFF
--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -425,6 +425,11 @@ Rubin Observatory's telemetry service
 | kafdrop.jmx.port | int | `8686` | Port to use for JMX. If unspecified, JMX will not be exposed. |
 | kafdrop.jvm.opts | string | `""` | JVM options |
 | kafdrop.kafka.broker | string | `"sasquatch-kafka-bootstrap.sasquatch:9092"` | Bootstrap list of Kafka host/port pairs |
+| kafdrop.logging.kafdrop.config.level | string | `"WARN"` | Log level for Kafdrop config package logger (TRACE, DEBUG, INFO, WARN, ERROR) |
+| kafdrop.logging.kafdrop.controller.level | string | `"INFO"` | Log level for Kafdrop controller package logger (TRACE, DEBUG, INFO, WARN, ERROR) |
+| kafdrop.logging.kafdrop.level | string | `"INFO"` | Log level for Kafdrop package logger (TRACE, DEBUG, INFO, WARN, ERROR) |
+| kafdrop.logging.kafdrop.service.level | string | `"INFO"` | Log level for Kafdrop service package logger (TRACE, DEBUG, INFO, WARN, ERROR) |
+| kafdrop.logging.root.level | string | `"WARN"` | Log level for Kafdrop root logger (TRACE, DEBUG, INFO, WARN, ERROR) |
 | kafdrop.nodeSelector | object | `{}` | Node selector configuration |
 | kafdrop.podAnnotations | object | `{}` | Pod annotations |
 | kafdrop.replicaCount | int | `1` | Number of kafdrop pods to run in the deployment. |

--- a/applications/sasquatch/charts/kafdrop/README.md
+++ b/applications/sasquatch/charts/kafdrop/README.md
@@ -25,6 +25,11 @@ A subchart to deploy the Kafdrop UI for Sasquatch.
 | jmx.port | int | `8686` | Port to use for JMX. If unspecified, JMX will not be exposed. |
 | jvm.opts | string | `""` | JVM options |
 | kafka.broker | string | `"sasquatch-kafka-bootstrap.sasquatch:9092"` | Bootstrap list of Kafka host/port pairs |
+| logging.kafdrop.config.level | string | `"WARN"` | Log level for Kafdrop config package logger (TRACE, DEBUG, INFO, WARN, ERROR) |
+| logging.kafdrop.controller.level | string | `"INFO"` | Log level for Kafdrop controller package logger (TRACE, DEBUG, INFO, WARN, ERROR) |
+| logging.kafdrop.level | string | `"INFO"` | Log level for Kafdrop package logger (TRACE, DEBUG, INFO, WARN, ERROR) |
+| logging.kafdrop.service.level | string | `"INFO"` | Log level for Kafdrop service package logger (TRACE, DEBUG, INFO, WARN, ERROR) |
+| logging.root.level | string | `"WARN"` | Log level for Kafdrop root logger (TRACE, DEBUG, INFO, WARN, ERROR) |
 | nodeSelector | object | `{}` | Node selector configuration |
 | podAnnotations | object | `{}` | Pod annotations |
 | replicaCount | int | `1` | Number of kafdrop pods to run in the deployment. |

--- a/applications/sasquatch/charts/kafdrop/templates/deployment.yaml
+++ b/applications/sasquatch/charts/kafdrop/templates/deployment.yaml
@@ -61,6 +61,16 @@ spec:
               secretKeyRef:
                 name: sasquatch
                 key: kafdrop-kafka-properties
+          - name: LOGGING_LEVEL_ROOT
+            value: {{ .Values.logging.root.level | upper | quote }}
+          - name: LOGGING_LEVEL_KAFDROP
+            value: {{ .Values.logging.kafdrop.level | upper | quote }}
+          - name: LOGGING_LEVEL_KAFDROP_CONFIG
+            value: {{ .Values.logging.kafdrop.config.level | upper | quote }}
+          - name: LOGGING_LEVEL_KAFDROP_SERVICE
+            value: {{ .Values.logging.kafdrop.service.level | upper | quote }}
+          - name: LOGGING_LEVEL_KAFDROP_CONTROLLER
+            value: {{ .Values.logging.kafdrop.controller.level | upper | quote }}
           ports:
             - name: http
               containerPort: {{ .Values.server.port }}

--- a/applications/sasquatch/charts/kafdrop/values.yaml
+++ b/applications/sasquatch/charts/kafdrop/values.yaml
@@ -54,6 +54,24 @@ existingSecret: ""
 # @default -- See `values.yaml`
 cmdArgs: "--message.format=AVRO --message.keyFormat=DEFAULT --topic.deleteEnabled=false --topic.createEnabled=false"
 
+
+logging:
+  root:
+    # -- Log level for Kafdrop root logger (TRACE, DEBUG, INFO, WARN, ERROR)
+    level: WARN
+  kafdrop:
+    # -- Log level for Kafdrop package logger (TRACE, DEBUG, INFO, WARN, ERROR)
+    level: INFO
+    config:
+      # -- Log level for Kafdrop config package logger (TRACE, DEBUG, INFO, WARN, ERROR)
+      level: WARN
+    service:
+      # -- Log level for Kafdrop service package logger (TRACE, DEBUG, INFO, WARN, ERROR)
+      level: INFO
+    controller:
+      # -- Log level for Kafdrop controller package logger (TRACE, DEBUG, INFO, WARN, ERROR)
+      level: INFO
+
 service:
   # -- Additional annotations to add to the service
   annotations: {}


### PR DESCRIPTION
Kafdrop is a Spring Boot application, logging level configuration is explained [here](https://docs.spring.io/spring-boot/reference/features/logging.html).

In this PR we add configuration to the Kafdrop Helm chart to configure logging.

We  set logging level for the root logger (LOGGING_LEVEL_ROOT=WARN by default)

But something in Kafdrop explicitly set the looging level for kafdrop, kafdrop.config,  kafdrop.service, and kafdrop.controller packages to INFO so they ignore the root logger.

We found that the kafdrop.config package with logging level INFO is too chatty so we se it to WARN by default.