### PR TITLE
[DM-54640] Review lsst.prompt database cardinality

### DIFF
--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -240,6 +240,7 @@ Rubin Observatory's telemetry service
 | influxdb-enterprise.data.config.cluster.termination-query-log | bool | `true` | Whether to log queries that are terminated due to resource limits |
 | influxdb-enterprise.data.config.continuousQueries.enabled | bool | `false` | Whether continuous queries are enabled |
 | influxdb-enterprise.data.config.data.cache-max-memory-size | int | `0` | Maximum size a shared cache can reach before it starts rejecting writes |
+| influxdb-enterprise.data.config.data.max-series-per-database | int | `10000000` | The maximum number of series allowed per database before writes are dropped when in-memory indexing is enabled. This is a safety mechanism to prevent OOM crashes when a large number of series are being written to the database. |
 | influxdb-enterprise.data.config.data.trace-logging-enabled | bool | `true` | Whether to enable verbose logging of additional debug information within the TSM engine and WAL |
 | influxdb-enterprise.data.config.data.wal-fsync-delay | string | `"100ms"` | Duration a write will wait before fsyncing. This is useful for slower disks or when WAL write contention is present. |
 | influxdb-enterprise.data.config.hintedHandoff.max-size | int | `107374182400` | Maximum size of the hinted-handoff queue in bytes |
@@ -337,6 +338,7 @@ Rubin Observatory's telemetry service
 | influxdb-enterprise-active.data.config.cluster.termination-query-log | bool | `true` | Whether to log queries that are terminated due to resource limits |
 | influxdb-enterprise-active.data.config.continuousQueries.enabled | bool | `false` | Whether continuous queries are enabled |
 | influxdb-enterprise-active.data.config.data.cache-max-memory-size | int | `0` | Maximum size a shared cache can reach before it starts rejecting writes |
+| influxdb-enterprise-active.data.config.data.max-series-per-database | int | `10000000` | The maximum number of series allowed per database before writes are dropped when in-memory indexing is enabled. This is a safety mechanism to prevent OOM crashes when a large number of series are being written to the database. |
 | influxdb-enterprise-active.data.config.data.trace-logging-enabled | bool | `true` | Whether to enable verbose logging of additional debug information within the TSM engine and WAL |
 | influxdb-enterprise-active.data.config.data.wal-fsync-delay | string | `"100ms"` | Duration a write will wait before fsyncing. This is useful for slower disks or when WAL write contention is present. |
 | influxdb-enterprise-active.data.config.hintedHandoff.max-size | int | `107374182400` | Maximum size of the hinted-handoff queue in bytes |
@@ -434,6 +436,7 @@ Rubin Observatory's telemetry service
 | influxdb-enterprise-standby.data.config.cluster.termination-query-log | bool | `true` | Whether to log queries that are terminated due to resource limits |
 | influxdb-enterprise-standby.data.config.continuousQueries.enabled | bool | `false` | Whether continuous queries are enabled |
 | influxdb-enterprise-standby.data.config.data.cache-max-memory-size | int | `0` | Maximum size a shared cache can reach before it starts rejecting writes |
+| influxdb-enterprise-standby.data.config.data.max-series-per-database | int | `10000000` | The maximum number of series allowed per database before writes are dropped when in-memory indexing is enabled. This is a safety mechanism to prevent OOM crashes when a large number of series are being written to the database. |
 | influxdb-enterprise-standby.data.config.data.trace-logging-enabled | bool | `true` | Whether to enable verbose logging of additional debug information within the TSM engine and WAL |
 | influxdb-enterprise-standby.data.config.data.wal-fsync-delay | string | `"100ms"` | Duration a write will wait before fsyncing. This is useful for slower disks or when WAL write contention is present. |
 | influxdb-enterprise-standby.data.config.hintedHandoff.max-size | int | `107374182400` | Maximum size of the hinted-handoff queue in bytes |

--- a/applications/sasquatch/charts/influxdb-enterprise/README.md
+++ b/applications/sasquatch/charts/influxdb-enterprise/README.md
@@ -25,6 +25,7 @@ Run InfluxDB Enterprise on Kubernetes
 | data.config.cluster.termination-query-log | bool | `true` | Whether to log queries that are terminated due to resource limits |
 | data.config.continuousQueries.enabled | bool | `false` | Whether continuous queries are enabled |
 | data.config.data.cache-max-memory-size | int | `0` | Maximum size a shared cache can reach before it starts rejecting writes |
+| data.config.data.max-series-per-database | int | `10000000` | The maximum number of series allowed per database before writes are dropped when in-memory indexing is enabled. This is a safety mechanism to prevent OOM crashes when a large number of series are being written to the database. |
 | data.config.data.trace-logging-enabled | bool | `true` | Whether to enable verbose logging of additional debug information within the TSM engine and WAL |
 | data.config.data.wal-fsync-delay | string | `"100ms"` | Duration a write will wait before fsyncing. This is useful for slower disks or when WAL write contention is present. |
 | data.config.hintedHandoff.max-size | int | `107374182400` | Maximum size of the hinted-handoff queue in bytes |

--- a/applications/sasquatch/charts/influxdb-enterprise/values.yaml
+++ b/applications/sasquatch/charts/influxdb-enterprise/values.yaml
@@ -368,6 +368,11 @@ data:
       # writes
       cache-max-memory-size: 0
 
+      # -- The maximum number of series allowed per database before writes are dropped
+      # when in-memory indexing is enabled. This is a safety mechanism to prevent OOM
+      # crashes when a large number of series are being written to the database.
+      max-series-per-database: 10000000
+
     antiEntropy:
       # -- Enable the anti-entropy service, which copies and repairs shards
       enabled: false

--- a/applications/sasquatch/values-usdfdev.yaml
+++ b/applications/sasquatch/values-usdfdev.yaml
@@ -133,7 +133,7 @@ telegraf:
         [ "lsst.prompt" ]
       timestamp_field: "timestamp"
       tags: |
-        [ "dataset_tag", "band", "instrument", "skymap", "detector", "physical_filter", "tract", "patch", "group"]
+        [ "dataset_tag", "band", "instrument", "skymap", "detector", "physical_filter", "tract", "patch"]
     dm:
       enabled: true
       debug: true


### PR DESCRIPTION
Convert `group` tag into field and increase `max-series-per-database` limit to run safer.