### PR TITLE
DM-54794: Add docverse Keeper-sync worker deployment

### DIFF
--- a/applications/docverse/Chart.yaml
+++ b/applications/docverse/Chart.yaml
@@ -1,5 +1,6 @@
 apiVersion: v2
-appVersion: "tickets-DM-54794-sync-engine-foundation"
+# https://github.com/lsst-sqre/docverse/pull/300
+appVersion: "tickets-DM-54794-run-service-and-queue"
 description: Publish versioned docs
 name: docverse
 sources:

--- a/applications/docverse/Chart.yaml
+++ b/applications/docverse/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "tickets-DM-54794-relax-edition-slug"
+appVersion: "tickets-DM-54794-sync-engine-foundation"
 description: Publish versioned docs
 name: docverse
 sources:

--- a/applications/docverse/Chart.yaml
+++ b/applications/docverse/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "tickets-DM-54794-config-schema"
+appVersion: "tickets-DM-54794-relax-edition-slug"
 description: Publish versioned docs
 name: docverse
 sources:

--- a/applications/docverse/Chart.yaml
+++ b/applications/docverse/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "tickets-DM-54689-rename-webhooks"
+appVersion: "tickets-DM-54794-config-schema"
 description: Publish versioned docs
 name: docverse
 sources:

--- a/applications/docverse/Chart.yaml
+++ b/applications/docverse/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-# https://github.com/lsst-sqre/docverse/pull/300
-appVersion: "tickets-DM-54794-run-service-and-queue"
+# https://github.com/lsst-sqre/docverse/pull/306
+appVersion: "tickets-DM-54794-dual-upload-convergence"
 description: Publish versioned docs
 name: docverse
 sources:

--- a/applications/docverse/Chart.yaml
+++ b/applications/docverse/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 # https://github.com/lsst-sqre/docverse/pull/306
-appVersion: "tickets-DM-54794-dual-upload-convergence"
+appVersion: "tickets-DM-54794-tier-crons"
 description: Publish versioned docs
 name: docverse
 sources:

--- a/applications/docverse/README.md
+++ b/applications/docverse/README.md
@@ -21,6 +21,7 @@ Publish versioned docs
 | config.arqRedisUrl | string | Points to embedded Redis | URL for Redis arq queue database |
 | config.databaseUrl | string | `""` | Database URL for PostgreSQL |
 | config.githubAppId | string | `nil` | GitHub App ID for Docverse to use when accessing GitHub repositories. If not set, Docverse will operate in a limited mode without GitHub integration. |
+| config.keeperSync.enabled | bool | `false` | Enable the Keeper-sync worker that consumes the `docverse:sync-queue` arq queue. Requires the docverse image to provide `docverse.worker.main.KeeperSyncWorkerSettings`. |
 | config.logLevel | string | `"INFO"` | Logging level |
 | config.logProfile | string | `"production"` | Logging profile (`production` for JSON, `development` for human-friendly) |
 | config.pathPrefix | string | `"/docverse/api"` | URL path prefix |
@@ -50,6 +51,12 @@ Publish versioned docs
 | replicaCount.worker | int | `1` | Number of worker deployment pods to start |
 | resources | object | See `values.yaml` | Resource limits and requests for the docverse deployment pod |
 | resources.requests.cpu | string | `"50m"` | GKE Autopilot requires a minimum CPU request of 50m |
+| syncWorker.affinity | object | `{}` | Affinity rules for the Keeper-sync worker pod |
+| syncWorker.nodeSelector | object | `{}` | Node selection rules for the Keeper-sync worker pod |
+| syncWorker.podAnnotations | object | `{}` | Annotations for the Keeper-sync worker pod |
+| syncWorker.replicaCount | int | `1` | Number of Keeper-sync worker pods to start |
+| syncWorker.resources | object | See `values.yaml` | Resource limits and requests for the Keeper-sync worker pod |
+| syncWorker.tolerations | list | `[]` | Tolerations for the Keeper-sync worker pod |
 | tolerations | list | `[]` | Tolerations for the docverse deployment pod |
 | workerResources | object | See `values.yaml` | Resource limits and requests for the docverse worker pod |
 | workerResources.requests.cpu | string | `"50m"` | GKE Autopilot requires a minimum CPU request of 50m |

