### PR TITLE
DM-54242: docverse - Disable in roundtable-prod

### DIFF
--- a/environments/values-roundtable-prod.yaml
+++ b/environments/values-roundtable-prod.yaml
@@ -13,7 +13,7 @@ vaultPathPrefix: "secret/phalanx/roundtable-prod"
 applications:
   atlantis: true
   checkerboard: true
-  docverse: true
+  docverse: false
   eups-distributor: true
   giftless: true
   google-cloud-observability: true


### PR DESCRIPTION
We can re-enable after the cluster rebuild.