### PR TITLE
DM-54773: Fix weka mount points for Prompt Publication

### DIFF
--- a/applications/prompt-pub/templates/statefulset.yaml
+++ b/applications/prompt-pub/templates/statefulset.yaml
@@ -89,7 +89,7 @@ spec:
             - name: gcp-int-repo-config-volume
               mountPath: /opt/lsst/configs/gcp-repo-path
             - name: sdf-data-rubin
-              mountPath: /sdf/data
+              mountPath: /sdf/data/rubin
             - name: s3-credentials-file
               mountPath: /opt/lsst/secrets/s3-credentials/credentials
               subPath: credentials

--- a/applications/prompt-pub/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-pub/values-usdfprod-prompt-processing.yaml
@@ -8,8 +8,8 @@ publication:
   stateDB: "postgresql+asyncpg://prompt_pub@usdf-butler-prompt-publication-db-tx.sdf.slac.stanford.edu/promptpub"
   repos:
     embargo: "s3://embargo@rubin-summit-users/butler.yaml"
-    main: "/sdf/data/repo/main/butler.yaml"
-    promptPrep: "/sdf/data/repo/prompt_prep/butler.yaml"
+    main: "/sdf/data/rubin/repo/main/butler.yaml"
+    promptPrep: "/sdf/data/rubin/repo/prompt_prep/butler.yaml"
   butlerWriterKafka:
     address: "prompt-kafka-kafka-bootstrap.prompt-kafka:9092"
     topic: "butler-writer-ingestion-events"


### PR DESCRIPTION
Fix an issue where the prompt publication service was mounting its Weka data volume at a different mount point than the "canonical" path used by interactive nodes.  This was causing it to write paths into the Butler database that were not reachable by end users.