### PR TITLE
DM-54754: Enable Herald metrics in sasquatch application for idfdev and idfint

### DIFF
--- a/applications/sasquatch/charts/app-metrics/values.yaml
+++ b/applications/sasquatch/charts/app-metrics/values.yaml
@@ -11,6 +11,10 @@ globalAppConfig:
     influxTags:
       - "service"
       - "username"
+  herald:
+    influxTags:
+      - "endpoint"
+      - "error_type"
   mobu:
     influxTags:
       - "sync"

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -148,6 +148,7 @@ app-metrics:
   apps:
     - bigquerykafka
     - gafaelfawr
+    - herald
     - mobu
     - noteburst
     - nublado

--- a/applications/sasquatch/values-idfint.yaml
+++ b/applications/sasquatch/values-idfint.yaml
@@ -104,6 +104,7 @@ app-metrics:
   apps:
     - bigquerykafka
     - gafaelfawr
+    - herald
     - mobu
     - noteburst
     - nublado


### PR DESCRIPTION
Changes to sasquatch config for idfdev and idfint to enable us to start sending metrics from Herald