### PR TITLE
DM-54922: Upgrade Nublado to 14.0.0

### DIFF
--- a/applications/nublado/Chart.yaml
+++ b/applications/nublado/Chart.yaml
@@ -5,12 +5,12 @@ description: JupyterHub and custom spawner for the Rubin Science Platform
 sources:
   - https://github.com/lsst-sqre/nublado
 home: https://nublado.lsst.io/
-appVersion: 13.0.0
+appVersion: 14.0.0
 
 dependencies:
   - name: jupyterhub
     # This is the Zero To Jupyterhub version (and quay.io/jupyterhub/k8s-hub)
-    version: "4.3.3"
+    version: "4.3.5"
     repository: https://jupyterhub.github.io/helm-chart/
 
 annotations:

--- a/applications/nublado/README.md
+++ b/applications/nublado/README.md
@@ -156,7 +156,7 @@ JupyterHub and custom spawner for the Rubin Science Platform
 | jupyterhub.hub.extraVolumeMounts | list | `hub-config` and the Gafaelfawr token | Additional volume mounts for JupyterHub |
 | jupyterhub.hub.extraVolumes | list | The `hub-config` `ConfigMap` and the Gafaelfawr token | Additional volumes to make available to JupyterHub |
 | jupyterhub.hub.image.name | string | `"ghcr.io/lsst-sqre/nublado-jupyterhub"` | Image to use for JupyterHub |
-| jupyterhub.hub.image.tag | string | `"13.0.0"` | Tag of image to use for JupyterHub |
+| jupyterhub.hub.image.tag | string | `"14.0.0"` | Tag of image to use for JupyterHub |
 | jupyterhub.hub.loadRoles.server.scopes | list | See `values.yaml` | Default scopes for the user's lab, overridden to allow the lab to delete itself (which we use for our added menu items) |
 | jupyterhub.hub.networkPolicy.enabled | bool | `false` | Whether to enable the default `NetworkPolicy` (currently, the upstream one does not work correctly) |
 | jupyterhub.hub.resources | object | See `values.yaml` | Resource limits and requests |

--- a/applications/nublado/values.yaml
+++ b/applications/nublado/values.yaml
@@ -570,7 +570,7 @@ jupyterhub:
       name: "ghcr.io/lsst-sqre/nublado-jupyterhub"
 
       # -- Tag of image to use for JupyterHub
-      tag: "13.0.0"
+      tag: "14.0.0"
 
     # -- Resource limits and requests
     # @default -- See `values.yaml`


### PR DESCRIPTION
The primary changes are to the JupyterLab base image, but this updates JupyterHub to 5.4.6 and Zero to JupyterHub to 4.3.5.