### PR TITLE
DM-54118: Consolidate tap-postgres and lsst-tap-service

### DIFF
--- a/applications/obsforgetap/README.md
+++ b/applications/obsforgetap/README.md
@@ -23,8 +23,8 @@ ObsForge TAP service
 | cadc-tap.tapSchema.database | string | `"obsforgetap"` | Database name |
 | cadc-tap.tapSchema.tapadm | object | `{"maxActive":2}` | Connection pool configuration for jdbc/tapadm |
 | cadc-tap.tapSchema.tapadm.maxActive | int | `2` | Maximum active connections (maxIdle will be set to this value) |
-| cadc-tap.tapSchema.tapuser | object | `{"maxActive":5}` | Connection pool configuration for jdbc/tapuser (query planning and tap_upload) |
-| cadc-tap.tapSchema.tapuser.maxActive | int | `5` | Maximum active connections (maxIdle will be set to this value) |
+| cadc-tap.tapSchema.tapschemauser | object | `{"maxActive":5}` | Connection pool configuration for jdbc/tapschemauser (tap_schema reads) |
+| cadc-tap.tapSchema.tapschemauser.maxActive | int | `5` | Maximum active connections (maxIdle will be set to this value) |
 | cadc-tap.tapSchema.type | string | "cloudsql" | Database backend type: "containerized", "cloudsql", or "external" |
 | cadc-tap.tapSchema.useVaultPassword | bool | `true` | Whether the TAP_SCHEMA database requires a password in Vault (true for cloudsql/external) |
 | cadc-tap.tapSchema.username | string | `"obsforgetap"` | Database username |

--- a/applications/obsforgetap/values.yaml
+++ b/applications/obsforgetap/values.yaml
@@ -50,8 +50,8 @@ cadc-tap:
       # -- Maximum active connections (maxIdle will be set to this value)
       maxActive: 2
 
-    # -- Connection pool configuration for jdbc/tapuser (query planning and tap_upload)
-    tapuser:
+    # -- Connection pool configuration for jdbc/tapschemauser (tap_schema reads)
+    tapschemauser:
       # -- Maximum active connections (maxIdle will be set to this value)
       maxActive: 5
 

--- a/applications/ssotap/README.md
+++ b/applications/ssotap/README.md
@@ -23,8 +23,8 @@ IVOA TAP service for Solar System Objects
 | cadc-tap.tapSchema.database | string | `"ssotap"` | Database name |
 | cadc-tap.tapSchema.tapadm | object | `{"maxActive":1}` | Connection pool configuration for jdbc/tapadm |
 | cadc-tap.tapSchema.tapadm.maxActive | int | `1` | Maximum active connections (maxIdle will be set to this value) |
-| cadc-tap.tapSchema.tapuser | object | `{"maxActive":2}` | Connection pool configuration for jdbc/tapuser (query planning and tap_upload) |
-| cadc-tap.tapSchema.tapuser.maxActive | int | `2` | Maximum active connections (maxIdle will be set to this value) |
+| cadc-tap.tapSchema.tapschemauser | object | `{"maxActive":2}` | Connection pool configuration for jdbc/tapschemauser (tap_schema reads) |
+| cadc-tap.tapSchema.tapschemauser.maxActive | int | `2` | Maximum active connections (maxIdle will be set to this value) |
 | cadc-tap.tapSchema.type | string | "cloudsql" | Database backend type: "containerized", "cloudsql", or "external" |
 | cadc-tap.tapSchema.useVaultPassword | bool | `true` | Whether the TAP_SCHEMA database requires a password in Vault (true for cloudsql/external) |
 | cadc-tap.tapSchema.username | string | `"ssotap"` | Database username |

--- a/applications/ssotap/values-idfdev.yaml
+++ b/applications/ssotap/values-idfdev.yaml
@@ -9,6 +9,10 @@ cadc-tap:
 
   config:
     jvmMaxHeapSize: 7G
+    pg:
+      image:
+        pullPolicy: "Always"
+        tag: "tickets-DM-54118"
 
   cloudsql:
     enabled: true

--- a/applications/ssotap/values.yaml
+++ b/applications/ssotap/values.yaml
@@ -49,8 +49,8 @@ cadc-tap:
       # -- Maximum active connections (maxIdle will be set to this value)
       maxActive: 1
 
-    # -- Connection pool configuration for jdbc/tapuser (query planning and tap_upload)
-    tapuser:
+    # -- Connection pool configuration for jdbc/tapschemauser (tap_schema reads)
+    tapschemauser:
       # -- Maximum active connections (maxIdle will be set to this value)
       maxActive: 2
 

--- a/applications/tap/secrets.yaml
+++ b/applications/tap/secrets.yaml
@@ -4,7 +4,7 @@
     Google Cloud Storage.
 qserv-password:
   description: >-
-    Password for the QServ database server
+    Password for the QServ database server (direct-to-Qserv execution only).
   if: cadc-tap.config.qserv.passwordEnabled
 sentry-dsn:
   description: >-

--- a/applications/tap/values-idfdev.yaml
+++ b/applications/tap/values-idfdev.yaml
@@ -1,5 +1,10 @@
 cadc-tap:
   config:
+    qserv:
+      image:
+        pullPolicy: "Always"
+        tag: "tickets-DM-54118"
+
     kafka:
       enabled: true
 

--- a/charts/cadc-tap/README.md
+++ b/charts/cadc-tap/README.md
@@ -36,7 +36,7 @@ IVOA TAP service
 | config.jvmMaxHeapSize | string | `"31G"` | Java heap size, which will set the maximum size of the heap. Otherwise Java would determine it based on how much memory is available and black maths. |
 | config.kafka | object | `{"consumerGroupId":"tap","enabled":false,"kafkaUserName":"tap","topics":{"jobDelete":"lsst.tap.job-delete","jobRun":"lsst.tap.job-run","jobStatus":"lsst.tap.job-status"}}` | Kafka configuration |
 | config.kafka.consumerGroupId | string | "tap" | Kafka consumer group ID. |
-| config.kafka.enabled | bool | `false` | Whether kafka is enabled |
+| config.kafka.enabled | bool | `false` | Whether kafka is enabled. For the `qserv` backend this also selects the execution mode: `true` dispatches queries to qserv-kafka, `false` runs the legacy direct-to-Qserv mode. |
 | config.kafka.kafkaUserName | string | "tap" | Name of the KafkaUser to use for authentication |
 | config.kafka.topics | object | `{"jobDelete":"lsst.tap.job-delete","jobRun":"lsst.tap.job-run","jobStatus":"lsst.tap.job-status"}` | Kafka topics |
 | config.kafka.topics.jobDelete | string | `"lsst.tap.job-delete"` | Job Delete topic |
