### PR TITLE
DM-52751: Update Repertoire, add app metrics support

### DIFF
--- a/applications/repertoire/Chart.yaml
+++ b/applications/repertoire/Chart.yaml
@@ -6,7 +6,7 @@ description: Service discovery
 home: "https://repertoire.lsst.io/"
 sources:
   - "https://github.com/lsst-sqre/repertoire"
-appVersion: 0.4.0
+appVersion: 0.5.0
 
 annotations:
   phalanx.lsst.io/docs: |

--- a/applications/repertoire/README.md
+++ b/applications/repertoire/README.md
@@ -26,6 +26,11 @@ Service discovery
 | config.influxdbDatabases | object | `{}` | Dictionary of InfluxDB database names to connection information for that database, with keys `url`, `database`, `username`, `passwordKey`, and `schemaRegistry`. `passwordKey` must match an entry in `secrets.yaml`. |
 | config.logLevel | string | `"INFO"` | Logging level |
 | config.logProfile | string | `"production"` | Logging profile (`production` for JSON, `development` for human-friendly) |
+| config.metrics.application | string | `"repertoire"` | Name under which to log metrics. Generally there is no reason to change this. |
+| config.metrics.enabled | bool | `false` | Whether to enable sending metrics |
+| config.metrics.events.topicPrefix | string | `"lsst.square.metrics.events"` | Topic prefix for events. It may sometimes be useful to change this in development environments. |
+| config.metrics.schemaManager.registryUrl | string | Sasquatch in the local cluster | URL of the Confluent-compatible schema registry server |
+| config.metrics.schemaManager.suffix | string | `""` | Suffix to add to all registered subjects. This is sometimes useful for experimentation during development. |
 | config.pathPrefix | string | `"/repertoire"` | URL path prefix |
 | config.rules | object | See `values.yaml` | Rules for determining the expected URLs of deployed services that use the main hostname. See the [Repertoire documentation](https://repertoire.lsst.io/) for more information. |
 | config.sentry.enabled | bool | `false` | Whether to enable the Sentry integration |

--- a/applications/repertoire/templates/deployment.yaml
+++ b/applications/repertoire/templates/deployment.yaml
@@ -27,6 +27,24 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           env:
+            {{- if .Values.config.metrics.enabled }}
+            - name: "KAFKA_BOOTSTRAP_SERVERS"
+              valueFrom:
+                secretKeyRef:
+                  name: "repertoire-kafka"
+                  key: "bootstrapServers"
+            - name: "KAFKA_CLIENT_CERT_PATH"
+              value: "/etc/repertoire-kafka/user.crt"
+            - name: "KAFKA_CLIENT_KEY_PATH"
+              value: "/etc/repertoire-kafka/user.key"
+            - name: "KAFKA_CLUSTER_CA_PATH"
+              value: "/etc/repertoire-kafka/ca.crt"
+            - name: "KAFKA_SECURITY_PROTOCOL"
+              valueFrom:
+                secretKeyRef:
+                  name: "repertoire-kafka"
+                  key: "securityProtocol"
+            {{- end }}
             {{- if .Values.config.slackAlerts }}
             - name: "REPERTOIRE_SLACK_WEBHOOK"
               valueFrom:
@@ -100,6 +118,20 @@ spec:
             - name: "secrets"
               mountPath: "/etc/repertoire/secrets"
               readOnly: true
+            {{- if .Values.config.metrics.enabled }}
+            - name: "kafka"
+              mountPath: "/etc/repertoire-kafka/ca.crt"
+              readOnly: true
+              subPath: "ssl.truststore.crt"
+            - name: "kafka"
+              mountPath: "/etc/repertoire-kafka/user.crt"
+              readOnly: true
+              subPath: "ssl.keystore.crt"
+            - name: "kafka"
+              mountPath: "/etc/repertoire-kafka/user.key"
+              readOnly: true
+              subPath: "ssl.keystore.key"
+            {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -119,3 +151,8 @@ spec:
         - name: "secrets"
           secret:
             secretName: "repertoire"
+        {{- if .Values.config.metrics.enabled }}
+        - name: "kafka"
+          secret:
+            secretName: "repertoire-kafka"
+        {{- end }}

--- a/applications/repertoire/templates/kafka-access.yaml
+++ b/applications/repertoire/templates/kafka-access.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.config.metrics.enabled -}}
+apiVersion: access.strimzi.io/v1alpha1
+kind: KafkaAccess
+metadata:
+  name: "repertoire-kafka"
+  labels:
+    {{- include "repertoire.labels" . | nindent 4 }}
+spec:
+  kafka:
+    name: "sasquatch"
+    namespace: "sasquatch"
+    listener: "tls"
+  user:
+    kind: "KafkaUser"
+    apiGroup: "kafka.strimzi.io"
+    name: "app-metrics-repertoire"
+    namespace: "sasquatch"
+{{- end }}

