### PR TITLE
DM-54689: Add GitHub App integration for Docverse

### DIFF
--- a/applications/docverse/Chart.yaml
+++ b/applications/docverse/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "tickets-DM-54689-github-webhook"
+appVersion: "tickets-DM-54689-stable-github-ids"
 description: Publish versioned docs
 name: docverse
 sources:

--- a/applications/docverse/Chart.yaml
+++ b/applications/docverse/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "tickets-DM-54734"
+appVersion: "tickets-DM-54689-github-webhook"
 description: Publish versioned docs
 name: docverse
 sources:

--- a/applications/docverse/Chart.yaml
+++ b/applications/docverse/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "tickets-DM-54689-stable-github-ids"
+appVersion: "tickets-DM-54689-rename-webhooks"
 description: Publish versioned docs
 name: docverse
 sources:

--- a/applications/docverse/README.md
+++ b/applications/docverse/README.md
@@ -20,6 +20,7 @@ Publish versioned docs
 | cloudsql.serviceAccount | string | `""` | The Google service account that has an IAM binding to the `docverse` Kubernetes service accounts and has the `cloudsql.client` role |
 | config.arqRedisUrl | string | Points to embedded Redis | URL for Redis arq queue database |
 | config.databaseUrl | string | `""` | Database URL for PostgreSQL |
+| config.githubAppId | string | `nil` | GitHub App ID for Docverse to use when accessing GitHub repositories. If not set, Docverse will operate in a limited mode without GitHub integration. |
 | config.logLevel | string | `"INFO"` | Logging level |
 | config.logProfile | string | `"production"` | Logging profile (`production` for JSON, `development` for human-friendly) |
 | config.pathPrefix | string | `"/docverse/api"` | URL path prefix |

--- a/applications/docverse/secrets.yaml
+++ b/applications/docverse/secrets.yaml
@@ -14,6 +14,8 @@ DOCVERSE_GITHUB_APP_PRIVATE_KEY:
   description: >-
     Private key for the GitHub App used by Docverse to access GitHub
     repositories.
+  onepassword:
+    encoded: true
 slack-webhook:
   description: >-
     Slack web hook used to report internal errors to Slack. This secret may be

--- a/applications/docverse/secrets.yaml
+++ b/applications/docverse/secrets.yaml
@@ -7,6 +7,13 @@ DOCVERSE_CREDENTIAL_ENCRYPTION_KEY:
 DOCVERSE_DATABASE_PASSWORD:
   description: >-
     Password for the PostgreSQL database used by Docverse.
+DOCVERSE_GITHUB_WEBHOOK_SECRET:
+  description: >-
+    Secret used to validate GitHub webhooks sent to Docverse.
+DOCVERSE_GITHUB_APP_PRIVATE_KEY:
+  description: >-
+    Private key for the GitHub App used by Docverse to access GitHub
+    repositories.
 slack-webhook:
   description: >-
     Slack web hook used to report internal errors to Slack. This secret may be

--- a/applications/docverse/templates/_helpers.tpl
+++ b/applications/docverse/templates/_helpers.tpl
@@ -65,6 +65,18 @@ Secret environment variables shared across all Docverse pods.
     secretKeyRef:
       name: "docverse"
       key: "DOCVERSE_DATABASE_PASSWORD"
+{{- if .Values.config.githubAppId }}
+- name: "DOCVERSE_GITHUB_APP_PRIVATE_KEY"
+  valueFrom:
+    secretKeyRef:
+      name: "docverse"
+      key: "DOCVERSE_GITHUB_APP_PRIVATE_KEY"
+- name: "DOCVERSE_GITHUB_WEBHOOK_SECRET"
+  valueFrom:
+    secretKeyRef:
+      name: "docverse"
+      key: "DOCVERSE_GITHUB_WEBHOOK_SECRET"
+{{- end }}
 {{- if .Values.config.slackAlerts }}
 - name: "DOCVERSE_SLACK_WEBHOOK"
   valueFrom:

--- a/applications/docverse/templates/configmap.yaml
+++ b/applications/docverse/templates/configmap.yaml
@@ -18,6 +18,6 @@ data:
   DOCVERSE_SUPERADMIN_USERNAMES: {{ toJson . | quote }}
   {{- end }}
   REPERTOIRE_BASE_URL: {{ .Values.global.repertoireUrl | quote }}
-  {{- with .Values.config.githubAppId }}
-  DOCVERSE_GITHUB_APP_ID: {{ . | quote }}
+  {{- if .Values.config.githubAppId }}
+  DOCVERSE_GITHUB_APP_ID: {{ .Values.config.githubAppId | quote }}
   {{- end }}

--- a/applications/docverse/templates/configmap.yaml
+++ b/applications/docverse/templates/configmap.yaml
@@ -18,3 +18,6 @@ data:
   DOCVERSE_SUPERADMIN_USERNAMES: {{ toJson . | quote }}
   {{- end }}
   REPERTOIRE_BASE_URL: {{ .Values.global.repertoireUrl | quote }}
+  {{- with .Values.config.githubAppId }}
+  DOCVERSE_GITHUB_APP_ID: {{ . | quote }}
+  {{- end }}

--- a/applications/docverse/templates/ingress-webhooks.yaml
+++ b/applications/docverse/templates/ingress-webhooks.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.config.githubAppId }}
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
+metadata:
+  name: "docverse-webhooks"
+  labels:
+    {{- include "docverse.labels" . | nindent 4 }}
+config:
+  scopes:
+    anonymous: true
+template:
+  metadata:
+    name: "docverse-webhooks"
+    {{- with .Values.ingress.annotations }}
+    annotations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  spec:
+    rules:
+      - host: {{ required "global.host must be set" .Values.global.host | quote }}
+        http:
+          paths:
+            - path: "{{ .Values.config.pathPrefix }}/webhooks"
+              pathType: "Prefix"
+              backend:
+                service:
+                  name: "docverse"
+                  port:
+                    number: 8080
+{{- end }}

--- a/applications/docverse/values-roundtable-dev.yaml
+++ b/applications/docverse/values-roundtable-dev.yaml
@@ -2,8 +2,9 @@ image:
   pullPolicy: "Always"
 
 config:
-  databaseUrl: "postgresql://docverse@localhost/docverse"
   logLevel: "DEBUG"
+  databaseUrl: "postgresql://docverse@localhost/docverse"
+  githubAppId: "3556766"
   updateSchema: true
   superadminUsers:
     - "jonathansick"

--- a/applications/docverse/values.yaml
+++ b/applications/docverse/values.yaml
@@ -44,6 +44,10 @@ config:
   # -- Whether to run Alembic schema migrations on install/upgrade
   updateSchema: false
 
+  # -- GitHub App ID for Docverse to use when accessing GitHub repositories. If
+  # not set, Docverse will operate in a limited mode without GitHub integration.
+  githubAppId: null
+
   # -- Usernames that have super admin (de facto admin in all organizations)
   superadminUsers:
     - "jonathansick"


### PR DESCRIPTION
Introduce GitHub App support in Docverse by adding necessary secrets and configuration. Update the application version to DM-54689 and ensure proper handling of GitHub webhooks. This enhances integration capabilities with GitHub repositories.