### PR TITLE
Fix paths pointing to old Nublado secrets mount

### DIFF
--- a/applications/nublado/values-ccin2p3.yaml
+++ b/applications/nublado/values-ccin2p3.yaml
@@ -13,7 +13,7 @@ controller:
     lab:
       defaultSize: "small"
       env:
-        PGPASSFILE: "/opt/lsst/software/jupyterlab/secrets/postgres-credentials.txt"
+        PGPASSFILE: "/etc/nublado/secrets/postgres-credentials.txt"
         PGUSER: "lsstprod_ro"
         NO_ACTIVITY_TIMEOUT: "432000"
         CULL_KERNEL_IDLE_TIMEOUT: "432000"

--- a/applications/nublado/values-summit.yaml
+++ b/applications/nublado/values-summit.yaml
@@ -15,14 +15,14 @@ controller:
       defaultSize: "small"
       env:
         AWS_REQUEST_CHECKSUM_CALCULATION: WHEN_REQUIRED
-        AWS_SHARED_CREDENTIALS_FILE: "/opt/lsst/software/jupyterlab/secrets/aws-credentials.ini"
+        AWS_SHARED_CREDENTIALS_FILE: "/etc/nublado/secrets/aws-credentials.ini"
         DAF_BUTLER_REPOSITORY_INDEX: "/project/data-repos.yaml"
         LSST_KAFKA_BROKER_ADDR: "sasquatch-kafka-bootstrap.sasquatch:9092"
-        LSST_KAFKA_PASSFILE: "/opt/lsst/software/jupyterlab/secrets/kafka_credentials.txt"
+        LSST_KAFKA_PASSFILE: "/etc/nublado/secrets/kafka_credentials.txt"
         LSST_SCHEMA_REGISTRY_URL: "http://sasquatch-schema-registry.sasquatch:8081"
         LSST_SITE: "summit"
         LSST_TOPIC_SUBNAME: "sal"
-        PGPASSFILE: "/opt/lsst/software/jupyterlab/secrets/postgres-credentials.txt"
+        PGPASSFILE: "/etc/nublado/secrets/postgres-credentials.txt"
         PGUSER: "oods"
         RSP_SITE_TYPE: "telescope"
         S3_ENDPOINT_URL: "https://s3-butler.cp.lsst.org"

--- a/applications/nublado/values-tucson-teststand.yaml
+++ b/applications/nublado/values-tucson-teststand.yaml
@@ -14,14 +14,14 @@ controller:
       defaultSize: "small"
       env:
         AWS_REQUEST_CHECKSUM_CALCULATION: WHEN_REQUIRED
-        AWS_SHARED_CREDENTIALS_FILE: "/opt/lsst/software/jupyterlab/secrets/aws-credentials.ini"
+        AWS_SHARED_CREDENTIALS_FILE: "/etc/nublado/secrets/aws-credentials.ini"
         DAF_BUTLER_REPOSITORY_INDEX: "/project/data-repos.yaml"
         LSST_SITE: "tucson"
         LSST_TOPIC_SUBNAME: "sal"
-        LSST_KAFKA_PASSFILE: "/opt/lsst/software/jupyterlab/secrets/kafka_credentials.txt"
+        LSST_KAFKA_PASSFILE: "/etc/nublado/secrets/kafka_credentials.txt"
         LSST_KAFKA_BROKER_ADDR: "sasquatch-kafka-bootstrap.sasquatch:9092"
         LSST_SCHEMA_REGISTRY_URL: "http://sasquatch-schema-registry.sasquatch:8081"
-        PGPASSFILE: "/opt/lsst/software/jupyterlab/secrets/postgres-credentials.txt"
+        PGPASSFILE: "/etc/nublado/secrets/postgres-credentials.txt"
         PGUSER: "oods"
         RSP_SITE_TYPE: "telescope"
         S3_ENDPOINT_URL: "https://s3-butler.tu.lsst.org"

--- a/applications/nublado/values-usdfdev.yaml
+++ b/applications/nublado/values-usdfdev.yaml
@@ -34,13 +34,13 @@ controller:
       extraAnnotations:
         edu.stanford.slac.sdf.project/rsp: "true"
       env:
