### PR TITLE
DM 54734: Update Docverse with Repertoire integration

### DIFF
--- a/applications/docverse/Chart.yaml
+++ b/applications/docverse/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "tickets-DM-54685"
+appVersion: "tickets-DM-54734"
 description: Publish versioned docs
 name: docverse
 sources:

--- a/applications/repertoire/values.yaml
+++ b/applications/repertoire/values.yaml
@@ -189,6 +189,11 @@ config:
           datalink-links-1.1:
             template: "https://{{base_hostname}}/api/datalink/links"
         openapi: "https://{{base_hostname}}/api/datalink/openapi.json"
+    docverse:
+      - type: "internal"
+        name: "docverse"
+        template: "https://{{base_hostname}}/docverse/api"
+        openapi: "https://{{base_hostname}}/docverse/api/openapi.json"
     gafaelfawr:
       - type: "internal"
         name: "gafaelfawr"


### PR DESCRIPTION
- Adds Docverse's API to Repertoire's service discovery data
- Deploys a new Docverse that consumes service discovery to configure the base URL that docverse serves for distributed queue workers. See https://github.com/lsst-sqre/docverse/pull/218