@@ -51,15 +51,15 @@ IVOA TAP service
 | config.pg.database | string | None, must be set if backend is `pg` | Database to connect to |
 | config.pg.host | string | None, must be set if backend is `pg` | Host to connect to |
 | config.pg.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the TAP image |
-| config.pg.image.repository | string | `"ghcr.io/lsst-sqre/tap-postgres-service"` | TAP image to use |
-| config.pg.image.tag | string | `"1.26.1"` | Tag of TAP image to use |
+| config.pg.image.repository | string | `"ghcr.io/lsst-sqre/lsst-tap-service"` | TAP image to use |
+| config.pg.image.tag | string | `"3.25.0"` | Tag of TAP image to use. |
 | config.pg.username | string | None, must be set if backend is `pg` | Username to connect with |
 | config.qserv.host | string | `"mock-db:3306"` (the mock QServ) | QServ hostname:port to connect to |
 | config.qserv.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the TAP image |
 | config.qserv.image.repository | string | `"ghcr.io/lsst-sqre/lsst-tap-service"` | TAP image to use |
 | config.qserv.image.tag | string | `"3.25.0"` | Tag of TAP image to use |
 | config.qserv.jdbcParams | string | `""` | Extra JDBC connection parameters |
-| config.qserv.passwordEnabled | bool | false | Whether the Qserv database is password protected |
+| config.qserv.passwordEnabled | bool | false | Whether the Qserv database is password protected. Only used for direct-to-Qserv execution (`config.kafka.enabled: false`). |
 | config.qserv.schemaMappings | string | `""` | Schema name mappings: comma-separated list of user_schema:internal_schema pairs. Example: "dp1:dp1_pilot" dp1 queries execute against dp1_pilot. |
 | config.qserv.tableMappings | list | `[]` | Table name mappings for query rewriting (as visible:backend pairs). The visible name is the Felis / TAP_SCHEMA table The backend name is the actual Qserv / BigQuery table name. Example: ["dp1.Object:dp1_pilot.Object"] rewrites references to dp1.Object so they query dp1_pilot.Object instead. |
 | config.sentryEnabled | bool | `false` | Whether Sentry is enabled in this environment |
@@ -111,7 +111,9 @@ IVOA TAP service
 | tapSchema.resources | object | See `values.yaml` | Resource limits and requests for the TAP schema database pod |
 | tapSchema.tapadm | object | `{"maxActive":2}` | Connection pool configuration for jdbc/tapadm |
 | tapSchema.tapadm.maxActive | int | `2` | Maximum active connections (maxIdle will be set to this value) |
-| tapSchema.tapuser | object | `{"maxActive":3}` | Connection pool configuration for jdbc/tapuser (query planning and tap_upload) |
+| tapSchema.tapschemauser | object | `{"maxActive":3}` | Connection pool configuration for jdbc/tapschemauser |
+| tapSchema.tapschemauser.maxActive | int | `3` | Maximum active connections (maxIdle will be set to this value) |
+| tapSchema.tapuser | object | `{"maxActive":3}` | Connection pool configuration for jdbc/tapuser |
 | tapSchema.tapuser.maxActive | int | `3` | Maximum active connections (maxIdle will be set to this value) |
 | tapSchema.tolerations | list | Tolerate GKE arm64 taint | Tolerations for the TAP schema database pod |
 | tapSchema.type | string | "containerized" | Database backend type: "containerized", "cloudsql", or "external" |

--- a/charts/cadc-tap/templates/_helpers.tpl
+++ b/charts/cadc-tap/templates/_helpers.tpl
@@ -52,6 +52,16 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Validate the configured data backend is one of the allowed values.
+*/}}
+{{- define "cadc-tap.validateBackend" -}}
+  {{- $validBackends := list "pg" "qserv" "bigquery" -}}
+  {{- if not (has .Values.config.backend $validBackends) -}}
+    {{- fail (printf "config.backend must be set to one of: %s (got '%s')" (join ", " $validBackends) .Values.config.backend) -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
 Validate database type is one of the allowed values.
 */}}
 {{- define "cadc-tap.validateDatabaseType" -}}
@@ -59,26 +69,6 @@ Validate database type is one of the allowed values.
   {{- $type := . -}}
   {{- if not (has $type $validTypes) -}}
     {{- fail (printf "Invalid database type '%s'. Must be one of: %s" $type (join ", " $validTypes)) -}}
-  {{- end -}}
-{{- end -}}
-
-{{/*
-Generate JDBC URL for a database service.
-*/}}
-{{- define "cadc-tap.jdbcUrl" -}}
-  {{- $service := .service -}}
-  {{- $serviceName := .serviceName -}}
-  {{- $context := .context -}}
-  {{- if eq $service.type "cloudsql" -}}
-    jdbc:postgresql://localhost:5432/{{ $service.database }}
-  {{- else if eq $service.type "external" -}}
-    jdbc:postgresql://{{ $service.external.host }}:{{ $service.external.port }}/{{ $service.database }}
-  {{- else -}}
-    {{- if eq $serviceName "tap-schema-db" -}}
-    jdbc:mysql://{{ template "cadc-tap.fullname" $context }}-tap-schema-db/
-    {{- else if eq $serviceName "uws-db" -}}
-    jdbc:postgresql://{{ template "cadc-tap.fullname" $context }}-uws-db/
-    {{- end -}}
   {{- end -}}
 {{- end -}}
 

--- a/charts/cadc-tap/templates/configmap.yaml
+++ b/charts/cadc-tap/templates/configmap.yaml
@@ -10,17 +10,137 @@ data:
     # Ignore this, it's only here to satisfy the availability check.
     ivo://ivoa.net/std/CDP#proxy-1.0 = ivo://cadc.nrc.ca/cred
     ivo://ivoa.net/sso#tls-with-password = {{ .Values.global.baseUrl }}
+
   catalina.properties: |
