### PR TITLE
Fix URL for fov-quicklook repository

### DIFF
--- a/applications/fov-quicklook/Chart.yaml
+++ b/applications/fov-quicklook/Chart.yaml
@@ -3,6 +3,6 @@ appVersion: 0.1.0
 description: Full focal plane viewer
 name: fov-quicklook
 sources:
-- https://github.com/michitaro/rubin-fov-quicklook
+ - https://github.com/lsst-sqre/fov-quicklook
 type: application
 version: 1.0.0

--- a/applications/fov-quicklook/README.md
+++ b/applications/fov-quicklook/README.md
@@ -4,7 +4,7 @@ Full focal plane viewer
 
 ## Source Code
 
-* <https://github.com/michitaro/rubin-fov-quicklook>
+* <https://github.com/lsst-sqre/fov-quicklook>
 
 ## Values
 


### PR DESCRIPTION
The repository has been moved under lsst-sqre, so the older path is producing a permanent redirect.