### PR TITLE
DM-54840: Add max_bytes setting to bigquery kafka to limit result size, default to 3 GiB

### DIFF
--- a/applications/bigquery-kafka/Chart.yaml
+++ b/applications/bigquery-kafka/Chart.yaml
@@ -5,7 +5,7 @@ version: 1.0.0
 description: "BigQuery Kafka bridge"
 sources:
   - "https://github.com/lsst-sqre/qserv-kafka"
-appVersion: 4.4.0
+appVersion: 4.5.0
 
 dependencies:
   - name: "redis"

--- a/applications/bigquery-kafka/README.md
+++ b/applications/bigquery-kafka/README.md
@@ -27,6 +27,7 @@ BigQuery Kafka bridge
 | config.jobStatusTopic | string | `"lsst.ppdbtap.job-status"` | Kafka topic for query status |
 | config.logLevel | string | `"INFO"` | Logging level |
 | config.logProfile | string | `"production"` | Logging profile (`production` for JSON, `development` for human-friendly) |
+| config.maxResultBytes | int | 3GiB | Maximum bytes of encoded output to return per query. Results exceeding this will be truncated with an overflow marker. |
 | config.maxWorkerJobs | int | `2` | Maximum number of arq jobs each worker can process simultaneously |
 | config.metrics.application | string | `"bigquerykafka"` | Name under which to log metrics. Generally there is no reason to change this. |
 | config.metrics.enabled | bool | `false` | Whether to enable sending metrics |

--- a/applications/bigquery-kafka/templates/configmap.yaml
+++ b/applications/bigquery-kafka/templates/configmap.yaml
@@ -17,6 +17,9 @@ data:
   {{- if .Values.config.bigqueryMaxBytesBilled }}
   QSERV_KAFKA_BIGQUERY_MAX_BYTES_BILLED: {{ int64 .Values.config.bigqueryMaxBytesBilled | quote }}
   {{- end }}
+  {{- if .Values.config.maxResultBytes }}
+  QSERV_KAFKA_MAX_RESULT_BYTES: {{ int64 .Values.config.maxResultBytes | quote }}
+  {{- end }}
   QSERV_KAFKA_JOB_CANCEL_TOPIC: {{ .Values.config.jobCancelTopic | quote }}
   QSERV_KAFKA_JOB_RUN_BATCH_SIZE: {{ .Values.config.jobRunBatchSize | quote }}
   QSERV_KAFKA_JOB_RUN_MAX_BYTES: {{ int64 .Values.config.jobRunMaxBytes | quote }}

--- a/applications/bigquery-kafka/values-idfdev.yaml
+++ b/applications/bigquery-kafka/values-idfdev.yaml
@@ -16,6 +16,3 @@ config:
 redis:
   persistence:
     enabled: true
-
-resultWorker:
-  allowRootDebug: true

--- a/applications/bigquery-kafka/values-idfint.yaml
+++ b/applications/bigquery-kafka/values-idfint.yaml
@@ -15,6 +15,3 @@ config:
 redis:
   persistence:
     enabled: true
-
-resultWorker:
-  allowRootDebug: false

--- a/applications/bigquery-kafka/values.yaml
+++ b/applications/bigquery-kafka/values.yaml
@@ -33,6 +33,11 @@ config:
   # @default -- 10MiB
   jobRunMaxBytes: 10485760
 
+  # -- Maximum bytes of encoded output to return per query. Results exceeding
+  # this will be truncated with an overflow marker.
+  # @default -- 3GiB
+  maxResultBytes: 3221225472
+
   # -- Kafka topic for query execution requests
   jobRunTopic: "lsst.ppdbtap.job-run"
 

--- a/applications/bigquery-kafka/values.yaml
+++ b/applications/bigquery-kafka/values.yaml
@@ -165,8 +165,8 @@ frontend:
   # @default -- See `values.yaml`
   resources:
     limits:
-      cpu: "1"
-      memory: "450Mi"
+      cpu: "2"
+      memory: "1Gi"
     requests:
       cpu: "100m"
       memory: "145Mi"
@@ -262,8 +262,8 @@ resultWorker:
   # @default -- See `values.yaml`
   resources:
     limits:
-      cpu: "1"
-      memory: "500Mi"
+      cpu: "2"
+      memory: "1Gi"
     requests:
       cpu: "1"
       memory: "145Mi"

--- a/applications/qserv-kafka/Chart.yaml
+++ b/applications/qserv-kafka/Chart.yaml
@@ -5,7 +5,7 @@ version: 1.0.0
 description: "Qserv Kafka bridge"
 sources:
   - "https://github.com/lsst-sqre/qserv-kafka"
-appVersion: 4.4.0
+appVersion: 4.5.0
 
 dependencies:
   - name: "redis"

--- a/applications/qserv-kafka/Chart.yaml
+++ b/applications/qserv-kafka/Chart.yaml
@@ -5,7 +5,7 @@ version: 1.0.0
 description: "Qserv Kafka bridge"
 sources:
   - "https://github.com/lsst-sqre/qserv-kafka"
-appVersion: 4.5.0
+appVersion: 4.4.0
 
 dependencies:
   - name: "redis"


### PR DESCRIPTION
## Changes
- Add a max result size (bytes) to 3GiB for bigquery-kafka
- Update qserv-kafka to version 4.5.0