--- a/applications/repertoire/values-idfdev.yaml
+++ b/applications/repertoire/values-idfdev.yaml
@@ -13,6 +13,8 @@ config:
       username: "efdreader"
       passwordKey: "idfdev_efd-password"
       schemaRegistry: "http://sasquatch-schema-registry.sasquatch:8081"
+  metrics:
+    enabled: true
   slackAlerts: true
   useSubdomains:
     - "nublado"

--- a/applications/repertoire/values-idfint.yaml
+++ b/applications/repertoire/values-idfint.yaml
@@ -6,6 +6,8 @@ config:
   hips:
     legacy:
       dataset: "dp1"
+  metrics:
+    enabled: true
   slackAlerts: true
   useSubdomains:
     - "nublado"

--- a/applications/repertoire/values-idfprod.yaml
+++ b/applications/repertoire/values-idfprod.yaml
@@ -6,6 +6,8 @@ config:
   hips:
     legacy:
       dataset: "dp1"
+  metrics:
+    enabled: true
   slackAlerts: true
   useSubdomains:
     - "nublado"

--- a/applications/repertoire/values.yaml
+++ b/applications/repertoire/values.yaml
@@ -116,6 +116,28 @@ config:
   # human-friendly)
   logProfile: "production"
 
+  metrics:
+    # -- Whether to enable sending metrics
+    enabled: false
+
+    # -- Name under which to log metrics. Generally there is no reason to
+    # change this.
+    application: "repertoire"
+
+    events:
+      # -- Topic prefix for events. It may sometimes be useful to change this
+      # in development environments.
+      topicPrefix: "lsst.square.metrics.events"
+
+    schemaManager:
+      # -- URL of the Confluent-compatible schema registry server
+      # @default -- Sasquatch in the local cluster
+      registryUrl: "http://sasquatch-schema-registry.sasquatch.svc.cluster.local:8081"
+
+      # -- Suffix to add to all registered subjects. This is sometimes useful
+      # for experimentation during development.
+      suffix: ""
+
   # -- URL path prefix
   pathPrefix: "/repertoire"
 

--- a/applications/sasquatch/charts/app-metrics/values.yaml
+++ b/applications/sasquatch/charts/app-metrics/values.yaml
@@ -31,6 +31,10 @@ globalAppConfig:
     influxTags:
       - "username"
       - "queue"
+  repertoire:
+    influxTags:
+      - "label"
+      - "username"
   sia:
     influxTags:
       - "username"

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -156,6 +156,7 @@ app-metrics:
     - noteburst
     - nublado
     - qservkafka
+    - repertoire
     - sia
     - wobbly
 

--- a/applications/sasquatch/values-idfint.yaml
+++ b/applications/sasquatch/values-idfint.yaml
@@ -116,6 +116,7 @@ app-metrics:
     - noteburst
     - nublado
     - qservkafka
+    - repertoire
     - sia
     - wobbly
 

--- a/applications/sasquatch/values-idfprod.yaml
+++ b/applications/sasquatch/values-idfprod.yaml
@@ -89,6 +89,7 @@ app-metrics:
     - noteburst
     - nublado
     - qservkafka
+    - repertoire
     - sia
     - wobbly
 


### PR DESCRIPTION
Update Repertoire to the 0.5.0 release and add support for publishing app metrics. Initially this will be used to record when people request credentials for an InfluxDB database.