### PR TITLE
Restore the old mount path for EPO secret

### DIFF
--- a/applications/nublado/values-idfprod.yaml
+++ b/applications/nublado/values-idfprod.yaml
@@ -50,6 +50,7 @@ controller:
       secrets:
         - secretName: "nublado-lab-secret"
           secretKey: "rubin-epo-cit-sci-pipeline.json"
+          path: "/opt/lsst/software/jupyterlab/secrets/rubin-epo-cit-sci-pipeline.json"
       tolerations:
         - key: "nublado.lsst.io/permitted"
           operator: "Exists"


### PR DESCRIPTION
The Citizen Science pipeline secret needs to be mounted in the old directory since they have software that looks for it there.