### PR TITLE
DM-54913: Update docverse for git ref-based lifecycle handling

### DIFF
--- a/applications/docverse/Chart.yaml
+++ b/applications/docverse/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "tickets-DM-55123"
+appVersion: "tickets-DM-55159"
 description: Publish versioned docs
 name: docverse
 sources:

--- a/applications/docverse/Chart.yaml
+++ b/applications/docverse/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "tickets-DM-54913-ref-deleted-triggers"
+appVersion: "tickets-DM-54914"
 description: Publish versioned docs
 name: docverse
 sources:

--- a/applications/docverse/Chart.yaml
+++ b/applications/docverse/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "tickets-DM-54914"
+appVersion: "tickets-DM-54688"
 description: Publish versioned docs
 name: docverse
 sources:

--- a/applications/docverse/Chart.yaml
+++ b/applications/docverse/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "tickets-DM-54913-project-github-binding"
+appVersion: "tickets-DM-54913-ref-deleted-triggers"
 description: Publish versioned docs
 name: docverse
 sources:

--- a/applications/docverse/Chart.yaml
+++ b/applications/docverse/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "tickets-DM-54916"
+appVersion: "tickets-DM-54913-project-github-binding"
 description: Publish versioned docs
 name: docverse
 sources:

--- a/applications/docverse/Chart.yaml
+++ b/applications/docverse/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "tickets-DM-54688"
+appVersion: "tickets-DM-55123"
 description: Publish versioned docs
 name: docverse
 sources:

--- a/applications/docverse/README.md
+++ b/applications/docverse/README.md
@@ -23,6 +23,7 @@ Publish versioned docs
 | config.githubAppId | string | `nil` | GitHub App ID for Docverse to use when accessing GitHub repositories. If not set, Docverse will operate in a limited mode without GitHub integration. |
 | config.keeperSync.enabled | bool | `false` | Enable the Keeper-sync worker that consumes the `docverse:sync-queue` arq queue. Requires the docverse image to provide `docverse.worker.main.KeeperSyncWorkerSettings`. |
 | config.lifecycleEval.enabled | bool | `false` | Enable the lifecycle-evaluation worker that consumes the `docverse:lifecycle-queue` arq queue. Requires the docverse image to provide `docverse.worker.main.LifecycleEvalWorkerSettings`. |
+| config.lifecycleEval.gitRefAuditEnabled | bool | `false` | Whether to enable auditing the git ref lifecycle rule. Enabling this will cause docverse to GitHub API calls to determine if the git ref associated with an edition still exists. |
 | config.logLevel | string | `"INFO"` | Logging level |
 | config.logProfile | string | `"production"` | Logging profile (`production` for JSON, `development` for human-friendly) |
 | config.pathPrefix | string | `"/docverse/api"` | URL path prefix |

--- a/applications/docverse/templates/configmap.yaml
+++ b/applications/docverse/templates/configmap.yaml
@@ -21,3 +21,4 @@ data:
   {{- if .Values.config.githubAppId }}
   DOCVERSE_GITHUB_APP_ID: {{ .Values.config.githubAppId | quote }}
   {{- end }}
+  DOCVERSE_GIT_REF_AUDIT_ENABLED: {{ .Values.config.lifecycleEval.gitRefAuditEnabled | quote }}

--- a/applications/docverse/values-roundtable-dev.yaml
+++ b/applications/docverse/values-roundtable-dev.yaml
@@ -12,6 +12,7 @@ config:
     enabled: true
   lifecycleEval:
     enabled: true
+    gitRefAuditEnabled: true
   sentry:
     enabled: true
 

--- a/applications/docverse/values.yaml
+++ b/applications/docverse/values.yaml
@@ -73,6 +73,11 @@ config:
     # provide `docverse.worker.main.LifecycleEvalWorkerSettings`.
     enabled: false
 
+    # -- Whether to enable auditing the git ref lifecycle rule.
+    # Enabling this will cause docverse to GitHub API calls to determine
+    # if the git ref associated with an edition still exists.
+    gitRefAuditEnabled: false
+
 ingress:
   # -- Additional annotations for the ingress rule
   annotations: {}


### PR DESCRIPTION
Update the docverse chart `appVersion` to the `tickets-DM-54913-project-github-binding` image tag.

This image is built from https://github.com/lsst-sqre/docverse/pull/385.