### PR TITLE
muster - New cached auth routes

### DIFF
--- a/applications/gafaelfawr/README.md
+++ b/applications/gafaelfawr/README.md
@@ -26,6 +26,7 @@ Authentication and identity system
 | cloudsql.tolerations | list | Tolerate GKE arm64 taint | Tolerations for the standalone Cloud SQL Proxy pod |
 | config.afterLogoutUrl | string | Top-level page of this Phalanx environment | Where to send the user after they log out |
 | config.allowSubdomains | bool | `false` | Whether to expose cookies to subdomains. DO NOT SET TO TRUE unless all subdomains of the environment base URL are guaranteed to only reference services protected by Gafaelfawr. |
+| config.baseCachingInternalUrl | string | FQDN under `svc.cluster.local` | URL for direct connections to the sidecar cache container in front of the Gafaelfawr service, bypassing the Ingress. Must use a service name of `gafaelfawr-vinyl-cache` and port 8081. |
 | config.baseInternalUrl | string | FQDN under `svc.cluster.local` | URL for direct connections to the Gafaelfawr service, bypassing the Ingress. Must use a service name of `gafaelfawr` and port 8080. |
 | config.cilogon.clientId | string | `nil` | CILogon client ID. One and only one of this, `config.github.clientId`, or `config.oidc.clientId` must be set. |
 | config.cilogon.enrollmentUrl | string | Login fails with an error | Where to send the user if their username cannot be found in LDAP |

--- a/applications/gafaelfawr/README.md
+++ b/applications/gafaelfawr/README.md
@@ -128,3 +128,6 @@ Authentication and identity system
 | replicaCount | int | `1` | Number of web frontend pods to start |
 | resources | object | See `values.yaml` | Resource limits and requests for the Gafaelfawr frontend pod |
 | tolerations | list | Tolerate GKE arm64 taint | Tolerations for the Gafaelfawr frontend pod |
+| vinyl.enabled | bool | `false` | Whether to enable the Vinyl cache sidecar container |
+| vinyl.port | int | `8081` | Port for the Vinyl cache to listen on |
+| vinyl.resources | object | See `values.yaml` | Resources limits and requests for the Vinyl cache pod |

--- a/applications/gafaelfawr/crds/ingress.yaml
+++ b/applications/gafaelfawr/crds/ingress.yaml
@@ -46,8 +46,7 @@ spec:
       schema:
         openAPIV3Schema:
           description: >-
-            GafaelfawrIngress defines the parameters used to create an Ingress
-            resource.
+            GafaelfawrIngress defines the parameters used to create an Ingress resource.
           type: object
           required:
             - config
@@ -60,29 +59,22 @@ spec:
                 allowCookies:
                   type: boolean
                   description: >-
-                    Whether to allow cookie authentication or only token
-                    authentication via the `Authorization` header.
+                    Whether to allow cookie authentication or only token authentication via the `Authorization` header.
                 allowOptions:
                   type: boolean
                   description: >-
-                    Whether to allow non-CORS-preflight OPTIONS requests to
-                    this backend. This must be enabled for WebDAV servers.
+                    Whether to allow non-CORS-preflight OPTIONS requests to this backend. This must be enabled for WebDAV servers.
                 authCacheDuration:
                   type: string
                   description: >-
-                    The length of time for which the Gafaelfawr authorization
-                    results should be cached by NGINX. The cache is
-                    invalidated if the `Cookie` or `Authorization` HTTP
-                    headers change. Must be a valid NGINX duration string.
+                    The length of time for which the Gafaelfawr authorization results should be cached by NGINX. The cache is invalidated if the `Cookie` or `Authorization` HTTP headers change. Must be a valid NGINX duration string.
                 authType:
                   type: string
                   enum:
                     - basic
                     - bearer
                   description: >-
-                    Controls the authentication type in the challenge
-                    returned in the `WWW-Authenticate` header if the user
-                    is not authenticated. By default, this is `bearer`.
+                    Controls the authentication type in the challenge returned in the `WWW-Authenticate` header if the user is not authenticated. By default, this is `bearer`.
                 baseUrl:
                   type: string
                   description: "Base URL for Gafaelfawr APIs."
