### PR TITLE
DM-52580: Make the logging level for the Butler Writer Service configurable

### DIFF
--- a/applications/butler-writer-service/README.md
+++ b/applications/butler-writer-service/README.md
@@ -21,6 +21,7 @@ Write proxy for the Butler that buffers concurrent requests.
 | kafka.clusterAddress | string | None, must be set | Address of Kafka broker containing Prompt Processing output events, for consumption by the Butler writer service. |
 | kafka.topic | string | None, must be set | Kafka topic containing Prompt Processing output events, for consumption by the Butler writer service. |
 | kafka.username | string | None, must be set | Username for Kafka broker containing Prompt Processing output events, for consumption by the Butler writer service. |
+| logLevel | string | `"INFO"` | Global logging level to use in the writer service. |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` | Node selection rules for the pod |
 | outputRepo | string | None, must be set | URI to the repo the writer should write to. |

--- a/applications/butler-writer-service/templates/butler-writer-service.yaml
+++ b/applications/butler-writer-service/templates/butler-writer-service.yaml
@@ -66,6 +66,10 @@ spec:
             {{- end }}
             - name: LSST_DB_AUTH
               value: /app/lsst-credentials/db-auth.yaml
+            {{- with .Values.logLevel }}
+            - name: WRITER_DEBUG_LEVEL
+              value: {{ . }}
+            {{- end }}
           volumeMounts:
             # /app is defined in Dockerfile
             - mountPath: /app/lsst-credentials

--- a/applications/butler-writer-service/values.yaml
+++ b/applications/butler-writer-service/values.yaml
@@ -33,6 +33,9 @@ s3:
   # -- If set, configure S3 checksum options.
   checksum: WHEN_REQUIRED
 
+# -- Global logging level to use in the writer service.
+logLevel: INFO
+
 nameOverride: ""
 fullnameOverride: ""
 


### PR DESCRIPTION
This PR configures a single, global logging level for the Butler Writer service. The implementation of the logging level is in lsst-dm/prompt_processing_butler_writer#6.