### PR TITLE
Update nightly digest image tag to cycle 42

### DIFF
--- a/applications/nightlydigest/values-base.yaml
+++ b/applications/nightlydigest/values-base.yaml
@@ -11,7 +11,7 @@ nightlydigest-nginx:
     frontend:
       image:
         repository: ts-dockerhub.lsst.org/nightlydigest-frontend
-        tag: c0041
+        tag: c0042
         pullPolicy: Always
   staticStore:
     name: nightlydigest-nginx-static
@@ -50,7 +50,7 @@ nightlydigest-nginx:
 nightlydigest-backend:
   image:
     repository: ts-dockerhub.lsst.org/nightlydigest-backend
-    tag: c0041
+    tag: c0042
     pullPolicy: Always
   env:
     - name: JIRA_API_HOSTNAME

--- a/applications/nightlydigest/values-usdfdev.yaml
+++ b/applications/nightlydigest/values-usdfdev.yaml
@@ -11,7 +11,7 @@ nightlydigest-nginx:
     frontend:
       image:
         repository: ts-dockerhub.lsst.org/nightlydigest-frontend
-        tag: c0041
+        tag: c0042
         pullPolicy: Always
   staticStore:
     name: nightlydigest-nginx-static
@@ -50,7 +50,7 @@ nightlydigest-nginx:
 nightlydigest-backend:
   image:
     repository: ts-dockerhub.lsst.org/nightlydigest-backend
-    tag: c0041
+    tag: c0042
     pullPolicy: Always
   env:
     - name: JIRA_API_HOSTNAME


### PR DESCRIPTION
We have a new cycle build for T&S, and so we update the image tag to get the new image and its revisions. 