### PR TITLE
DM-54725: Add sasquatch metrics to Herald application

### DIFF
--- a/applications/herald/Chart.yaml
+++ b/applications/herald/Chart.yaml
@@ -5,4 +5,4 @@ version: 1.0.0
 description: "Rubin alert packet retrieval service"
 sources:
   - "https://github.com/lsst-sqre/herald"
-appVersion: "0.1.0"
+appVersion: "0.2.0"

--- a/applications/herald/README.md
+++ b/applications/herald/README.md
@@ -18,6 +18,11 @@ Rubin alert packet retrieval service
 | autoscaling.targetMemoryUtilizationPercentage | string | `""` | Target memory utilization as a percentage of requested memory for autoscaling |
 | config.logLevel | string | `"INFO"` | Logging level |
 | config.logProfile | string | `"production"` | Logging profile (`production` for JSON, `development` for human-friendly) |
+| config.metrics.application | string | `"herald"` | Name under which to log metrics. Generally there is no reason to change this. |
+| config.metrics.enabled | bool | `false` | Whether to enable sending metrics |
+| config.metrics.events.topicPrefix | string | `"lsst.square.metrics.events"` | Topic prefix for events. It may sometimes be useful to change this in development environments. |
+| config.metrics.schemaManager.registryUrl | string | Sasquatch in the local cluster | URL of the Confluent-compatible schema registry server |
+| config.metrics.schemaManager.suffix | string | `""` | Suffix to add to all registered subjects. This is sometimes useful for experimentation during development. |
 | config.pathPrefix | string | `"/api/alerts"` | URL path prefix |
 | config.s3AlertsBucket | string | `""` | S3 bucket name containing the alert archive packets |
 | config.s3AlertsPrefix | string | `"v2/alerts"` | S3 key prefix for alert packets. |

--- a/applications/herald/templates/configmap.yaml
+++ b/applications/herald/templates/configmap.yaml
@@ -5,6 +5,14 @@ metadata:
   labels:
     {{- include "herald.labels" . | nindent 4 }}
 data:
+  METRICS_APPLICATION: {{ .Values.config.metrics.application | quote }}
+  {{- if .Values.config.metrics.enabled }}
+  METRICS_ENABLED: "true"
+  METRICS_EVENTS_TOPIC_PREFIX: {{ .Values.config.metrics.events.topicPrefix | quote }}
+  SCHEMA_MANAGER_REGISTRY_URL: {{ .Values.config.metrics.schemaManager.registryUrl | quote }}
+  {{- else }}
+  METRICS_ENABLED: "false"
+  {{- end }}
   HERALD_LOG_LEVEL: {{ .Values.config.logLevel | quote }}
   HERALD_LOG_PROFILE: {{ .Values.config.logProfile | quote }}
   HERALD_PATH_PREFIX: {{ .Values.config.pathPrefix | quote }}

--- a/applications/herald/templates/deployment.yaml
+++ b/applications/herald/templates/deployment.yaml
@@ -27,6 +27,24 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           env:
+            {{- if .Values.config.metrics.enabled }}
+            - name: "KAFKA_BOOTSTRAP_SERVERS"
+              valueFrom:
+                secretKeyRef:
+                  name: "herald-kafka"
+                  key: "bootstrapServers"
+            - name: "KAFKA_CLIENT_CERT_PATH"
+              value: "/etc/herald-kafka/user.crt"
+            - name: "KAFKA_CLIENT_KEY_PATH"
+              value: "/etc/herald-kafka/user.key"
+            - name: "KAFKA_CLUSTER_CA_PATH"
+              value: "/etc/herald-kafka/ca.crt"
+            - name: "KAFKA_SECURITY_PROTOCOL"
+              valueFrom:
+                secretKeyRef:
+                  name: "herald-kafka"
+                  key: "securityProtocol"
+            {{- end }}
             {{- if .Values.config.s3Credentials }}
             - name: "HERALD_AWS_ACCESS_KEY_ID"
               valueFrom:
@@ -85,6 +103,27 @@ spec:
               drop:
                 - "all"
             readOnlyRootFilesystem: true
+          {{- if .Values.config.metrics.enabled }}
+          volumeMounts:
+            - name: "kafka"
+              mountPath: "/etc/herald-kafka/ca.crt"
+              readOnly: true
+              subPath: "ssl.truststore.crt"
+            - name: "kafka"
+              mountPath: "/etc/herald-kafka/user.crt"
+              readOnly: true
+              subPath: "ssl.keystore.crt"
+            - name: "kafka"
+              mountPath: "/etc/herald-kafka/user.key"
+              readOnly: true
+              subPath: "ssl.keystore.key"
+          {{- end }}
+      {{- if .Values.config.metrics.enabled }}
+      volumes:
+        - name: "kafka"
+          secret:
+            secretName: "herald-kafka"
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/applications/herald/templates/kafka-access.yaml
+++ b/applications/herald/templates/kafka-access.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.config.metrics.enabled -}}
+apiVersion: access.strimzi.io/v1alpha1
+kind: KafkaAccess
+metadata:
+  name: "herald-kafka"
+  labels:
+    {{- include "herald.labels" . | nindent 4 }}
+spec:
+  kafka:
+    name: "sasquatch"
+    namespace: "sasquatch"
+    listener: "tls"
+  user:
+    kind: "KafkaUser"
+    apiGroup: "kafka.strimzi.io"
+    name: "app-metrics-herald"
+    namespace: "sasquatch"
+{{- end }}

--- a/applications/herald/values-idfdev.yaml
+++ b/applications/herald/values-idfdev.yaml
@@ -1,4 +1,6 @@
 config:
+  metrics:
+    enabled: true
   s3AlertsBucket: "rubin-alert-archive"
   s3SchemasBucket: "rubin-alert-archive"
   s3AlertsPrefix: "v2/alerts"

--- a/applications/herald/values.yaml
+++ b/applications/herald/values.yaml
@@ -69,6 +69,28 @@ config:
   # at USDF).
   s3Credentials: false
 
+  metrics:
+    # -- Whether to enable sending metrics
+    enabled: false
+
+    # -- Name under which to log metrics. Generally there is no reason to
+    # change this.
+    application: "herald"
+
+    events:
+      # -- Topic prefix for events. It may sometimes be useful to change this
+      # in development environments.
+      topicPrefix: "lsst.square.metrics.events"
+
+    schemaManager:
+      # -- URL of the Confluent-compatible schema registry server
+      # @default -- Sasquatch in the local cluster
+      registryUrl: "http://sasquatch-schema-registry.sasquatch.svc.cluster.local:8081"
+
+      # -- Suffix to add to all registered subjects. This is sometimes useful
+      # for experimentation during development.
+      suffix: ""
+
 ingress:
   # -- Additional annotations for the ingress rule
   annotations: {}


### PR DESCRIPTION
We'd like to have Herald emit success/failure events, so this PR adds the necessary configuration to herald and sasquatch to enable this. 