-    # tomcat properties
+    {{- $fullname := include "cadc-tap.fullname" . -}}
+    {{- $isPg := eq .Values.config.backend "pg" -}}
+
+    {{- /* tap_schema connection (shared by jdbc/tapschemauser and jdbc/tapadm) */ -}}
+    {{- $tsDriver := "org.postgresql.Driver" -}}
+    {{- $tsUrl := printf "jdbc:postgresql://localhost:5432/%s" .Values.tapSchema.database -}}
+    {{- if eq .Values.tapSchema.type "containerized" -}}
+      {{- $tsDriver = "com.mysql.cj.jdbc.Driver" -}}
+      {{- $tsUrl = printf "jdbc:mysql://%s-schema-db:3306/" $fullname -}}
+    {{- else if eq .Values.tapSchema.type "external" -}}
+      {{- $tsUrl = printf "jdbc:postgresql://%s:%v/%s" .Values.tapSchema.external.host .Values.tapSchema.external.port .Values.tapSchema.database -}}
+    {{- end -}}
+
+    {{- /* uws connection (jdbc/uws) -- always PostgreSQL */ -}}
+    {{- $uwsUrl := printf "jdbc:postgresql://localhost:5432/%s" .Values.uws.database -}}
+    {{- if eq .Values.uws.type "containerized" -}}
+      {{- $uwsUrl = printf "jdbc:postgresql://%s-uws-db/" $fullname -}}
+    {{- else if eq .Values.uws.type "external" -}}
+      {{- $uwsUrl = printf "jdbc:postgresql://%s:%v/%s" .Values.uws.external.host .Values.uws.external.port .Values.uws.database -}}
+    {{- end }}
+    # tomcat connector
     tomcat.connector.connectionTimeout=20000
     tomcat.connector.keepAliveTimeout=120000
     tomcat.connector.secure=false
     tomcat.connector.scheme=http
     tomcat.connector.proxyName={{ .Values.global.host }}
     tomcat.connector.proxyPort=80
-
-    # authentication provider
     ca.nrc.cadc.auth.IdentityManager=org.opencadc.auth.StandardIdentityManager
+    ca.nrc.cadc.util.PropertiesReader.dir=/config/
+
+    # tap_schema database: jdbc/tapschemauser and
+    # jdbc/tapadm are the same connection, different pools.
+    tapschemauser.username={{ .Values.tapSchema.username }}
+    tapschemauser.driverClassName={{ $tsDriver }}
+    tapschemauser.url={{ $tsUrl }}
+    tapschemauser.maxActive={{ .Values.tapSchema.tapschemauser.maxActive }}
+    tapadm.maxActive={{ .Values.tapSchema.tapadm.maxActive }}
+
+    # jdbc/tapuser is the primary query connection, data database for the
+    # pg backend, or tap_schema otherwise.
+    {{- if $isPg }}
+    tap.username={{ .Values.config.pg.username }}
+    tap.driverClassName=org.postgresql.Driver
+    tap.url=jdbc:postgresql://{{ .Values.config.pg.host }}/{{ .Values.config.pg.database }}
+    tap.maxActive=100
+    {{- else }}
+    tap.username={{ .Values.tapSchema.username }}
+    tap.driverClassName={{ $tsDriver }}
+    tap.url={{ $tsUrl }}
+    tap.maxActive={{ .Values.tapSchema.tapuser.maxActive }}
+    {{- end }}
+    # kept for the 2.x direct-Qserv image, whose context.xml still reads it
+    tapuser.maxActive={{ .Values.tapSchema.tapuser.maxActive }}
+
+    # jdbc/uws
+    uws.username={{ .Values.uws.username }}
+    uws.driverClassName=org.postgresql.Driver
+    uws.url={{ $uwsUrl }}
+    uws.maxActive={{ .Values.uws.maxActive }}
+    {{- if and (eq .Values.config.backend "qserv") (not .Values.config.kafka.enabled) }}
+
+    # direct-to-Qserv execution (no Kafka)
+    qservuser.username=qsmaster
+    qservuser.driverClassName=com.mysql.cj.jdbc.Driver
+    qservuser.url=jdbc:mysql://{{ .Values.config.qserv.host }}/{{ .Values.config.qserv.jdbcParams }}
+    qservuser.maxActive=100
+    {{- end }}
+    {{- if eq .Values.config.backend "bigquery" }}
+
+    tap.bigquery.project={{ .Values.config.bigquery.project }}
+    tap.bigquery.dataset={{ .Values.config.bigquery.dataset }}
+    {{- with .Values.config.bigquery.schema }}
+    tap.bigquery.schema={{ . }}
+    {{- end }}
+    {{- end }}
+    {{- with .Values.config.qserv.schemaMappings }}
+    tap.schema.mappings={{ . }}
+    {{- end }}
+    {{- if .Values.config.qserv.tableMappings }}
+    tap.table.mappings={{ .Values.config.qserv.tableMappings | join "," }}
+    {{- end }}
+
+    # service configuration
+    base_url={{ .Values.global.baseUrl }}
+    path_prefix=/api/{{ .Values.ingress.path }}
+    gafaelfawr_url={{ .Values.global.baseUrl }}/auth/api/v1/user-info
+    database={{ .Values.config.database }}
+    gcs_bucket={{ .Values.config.gcsBucket }}
+    gcs_bucket_url={{ .Values.config.gcsBucketUrl }}
+    gcs_bucket_type={{ .Values.config.gcsBucketType }}
+    url.rewrite.enabled={{ .Values.config.urlRewrite.enabled | default true }}
+    url.rewrite.rules={{ .Values.config.urlRewrite.rules | default (list "ivoa.ObsCore:access_url") | join "," }}
+    {{- if .Values.config.kafka.enabled }}
+
+    # kafka
+    kafka.ssl.truststore=/etc/cadc-tap/kafka/ca.crt
+    kafka.ssl.keystore=/etc/cadc-tap/kafka/user.crt
+    kafka.ssl.key=/etc/cadc-tap/kafka/user.key
+    kafka.query.topic={{ .Values.config.kafka.topics.jobRun }}
+    kafka.status.topic={{ .Values.config.kafka.topics.jobStatus }}
+    kafka.delete.topic={{ .Values.config.kafka.topics.jobDelete }}
+    {{- end }}
+
+    {{- /* Optional limits -- omit key to use the app default. */}}
+    {{- with .Values.config.outputLimit }}
+    tap.outputLimit={{ . }}
+    {{- end }}
+    {{- with .Values.config.outputLimitUnit }}
+    tap.outputLimitUnit={{ . }}
+    {{- end }}
+    {{- with .Values.config.maxRec }}
+    tap.maxRec={{ . }}
+    {{- end }}
+    {{- with .Values.config.maxExecutionDuration }}
+    tap.maxExecutionDuration={{ . }}
+    {{- end }}
+    {{- with .Values.config.maxDestruction }}
+    tap.maxDestruction={{ . }}
+    {{- end }}
+    {{- with .Values.config.maxQuote }}
+    tap.maxQuote={{ . }}
+    {{- end }}
+    {{- if .Values.config.voParquet }}
+    tap.enableVOParquet=true
+    {{- end }}
+    {{- if .Values.config.uploadPartitionDirectors }}
+    upload.partition.directors={{ .Values.config.uploadPartitionDirectors | join "," }}
+    {{- end }}
+
   tap-config.properties: |
     # URL rewrite configuration
     url.rewrite.enabled={{ .Values.config.urlRewrite.enabled | default true }}

