### PR TITLE
Increase memory quota for notebooks on idfprod

### DIFF
--- a/applications/gafaelfawr/values-idfprod.yaml
+++ b/applications/gafaelfawr/values-idfprod.yaml
@@ -55,7 +55,7 @@ config:
         vo-cutouts: 35
       notebook:
         cpu: 4.0
-        memory: 16
+        memory: 32
       tap:
         qserv:
           concurrent: 12


### PR DESCRIPTION
We're now using large memory instances and are allowing more memory in notebooks.