### PR TITLE
atlantis - Update allowed commands and who can run them

### DIFF
--- a/applications/atlantis/README.md
+++ b/applications/atlantis/README.md
@@ -9,6 +9,7 @@ Tool for github terraform workflows: https://runatlantis.io
 | affinity | object | `{}` | Affinity rules for the atlantis deployment pod |
 | config.repoConfig | object | See `values.yaml` | Content for the [server-side repo config](https://www.runatlantis.io/docs/server-side-repo-config.html) file |
 | config.serverConfig | object | See `values.yaml` | Content for the [server config](https://www.runatlantis.io/docs/server-configuration.html) file. Note the format of the keys (kebab-case) |
+| config.serverConfig.allow-commands | string | `"version,plan,apply,unlock,approve_policies,import"` | Add `import` to the defaults |
 | config.serverConfig.automerge | bool | `false` | Whether to automatically merge PRs after plans have been applied (see [docs](https://www.runatlantis.io/docs/automerging.html)) |
 | config.serverConfig.log-level | string | `"info"` | One of: debug, info, warn, or error. |
 | config.serverConfig.repo-allowlist | string | `""` | Specification of GitHub repos that Atlantis will accept webooks from: [docs](https://www.runatlantis.io/docs/server-configuration.html#repo-allowlist) |

--- a/applications/atlantis/values.yaml
+++ b/applications/atlantis/values.yaml
@@ -7,21 +7,20 @@ config:
   # Kubernetes service account to impersonate it.
   # googleServiceAccount:
 
-
   # -- Content for the [server-side repo
   # config](https://www.runatlantis.io/docs/server-side-repo-config.html) file
   # @default -- See `values.yaml`
   repoConfig:
     repos:
-    - id: "/.*/"
-      apply_requirements: ["mergeable", "undiverged"]
-      pre_workflow_hooks:
-      - run: "rm -rf src/prodromos/templates"
-        description: |
-          The prodromos repo has .tf files in the templates dir
-          which confuses the module autoplanner. There is no way
-          to tell the module autoplanner to ignore anything :(
-        commands: "plan, apply"
+      - id: "/.*/"
+        apply_requirements: ["mergeable", "undiverged"]
+        pre_workflow_hooks:
+          - run: "rm -rf src/prodromos/templates"
+            description: |
+              The prodromos repo has .tf files in the templates dir
+              which confuses the module autoplanner. There is no way
+              to tell the module autoplanner to ignore anything :(
+            commands: "plan, apply"
 
   # -- Content for the [server
   # config](https://www.runatlantis.io/docs/server-configuration.html) file.
@@ -42,6 +41,9 @@ config:
     # -- We're delegating auth for the web UI to gafaelfawr
     web-basic-auth: false
     autoplan-modules: true
+    # -- Add `import` to the defaults
+    allow-commands: "version,plan,apply,unlock,approve_policies,import"
+    gh-team-allowlist: "square:version,square:plan,square:apply,square:unlock,square:approve_policies,square:import"
 
 image:
   # -- atlantis image to use


### PR DESCRIPTION
* Add `import` to the allowed commands
* Restrict all commands to GitHub `square` team members