### PR TITLE
[DM-54707] Add lsst.cp namespace to Sasquatch at BTS

### DIFF
--- a/applications/sasquatch/values-base.yaml
+++ b/applications/sasquatch/values-base.yaml
@@ -132,6 +132,23 @@ telegraf:
   enabled: true
   kafkaVersion: "3.9.1"
   kafkaConsumers:
+    # Application connectors
+    obsenv:
+      enabled: true
+      database: "lsst.obsenv"
+      timestamp_format: "unix_ms"
+      timestamp_field: "timestamp"
+      topicRegexps: |
+        [ "lsst.obsenv" ]
+    scimma:
+      enabled: true
+      database: "lsst.scimma"
+      timestamp_format: "unix_ms"
+      timestamp_field: "timestamp"
+      topicRegexps: |
+        [ "lsst.scimma" ]
+      offset: oldest
+    # CSC connectors
     auxtel:
       enabled: true
       database: "efd"
@@ -259,21 +276,7 @@ telegraf:
       timestamp_field: "private_efdStamp"
       topicRegexps: |
         [ "lsst.sal.MTVMS" ]
-    obsenv:
-      enabled: true
-      database: "lsst.obsenv"
-      timestamp_format: "unix_ms"
-      timestamp_field: "timestamp"
-      topicRegexps: |
-        [ "lsst.obsenv" ]
-    scimma:
-      enabled: true
-      database: "lsst.scimma"
-      timestamp_format: "unix_ms"
-      timestamp_field: "timestamp"
-      topicRegexps: |
-        [ "lsst.scimma" ]
-      offset: oldest
+    # CCS connectors (experimental) data is being written on separate databases for now
     atcamera:
       enabled: true
       database: "lsst.ATCamera"

--- a/applications/sasquatch/values-base.yaml
+++ b/applications/sasquatch/values-base.yaml
@@ -148,6 +148,15 @@ telegraf:
       topicRegexps: |
         [ "lsst.scimma" ]
       offset: oldest
+    cp:
+      enabled: true
+      database: "lsst.cp"
+      timestamp_format: "unix"
+      timestamp_field: "timestamp"
+      topicRegexps: |
+        [ "lsst.cp" ]
+      tags: |
+        [ "dataset_tag", "band", "instrument", "skymap", "detector", "physical_filter", "tract", "patch", "pipeline" ]
     # CSC connectors
     auxtel:
       enabled: true
@@ -318,6 +327,7 @@ rest-proxy:
     topicPrefixes:
       - lsst.obsenv
       - lsst.scimma
+      - lsst.cp
 
 chronograf:
   persistence:


### PR DESCRIPTION
This PR adds a new connector for the Calibration pipeline at BTS and exposes topics prefixed with `lsst.cp` to the REST Proxy - that's the mechanism Pipelines use to send data to Sasquatch. 

Also while I was there I grouped Application, CSC and CCS connector configurations.