### PR TITLE
Updating tap_schema image versions

### DIFF
--- a/applications/ssotap/values-ukidacdev.yaml
+++ b/applications/ssotap/values-ukidacdev.yaml
@@ -2,7 +2,7 @@ cadc-tap:
   tapSchema:
     image:
       repository: "lsstuk/tap-schema-ukidacdev-sso"
-      tag: "29.0.1"
+      tag: "29.2.1"
   config:
     gcsBucket: "async"
     gcsBucketUrl: "https://somerville.ed.ac.uk:6780"

--- a/applications/ssotap/values-ukidacprod.yaml
+++ b/applications/ssotap/values-ukidacprod.yaml
@@ -2,7 +2,7 @@ cadc-tap:
   tapSchema:
     image:
       repository: "lsstuk/tap-schema-ukidacprod-sso"
-      tag: "29.0.1"
+      tag: "29.2.1"
 
   config:
     gcsBucket: "async"

--- a/applications/tap/values-ukidacdev.yaml
+++ b/applications/tap/values-ukidacdev.yaml
@@ -2,7 +2,7 @@ cadc-tap:
   tapSchema:
     image:
       repository: "lsstuk/tap-schema-ukidacdev"
-      tag: "29.0.1"
+      tag: "29.2.1"
 
   config:
     gcsBucket: "async-test"

--- a/applications/tap/values-ukidacprod.yaml
+++ b/applications/tap/values-ukidacprod.yaml
@@ -2,7 +2,7 @@ cadc-tap:
   tapSchema:
     image:
       repository: "lsstuk/tap-schema-ukidacprod"
-      tag: "29.0.1"
+      tag: "29.2.1"
 
   config:
     gcsBucket: "async"


### PR DESCRIPTION
Tap scheme images are now (from Docker Hub):

- lsstuk/tap-schema-ukidacdev
- lsstuk/tap-schema-ukidacdev-sso
- lsstuk/tap-schema-ukidacprod
- lsstuk/tap-schema-ukidacprod-sso