### PR TITLE
DM-54688: Wire up docverse lifecycle_eval arq worker pool

### DIFF
--- a/applications/docverse/Chart.yaml
+++ b/applications/docverse/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-# https://github.com/lsst-sqre/docverse/pull/306
-appVersion: "tickets-DM-54794-tier-crons"
+# https://github.com/lsst-sqre/docverse/pull/364
+appVersion: "tickets-DM-54688-worker-pool"
 description: Publish versioned docs
 name: docverse
 sources:

--- a/applications/docverse/README.md
+++ b/applications/docverse/README.md
@@ -22,6 +22,7 @@ Publish versioned docs
 | config.databaseUrl | string | `""` | Database URL for PostgreSQL |
 | config.githubAppId | string | `nil` | GitHub App ID for Docverse to use when accessing GitHub repositories. If not set, Docverse will operate in a limited mode without GitHub integration. |
 | config.keeperSync.enabled | bool | `false` | Enable the Keeper-sync worker that consumes the `docverse:sync-queue` arq queue. Requires the docverse image to provide `docverse.worker.main.KeeperSyncWorkerSettings`. |
+| config.lifecycleEval.enabled | bool | `false` | Enable the lifecycle-evaluation worker that consumes the `docverse:lifecycle-queue` arq queue. Requires the docverse image to provide `docverse.worker.main.LifecycleEvalWorkerSettings`. |
 | config.logLevel | string | `"INFO"` | Logging level |
 | config.logProfile | string | `"production"` | Logging profile (`production` for JSON, `development` for human-friendly) |
 | config.pathPrefix | string | `"/docverse/api"` | URL path prefix |
@@ -35,6 +36,12 @@ Publish versioned docs
 | image.repository | string | `"ghcr.io/lsst-sqre/docverse"` | Image to use in the docverse deployment |
 | image.tag | string | The appVersion of the chart | Tag of image to use |
 | ingress.annotations | object | `{}` | Additional annotations for the ingress rule |
+| lifecycleWorker.affinity | object | `{}` | Affinity rules for the lifecycle-eval worker pod |
+| lifecycleWorker.nodeSelector | object | `{}` | Node selection rules for the lifecycle-eval worker pod |
+| lifecycleWorker.podAnnotations | object | `{}` | Annotations for the lifecycle-eval worker pod |
+| lifecycleWorker.replicaCount | int | `1` | Number of lifecycle-eval worker pods to start |
+| lifecycleWorker.resources | object | See `values.yaml` | Resource limits and requests for the lifecycle-eval worker pod |
+| lifecycleWorker.tolerations | list | `[]` | Tolerations for the lifecycle-eval worker pod |
 | nodeSelector | object | `{}` | Node selection rules for the docverse deployment pod |
 | podAnnotations | object | `{}` | Annotations for the docverse deployment pod |
 | redis.affinity | object | `{}` | Affinity rules for the Redis pod |

--- a/applications/docverse/templates/lifecycle-worker-deployment.yaml
+++ b/applications/docverse/templates/lifecycle-worker-deployment.yaml
@@ -1,0 +1,74 @@
+{{- if .Values.config.lifecycleEval.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "docverse-lifecycle-worker"
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  labels:
+    {{- include "docverse.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "lifecycle-worker"
+    docverse-redis-client: "true"
+spec:
+  replicas: {{ .Values.lifecycleWorker.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "docverse.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: "lifecycle-worker"
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.lifecycleWorker.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "docverse.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: "lifecycle-worker"
+        docverse-redis-client: "true"
+    spec:
+      {{- with .Values.lifecycleWorker.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.cloudsql.enabled }}
+      serviceAccountName: "docverse"
+      {{- else }}
+      automountServiceAccountToken: false
+      {{- end }}
+      containers:
+        - name: "docverse-lifecycle-worker"
+          command: ["arq"]
+          args: ["docverse.worker.main.LifecycleEvalWorkerSettings"]
+          env:
+            {{- include "docverse.envVars" . | nindent 12 }}
+          envFrom:
+            - configMapRef:
+                name: "docverse"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          resources:
+            {{- toYaml .Values.lifecycleWorker.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+            readOnlyRootFilesystem: true
+      {{- if .Values.cloudsql.enabled }}
+      initContainers:
+        {{- include "docverse.cloudsqlSidecar" . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.lifecycleWorker.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.lifecycleWorker.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+{{- end }}

--- a/applications/docverse/values-roundtable-dev.yaml
+++ b/applications/docverse/values-roundtable-dev.yaml
@@ -10,6 +10,8 @@ config:
     - "jonathansick"
   keeperSync:
     enabled: true
+  lifecycleEval:
+    enabled: true
 
 cloudsql:
   enabled: true

--- a/applications/docverse/values.yaml
+++ b/applications/docverse/values.yaml
@@ -58,6 +58,12 @@ config:
     # provide `docverse.worker.main.KeeperSyncWorkerSettings`.
     enabled: false
 
+  lifecycleEval:
+    # -- Enable the lifecycle-evaluation worker that consumes the
+    # `docverse:lifecycle-queue` arq queue. Requires the docverse image to
+    # provide `docverse.worker.main.LifecycleEvalWorkerSettings`.
+    enabled: false
+
 ingress:
   # -- Additional annotations for the ingress rule
   annotations: {}
@@ -117,6 +123,32 @@ syncWorker:
   podAnnotations: {}
 
   # -- Tolerations for the Keeper-sync worker pod
+  tolerations: []
+
+lifecycleWorker:
+  # -- Number of lifecycle-eval worker pods to start
+  replicaCount: 1
+
+  # -- Resource limits and requests for the lifecycle-eval worker pod
+  # @default -- See `values.yaml`
+  resources:
+    limits:
+      cpu: "1"
+      memory: "512Mi"
+    requests:
+      cpu: "50m"
+      memory: "128Mi"
+
+  # -- Affinity rules for the lifecycle-eval worker pod
+  affinity: {}
+
+  # -- Node selection rules for the lifecycle-eval worker pod
+  nodeSelector: {}
+
+  # -- Annotations for the lifecycle-eval worker pod
+  podAnnotations: {}
+
+  # -- Tolerations for the lifecycle-eval worker pod
   tolerations: []
 
 # -- Tolerations for the docverse deployment pod


### PR DESCRIPTION
## Summary

- Adds a `docverse-lifecycle-worker` Deployment that runs `arq docverse.worker.main.LifecycleEvalWorkerSettings` against the `docverse:lifecycle-queue` broker, mirroring the existing Keeper-sync worker pattern.
- Gated on a new `config.lifecycleEval.enabled` flag (default `false`); enabled on `roundtable-dev` so the new pool can be exercised in dev. `roundtable-prod` is intentionally untouched and follows as a separate change after dev burn-in.
- Bumps `appVersion` to `tickets-DM-54688-worker-pool` so the running image contains the `LifecycleEvalWorkerSettings` class introduced in docverse PR [#364](https://github.com/lsst-sqre/docverse/pull/364).

## Validation steps

- [ ] After deploy on `roundtable-dev`, confirm the `docverse-lifecycle-worker-*` pod starts and reaches `Ready`.
- [ ] Tail the pod logs and confirm the worker attaches to `docverse:lifecycle-queue` on startup.
- [ ] Confirm the lifecycle-eval dispatcher cron fires on the hour and the reaper fires at `:00` / `:30`.
- [ ] Confirm `roundtable-prod` is unaffected (no new pod, no new Argo CD sync activity for docverse beyond the appVersion bump).

## References

- PRD: lsst-sqre/docverse#337
- Jira: https://rubinobs.atlassian.net/browse/DM-54688