--- a/charts/cadc-tap/templates/configmap.yaml
+++ b/charts/cadc-tap/templates/configmap.yaml
@@ -140,9 +140,3 @@ data:
     {{- if .Values.config.uploadPartitionDirectors }}
     upload.partition.directors={{ .Values.config.uploadPartitionDirectors | join "," }}
     {{- end }}
-
-  tap-config.properties: |
-    # URL rewrite configuration
-    url.rewrite.enabled={{ .Values.config.urlRewrite.enabled | default true }}
-    # Format: table1:column1,table2:column2,table3:column3
-    url.rewrite.rules={{ .Values.config.urlRewrite.rules | default "ivoa.ObsCore:access_url" }}

--- a/charts/cadc-tap/templates/tap-deployment.yaml
+++ b/charts/cadc-tap/templates/tap-deployment.yaml
@@ -1,3 +1,6 @@
+{{- include "cadc-tap.validateBackend" . }}
+{{- include "cadc-tap.validateDatabaseType" .Values.tapSchema.type }}
+{{- include "cadc-tap.validateDatabaseType" .Values.uws.type }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -12,10 +15,11 @@ spec:
       app.kubernetes.io/component: "server"
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "cadc-tap.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: "server"
@@ -61,15 +65,17 @@ spec:
                 cd ..
               done
 
-              {{- if eq .Values.config.backend "bigquery" }}
-              # Swap to BigQuery PluginFactory
+              # Select the PluginFactory for the configured backend
               for dir in /var/lib/tomcat/webapps/*/; do
-                if [ -f "${dir}WEB-INF/classes/PluginFactory-bigquery.properties" ]; then
-                  cp "${dir}WEB-INF/classes/PluginFactory-bigquery.properties" "${dir}WEB-INF/classes/PluginFactory.properties"
-                  echo "Using BigQuery PluginFactory.properties in $dir"
+                src="${dir}WEB-INF/classes/PluginFactory-{{ .Values.config.backend }}.properties"
+                if [ -f "$src" ]; then
+                  cp "$src" "${dir}WEB-INF/classes/PluginFactory.properties"
+                  echo "Using {{ .Values.config.backend }} PluginFactory.properties in $dir"
+                else
+                  echo "ERROR: $src not found in $dir" >&2
+                  exit 1
                 fi
               done
-              {{- end }}
 
               echo "org.apache.catalina.startup.VersionLoggerListener.level = OFF" >> /var/lib/tomcat/conf/logging.properties
           securityContext:
@@ -111,119 +117,36 @@ spec:
             runAsGroup: 1001
           env:
             - name: CATALINA_OPTS
+              {{- /*
+                Service and database configuration lives in the
+                catalina.properties key of the cadc-tap-config ConfigMap, which
+                the entrypoint appends to Tomcat's catalina.properties so every
+                entry becomes a system property. Only the JVM heap size and the
+                database passwords stay here.
+              */}}
               value: >-
-                -Dtapschemauser.username={{ .Values.tapSchema.username }}
+                -Xmx{{ .Values.config.jvmMaxHeapSize }}
                 -Dtapschemauser.password=$TAP_SCHEMA_PASSWORD
-                {{- if eq .Values.tapSchema.type "containerized" }}
-                -Dtapschemauser.driverClassName=com.mysql.cj.jdbc.Driver
-                -Dtapschemauser.url=jdbc:mysql://{{ template "cadc-tap.fullname" . }}-schema-db:3306/
-                {{- else if eq .Values.tapSchema.type "external" }}
-                -Dtapschemauser.driverClassName=org.postgresql.Driver
-                -Dtapschemauser.url=jdbc:postgresql://{{ .Values.tapSchema.external.host }}:{{ .Values.tapSchema.external.port }}/{{ .Values.tapSchema.database }}
-                {{- else }}
-                -Dtapschemauser.driverClassName=org.postgresql.Driver
-                -Dtapschemauser.url=jdbc:postgresql://localhost:5432/{{ .Values.tapSchema.database }}
-                {{- end }}
-                -Dtapschemauser.maxActive={{ .Values.tapSchema.tapuser.maxActive }}
-                -Dtapadm.maxActive={{ .Values.tapSchema.tapadm.maxActive }}
-                -Dtapuser.maxActive={{ .Values.tapSchema.tapuser.maxActive }}
-                -Duws.username={{ .Values.uws.username }}
                 {{- if or (eq .Values.uws.type "cloudsql") (eq .Values.uws.type "external") }}
                 -Duws.password=$UWS_DB_PASSWORD
                 {{- end }}
-                {{- if eq .Values.uws.type "containerized" }}
-                -Duws.url=jdbc:postgresql://{{ template "cadc-tap.fullname" . }}-uws-db/
-                {{- else if eq .Values.uws.type "external" }}
-                -Duws.url=jdbc:postgresql://{{ .Values.uws.external.host }}:{{ .Values.uws.external.port }}/{{ .Values.uws.database }}
-                {{- else }}
-                -Duws.url=jdbc:postgresql://localhost:5432/{{ .Values.uws.database }}
-                {{- end }}
-                -Duws.driverClassName=org.postgresql.Driver
-                -Duws.maxActive={{ .Values.uws.maxActive }}
                 {{- if eq .Values.config.backend "pg" }}
-                -Dtap.username={{ .Values.config.pg.username }}
                 -Dtap.password=$TAP_DB_PASSWORD
-                -Dtap.url=jdbc:postgresql://{{ .Values.config.pg.host }}/{{ .Values.config.pg.database }}
-                -Dtap.maxActive=100
-                -Dqservuser.username=unused
-                -Dqservuser.password=unused
-                -Dqservuser.driverClassName=com.mysql.cj.jdbc.Driver
-                -Dqservuser.url=jdbc:mysql://localhost:3306/unused
-                -Dqservuser.maxActive=1
-                {{- else if eq .Values.config.backend "bigquery" }}
-                -Dtap.bigquery.project={{ .Values.config.bigquery.project }}
-                -Dtap.bigquery.dataset={{ .Values.config.bigquery.dataset }}
-                {{- if .Values.config.bigquery.schema }}
-                -Dtap.bigquery.schema={{ .Values.config.bigquery.schema }}
-                {{- end }}
-                -Dqservuser.username=unused
-                -Dqservuser.password=unused
-                -Dqservuser.driverClassName=com.mysql.cj.jdbc.Driver
-                -Dqservuser.url=jdbc:mysql://localhost:3306/unused
-                -Dqservuser.maxActive=1
                 {{- else }}
