### PR TITLE
Disable remote registry on idfdev

### DIFF
--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -42,11 +42,6 @@ schema-registry:
   ingress:
     enabled: true
 
-schema-registry-remote:
-  enabled: true
-  topic:
-    name: registry-schemas-remote
-
 influxdb:
   image:
     tag: 1.12.3


### PR DESCRIPTION
- The remote registry is used by Sasquatch remote context, this should not be enabled on this environment.