### PR TITLE
Fix paths to Nublado secrets at base

### DIFF
--- a/applications/nublado/values-base.yaml
+++ b/applications/nublado/values-base.yaml
@@ -16,14 +16,14 @@ controller:
       defaultSize: "small"
       env:
         AWS_REQUEST_CHECKSUM_CALCULATION: WHEN_REQUIRED
-        AWS_SHARED_CREDENTIALS_FILE: "/opt/lsst/software/jupyterlab/secrets/aws-credentials.ini"
+        AWS_SHARED_CREDENTIALS_FILE: "/etc/nublado/secrets/aws-credentials.ini"
         DAF_BUTLER_REPOSITORY_INDEX: "/project/data-repos.yaml"
         LSST_SITE: "base"
         LSST_TOPIC_SUBNAME: "sal"
-        LSST_KAFKA_PASSFILE: "/opt/lsst/software/jupyterlab/secrets/kafka_credentials.txt"
+        LSST_KAFKA_PASSFILE: "/etc/nublado/secrets/kafka_credentials.txt"
         LSST_KAFKA_BROKER_ADDR: "sasquatch-kafka-bootstrap.sasquatch:9092"
         LSST_SCHEMA_REGISTRY_URL: "http://sasquatch-schema-registry.sasquatch:8081"
-        PGPASSFILE: "/opt/lsst/software/jupyterlab/secrets/postgres-credentials.txt"
+        PGPASSFILE: "/etc/nublado/secrets/postgres-credentials.txt"
         PGUSER: "oods"
         RSP_SITE_TYPE: "telescope"
         S3_ENDPOINT_URL: "https://s3-butler.ls.lsst.org"


### PR DESCRIPTION
The change to Nublado to mount secrets on a different path by default requires additional changes to the paths in Phalanx.