@@ -90,8 +82,7 @@ spec:
                 delegate:
                   type: object
                   description: >-
-                    Create a (or reuse a cached) delegated token and
-                    include it in the request to the backend service.
+                    Create a (or reuse a cached) delegated token and include it in the request to the backend service.
                   properties:
                     internal:
                       type: object
@@ -104,17 +95,13 @@ spec:
                         scopes:
                           type: array
                           description: >-
-                            Scopes to include in the delegated token if they
-                            are available. These scopes are not required to
-                            access the service; to make them required, include
-                            them in spec.scopes as well.
+                            Scopes to include in the delegated token if they are available. These scopes are not required to access the service; to make them required, include them in spec.scopes as well.
                           items:
                             type: string
                         service:
                           type: string
                           description: >-
-                            Name of the service to which the token is
-                            delegated.
+                            Name of the service to which the token is delegated.
                     notebook:
                       type: object
                       description: >-
@@ -122,15 +109,11 @@ spec:
                     minimumLifetime:
                       type: integer
                       description: >-
-                        Minimum lifetime of delegated token in seconds. If the
-                        user's token has less than that time remaining, force
-                        them to reauthenticate.
+                        Minimum lifetime of delegated token in seconds. If the user's token has less than that time remaining, force them to reauthenticate.
                     useAuthorization:
                       type: boolean
                       description: >-
-                        If set to true, put the delegated token in the
-                        Authorization header of the request as a bearer token,
-                        in addition to X-Auth-Request-Token.
+                        If set to true, put the delegated token in the Authorization header of the request as a bearer token, in addition to X-Auth-Request-Token.
                   oneOf:
                     - required:
                         - internal
@@ -139,15 +122,11 @@ spec:
                 loginRedirect:
                   type: boolean
                   description: >-
-                    Whether to redirect to the login flow if the user is
-                    not currently authenticated.
+                    Whether to redirect to the login flow if the user is not currently authenticated.
                 onlyServices:
                   type: array
                   description: >-
-                    If set, access is restricted to tokens issued to one of
-                    the listed services, in addition to any other access
-                    constraints. Users will not be able to access the ingress
-                    directly with their own tokens.
+                    If set, access is restricted to tokens issued to one of the listed services, in addition to any other access constraints. Users will not be able to access the ingress directly with their own tokens.
                   items:
                     type: string
                 replace403:
@@ -157,30 +136,24 @@ spec:
                 scopes:
                   type: object
                   description: >-
-                    The token scope or scopes required to access this service.
-                    May be omitted if the service allows anonymous access.
+                    The token scope or scopes required to access this service. May be omitted if the service allows anonymous access.
                   properties:
                     any:
                       type: array
                       description: >-
-                        Access is granted if any of the listed scopes are
-                        present.
+                        Access is granted if any of the listed scopes are present.
                       items:
                         type: string
                     all:
                       type: array
                       description: >-
-                        Access is granted if all of the listed scopes are
-                        present.
+                        Access is granted if all of the listed scopes are present.
                       items:
                         type: string
                     anonymous:
                       type: boolean
                       description: >-
-                        Allow anonymous access to this ingress. No access
-                        control checks will be made and no token delegation is
-                        possible, but Gafaelfawr tokens will still be stripped
-                        from the `Authorization` and `Cookie` headers.
+                        Allow anonymous access to this ingress. No access control checks will be made and no token delegation is possible, but Gafaelfawr tokens will still be stripped from the `Authorization` and `Cookie` headers.
                   oneOf:
                     - required:
                         - any
@@ -195,23 +168,23 @@ spec:
                 service:
                   type: string
                   description: >-
-                    The name of the service corresponding to this ingress,
-                    used for metrics reporting. When delegating internal
-                    tokens, this must match config.delegate.internal.service.
-                    This attribute will be required in the future.
+                    The name of the service corresponding to this ingress, used for metrics reporting. When delegating internal tokens, this must match config.delegate.internal.service. This attribute will be required in the future.
                 userDomain:
                   type: boolean
                   description: >-