-                -Dqservuser.username=qsmaster
+                -Dtap.password=$TAP_SCHEMA_PASSWORD
+                {{- end }}
+                {{- if and (eq .Values.config.backend "qserv") (not .Values.config.kafka.enabled) }}
                 -Dqservuser.password=$QSERV_DB_PASSWORD
-                -Dqservuser.driverClassName=com.mysql.cj.jdbc.Driver
-                -Dqservuser.url=jdbc:mysql://{{ .Values.config.qserv.host }}/{{ .Values.config.qserv.jdbcParams }}
-                -Dqservuser.maxActive=100
-                {{- if .Values.config.qserv.schemaMappings }}
-                -Dtap.schema.mappings={{ .Values.config.qserv.schemaMappings }}
                 {{- end }}
-                {{- if .Values.config.qserv.tableMappings }}
-                -Dtap.table.mappings={{ .Values.config.qserv.tableMappings | join "," }}
-                {{- end }}
-                {{- end }}
-                -Dgafaelfawr_url={{ .Values.global.baseUrl }}/auth/api/v1/user-info
-                -Dgcs_bucket={{ .Values.config.gcsBucket }}
-                -Dgcs_bucket_url={{ .Values.config.gcsBucketUrl }}
-                -Dgcs_bucket_type={{ .Values.config.gcsBucketType }}
-                -Ddatabase={{ .Values.config.database }}
-                {{- if .Values.config.kafka.enabled }}
-                -Dkafka.ssl.truststore=/etc/cadc-tap/kafka/ca.crt
-                -Dkafka.ssl.keystore=/etc/cadc-tap/kafka/user.crt
-                -Dkafka.ssl.key=/etc/cadc-tap/kafka/user.key
-                -Dkafka.query.topic={{ .Values.config.kafka.topics.jobRun }}
-                -Dkafka.status.topic={{ .Values.config.kafka.topics.jobStatus }}
-                -Dkafka.delete.topic={{ .Values.config.kafka.topics.jobDelete }}
-                {{- end }}
-                {{- if .Values.config.outputLimit }}
-                -Dtap.outputLimit={{ .Values.config.outputLimit }}
-                {{- end }}
-                {{- if .Values.config.outputLimitUnit }}
-                -Dtap.outputLimitUnit={{ .Values.config.outputLimitUnit }}
-                {{- end }}
-                {{- if .Values.config.maxRec }}
-                -Dtap.maxRec={{ .Values.config.maxRec }}
-                {{- end }}
-                {{- if .Values.config.maxExecutionDuration }}
-                -Dtap.maxExecutionDuration={{ .Values.config.maxExecutionDuration }}
-                {{- end }}
-                {{- if .Values.config.maxDestruction }}
-                -Dtap.maxDestruction={{ .Values.config.maxDestruction }}
-                {{- end }}
-                {{- if .Values.config.maxQuote }}
-                -Dtap.maxQuote={{ .Values.config.maxQuote }}
-                {{- end }}
-                {{- if .Values.config.voParquet }}
-                -Dtap.enableVOParquet=true
-                {{- end }}
-                {{- if .Values.config.uploadPartitionDirectors }}
-                -Dupload.partition.directors={{ .Values.config.uploadPartitionDirectors | join "," }}
-                {{- end }}
-                -Dbase_url={{ .Values.global.baseUrl }}
-                -Dpath_prefix=/api/{{ .Values.ingress.path }}
-                -Dca.nrc.cadc.util.PropertiesReader.dir=/config/
-                -Durl.rewrite.enabled={{ .Values.config.urlRewrite.enabled | default true }}
-                -Durl.rewrite.rules="{{ .Values.config.urlRewrite.rules | default (list "ivoa.ObsCore:access_url") | join "," }}"
-                -Xmx{{ .Values.config.jvmMaxHeapSize }}
+            - name: "BACKEND"
+              value: {{ .Values.config.backend | quote }}
             - name: "CATALINA_BASE"
               value: "/var/lib/tomcat"
             - name: "CATALINA_HOME"
               value: "/usr/share/tomcat"
             - name: "HOME"
               value: "/home/tomcat"
-            {{- if (and (eq .Values.config.backend "qserv") .Values.config.qserv.passwordEnabled) }}
+            {{- if (and (eq .Values.config.backend "qserv") (not .Values.config.kafka.enabled) .Values.config.qserv.passwordEnabled) }}
             - name: "QSERV_DB_PASSWORD"
               valueFrom:
                 secretKeyRef:

--- a/charts/cadc-tap/templates/tap-deployment.yaml
+++ b/charts/cadc-tap/templates/tap-deployment.yaml
@@ -71,8 +71,10 @@ spec:
                 if [ -f "$src" ]; then
                   cp "$src" "${dir}WEB-INF/classes/PluginFactory.properties"
                   echo "Using {{ .Values.config.backend }} PluginFactory.properties in $dir"
+                elif [ -f "${dir}WEB-INF/classes/PluginFactory.properties" ]; then
+                  echo "WARNING: $src not found, using the image's default PluginFactory.properties in $dir" >&2
                 else
-                  echo "ERROR: $src not found in $dir" >&2
+                  echo "ERROR: neither $src nor a default PluginFactory.properties found in $dir" >&2
                   exit 1
                 fi
               done

