### PR TITLE
DM-54874: Add Cronjobs to scale up and down Prompt Pub Replicas

### DIFF
--- a/applications/prompt-pub/README.md
+++ b/applications/prompt-pub/README.md
@@ -37,4 +37,7 @@ Manages the lifecycle of Butler Prompt Data Products as they move from the embar
 | publication.stateDB | string | `""` | Postgres database for holding publication state |
 | replicaCount | int | `1` | Number of statefulset pods to start |
 | resources | object | See `values.yaml` | Resource limits and requests for the prompt-pub statefulset pod |
+| scaleReplica.downSchedule | string | `"30 21 * * *"` | Time in Cron format to scale down replica in UTC |
+| scaleReplica.enabled | bool | `false` | Enable scale up and down of prompt pub statefulset on a schedule |
+| scaleReplica.upSchedule | string | `"0 12 * * *"` | Time to Cron format scale up replica in UTC |
 | tolerations | list | `[]` | Tolerations for the prompt-pub deployment pod |

--- a/applications/prompt-pub/templates/scale-cronjob.yaml
+++ b/applications/prompt-pub/templates/scale-cronjob.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.scaleReplica.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: scale-down-prompt-pub
+  namespace: prompt-pub
+spec:
+  schedule: {{ .Values.scaleReplica.downSchedule | quote }}
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: scale-replica
+          containers:
+          - name: scale-replica
+            image: bitnami/kubectl:latest
+            command:
+            - /bin/sh
+            - -c
+            - kubectl scale statefulset prompt-pub --replicas=0
+          restartPolicy: OnFailure
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: scale-up-prompt-pub
+  namespace: prompt-pub
+spec:
+  schedule: {{ .Values.scaleReplica.upSchedule | quote }}
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: scale-replica
+          containers:
+          - name: scale-replica
+            image: bitnami/kubectl:latest
+            command:
+            - /bin/sh
+            - -c
+            - kubectl scale statefulset prompt-pub --replicas=1
+          restartPolicy: OnFailure
+{{- end }}

--- a/applications/prompt-pub/templates/scale-replica-rbac.yaml
+++ b/applications/prompt-pub/templates/scale-replica-rbac.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.scaleReplica.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prompt-pub-scale-replica
+  namespace: prompt-pub
+rules:
+- apiGroups: ["apps"]
+  resources: ["statefulsets", "statefulsets/scale"]
+  verbs: ["get", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prompt-pub-scale-replica-binding
+  namespace: prompt-pub
+subjects:
+- kind: ServiceAccount
+  name: scale-replica
+  namespace: prompt-pub
+roleRef:
+  kind: Role
+  name: prompt-pub-scale-replica
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: scale-replica
+  namespace: prompt-pub
+{{- end }}

--- a/applications/prompt-pub/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-pub/values-usdfprod-prompt-processing.yaml
@@ -44,3 +44,6 @@ alloyDbProxy:
     limits:
       memory: "1Gi"
       cpu: "1"
+
+scaleReplica:
+  enabled: true

--- a/applications/prompt-pub/values.yaml
+++ b/applications/prompt-pub/values.yaml
@@ -79,6 +79,13 @@ alloyDbProxy:
       memory: "256Mi"
       cpu: "0.2"
 
+scaleReplica:
+  # -- Enable scale up and down of prompt pub statefulset on a schedule
+  enabled: false
+  # -- Time in Cron format to scale down replica in UTC
+  downSchedule: "30 21 * * *"
+  # -- Time to Cron format scale up replica in UTC
+  upSchedule: "0 12 * * *"
 
 # -- Affinity rules for the prompt-pub statefulset pod
 affinity: {}


### PR DESCRIPTION
Add cronjobs, service account, role, and role bindings to scale up and down the Prompt Publication statefulset on a schedule  to avoid running during observing.