-                    Expect the last component of the request URL hostname to
-                    be a username and only allow access from matching
-                    usernames. Requires that the ingress host be a wildcard.
+                    Expect the last component of the request URL hostname to be a username and only allow access from matching usernames. Requires that the ingress host be a wildcard.
                 username:
                   type: string
                   description: >-
-                    Restrict access to this ingress to the given username. All
-                    other users, regardless of their scopes, will receive 403
-                    errors. The user's token must still satisfy any scope
-                    constraints.
+                    Restrict access to this ingress to the given username. All other users, regardless of their scopes, will receive 403 errors. The user's token must still satisfy any scope constraints.
+                vinylAuthCacheEnabled:
+                  type: boolean
+                  description: >-
+                    Whether Gafaelfawr authorization results should be cached by Vinyl. The Vinyl cache is configured to cache results for five minutes. The cache is invalidated if the `Cookie` or `Authorization` HTTP headers change.
+              not:
+                required:
+                  - authCacheDuration
+                  - vinylAuthCacheEnabled
             template:
               type: object
               description: "The template used to create the ingress."
@@ -226,11 +199,7 @@ spec:
                     annotations:
                       type: object
                       description: >-
-                        Annotations to apply to the generated ingress. These
-                        will be merged with the annotations required by
-                        Gafaelfawr. If there is a conflict, the
-                        Gafaelfawr-generated annotations will override the
-                        ones provided in this field.
+                        Annotations to apply to the generated ingress. These will be merged with the annotations required by Gafaelfawr. If there is a conflict, the Gafaelfawr-generated annotations will override the ones provided in this field.
                       additionalProperties:
                         type: string
                     labels:
@@ -250,9 +219,7 @@ spec:
                     rules:
                       type: array
                       description: >-
-                        Host rules for the generated ingress. See the schema
-                        for the regular Ingress resource for descriptions of
-                        the individual fields.
+                        Host rules for the generated ingress. See the schema for the regular Ingress resource for descriptions of the individual fields.
                       items:
                         type: object
                         properties:
@@ -298,10 +265,7 @@ spec:
                     tls:
                       type: array
                       description: >-
-                        TLS configuration if one should be added to this
-                        generated ingress. See the schema for the regular
-                        Ingress resource for descriptions of the individual
-                        fields.
+                        TLS configuration if one should be added to this generated ingress. See the schema for the regular Ingress resource for descriptions of the individual fields.
                       items:
                         type: object
                         properties:
@@ -314,15 +278,13 @@ spec:
             status:
               type: object
               description: >-
-                The current state of the GafaelfawrIngress, its processing by
-                Gafaelfawr, and its child resources.
+                The current state of the GafaelfawrIngress, its processing by Gafaelfawr, and its child resources.
               x-kubernetes-preserve-unknown-fields: true
               properties:
                 create:
                   type: object
                   description: >-
-                    Status of processing of the last creation or update of the
-                    GafaelfawrIngress object.
+                    Status of processing of the last creation or update of the GafaelfawrIngress object.
                   required:
                     - lastTransitionTime
                     - message
@@ -338,29 +300,18 @@ spec:
                     message:
                       type: string
                       description: >
-                        A human readable message indicating details about the
-                        transition. This may be an empty string.
+                        A human readable message indicating details about the transition. This may be an empty string.
                       maxLength: 32768
                     observedGeneration:
                       description: >
-                        The .metadata.generation that the condition was set
-                        based upon. For instance, if .metadata.generation is
-                        currently 12, but the
-                        .status.create.observedGeneration is 9, the condition
-                        is out of date with respect to the current state of
-                        the instance.
+                        The .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.create.observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
                       type: string
                       description: >
-                        A programmatic identifier indicating the reason for
-                        the condition's last transition. Producers of specific
-                        condition types may define expected values and
-                        meanings for this field, and whether the values are
-                        considered a guaranteed API. The value should be a
-                        CamelCase string. This field may not be empty.
+                        A programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
                       maxLength: 1024
                       minLength: 1
                       pattern: "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$"
@@ -375,7 +326,6 @@ spec:
                     type:
                       type: string
                       description: >
-                        Type of condition in CamelCase or in
-                        foo.example.com/CamelCase.
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$"