-        AWS_SHARED_CREDENTIALS_FILE: "/opt/lsst/software/jupyterlab/secrets/aws-credentials.ini"
+        AWS_SHARED_CREDENTIALS_FILE: "/etc/nublado/secrets/aws-credentials.ini"
         AWS_REQUEST_CHECKSUM_CALCULATION: "WHEN_REQUIRED"
         DAF_BUTLER_REPOSITORY_INDEX: "/project/data-repos.yaml"
         DAX_APDB_INDEX_URI: "/sdf/group/rubin/shared/apdb_config/apdb-index.yaml"
         HUB_ROUTE: "/nb/hub"
         HOMEDIR_SCHEMA: "initialThenUsername"
-        PGPASSFILE: "/opt/lsst/software/jupyterlab/secrets/postgres-credentials.txt"
+        PGPASSFILE: "/etc/nublado/secrets/postgres-credentials.txt"
         PGUSER: "rubin"
         RSP_SITE_TYPE: "staff"
         S3_ENDPOINT_URL: "https://s3dfrgw.slac.stanford.edu"

--- a/applications/nublado/values-usdfint.yaml
+++ b/applications/nublado/values-usdfint.yaml
@@ -32,13 +32,13 @@ controller:
       extraAnnotations:
         edu.stanford.slac.sdf.project/rsp: "true"
       env:
-        AWS_SHARED_CREDENTIALS_FILE: "/opt/lsst/software/jupyterlab/secrets/aws-credentials.ini"
+        AWS_SHARED_CREDENTIALS_FILE: "/etc/nublado/secrets/aws-credentials.ini"
         AWS_REQUEST_CHECKSUM_CALCULATION: "WHEN_REQUIRED"
         DAF_BUTLER_REPOSITORY_INDEX: "/project/data-repos.yaml"
         DAX_APDB_INDEX_URI: "/sdf/group/rubin/shared/apdb_config/apdb-index.yaml"
         HOMEDIR_SCHEMA: "initialThenUsername"
         HUB_ROUTE: "/nb/hub"
-        PGPASSFILE: "/opt/lsst/software/jupyterlab/secrets/postgres-credentials.txt"
+        PGPASSFILE: "/etc/nublado/secrets/postgres-credentials.txt"
         PGUSER: "rubin"
         RSP_SITE_TYPE: "staff"
         S3_ENDPOINT_URL: "https://s3dfrgw.slac.stanford.edu"

--- a/applications/nublado/values-usdfprod.yaml
+++ b/applications/nublado/values-usdfprod.yaml
@@ -32,13 +32,13 @@ controller:
       extraAnnotations:
         edu.stanford.slac.sdf.project/rsp: "true"
       env:
-        AWS_SHARED_CREDENTIALS_FILE: "/opt/lsst/software/jupyterlab/secrets/aws-credentials.ini"
+        AWS_SHARED_CREDENTIALS_FILE: "/etc/nublado/secrets/aws-credentials.ini"
         AWS_REQUEST_CHECKSUM_CALCULATION: "WHEN_REQUIRED"
         DAF_BUTLER_REPOSITORY_INDEX: "/project/data-repos.yaml"
         DAX_APDB_INDEX_URI: "/sdf/group/rubin/shared/apdb_config/apdb-index.yaml"
         HOMEDIR_SCHEMA: "initialThenUsername"
         HUB_ROUTE: "/nb/hub"
-        PGPASSFILE: "/opt/lsst/software/jupyterlab/secrets/postgres-credentials.txt"
+        PGPASSFILE: "/etc/nublado/secrets/postgres-credentials.txt"
         PGUSER: "rubin"
         RSP_SITE_TYPE: "staff"
         S3_ENDPOINT_URL: "https://s3dfrgw.slac.stanford.edu"


### PR DESCRIPTION
Fix the environment variables in the other environments to expect secrets to be mounted in `/etc/nublado/secrets` instead of the old `/opt/lsst/software/jupyterlab` path.