### PR TITLE
DM-54647: Add IVOA registry configuration to repertoire

### DIFF
--- a/applications/repertoire/Chart.yaml
+++ b/applications/repertoire/Chart.yaml
@@ -6,7 +6,7 @@ description: Service discovery
 home: "https://repertoire.lsst.io/"
 sources:
   - "https://github.com/lsst-sqre/repertoire"
-appVersion: 0.13.0
+appVersion: 0.13.1
 
 annotations:
   phalanx.lsst.io/docs: |

--- a/applications/repertoire/Chart.yaml
+++ b/applications/repertoire/Chart.yaml
@@ -6,7 +6,7 @@ description: Service discovery
 home: "https://repertoire.lsst.io/"
 sources:
   - "https://github.com/lsst-sqre/repertoire"
-appVersion: 0.12.1
+appVersion: 0.13.0
 
 annotations:
   phalanx.lsst.io/docs: |

--- a/applications/repertoire/README.md
+++ b/applications/repertoire/README.md
@@ -32,6 +32,7 @@ Service discovery
 | config.hips.pathPrefix | string | `"/api/hips/v2"` | Path prefix at which the HiPS lists should be served |
 | config.hips.sourceTemplate | string | See `values.yaml` | Jinja template to construct the base URLs of the underlying HiPS surveys, used to construct the HiPS list. |
 | config.influxdbDatabases | object | `{}` | Dictionary of InfluxDB database names to connection information for that database, with keys `url`, `database`, `username`, `passwordKey`, and `schemaRegistry`. `passwordKey` must match an entry in `secrets.yaml`. |
+| config.ivoaRegistry | object | See `values.yaml` | IVOA publishing registry configuration. |
 | config.logLevel | string | `"INFO"` | Logging level |
 | config.logProfile | string | `"production"` | Logging profile (`production` for JSON, `development` for human-friendly) |
 | config.metrics.application | string | `"repertoire"` | Name under which to log metrics. Generally there is no reason to change this. |

--- a/applications/repertoire/templates/ingress-registry.yaml
+++ b/applications/repertoire/templates/ingress-registry.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.config.ivoaRegistry }}
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
+metadata:
+  name: "repertoire-registry"
+  labels:
+    {{- include "repertoire.labels" . | nindent 4 }}
+config:
+  scopes:
+    anonymous: true
+template:
+  metadata:
+    name: "repertoire-registry"
+    {{- with .Values.ingress.annotations }}
+    annotations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  spec:
+    rules:
+      - host: {{ required "global.host must be set" .Values.global.host | quote }}
+        http:
+          paths:
+            - path: "{{ .Values.config.ivoaRegistry.pathPrefix }}"
+              pathType: "Prefix"
+              backend:
+                service:
+                  name: "repertoire"
+                  port:
+                    number: 8080
+{{- end }}

--- a/applications/repertoire/values-idfdev.yaml
+++ b/applications/repertoire/values-idfdev.yaml
@@ -1,3 +1,7 @@
+image:
+  pullPolicy: "Always"
+  tag: "tickets-DM-54647"
+
 config:
   availableDatasets:
     - "dp02"

--- a/applications/repertoire/values-idfdev.yaml
+++ b/applications/repertoire/values-idfdev.yaml
@@ -1,7 +1,3 @@
-image:
-  pullPolicy: "Always"
-  tag: "tickets-DM-54647"
-
 config:
   availableDatasets:
     - "dp02"

--- a/applications/repertoire/values.yaml
+++ b/applications/repertoire/values.yaml
@@ -132,23 +132,24 @@ config:
   # -- IVOA publishing registry configuration.
   # @default -- See `values.yaml`
   ivoaRegistry:
-    adminEmail: "vo-registry@lsst.org"
-    authority: "ivo://rubin"
-    created: "2026-04-20T00:00:00"
+    adminEmail: "rubin-vo@lists.lsst.org"
+    authority: "ivo://org.rubinobs"
+    created: "2026-05-20T00:00:00"
     creator: "Vera C. Rubin Observatory"
-    ivoid: "ivo://rubin/registry"
+    ivoid: "ivo://org.rubinobs/registry"
     pathPrefix: "/discovery"
     repositoryName: "Rubin Science Platform IVOA Publishing Registry"
     rights: "Restricted to authorized Rubin data rights holders. See https://www.lsst.org/content/data-rights"
     rightsUri: "https://www.lsst.org/content/data-rights"
     shortName: "Rubin RSP"
     organisation:
-      created: "2026-05-05T00:00:00Z"
+      created: "2026-05-20T00:00:00Z"
       description: >-
-        Vera C. Rubin Observatory operates the Vera C. Rubin Observatory
-        telescope and conducts the Legacy Survey of Space and Time (LSST).
+        The NSF-DOE Vera C. Rubin Observatory conducts the Legacy Survey of
+        Space and Time (LSST) using the Simonyi Survey Telescope on Cerro
+        Pachón, Chile.
       homepage: "https://rubinobservatory.org"
-      ivoid: "ivo://rubin/org"
+      ivoid: "ivo://org.rubinobs/org"
       title: "Vera C. Rubin Observatory"
 
   metrics:
@@ -301,18 +302,10 @@ config:
         ivoaRegistry:
           ivoaServiceType: "sia"
           records:
-            dp02:
-              ivoid: "ivo://rubin/sia/dp02"
-              title: "Rubin Science Platform SIA Service (DP0.2)"
-              created: "2026-04-20T00:00:00"
-              description: >-
-                Simple Image Access v2 service for Data Preview 0.2, providing
-                image access to the DESC DC2 simulation processed with Rubin
-                Science Pipelines.
             dp1:
