### PR TITLE
Set HiPS quota of 1,000/minute on idfprod

### DIFF
--- a/applications/gafaelfawr/values-idfprod.yaml
+++ b/applications/gafaelfawr/values-idfprod.yaml
@@ -49,6 +49,7 @@ config:
   quota:
     default:
       api:
+        hips: 1000
         sia: 70
         tap: 1000
         vo-cutouts: 35


### PR DESCRIPTION
This seems roughly twice what normal vigorous usage produces.