### PR TITLE
[DM-55025] Enable Sasquatch REST proxy at USDF environments

### DIFF
--- a/applications/sasquatch/values-usdfint.yaml
+++ b/applications/sasquatch/values-usdfint.yaml
@@ -126,22 +126,15 @@ kafdrop-remote:
     path: /kafdrop-remote
 
 rest-proxy:
-  enabled: false
+  enabled: true
   ingress:
     enabled: true
     hostname: usdf-rsp-int.slac.stanford.edu
   kafka:
-    topics:
-      - test.next-visit
     topicPrefixes:
-      - test
       - lsst.dm
-      - lsst.debug
-      - lsst.example
-      - lsst.rubintv
-      - lsst.camera
       - lsst.verify
-      - lsst.lf
+      - lsst.prompt
 
 chronograf:
   ingress:

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -660,6 +660,17 @@ kafdrop-remote:
     hostname: usdf-rsp.slac.stanford.edu
     path: /kafdrop-remote
 
+rest-proxy:
+  enabled: true
+  ingress:
+    enabled: true
+    hostname: usdf-rsp.slac.stanford.edu
+  kafka:
+    topicPrefixes:
+      - lsst.dm
+      - lsst.verify
+      - lsst.prompt
+
 chronograf:
   ingress:
     enabled: true


### PR DESCRIPTION
Enable Sasquatch REST proxy on both `usdf-rsp-int` and `usdf-rsp` environments and configure `lsst.dm`, `lsst.prompt` and `lsst.verify` namespaces.