### PR TITLE
[DM-52710] Default Sasquatch to Kafka 4.0.0

### DIFF
--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -618,7 +618,7 @@ Rubin Observatory's telemetry service
 | strimzi-kafka.kafka.metricsConfig.enabled | bool | `false` | Whether metric configuration is enabled |
 | strimzi-kafka.kafka.minInsyncReplicas | int | `2` | The minimum number of in-sync replicas that must be available for the producer to successfully send records Cannot be greater than the number of replicas. |
 | strimzi-kafka.kafka.replicas | int | `3` | Number of Kafka broker replicas to run |
-| strimzi-kafka.kafka.version | string | `"3.8.0"` | Version of Kafka to deploy |
+| strimzi-kafka.kafka.version | string | `"4.0.0"` | Version of Kafka to deploy |
 | strimzi-kafka.kafkaExporter.enableSaramaLogging | bool | `false` | Enable Sarama logging for pod |
 | strimzi-kafka.kafkaExporter.enabled | bool | `false` | Enable Kafka exporter |
 | strimzi-kafka.kafkaExporter.groupRegex | string | `".*"` | Consumer groups to monitor |

--- a/applications/sasquatch/charts/strimzi-kafka/README.md
+++ b/applications/sasquatch/charts/strimzi-kafka/README.md
@@ -65,7 +65,7 @@ A subchart to deploy Strimzi Kafka components for Sasquatch.
 | kafka.metricsConfig.enabled | bool | `false` | Whether metric configuration is enabled |
 | kafka.minInsyncReplicas | int | `2` | The minimum number of in-sync replicas that must be available for the producer to successfully send records Cannot be greater than the number of replicas. |
 | kafka.replicas | int | `3` | Number of Kafka broker replicas to run |
-| kafka.version | string | `"3.8.0"` | Version of Kafka to deploy |
+| kafka.version | string | `"4.0.0"` | Version of Kafka to deploy |
 | kafkaExporter.enableSaramaLogging | bool | `false` | Enable Sarama logging for pod |
 | kafkaExporter.enabled | bool | `false` | Enable Kafka exporter |
 | kafkaExporter.groupRegex | string | `".*"` | Consumer groups to monitor |

--- a/applications/sasquatch/charts/strimzi-kafka/values.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/values.yaml
@@ -11,7 +11,7 @@ cluster:
 
 kafka:
   # -- Version of Kafka to deploy
-  version: "3.8.0"
+  version: "4.0.0"
 
   # -- The KRaft metadata version used by the Kafka cluster.
   # If the property is not set, it defaults to the metadata version that corresponds to the version property.

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -1,6 +1,5 @@
 strimzi-kafka:
   kafka:
-    version: "4.0.0"
     listeners:
       tls:
         enabled: true

--- a/applications/sasquatch/values-idfint.yaml
+++ b/applications/sasquatch/values-idfint.yaml
@@ -1,6 +1,5 @@
 strimzi-kafka:
   kafka:
-    version: "4.0.0"
     listeners:
       tls:
         enabled: true

--- a/applications/sasquatch/values-idfprod.yaml
+++ b/applications/sasquatch/values-idfprod.yaml
@@ -1,6 +1,5 @@
 strimzi-kafka:
   kafka:
-    version: "3.9.0"
     listeners:
       tls:
         enabled: true
@@ -83,6 +82,7 @@ chronograf:
 
 app-metrics:
   enabled: true
+  kafkaVersion: "4.0.0"
   apps:
     - gafaelfawr
     - mobu

--- a/applications/sasquatch/values-roundtable-dev.yaml
+++ b/applications/sasquatch/values-roundtable-dev.yaml
@@ -1,6 +1,5 @@
 strimzi-kafka:
   kafka:
-    version: "3.9.0"
     listeners:
       plain:
         enabled: false

--- a/applications/sasquatch/values-roundtable-prod.yaml
+++ b/applications/sasquatch/values-roundtable-prod.yaml
@@ -1,6 +1,5 @@
 strimzi-kafka:
   kafka:
-    version: "3.9.0"
     listeners:
       plain:
         enabled: false

--- a/applications/sasquatch/values-summit.yaml
+++ b/applications/sasquatch/values-summit.yaml
@@ -3,6 +3,7 @@ strimzi-kafka:
     monitorLabel:
       lsst.io/monitor: "true"
   kafka:
+    version: 3.8.0
     config:
       auto.create.topics.enable: false
       log.cleaner.min.compaction.lag.ms: 604800000

--- a/environments/values-usdfdev.yaml
+++ b/environments/values-usdfdev.yaml
@@ -51,6 +51,3 @@ applications:
   tap: true
   tasso: true
   times-square: true
-
-revisions:
-  strimzi: strimzi-0.45.0


### PR DESCRIPTION
We can run kafka 4.0.0 (Strimzi 0.47.0) in most of the Sasquatch environmets now so that can be set as the default.

Exceptions are:
- Summit that still requires Kafka 3.8.0 with Strimzi pinned to 0.45.0 (will move soon to Kafka 3.9.1 and Strimzi 0.47.0)
- BTS and TTS that require Kafka 3.9.1 with default Strimzi 0.47.0
- USDF environments are still on 3.9.0 waiting for testing MM2 with Kafka 4.0.0 before upgrading.
