### PR TITLE
DM-54182: Change repertoire configuration on idfdev to use GCS bucket for sdm_schemas artifacts

### DIFF
--- a/applications/repertoire/values-idfdev.yaml
+++ b/applications/repertoire/values-idfdev.yaml
@@ -17,6 +17,8 @@ config:
     enabled: true
   slackAlerts: true
   tap:
+    schemaVersion: "tickets/DM-54182"
+    schemaSourceTemplate: "gs://rubin-sdm-schemas-artifacts/{version}/schemas.tar.gz"
     servers:
       tap:
         enabled: true


### PR DESCRIPTION
When schema_version contains a slash (e.g. a branch name like tickets/DM-54182), the local archive path includes a subdirectory that was never created  causing a FileNotFoundError.
This PR ensures that parent directories are created before downloading if they do not exist.