--- a/charts/cadc-tap/tests/configmap_test.yaml
+++ b/charts/cadc-tap/tests/configmap_test.yaml
@@ -1,0 +1,141 @@
+suite: catalina.properties datasource configuration
+templates:
+  - configmap.yaml
+
+set:
+  global:
+    host: "example.com"
+    baseUrl: "https://example.com"
+
+tests:
+  - it: tap_schema external -> postgresql url + driver
+    set:
+      tapSchema:
+        type: "external"
+        username: "TAP_SCHEMA"
+        database: "tap_schema"
+        external: {host: "tap-schema-address", port: 5432}
+    asserts:
+      - matchRegex:
+          path: data["catalina.properties"]
+          pattern: "tapschemauser.url=jdbc:postgresql://tap-schema-address:5432/tap_schema"
+      - matchRegex:
+          path: data["catalina.properties"]
+          pattern: "tapschemauser.driverClassName=org.postgresql.Driver"
+
+  - it: tap_schema containerized -> mysql url + driver
+    set:
+      tapSchema: {type: "containerized", username: "TAP_SCHEMA"}
+    asserts:
+      - matchRegex:
+          path: data["catalina.properties"]
+          pattern: "tapschemauser.url=jdbc:mysql://cadc-tap-schema-db:3306/"
+      - matchRegex:
+          path: data["catalina.properties"]
+          pattern: "tapschemauser.driverClassName=com.mysql.cj.jdbc.Driver"
+
+  - it: tap_schema cloudsql -> localhost:5432
+    set:
+      tapSchema: {type: "cloudsql", username: "schemauser", database: "schemadb"}
+    asserts:
+      - matchRegex:
+          path: data["catalina.properties"]
+          pattern: "tapschemauser.username=schemauser"
+      - matchRegex:
+          path: data["catalina.properties"]
+          pattern: "tapschemauser.url=jdbc:postgresql://localhost:5432/schemadb"
+
+  - it: uws cloudsql -> localhost:5432
+    set:
+      uws: {type: "cloudsql", username: "uwsuser", database: "uwsdb"}
+    asserts:
+      - matchRegex:
+          path: data["catalina.properties"]
+          pattern: "uws.username=uwsuser"
+      - matchRegex:
+          path: data["catalina.properties"]
+          pattern: "uws.url=jdbc:postgresql://localhost:5432/uwsdb"
+
+  - it: uws external -> host:port/db
+    set:
+      uws:
+        type: "external"
+        username: "externaluser"
+        database: "externaldb"
+        external: {host: "external-db.example.com", port: 5432}
+    asserts:
+      - matchRegex:
+          path: data["catalina.properties"]
+          pattern: "uws.url=jdbc:postgresql://external-db.example.com:5432/externaldb"
+
+  - it: pg backend -> jdbc/tapuser points at the data database
+    set:
+      config:
+        backend: "pg"
+        pg: {username: "postgres", host: "postgres-server", database: "tapdb"}
+    asserts:
+      - matchRegex:
+          path: data["catalina.properties"]
+          pattern: "tap.url=jdbc:postgresql://postgres-server/tapdb"
+      - matchRegex:
+          path: data["catalina.properties"]
+          pattern: "tap.maxActive=100"
+
+  - it: qserv + kafka -> no qservuser, jdbc/tapuser = tap_schema
+    set:
+      tapSchema: {type: "containerized", username: "TAP_SCHEMA"}
+      config:
+        backend: "qserv"
+        qserv: {host: "qserv:30040"}
+        kafka: {enabled: true}
+    asserts:
+      - matchRegex:
+          path: data["catalina.properties"]
+          pattern: "tap.url=jdbc:mysql://cadc-tap-schema-db:3306/"
+      - notMatchRegex:
+          path: data["catalina.properties"]
+          pattern: "qservuser"
+
+  - it: qserv direct (no kafka) -> jdbc/qservuser configured
+    set:
+      config:
+        backend: "qserv"
+        qserv: {host: "qserv:30040"}
+    asserts:
+      - matchRegex:
+          path: data["catalina.properties"]
+          pattern: "qservuser.username=qsmaster"
+      - matchRegex:
+          path: data["catalina.properties"]
+          pattern: "qservuser.url=jdbc:mysql://qserv:30040/"
+
+  - it: bigquery -> project/dataset set
+    set:
+      config:
+        backend: "bigquery"
+        kafka: {enabled: true}
+        bigquery: {project: "my-project", dataset: "my-dataset"}
+    asserts:
+      - matchRegex:
+          path: data["catalina.properties"]
+          pattern: "tap.bigquery.project=my-project"
+      - matchRegex:
+          path: data["catalina.properties"]
+          pattern: "tap.bigquery.dataset=my-dataset"
+
+  - it: GCS / S3 result bucket configuration
+    set:
+      config:
+        gcsBucket: "async-results.lsst.codes"
+        gcsBucketUrl: "https://async-results.codes:8080"
+        gcsBucketType: "S3"
+    asserts:
+      - matchRegex:
+          path: data["catalina.properties"]
+          pattern: "gcs_bucket=async-results.lsst.codes"
+      - matchRegex:
+          path: data["catalina.properties"]
+          pattern: "gcs_bucket_url=https://async-results.codes:8080"
+      - matchRegex:
+          path: data["catalina.properties"]
+          pattern: "gcs_bucket_type=S3"

--- a/charts/cadc-tap/tests/tap-deployment_test.yaml
+++ b/charts/cadc-tap/tests/tap-deployment_test.yaml
@@ -66,6 +66,19 @@ tests:
       - isNotNullOrEmpty:
           path: spec.template.metadata.annotations["checksum/config"]
 
+  - it: selects the backend PluginFactory but tolerates an image without one
+    template: "tap-deployment.yaml"
+    set:
+      config: {backend: "pg", pg: {host: "h", database: "d", username: "u"}}
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: 'PluginFactory-pg\.properties'
+      # older images ship only PluginFactory.properties -- fall back, do not exit 1
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "using the image's default PluginFactory.properties"
+
   - it: fails when cloudsql is enabled but instanceConnectionName is unset
     template: "tap-deployment.yaml"
     set:

--- a/charts/cadc-tap/tests/tap-deployment_test.yaml
+++ b/charts/cadc-tap/tests/tap-deployment_test.yaml
@@ -1,195 +1,21 @@
 suite: TAP deployment
+# configmap.yaml is listed so the deployment's checksum/config `include` resolves
 templates:
   - tap-deployment.yaml
+  - configmap.yaml
+
+set:
+  global:
+    host: "example.com"
+    baseUrl: "https://example.com"
+  config:
+    backend: "qserv"
+    serviceName: "tap"
 
 tests:
-  - it: Should configure environment variables correctly for PostgreSQL backend
+  - it: passes the tap_schema password through CATALINA_OPTS for shell expansion
+    template: "tap-deployment.yaml"
     set:
