### PR TITLE
DM-52784: Add Repertoire rule for nublado-controller

### DIFF
--- a/applications/repertoire/values.yaml
+++ b/applications/repertoire/values.yaml
@@ -189,6 +189,9 @@ config:
             template: "https://{{base_hostname}}/noteburst/v1"
         openapi: "https://{{base_hostname}}/noteburst/openapi.json"
     nublado:
+      - type: "internal"
+        name: "nublado-controller"
+        template: "https://{{base_hostname}}/nublado"
       - type: "ui"
         name: "nublado"
         template: "https://{{base_hostname}}/nb"


### PR DESCRIPTION
This will be used by the spawner plugin for JupyterHub.