### PR TITLE
nublado - Update mem reqs/limits and idle culler timeouts

### DIFF
--- a/applications/nublado/values-idfint.yaml
+++ b/applications/nublado/values-idfint.yaml
@@ -120,7 +120,7 @@ hub:
 
 jupyterhub:
   cull:
-    timeout: 108000  # 30 hours
+    timeout: 90000 # 25hrs
   hub:
     config:
       JupyterHub:

--- a/applications/nublado/values-idfprod.yaml
+++ b/applications/nublado/values-idfprod.yaml
@@ -105,6 +105,9 @@ hub:
   landingPage: "/lab/tree/notebooks/tutorials/welcome.md"
 
 jupyterhub:
+  cull:
+    timeout: 90000  # 25hrs
+
   hub:
     config:
       JupyterHub:

--- a/applications/nublado/values-idfprod.yaml
+++ b/applications/nublado/values-idfprod.yaml
@@ -51,6 +51,25 @@ controller:
         - secretName: "nublado-lab-secret"
           secretKey: "rubin-epo-cit-sci-pipeline.json"
           path: "/opt/lsst/software/jupyterlab/secrets/rubin-epo-cit-sci-pipeline.json"
+      sizes:
+        # Double the memory because these are running on nodes with a 2x ratio
+        # of mem to CPU compared to standard nodes
+        - size: "small"
+          resources:
+            limits:
+              cpu: 1.0
+              memory: "8Gi"
+            requests:
+              cpu: 0.25
+              memory: "1.5Gi"
+        - size: "large"
+          resources:
+            limits:
+              cpu: 4.0
+              memory: "32Gi"
+            requests:
+              cpu: 1.0
+              memory: "8Gi"
       tolerations:
         - key: "nublado.lsst.io/permitted"
           operator: "Exists"


### PR DESCRIPTION
*DO NOT MERGE* this until after the idfprod cluster rebuild.

* The new cluster will have the highmem nodes, with 2x more memory per CPU.
* New idle timeouts in idfprod and idfint are 25 hrs