--- a/applications/gafaelfawr/templates/_helpers.tpl
+++ b/applications/gafaelfawr/templates/_helpers.tpl
@@ -66,6 +66,10 @@ Common environment variables
 - name: "GAFAELFAWR_BASE_INTERNAL_URL"
   value: "http://gafaelfawr.{{ .Release.Namespace }}.svc.cluster.local:8080"
 {{- end }}
+{{- if not .Values.config.baseCachingInternalUrl }}
+- name: "GAFAELFAWR_BASE_CACHING_INTERNAL_URL"
+  value: "http://gafaelfawr-vinyl-cache.{{ .Release.Namespace }}.svc.cluster.local:8081"
+{{- end }}
 - name: "GAFAELFAWR_BOOTSTRAP_TOKEN"
   valueFrom:
     secretKeyRef:

--- a/applications/gafaelfawr/templates/configmap-vinyl-cache.yaml
+++ b/applications/gafaelfawr/templates/configmap-vinyl-cache.yaml
@@ -1,0 +1,103 @@
+{{- if .Values.vinyl.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "gafaelfawr-vinyl"
+  labels:
+    {{- include "gafaelfawr.labels" . | nindent 4 }}
+data:
+  default.vcl: |
+    vcl 4.1;
+
+    # This was partly slopped with claude.ai
+    #
+    # ---------------------------------------------------------------
+    # Replicates ingress-nginx annotations:
+    #   auth-method:          GET
+    #   auth-cache-key:       $request_method$http_cookie$http_authorization
+    #   auth-cache-duration:  200 202 401 5m
+    # ---------------------------------------------------------------
+
+    import std;
+
+    backend auth_server {
+        .host = "127.0.0.1";
+        .port = "8080";
+    }
+
+    sub vcl_recv {
+        # auth-method: GET
+        # Only cache GET requests; pass everything else straight through.
+        if (req.method != "GET") {
+            std.log(":::Method wasn't GET, it was: " + req.method);
+            return (pass);
+        }
+
+        if (!req.http.Authorization) {
+          std.log(":::No Authorization!");
+          return (pass);
+        }
+
+        # All other GET requests go through normal cache lookup.
+        return (hash);
+    }
+
+    sub vcl_hash {
+        # auth-cache-key: $request_method$http_cookie$http_authorization
+        #
+        # Varnish always hashes req.url + req.http.Host by default.
+        # We extend that with the three components of the cache key.
+        # hash_data() calls are additive — all values are concatenated
+        # into the cache key before the lookup.
+
+        hash_data(req.method);
+
+        if (req.http.Cookie) {
+            hash_data(req.http.Cookie);
+        } else {
+            hash_data("__no_cookie__");
+        }
+
+        # Fall through to the built-in, which hashes req.url + req.http.Host.
+        return (lookup);
+    }
+
+    sub vcl_backend_response {
+        # auth-cache-duration: 200 202 401 5m
+        #
+        # Cache only the listed status codes for 5 minutes.
+        # Mark everything else as uncacheable (hit-for-miss with TTL 0).
+
+        if (beresp.status == 200 ||
+            beresp.status == 202 ||
+            beresp.status == 401) {
+
+            set beresp.ttl = 5m;
+
+            # Don't let downstream Cache-Control headers override our TTL.
+            set beresp.http.Cache-Control = "max-age=300";
+
+            # Strip Set-Cookie so Varnish doesn't refuse to cache the response.
+            unset beresp.http.Set-Cookie;
+
+            return (deliver);
+        }
+
+        # All other status codes: treat as uncacheable.
+        # hit_for_miss keeps the object in cache as a "don't cache" marker
+        # briefly, avoiding a thundering herd on error responses.
+        set beresp.uncacheable = true;
+        set beresp.ttl = 120s;
+        return (deliver);
+    }
+
+    sub vcl_deliver {
+        # Optional: expose cache status for debugging.
+        if (obj.hits > 0) {
+            set resp.http.X-Cache = "HIT";
+            set resp.http.X-Cache-Hits = obj.hits;
+        } else {
+            set resp.http.X-Cache = "MISS";
+        }
+    }
+    {{- end }}

--- a/applications/gafaelfawr/templates/deployment.yaml
+++ b/applications/gafaelfawr/templates/deployment.yaml
@@ -14,6 +14,9 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if .Values.vinyl.enabled }}
+        checksum/vinyl-config: {{ include (print $.Template.BasePath "/configmap-vinyl-cache.yaml") . | sha256sum }}
+        {{- end }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -120,6 +123,56 @@ spec:
             - name: "tmp"
               mountPath: "/tmp"
             {{- end }}
+        {{- if .Values.vinyl.enabled }}
+        - name: "vinyl"
+          image: varnish:8
+          env:
+            - name: VARNISH_HTTP_PORT
+              value: {{ .Values.vinyl.port | quote }}
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            tcpSocket:
+              port: 8081
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            tcpSocket:
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          startupProbe:
+            tcpSocket:
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          ports:
+            - containerPort: 8081
+              name: "http-vinyl"
+              protocol: "TCP"
+          resources:
+            {{- toYaml .Values.vinyl.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: "vinyl"
+              mountPath: "/var/lib/varnish"
+            - name: "vinyl-config"
+              mountPath: "/etc/varnish/default.vcl"
+              subPath: "default.vcl"
+        {{- end}}
       {{- if .Values.cloudsql.enabled }}
       initContainers:
         {{- include "gafaelfawr.cloudsqlSidecar" . | nindent 8 }}
@@ -132,6 +185,15 @@ spec:
         - name: "config"
           configMap:
             name: "gafaelfawr"
+        {{- if .Values.vinyl.enabled }}
+        - name: "vinyl"
+          emptyDir:
+            medium: Memory
+            sizeLimit: 100Mi
+        - name: "vinyl-config"
+          configMap:
+            name: "gafaelfawr-vinyl"
+        {{- end }}
         {{- if .Values.config.metrics.enabled }}
         - name: "kafka"
           secret:

--- a/applications/gafaelfawr/templates/networkpolicy.yaml
+++ b/applications/gafaelfawr/templates/networkpolicy.yaml
@@ -23,3 +23,8 @@ spec:
       ports:
         - protocol: "TCP"
           port: 8080
+        {{- if .Values.vinyl.enabled }}
+        # The vinyl cache sidecar
+        - protocol: "TCP"
+          port: 8081
+        {{- end }}

--- a/applications/gafaelfawr/templates/service-vinyl-cache.yaml
+++ b/applications/gafaelfawr/templates/service-vinyl-cache.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.vinyl.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: "gafaelfawr-vinyl-cache"
+  labels:
+    {{- include "gafaelfawr.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - protocol: "TCP"
+      port: 8081
+      targetPort: "http-vinyl"
+  selector:
+    {{- include "gafaelfawr.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: "frontend"
+  sessionAffinity: "None"
+{{- end }}

--- a/applications/gafaelfawr/values-idfdev.yaml
+++ b/applications/gafaelfawr/values-idfdev.yaml
@@ -90,6 +90,10 @@ config:
     - "svoutsin"
     - "kai"
 
+vinyl:
+  # -- Whether to enable the Vinyl cache sidecar container
+  enabled: true
+
 cloudsql:
   enabled: true
   instanceConnectionName: "science-platform-dev-7696:us-central1:science-platform-dev-e9e11de2"

--- a/applications/gafaelfawr/values-idfdev.yaml
+++ b/applications/gafaelfawr/values-idfdev.yaml
@@ -15,6 +15,7 @@ config:
 
   sentry:
     enabled: true
+    tracesSampleRate: 0.05
 
   cilogon:
     clientId: "cilogon:/client_id/46f9ae932fd30e9fb1b246972a3c0720"

--- a/applications/gafaelfawr/values-idfdev.yaml
+++ b/applications/gafaelfawr/values-idfdev.yaml
@@ -1,3 +1,7 @@
+image:
+  pullPolicy: Always
+  tag: tickets-DM-54376
+
 # Use the CSI storage class so that we can use snapshots.
 redis:
   persistence:

--- a/applications/gafaelfawr/values.yaml
+++ b/applications/gafaelfawr/values.yaml
@@ -285,6 +285,23 @@ image:
   # @default -- The appVersion of the chart
   tag: ""
 
+vinyl:
+  # -- Whether to enable the Vinyl cache sidecar container
+  enabled: false
+
+  # -- Port for the Vinyl cache to listen on
+  port: 8081
+
+  # -- Resources limits and requests for the Vinyl cache pod
+  # @default -- See `values.yaml`
+  resources:
+    limits:
+      cpu: "1"
+      memory: "512Mi"
+    requests:
+      cpu: "100m"
+      memory: "128Mi"
+
 ingress:
   # -- Defines additional FQDNs for Gafaelfawr. This doesn't work for cookie
   # or browser authentication, but for token-based services like git-lfs or

--- a/applications/gafaelfawr/values.yaml
+++ b/applications/gafaelfawr/values.yaml
@@ -1,4 +1,5 @@
 # Default values for Gafaelfawr.
+
 config:
   # -- Where to send the user after they log out
   # @default -- Top-level page of this Phalanx environment
@@ -13,6 +14,12 @@ config:
   # Ingress. Must use a service name of `gafaelfawr` and port 8080.
   # @default -- FQDN under `svc.cluster.local`
   baseInternalUrl: null
+
+  # -- URL for direct connections to the sidecar cache container in front of
+  # the Gafaelfawr service, bypassing the Ingress. Must use a service name of
+  # `gafaelfawr-vinyl-cache` and port 8081.
+  # @default -- FQDN under `svc.cluster.local`
+  baseCachingInternalUrl: null
 
   # -- URL for the PostgreSQL database
   # @default -- None, must be set if neither `cloudsql.enabled` nor

--- a/applications/gafaelfawr/values.yaml
+++ b/applications/gafaelfawr/values.yaml
@@ -1,5 +1,4 @@
 # Default values for Gafaelfawr.
-
 config:
   # -- Where to send the user after they log out
   # @default -- Top-level page of this Phalanx environment

--- a/applications/muster/templates/ingress-auth-cached.yaml
+++ b/applications/muster/templates/ingress-auth-cached.yaml
@@ -1,0 +1,31 @@
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
+metadata:
+  name: "muster-auth-cached"
+  labels:
+    {{- include "muster.labels" . | nindent 4 }}
+config:
+  authCacheDuration: 5m
+  scopes:
+    all:
+      - "read:image"
+  service: "muster"
+template:
+  metadata:
+    name: "muster-auth-cached"
+    {{- with .Values.ingress.annotations }}
+    annotations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  spec:
+    rules:
+      - host: {{ required "global.host must be set" .Values.global.host | quote }}
+        http:
+          paths:
+            - path: "{{ .Values.config.pathPrefix }}/auth/cached"
+              pathType: "Exact"
+              backend:
+                service:
+                  name: "muster"
+                  port:
+                    number: 8080

--- a/applications/muster/templates/ingress-auth-vinyl.yaml
+++ b/applications/muster/templates/ingress-auth-vinyl.yaml
@@ -1,0 +1,31 @@
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
+metadata:
+  name: "muster-auth-vinyl"
+  labels:
+    {{- include "muster.labels" . | nindent 4 }}
+config:
+  vinylAuthCacheEnabled: true
+  scopes:
+    all:
+      - "read:image"
+  service: "muster"
+template:
+  metadata:
+    name: "muster-auth-vinyl"
+    {{- with .Values.ingress.annotations }}
+    annotations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  spec:
+    rules:
+      - host: {{ required "global.host must be set" .Values.global.host | quote }}
+        http:
+          paths:
+            - path: "{{ .Values.config.pathPrefix }}/auth/vinyl"
+              pathType: "Exact"
+              backend:
+                service:
+                  name: "muster"
+                  port:
+                    number: 8080

--- a/applications/muster/values-idfdev.yaml
+++ b/applications/muster/values-idfdev.yaml
@@ -1,2 +1,5 @@
+image:
+  pullPolicy: Always
+  tag: tickets-DM-54376
 config:
   slackAlerts: true


### PR DESCRIPTION
Add a new `GafaelfawrIngress` to muster with auth caching enabled. The initial usecase for this is Gafaelfawr performance testing.

Routes to the Muster path added in https://github.com/lsst-sqre/muster/pull/14/