-      global:
-        host: "example.com"
-      uws:
-        type: "cloudsql"
-        username: "mydb"
-        database: "mydb"
-        useVaultPassword: true
-      cloudsql:
-        enabled: true
-        instanceConnectionName: "science-platform--xyz:test"
-        serviceAccount: "sa@xyz"
-      serviceAccount:
-        create: true
-        name: "sa"
-      config:
-        pg:
-          username: "postgres"
-          host: "postgres-server"
-          database: "tapdb"
-          image:
-            repository: "postgres"
-            tag: "latest"
-            pullPolicy: "IfNotPresent"
-    asserts:
-      - matchRegex:
-          path: spec.template.spec.containers[0].env[0].value
-          pattern: "-Duws.username=mydb"
-      - matchRegex:
-          path: spec.template.spec.containers[0].env[0].value
-          pattern: "-Duws.url=jdbc:postgresql://localhost:5432/mydb"
-      - matchRegex:
-          path: spec.template.spec.containers[0].env[0].value
-          pattern: "-Duws.password=\\$UWS_DB_PASSWORD"
-
-  - it: Should setup TAP_SCHEMA database configuration with external address
-    set:
-      global:
-        host: "example.com"
-      tapSchema:
-        type: "external"
-        username: "TAP_SCHEMA"
-        database: "tap_schema"
-        useVaultPassword: true
-        external:
-          host: "tap-schema-address"
-          port: 5432
-    asserts:
-      - matchRegex:
-          path: spec.template.spec.containers[0].env[0].value
-          pattern: "-Dtapschemauser.url=jdbc:postgresql://tap-schema-address:5432/tap_schema"
-      - matchRegex:
-          path: spec.template.spec.containers[0].env[0].value
-          pattern: "-Dtapschemauser.driverClassName=org.postgresql.Driver"
-
-  - it: Should setup TAP_SCHEMA database configuration with containerized
-    set:
-      global:
-        host: "example.com"
-      tapSchema:
-        type: "containerized"
-        username: "TAP_SCHEMA"
-        password: "TAP_SCHEMA"
-        useVaultPassword: false
-    asserts:
-      - matchRegex:
-          path: spec.template.spec.containers[0].env[0].value
-          pattern: "-Dtapschemauser.url=jdbc:mysql://cadc-tap-schema-db:3306/"
-      - matchRegex:
-          path: spec.template.spec.containers[0].env[0].value
-          pattern: "-Dtapschemauser.driverClassName=com.mysql.cj.jdbc.Driver"
-
-  - it: Create GCS bucket configuration with QServ and CloudSQL UWS database
-    set:
-      cloudsql:
-        enabled: true
-        instanceConnectionName: "science-platform--xyz:test"
-        serviceAccount: "sa@xyz"
-      uws:
-        type: "cloudsql"
-        username: "mydb"
-        database: "mydb"
-        useVaultPassword: true
-      serviceAccount:
-        create: true
-        name: "sa"
-      global:
-        host: "example.com"
-      config:
-        backend: "qserv"
-        qserv:
-          host: "qserv:30040"
-        gcsBucket: "async-results.lsst.codes"
-        gcsBucketUrl: "https://async-results.codes:8080"
-        gcsBucketType: "S3"
-    asserts:
-      - matchRegex:
-          path: spec.template.spec.containers[0].env[0].value
-          pattern: "-Duws.username=mydb"
-      - matchRegex:
-          path: spec.template.spec.containers[0].env[0].value
-          pattern: "-Duws.url=jdbc:postgresql://localhost:5432/mydb"
-      - matchRegex:
-          path: spec.template.spec.containers[0].env[0].value
-          pattern: "-Duws.password=\\$UWS_DB_PASSWORD"
-      - equal:
-          path: spec.template.spec.serviceAccountName
-          value: "sa"
-      - matchRegex:
-          path: spec.template.spec.containers[0].env[0].value
-          pattern: "-Dqservuser.username=qsmaster"
-      - matchRegex:
-          path: spec.template.spec.containers[0].env[0].value
-          pattern: "-Dqservuser.url=jdbc:mysql://qserv:30040/"
-      - matchRegex:
-          path: spec.template.spec.containers[0].env[0].value
-          pattern: "-Dgcs_bucket=async-results.lsst.codes"
-      - matchRegex:
-          path: spec.template.spec.containers[0].env[0].value
-          pattern: "-Dgcs_bucket_url=https://async-results.codes:8080"
-      - matchRegex:
-          path: spec.template.spec.containers[0].env[0].value
-          pattern: "-Dgcs_bucket_type=S3"
-
-  - it: Test that deployment build fails when cloudsql is enabled but no instanceConnectionName
-    set:
-      cloudsql:
-        enabled: true
-        serviceAccount: "sa@xyz"
-        database: "mydb"
-      global:
-        host: "example.com"
-    asserts:
-      - failedTemplate:
-          errorMessage: cloudsql.instanceConnectionName must be specified
-
-  - it: Test that we configure UWS with CloudSQL database
-    set:
-      global:
-        host: "example.com"
-      uws:
-        type: "cloudsql"
-        username: "uwsuser"
-        database: "uwsdb"
-      cloudsql:
-        enabled: true
-        instanceConnectionName: "project:region:instance"
-        serviceAccount: "sa@project.iam.gserviceaccount.com"
-      serviceAccount:
-        create: true
-        name: "sa"
-    asserts:
-      - matchRegex:
-          path: spec.template.spec.containers[0].env[0].value
-          pattern: "-Duws.username=uwsuser"
-      - matchRegex:
-          path: spec.template.spec.containers[0].env[0].value
-          pattern: "-Duws.url=jdbc:postgresql://localhost:5432/uwsdb"
-
-  - it: Test that we configure TAP_SCHEMA with CloudSQL database
-    set:
-      global:
-        host: "example.com"
-      tapSchema:
-        type: "cloudsql"
-        username: "schemauser"
-        database: "schemadb"
-      cloudsql:
-        enabled: true
-        instanceConnectionName: "project:region:instance"
-        serviceAccount: "sa@project.iam.gserviceaccount.com"
-      serviceAccount:
-        create: true
-        name: "sa"
-    asserts:
-      - matchRegex:
-          path: spec.template.spec.containers[0].env[0].value
-          pattern: "-Dtapschemauser.username=schemauser"
-      - matchRegex:
-          path: spec.template.spec.containers[0].env[0].value
-          pattern: "-Dtapschemauser.url=jdbc:postgresql://localhost:5432/schemadb"
-
-  - it: Test that TAP_SCHEMA uses inline password for containerized
-    set:
-      global:
-        host: "example.com"
       tapSchema:
         type: "containerized"
         username: "TAP_SCHEMA"
@@ -199,14 +25,14 @@ tests:
       - matchRegex:
           path: spec.template.spec.containers[0].env[0].value
           pattern: "-Dtapschemauser.password=\\$TAP_SCHEMA_PASSWORD"
