### PR TITLE
mobu - adjust phalanx-test flock idle times

### DIFF
--- a/applications/mobu/values-idfdev.yaml
+++ b/applications/mobu/values-idfdev.yaml
@@ -56,6 +56,8 @@ config:
             image_class: "latest-weekly"
           repo_url: "https://github.com/lsst-sqre/phalanx-test.git"
           repo_ref: "main"
+          execution_idle_time: 0
+          idle_time: 300
         restart: true
     - name: "muster"
       count: 1

--- a/applications/mobu/values-idfint.yaml
+++ b/applications/mobu/values-idfint.yaml
@@ -39,6 +39,8 @@ config:
             image_class: "latest-daily"
           repo_url: "https://github.com/lsst-sqre/phalanx-test.git"
           repo_ref: "main"
+          execution_idle_time: 0
+          idle_time: 300
         restart: true
     - name: "phalanx-recommended"
       count: 1
@@ -56,6 +58,8 @@ config:
         options:
           repo_url: "https://github.com/lsst-sqre/phalanx-test.git"
           repo_ref: "main"
+          execution_idle_time: 0
+          idle_time: 300
         restart: true
     - name: "tutorial"
       count: 1

--- a/applications/mobu/values-idfprod.yaml
+++ b/applications/mobu/values-idfprod.yaml
@@ -37,6 +37,8 @@ config:
         options:
           repo_url: "https://github.com/lsst-sqre/phalanx-test.git"
           repo_ref: "main"
+          execution_idle_time: 0
+          idle_time: 300
         restart: true
     - name: "tutorial"
       count: 1


### PR DESCRIPTION
No time in between cells, 5 minutes in between groups. Unfortunately, this is currently every 25 notebook executions. There is no way to set an idle time between excecutions of all notebooks in a repo.