### PR TITLE
DM-52784: Fix syntax of datalink Repertoire rule

### DIFF
--- a/applications/repertoire/values.yaml
+++ b/applications/repertoire/values.yaml
@@ -155,6 +155,7 @@ config:
         template: "https://{{base_hostname}}/argo-cd"
     datalinker:
       - type: "data"
+        name: "datalink"
         template: "https://{{base_hostname}}/api/datalinker"
         versions:
           datalink-links-1.1:


### PR DESCRIPTION
Service rules must have names.