-      - matchRegex:
+      # datasource URLs/drivers now live in the ConfigMap, not CATALINA_OPTS
+      - notMatchRegex:
           path: spec.template.spec.containers[0].env[0].value
-          pattern: "-Dtapschemauser.url=jdbc:mysql://cadc-tap-schema-db:3306/"
+          pattern: "-Dtapschemauser.url="
 
-  - it: Test that we set UWS_DB_PASSWORD from secret for CloudSQL
+  - it: passes UWS_DB_PASSWORD from the secret for a CloudSQL UWS database
+    template: "tap-deployment.yaml"
     set:
-      global:
-        host: "example.com"
       uws:
         type: "cloudsql"
         username: "uwsuser"
@@ -216,36 +42,42 @@ tests:
         enabled: true
         instanceConnectionName: "project:region:instance"
         serviceAccount: "sa@project.iam.gserviceaccount.com"
-      serviceAccount:
-        create: true
-        name: "sa"
+      serviceAccount: {create: true, name: "sa"}
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].env[0].value
-          pattern: "-Duws.url=jdbc:postgresql://localhost:5432/uwsdb"
-      - matchRegex:
-          path: spec.template.spec.containers[0].env[0].value
           pattern: "-Duws.password=\\$UWS_DB_PASSWORD"
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: "sa"
 
-  - it: Test that we configure UWS with external database
+  - it: omits the UWS password for a containerized UWS database
+    template: "tap-deployment.yaml"
     set:
-      global:
-        host: "example.com"
-      uws:
-        type: "external"
-        username: "externaluser"
-        database: "externaldb"
-        useVaultPassword: true
-        external:
-          host: "external-db.example.com"
-          port: 5432
+      uws: {type: "containerized", username: "postgres", database: "postgres"}
     asserts:
-      - matchRegex:
+      - notMatchRegex:
           path: spec.template.spec.containers[0].env[0].value
-          pattern: "-Duws.username=externaluser"
-      - matchRegex:
-          path: spec.template.spec.containers[0].env[0].value
-          pattern: "-Duws.url=jdbc:postgresql://external-db.example.com:5432/externaldb"
-      - matchRegex:
-          path: spec.template.spec.containers[0].env[0].value
-          pattern: "-Duws.password=\\$UWS_DB_PASSWORD"
+          pattern: "-Duws.password"
+
+  - it: rolls the pods when the config changes (checksum annotation)
+    template: "tap-deployment.yaml"
+    asserts:
+      - isNotNullOrEmpty:
+          path: spec.template.metadata.annotations["checksum/config"]
+
+  - it: fails when cloudsql is enabled but instanceConnectionName is unset
+    template: "tap-deployment.yaml"
+    set:
+      cloudsql: {enabled: true, serviceAccount: "sa@xyz", database: "mydb"}
+    asserts:
+      - failedTemplate:
+          errorMessage: cloudsql.instanceConnectionName must be specified
+
+  - it: fails on an invalid config.backend
+    template: "tap-deployment.yaml"
+    set:
+      config: {backend: "mysql"}
+    asserts:
+      - failedTemplate:
+          errorPattern: "config.backend must be set to one of: pg, qserv, bigquery"

--- a/charts/cadc-tap/values.yaml
+++ b/charts/cadc-tap/values.yaml
@@ -70,13 +70,13 @@ config:
 
     image:
       # -- TAP image to use
-      repository: "ghcr.io/lsst-sqre/tap-postgres-service"
+      repository: "ghcr.io/lsst-sqre/lsst-tap-service"
 
       # -- Pull policy for the TAP image
       pullPolicy: "IfNotPresent"
 
-      # -- Tag of TAP image to use
-      tag: "1.26.1"
+      # -- Tag of TAP image to use.
+      tag: "3.25.0"
 
   qserv:
     # -- QServ hostname:port to connect to
@@ -107,7 +107,8 @@ config:
       # -- Tag of TAP image to use
       tag: "3.25.0"
 
-    # -- Whether the Qserv database is password protected
+    # -- Whether the Qserv database is password protected. Only used for
+    # direct-to-Qserv execution (`config.kafka.enabled: false`).
     # @default -- false
     passwordEnabled: false
 
@@ -191,7 +192,9 @@ config:
     # @default -- "tap"
     consumerGroupId: "tap"
 
-    # -- Whether kafka is enabled
+    # -- Whether kafka is enabled. For the `qserv` backend this also selects the
+    # execution mode: `true` dispatches queries to qserv-kafka, `false` runs the
+    # legacy direct-to-Qserv mode.
     enabled: false
 
   # -- Output limit value for TAP queries advertised in capabilities.
@@ -300,7 +303,12 @@ tapSchema:
     # -- Maximum active connections (maxIdle will be set to this value)
     maxActive: 2
 
-  # -- Connection pool configuration for jdbc/tapuser (query planning and tap_upload)
+  # -- Connection pool configuration for jdbc/tapschemauser
+  tapschemauser:
+    # -- Maximum active connections (maxIdle will be set to this value)
+    maxActive: 3
+
+  # -- Connection pool configuration for jdbc/tapuser
   tapuser:
     # -- Maximum active connections (maxIdle will be set to this value)
     maxActive: 3


### PR DESCRIPTION
PR to upgrade the TAP image and consolidate the tap-postgres and lsst-tap-service based apps onto a single image that supports Postgres / Qserv / BigQuery picked at runtime by a `BACKEND` env var. 

Postgres used to be its own image (tap-postgres-service), it's now just another backend. 
TAP PR: https://github.com/lsst-sqre/lsst-tap-service/pull/223 (the two need to merge together).

Changes include:

- Point the pg backend at ghcr.io/lsst-sqre/lsst-tap-service (was tap-postgres-service) and bump the image tag
- Wire up the `BACKEND` env var and make the PluginFactory swap work for every backend (fall back to the image's default `PluginFactory.properties` if there's no per-backend one)
- Move the datasource and service config out of the `CATALINA_OPTS -D` string into the catalina.properties key of the ConfigMap
- `config.kafka.enabled` now also picks the Qserv execution mode (Kafka bridge vs the old direct-to-Qserv)
- Add config.backend validation and a tapSchema.tapschemauser pool, fix tapschemauser.maxActive reading the wrong key

Tested with helm unittest and helm template for the qserv+kafka, pg and direct-qserv cases, plus deployed on idfdev for tap and ssotap.

**NOTE**: This needs a new release of the TAP service image first, as the dev environments are still set to the ticket branch.