### PR TITLE
Disable replication from idfdev

### DIFF
--- a/applications/sasquatch/values-idfint.yaml
+++ b/applications/sasquatch/values-idfint.yaml
@@ -23,15 +23,7 @@ strimzi-kafka:
         - broker: 2
           loadBalancerIP: "34.173.225.150"
           host: sasquatch-int-kafka-2.lsst.cloud
-  mirrormaker2:
-    enabled: true
-    source:
-      alias: "idfdev"
-      bootstrapServer: sasquatch-dev-kafka-bootstrap.lsst.cloud:9094
-      topicsPattern: "registry-schemas, lsst.sal.*, lsst.dm.*"
   users:
-    replicator:
-      enabled: true
     telegraf:
       enabled: true
   controller:


### PR DESCRIPTION
- This was overriding the registry-schemas topic and causing schema conflicts with other applications that use the schema registry on idfint.