### PR TITLE
DM-52784: Add service discovery rule for datalinker

### DIFF
--- a/applications/repertoire/values.yaml
+++ b/applications/repertoire/values.yaml
@@ -153,6 +153,14 @@ config:
       - type: "ui"
         name: "argocd"
         template: "https://{{base_hostname}}/argo-cd"
+    datalinker:
+      - type: "data"
+        template: "https://{{base_hostname}}/api/datalinker"
+        versions:
+          datalink-links-1.1:
+            template: "https://{{base_hostname}}/api/datalinker/links"
+            ivoaStandardId: "ivo://ivoa.net/std/DataLink#links-1.1"
+        openapi: "https://{{base_hostname}}/api/datalinker/openapi.json"
     gafaelfawr:
       - type: "internal"
         name: "gafaelfawr"


### PR DESCRIPTION
TAP needs to locate the datalinker service for rewriting of the `access_url` column of some tables.