--- a/applications/docverse/templates/sync-worker-deployment.yaml
+++ b/applications/docverse/templates/sync-worker-deployment.yaml
@@ -1,0 +1,74 @@
+{{- if .Values.config.keeperSync.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "docverse-sync-worker"
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  labels:
+    {{- include "docverse.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "sync-worker"
+    docverse-redis-client: "true"
+spec:
+  replicas: {{ .Values.syncWorker.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "docverse.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: "sync-worker"
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.syncWorker.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "docverse.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: "sync-worker"
+        docverse-redis-client: "true"
+    spec:
+      {{- with .Values.syncWorker.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.cloudsql.enabled }}
+      serviceAccountName: "docverse"
+      {{- else }}
+      automountServiceAccountToken: false
+      {{- end }}
+      containers:
+        - name: "docverse-sync-worker"
+          command: ["arq"]
+          args: ["docverse.worker.main.KeeperSyncWorkerSettings"]
+          env:
+            {{- include "docverse.envVars" . | nindent 12 }}
+          envFrom:
+            - configMapRef:
+                name: "docverse"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          resources:
+            {{- toYaml .Values.syncWorker.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+            readOnlyRootFilesystem: true
+      {{- if .Values.cloudsql.enabled }}
+      initContainers:
+        {{- include "docverse.cloudsqlSidecar" . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.syncWorker.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.syncWorker.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+{{- end }}

--- a/applications/docverse/values-roundtable-dev.yaml
+++ b/applications/docverse/values-roundtable-dev.yaml
@@ -8,6 +8,8 @@ config:
   updateSchema: true
   superadminUsers:
     - "jonathansick"
+  keeperSync:
+    enabled: true
 
 cloudsql:
   enabled: true

--- a/applications/docverse/values.yaml
+++ b/applications/docverse/values.yaml
@@ -52,6 +52,12 @@ config:
   superadminUsers:
     - "jonathansick"
 
+  keeperSync:
+    # -- Enable the Keeper-sync worker that consumes the
+    # `docverse:sync-queue` arq queue. Requires the docverse image to
+    # provide `docverse.worker.main.KeeperSyncWorkerSettings`.
+    enabled: false
+
 ingress:
   # -- Additional annotations for the ingress rule
   annotations: {}
@@ -86,6 +92,32 @@ workerResources:
     # -- GKE Autopilot requires a minimum CPU request of 50m
     cpu: "50m"
     memory: "128Mi"
+
+syncWorker:
+  # -- Number of Keeper-sync worker pods to start
+  replicaCount: 1
+
+  # -- Resource limits and requests for the Keeper-sync worker pod
+  # @default -- See `values.yaml`
+  resources:
+    limits:
+      cpu: "1"
+      memory: "512Mi"
+    requests:
+      cpu: "50m"
+      memory: "128Mi"
+
+  # -- Affinity rules for the Keeper-sync worker pod
+  affinity: {}
+
+  # -- Node selection rules for the Keeper-sync worker pod
+  nodeSelector: {}
+
+  # -- Annotations for the Keeper-sync worker pod
+  podAnnotations: {}
+
+  # -- Tolerations for the Keeper-sync worker pod
+  tolerations: []
 
 # -- Tolerations for the docverse deployment pod
 tolerations: []


### PR DESCRIPTION
## Summary

- Add a second arq worker `Deployment` (`docverse-sync-worker`) for the new `docverse:sync-queue` queue, gated behind a `config.keeperSync.enabled` flag (default off) so this can land before the docverse image ships `KeeperSyncWorkerSettings`.
- Introduce a `syncWorker` values block (replicaCount, resources, affinity, nodeSelector, podAnnotations, tolerations) so the new pod is sized and scaled independently of the main worker. Existing `replicaCount.worker` / `workerResources` keys are left untouched.
- Bump docverse `appVersion` to `tickets-DM-54794-run-service-and-queue` (lsst-sqre/docverse#300) so the image actually contains `KeeperSyncWorkerSettings` once a follow-up flips the flag in `values-roundtable-dev.yaml`.

## Validation steps

- [ ] With the flag off (default), `phalanx application template docverse roundtable-dev` should not emit a `docverse-sync-worker` Deployment.
- [ ] With `config.keeperSync.enabled=true`, the rendered `docverse-sync-worker` Deployment has `args: ["docverse.worker.main.KeeperSyncWorkerSettings"]`, `app.kubernetes.io/component: sync-worker`, the `docverse-redis-client: "true"` label, and the Cloud SQL Auth Proxy init container.
- [ ] After merge + a follow-up PR enabling `config.keeperSync.enabled: true` in `values-roundtable-dev.yaml`, confirm Argo CD creates `Deployment/docverse-sync-worker` and arq logs show it consuming `docverse:sync-queue`.

## References

- PRD: lsst-sqre/docverse#275
- Companion docverse PR: lsst-sqre/docverse#300
- Jira: https://rubinobs.atlassian.net/browse/DM-54794