-              ivoid: "ivo://rubin/sia/dp1"
+              ivoid: "ivo://org.rubinobs/sia/lsst-dp1"
               title: "Rubin Science Platform SIA Service (DP1)"
-              created: "2026-04-20T00:00:00"
+              created: "2026-05-20T00:00:00"
               description: >-
                 Simple Image Access v2 service for Data Preview 1, providing
                 image access to commissioning data from Rubin Observatory.
@@ -338,9 +331,9 @@ config:
         template: "https://{{base_hostname}}/api/tap"
         ivoaRegistry:
           ivoaServiceType: "tap"
-          ivoid: "ivo://rubin/tap"
+          ivoid: "ivo://org.rubinobs/tap"
           title: "Rubin Science Platform TAP Service"
-          created: "2026-04-20T00:00:00"
+          created: "2026-05-20T00:00:00"
           description: >-
             Table Access Protocol service for the Rubin Science Platform,
             providing access to catalog data from Rubin Observatory data
@@ -372,9 +365,9 @@ config:
         openapi: "https://{{base_hostname}}/api/cutout/openapi.json"
         ivoaRegistry:
           ivoaServiceType: "soda"
-          ivoid: "ivo://rubin/cutout"
+          ivoid: "ivo://org.rubinobs/cutout"
           title: "Rubin Science Platform Image Cutout Service"
-          created: "2026-04-20T00:00:00"
+          created: "2026-05-20T00:00:00"
           description: >-
             Image cutout service (SODA) for the Rubin Science Platform,
             supporting both synchronous and asynchronous image cutout requests.

--- a/applications/repertoire/values.yaml
+++ b/applications/repertoire/values.yaml
@@ -129,6 +129,28 @@ config:
   # human-friendly)
   logProfile: "production"
 
+  # -- IVOA publishing registry configuration.
+  # @default -- See `values.yaml`
+  ivoaRegistry:
+    adminEmail: "vo-registry@lsst.org"
+    authority: "ivo://rubin"
+    created: "2026-04-20T00:00:00"
+    creator: "Vera C. Rubin Observatory"
+    ivoid: "ivo://rubin/registry"
+    pathPrefix: "/discovery"
+    repositoryName: "Rubin Science Platform IVOA Publishing Registry"
+    rights: "Restricted to authorized Rubin data rights holders. See https://www.lsst.org/content/data-rights"
+    rightsUri: "https://www.lsst.org/content/data-rights"
+    shortName: "Rubin RSP"
+    organisation:
+      created: "2026-05-05T00:00:00Z"
+      description: >-
+        Vera C. Rubin Observatory operates the Vera C. Rubin Observatory
+        telescope and conducts the Legacy Survey of Space and Time (LSST).
+      homepage: "https://rubinobservatory.org"
+      ivoid: "ivo://rubin/org"
+      title: "Vera C. Rubin Observatory"
+
   metrics:
     # -- Whether to enable sending metrics
     enabled: false
@@ -276,6 +298,24 @@ config:
             template: "https://{{base_hostname}}/api/sia/{{dataset}}/query"
             ivoaStandardId: "ivo://ivoa.net/std/SIA#query-2.0"
         openapi: "https://{{base_hostname}}/api/sia/openapi.json"
+        ivoaRegistry:
+          ivoaServiceType: "sia"
+          records:
+            dp02:
+              ivoid: "ivo://rubin/sia/dp02"
+              title: "Rubin Science Platform SIA Service (DP0.2)"
+              created: "2026-04-20T00:00:00"
+              description: >-
+                Simple Image Access v2 service for Data Preview 0.2, providing
+                image access to the DESC DC2 simulation processed with Rubin
+                Science Pipelines.
+            dp1:
+              ivoid: "ivo://rubin/sia/dp1"
+              title: "Rubin Science Platform SIA Service (DP1)"
+              created: "2026-04-20T00:00:00"
+              description: >-
+                Simple Image Access v2 service for Data Preview 1, providing
+                image access to commissioning data from Rubin Observatory.
     squareone:
       - type: "ui"
         name: "settings"
@@ -296,6 +336,17 @@ config:
           - "dp02"
           - "dp1"
         template: "https://{{base_hostname}}/api/tap"
+        ivoaRegistry:
+          ivoaServiceType: "tap"
+          ivoid: "ivo://rubin/tap"
+          title: "Rubin Science Platform TAP Service"
+          created: "2026-04-20T00:00:00"
+          description: >-
+            Table Access Protocol service for the Rubin Science Platform,
+            providing access to catalog data from Rubin Observatory data
+            releases.
+          adqlVersion: "2.1"
+          uploadSupported: true
     times-square:
       - type: "internal"
         name: "times-square"
@@ -319,6 +370,14 @@ config:
             template: "https://{{base_hostname}}/api/cutout/sync"
             ivoaStandardId: "ivo://ivoa.net/std/SODA#sync-1.0"
         openapi: "https://{{base_hostname}}/api/cutout/openapi.json"
+        ivoaRegistry:
+          ivoaServiceType: "soda"
+          ivoid: "ivo://rubin/cutout"
+          title: "Rubin Science Platform Image Cutout Service"
+          created: "2026-04-20T00:00:00"
+          description: >-
+            Image cutout service (SODA) for the Rubin Science Platform,
+            supporting both synchronous and asynchronous image cutout requests.
     wobbly:
       - type: "internal"
         name: "wobbly"


### PR DESCRIPTION
## Changes
- Update repertoire to version 0.13.1
- Add relevant ivoa metadata to repertoire/values.yaml
- Includes general organization/authority information at the top level ivoaRegistry section
- Per service specific information included for each service that will be published in registry