### PR TITLE
DM-54916: Wire Sentry into the Docverse chart

### DIFF
--- a/applications/docverse/Chart.yaml
+++ b/applications/docverse/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "tickets-DM-54916-sentry-init"
+appVersion: "tickets-DM-54916"
 description: Publish versioned docs
 name: docverse
 sources:

--- a/applications/docverse/Chart.yaml
+++ b/applications/docverse/Chart.yaml
@@ -1,6 +1,5 @@
 apiVersion: v2
-# https://github.com/lsst-sqre/docverse/pull/364
-appVersion: "tickets-DM-54688-worker-pool"
+appVersion: "tickets-DM-54916-sentry-init"
 description: Publish versioned docs
 name: docverse
 sources:

--- a/applications/docverse/README.md
+++ b/applications/docverse/README.md
@@ -26,6 +26,8 @@ Publish versioned docs
 | config.logLevel | string | `"INFO"` | Logging level |
 | config.logProfile | string | `"production"` | Logging profile (`production` for JSON, `development` for human-friendly) |
 | config.pathPrefix | string | `"/docverse/api"` | URL path prefix |
+| config.sentry.enabled | bool | `false` | Whether to send error reports and tracing data to Sentry. Requires the sentry-dsn secret to be set in Vault. |
+| config.sentry.tracesSampleRate | float | `0` | The percentage of requests that should be traced. This should be a float between 0 and 1. |
 | config.slackAlerts | bool | `false` | Whether to send Slack alerts for unexpected failures |
 | config.superadminUsers | list | `["jonathansick"]` | Usernames that have super admin (de facto admin in all organizations) |
 | config.updateSchema | bool | `false` | Whether to run Alembic schema migrations on install/upgrade |

--- a/applications/docverse/secrets.yaml
+++ b/applications/docverse/secrets.yaml
@@ -16,6 +16,10 @@ DOCVERSE_GITHUB_APP_PRIVATE_KEY:
     repositories.
   onepassword:
     encoded: true
+SENTRY_DSN:
+  description: >-
+    DSN URL to which Sentry trace and error logging will be sent.
+  if: config.sentry.enabled
 slack-webhook:
   description: >-
     Slack web hook used to report internal errors to Slack. This secret may be

--- a/applications/docverse/templates/_helpers.tpl
+++ b/applications/docverse/templates/_helpers.tpl
@@ -84,4 +84,15 @@ Secret environment variables shared across all Docverse pods.
       name: "docverse"
       key: "slack-webhook"
 {{- end }}
+{{- if .Values.config.sentry.enabled }}
+- name: "SENTRY_DSN"
+  valueFrom:
+    secretKeyRef:
+      name: "docverse"
+      key: "SENTRY_DSN"
+- name: "SENTRY_ENVIRONMENT"
+  value: {{ .Values.global.environmentName | quote }}
+- name: "SENTRY_TRACES_SAMPLE_RATE"
+  value: {{ .Values.config.sentry.tracesSampleRate | quote }}
+{{- end }}
 {{- end }}

--- a/applications/docverse/values-roundtable-dev.yaml
+++ b/applications/docverse/values-roundtable-dev.yaml
@@ -12,6 +12,8 @@ config:
     enabled: true
   lifecycleEval:
     enabled: true
+  sentry:
+    enabled: true
 
 cloudsql:
   enabled: true

--- a/applications/docverse/values-roundtable-prod.yaml
+++ b/applications/docverse/values-roundtable-prod.yaml
@@ -2,6 +2,8 @@ config:
   databaseUrl: "postgresql://docverse@localhost/docverse"
   superadminUsers:
     - "jonathansick"
+  sentry:
+    enabled: true
 
 cloudsql:
   enabled: true

--- a/applications/docverse/values.yaml
+++ b/applications/docverse/values.yaml
@@ -34,6 +34,15 @@ config:
   # -- Whether to send Slack alerts for unexpected failures
   slackAlerts: false
 
+  sentry:
+    # -- Whether to send error reports and tracing data to Sentry. Requires
+    # the sentry-dsn secret to be set in Vault.
+    enabled: false
+
+    # -- The percentage of requests that should be traced. This should be a
+    # float between 0 and 1.
+    tracesSampleRate: 0.0
+
   # -- Database URL for PostgreSQL
   databaseUrl: ""
 


### PR DESCRIPTION
## Summary

- Add a `config.sentry` block (matching the gafaelfawr pattern) and a `sentry-dsn` Vault secret gated on `config.sentry.enabled`, then inject `SENTRY_DSN`, `SENTRY_ENVIRONMENT`, and `SENTRY_TRACES_SAMPLE_RATE` via the shared `docverse.envVars` helper so the API, default arq worker, and keeper-sync worker stay in lockstep.
- Enable Sentry in both `roundtable-dev` and `roundtable-prod` overlays.
- Bump `appVersion` to `tickets-DM-54916-sentry-init` so deployed pods include the Sentry-instrumented Docverse build.

## Validation steps

- [ ] Confirm Prodromos has registered the `docverse` Sentry project DSN in Vault for `roundtable-dev` (and for `roundtable-prod` whenever docverse is enabled there) before Argo CD syncs this change — otherwise the VaultSecret reconcile will fail.
- [ ] After sync to `roundtable-dev`, verify the `docverse`, `docverse-worker`, and `docverse-sync-worker` pods come up with `SENTRY_DSN`, `SENTRY_ENVIRONMENT=roundtable-dev`, and `SENTRY_TRACES_SAMPLE_RATE` set, and that the image tag is `tickets-DM-54916-sentry-init`.
- [ ] Trigger one error path per `lsst-sqre/docverse#348` and confirm the event appears in Sentry with the expected `environment` and `release` tags.

## References

- PRD: lsst-sqre/docverse#338
- Task: lsst-sqre/docverse#348
- Jira: https://rubinobs.atlassian.net/browse/DM-54916