### PR TITLE
Enable the efd, live, and prompt datasets

### DIFF
--- a/applications/repertoire/values-idfdev.yaml
+++ b/applications/repertoire/values-idfdev.yaml
@@ -3,6 +3,7 @@ config:
     - "dp02"
     - "dp03"
     - "dp1"
+    - "prompt"
   hips:
     legacy:
       dataset: "dp1"

--- a/applications/repertoire/values-idfint.yaml
+++ b/applications/repertoire/values-idfint.yaml
@@ -3,6 +3,7 @@ config:
     - "dp02"
     - "dp03"
     - "dp1"
+    - "prompt"
   hips:
     legacy:
       dataset: "dp1"

--- a/applications/repertoire/values-usdfdev.yaml
+++ b/applications/repertoire/values-usdfdev.yaml
@@ -3,6 +3,8 @@ config:
     - "dp02"
     - "dp03"
     - "dp1"
+    - "efd"
+    - "live"
   hips:
     datasets: {}
   influxdbDatabases:

--- a/applications/repertoire/values-usdfint.yaml
+++ b/applications/repertoire/values-usdfint.yaml
@@ -3,5 +3,7 @@ config:
     - "dp02"
     - "dp03"
     - "dp1"
+    - "efd"
+    - "live"
   hips:
     datasets: {}

--- a/applications/repertoire/values-usdfprod.yaml
+++ b/applications/repertoire/values-usdfprod.yaml
@@ -3,6 +3,8 @@ config:
     - "dp02"
     - "dp03"
     - "dp1"
+    - "efd"
+    - "live"
   hips:
     datasets: {}
   influxdbDatabases:

--- a/applications/repertoire/values.yaml
+++ b/applications/repertoire/values.yaml
@@ -170,16 +170,6 @@ config:
         datasets:
           - "efd"
         template: "https://{{base_hostname}}/api/consdbtap"
-    herald:
-      - type: "data"
-        name: "alerts"
-        datasets:
-          - "dp02"
-          - "dp03"
-          - "dp1"
-          - "prompt"
-        template: "https://{{base_hostname}}/api/alerts"
-        openapi: "https://{{base_hostname}}/api/alerts/openapi.json"
     datalinker:
       - type: "data"
         name: "datalink"
@@ -213,6 +203,13 @@ config:
       - type: "ui"
         name: "logout"
         template: "https://{{base_hostname}}/logout"
+    herald:
+      - type: "data"
+        name: "alerts"
+        datasets:
+          - "prompt"
+        template: "https://{{base_hostname}}/api/alerts"
+        openapi: "https://{{base_hostname}}/api/alerts/openapi.json"
     livetap:
       - type: "data"
         name: "tap"


### PR DESCRIPTION
Now that lsst.rsp has been fixed to not break when new datasets are added, enable the prompt dataset on idfdev and idfint and the efd and live datasets on the USDF RSP environments.