### PR TITLE
DM-54836: Add standard hardening to Portal

### DIFF
--- a/applications/portal/README.md
+++ b/applications/portal/README.md
@@ -45,5 +45,4 @@ Rubin Science Platform Portal Aspect
 | redis.tolerations | list | `[]` | Tolerations for the Redis pod |
 | replicaCount | int | `1` | Number of pods to start |
 | resources | object | See `values.yaml` | Resource limits and requests. The Portal will use (by default) 93% of container RAM.  This is a smallish Portal; tweak it as you need to in instance definitions in Phalanx. |
-| securityContext | object | See `values.yaml` | Security context for the Portal pod |
 | tolerations | list | `[]` | Tolerations for the Portal pod |

--- a/applications/portal/templates/statefulset.yaml
+++ b/applications/portal/templates/statefulset.yaml
@@ -226,6 +226,11 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
           volumeMounts:
             - mountPath: "/firefly/alerts"
               name: "alerts"
@@ -239,10 +244,11 @@ spec:
               name: "workarea"
       imagePullSecrets:
         - name: "pull-secret"
-      {{- with .Values.securityContext }}
       securityContext:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        runAsNonRoot: true
+        runAsUser: 91
+        runAsGroup: 91
+        fsGroup: 91
       volumes:
         - name: "alerts"
           configMap:

--- a/applications/portal/values.yaml
+++ b/applications/portal/values.yaml
@@ -49,13 +49,6 @@ tolerations: []
 # -- Affinity rules for the Portal pod
 affinity: {}
 
-# -- Security context for the Portal pod
-# @default -- See `values.yaml`
-securityContext:
-  runAsUser: 91
-  runAsGroup: 91
-  fsGroup: 91
-
 config:
   # -- If not null, display this alert to all users in a banner
   alertMessage: null


### PR DESCRIPTION
Move the `securityContext` configuration into the template since there should be no need to change it, and add standard security hardening to see if Portal now works properly with that in place.