### PR TITLE
DM-54842: Add resource limits to herald and configure autoscaling

### DIFF
--- a/applications/herald/Chart.yaml
+++ b/applications/herald/Chart.yaml
@@ -5,4 +5,4 @@ version: 1.0.0
 description: "Rubin alert packet retrieval service"
 sources:
   - "https://github.com/lsst-sqre/herald"
-appVersion: "0.2.0"
+appVersion: "0.3.0"

--- a/applications/herald/README.md
+++ b/applications/herald/README.md
@@ -12,7 +12,7 @@ Rubin alert packet retrieval service
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules for the herald deployment pod |
 | autoscaling.enabled | bool | `false` | Enable autoscaling of the herald deployment |
-| autoscaling.maxReplicas | int | `4` | Maximum number of herald deployment pods |
+| autoscaling.maxReplicas | int | `10` | Maximum number of herald deployment pods |
 | autoscaling.minReplicas | int | `1` | Minimum number of herald deployment pods |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU utilization as a percentage of requested CPU for autoscaling |
 | autoscaling.targetMemoryUtilizationPercentage | string | `""` | Target memory utilization as a percentage of requested memory for autoscaling |

--- a/applications/herald/values-idfint.yaml
+++ b/applications/herald/values-idfint.yaml
@@ -1,3 +1,7 @@
+autoscaling:
+  enabled: true
+  targetCPUUtilizationPercentage: 800
+
 config:
   metrics:
     enabled: true

--- a/applications/herald/values.yaml
+++ b/applications/herald/values.yaml
@@ -11,7 +11,7 @@ autoscaling:
   minReplicas: 1
 
   # -- Maximum number of herald deployment pods
-  maxReplicas: 4
+  maxReplicas: 10
 
   # -- Target CPU utilization as a percentage of requested CPU for autoscaling
   targetCPUUtilizationPercentage: 80
@@ -106,7 +106,13 @@ podAnnotations: {}
 
 # -- Resource limits and requests for the herald deployment pod
 # @default -- See `values.yaml`
-resources: {}
+resources:
+  requests:
+    cpu: "100m"
+    memory: "256Mi"
+  limits:
+    cpu: "1"
+    memory: "512Mi"
 
 # -- Tolerations for the herald deployment pod
 tolerations: []


### PR DESCRIPTION
## Description
Upgrades herald to version 0.3.0 which includes metrics for how long requests & processing took.
Adds autoscaler for idfint & sets resource limits for all envs.