### PR TITLE
DM-52729: Serve eups-distributor at eups(-dev).lsst.codes

### DIFF
--- a/applications/eups-distributor/README.md
+++ b/applications/eups-distributor/README.md
@@ -18,6 +18,11 @@ Distributes EUPS binaries
 | image.tag | string | The appVersion of the chart | Tag of image to use |
 | ingress."nginx.ingress.kubernetes.io/preserve-trailing-slash" | string | `"true"` |  |
 | ingress.hostname | string | `""` | Additional annotations for the ingress rule |
+| lsstDotCodes.awsAccessKeyId | string | `"AKIAQSJOS2SFBNRYNM4I"` |  |
+| lsstDotCodes.email | string | `"sqre-admin@lists.lsst.org"` | Contact email address registered with Let's Encrypt |
+| lsstDotCodes.enabled | bool | `false` |  |
+| lsstDotCodes.hostedZoneId | string | `"Z06873202D7WVTZUFOQ42"` |  |
+| lsstDotCodes.hostname | string | `nil` |  |
 | nodeSelector | object | `{}` | Node selection rules for the eups-distributor deployment pod |
 | podAnnotations | object | `{"gke-gcsfuse/volumes":"true"}` | Annotations for the eups-distributor deployment pod |
 | replicaCount | int | `1` | Number of web deployment pods to start |

--- a/applications/eups-distributor/secrets.yaml
+++ b/applications/eups-distributor/secrets.yaml
@@ -1,0 +1,4 @@
+aws-secret-access-key:
+  description: >-
+    AWS credentials with write access to the tls.lsst.code subdomain
+  if: lsstDotCodes.enabled

--- a/applications/eups-distributor/templates/ingress-dotcodes.yaml
+++ b/applications/eups-distributor/templates/ingress-dotcodes.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.lsstDotCodes.enabled }}
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
+metadata:
+  name: "eups-distributor-dot-codes"
+  labels:
+    {{- include "eups-distributor.labels" . | nindent 4 }}
+config:
+  scopes:
+    anonymous: true
+  service: "eups-distributor"
+template:
+  metadata:
+    name: "eups-distributor-dot-codes"
+    annotations:
+      cert-manager.io/issuer: "letsencrypt-dns-eups-dot-codes"
+      {{- with .Values.ingress.annotations }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+  spec:
+    tls:
+      - hosts:
+        - {{ .Values.lsstDotCodes.hostname | quote }}
+        secretName: eups-distributor-tls-dot-codes
+    rules:
+      - host: {{ required "lsstDotCodes.hostname must be set" .Values.lsstDotCodes.hostname | quote }}
+        http:
+          paths:
+            - path: "/"
+              pathType: Prefix
+              backend:
+                service:
+                  name: "eups-distributor"
+                  port:
+                    number: 8080
+{{- end }}

--- a/applications/eups-distributor/templates/issuer.yaml
+++ b/applications/eups-distributor/templates/issuer.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.lsstDotCodes.enabled -}}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: "letsencrypt-dns-eups-dot-codes"
+  labels:
+    {{- include "eups-distributor.labels" . | nindent 4 }}
+spec:
+  acme:
+    email: {{ required "lsstDotCodes.email must be set" .Values.lsstDotCodes.email | quote }}
+    server: "https://acme-v02.api.letsencrypt.org/directory"
+    privateKeySecretRef:
+      name: "cert-manager-letsencrypt-dot-codes"
+    solvers:
+      - dns01:
+          cnameStrategy: "Follow"
+          route53:
+            region: "us-east-1"
+            accessKeyID: {{ required "lsstDotCodes.awsAccessKeyId must be set" .Values.lsstDotCodes.awsAccessKeyId | quote }}
+            hostedZoneID: {{ required "lsstDotCodes.hostedZoneId must be set" .Values.lsstDotCodes.hostedZoneId | quote }}
+            secretAccessKeySecretRef:
+              name: "eups-distributor"
+              key: "aws-secret-access-key"
+{{- end }}

--- a/applications/eups-distributor/templates/vault-secret.yaml
+++ b/applications/eups-distributor/templates/vault-secret.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.lsstDotCodes.enabled }}
+apiVersion: ricoberger.de/v1alpha1
+kind: VaultSecret
+metadata:
+  name: "eups-distributor"
+  labels:
+    {{- include "eups-distributor.labels" . | nindent 4 }}
+spec:
+  path: "{{ .Values.global.vaultSecretsPath }}/eups-distributor"
+  type: "Opaque"
+{{- end }}

--- a/applications/eups-distributor/values-roundtable-dev.yaml
+++ b/applications/eups-distributor/values-roundtable-dev.yaml
@@ -3,5 +3,10 @@ image:
 ingress:
   # -- Additional annotations for the ingress rule
   hostname: "eups-dev.lsst.cloud"
+
+lsstDotCodes:
+  enabled: true
+  hostname: "eups-dev.lsst.codes"
+
 config:
   serviceAccountReadonly: eups-distributor@roundtable-dev-abe2.iam.gserviceaccount.com

--- a/applications/eups-distributor/values-roundtable-prod.yaml
+++ b/applications/eups-distributor/values-roundtable-prod.yaml
@@ -3,5 +3,10 @@ image:
 ingress:
   # -- Additional annotations for the ingress rule
   hostname: "eups.lsst.cloud"
+
+lsstDotCodes:
+  enabled: true
+  hostname: "eups.lsst.codes"
+
 config:
   serviceAccountReadonly: eups-distributor@roundtable-prod-f6fd.iam.gserviceaccount.com

--- a/applications/eups-distributor/values.yaml
+++ b/applications/eups-distributor/values.yaml
@@ -22,6 +22,23 @@ ingress:
   hostname: ""
   nginx.ingress.kubernetes.io/preserve-trailing-slash: "true"
 
+lsstDotCodes:
+  # Whether to additionally serve the app at an .lsst.code domain
+  enabled: false
+
+  # The .lsst.code hostname to serve the app at
+  hostname: null
+
+  # The access key id for an AWS IAM user with powers to create records in
+  # tls.lsst.codes
+  awsAccessKeyId: "AKIAQSJOS2SFBNRYNM4I"
+
+  # The ID of the AWS Route53 tls.lsst.codes
+  hostedZoneId: "Z06873202D7WVTZUFOQ42"
+
+  # -- Contact email address registered with Let's Encrypt
+  email: "sqre-admin@lists.lsst.org"
+
 # -- Affinity rules for the eups-distributor deployment pod
 affinity: {}
 


### PR DESCRIPTION
I also:

* Added _acme-challenge.eups.lsst.codes → _acme-challenge.tls.lsst.codes CNAME to lsst.codes hosted zone
* Added _acme-challenge.eups-dev.lsst.codes → _acme-challenge.tls.lsst.codes CNAME to lsst.codes hosted zone
* Added another AWS access key to the cert-manager-lsst-codes user
* Added an eups-distributor secret to 1password for roundtable-dev vault
* Added an eups-distributor secret to 1password for roundtable-prod vault
* Sync’d secrets in both envs