### PR TITLE
DM-55098: Add support to TAP services for advertising vo-parquet as an available format

### DIFF
--- a/applications/ppdbtap/README.md
+++ b/applications/ppdbtap/README.md
@@ -13,6 +13,7 @@ TAP service for the ppdb BigQuery backend
 | cadc-tap.config.sentryEnabled | bool | `false` | Whether Sentry is enabled in this environment |
 | cadc-tap.config.serviceName | string | `"ppdbtap"` | Name of the service from Gafaelfawr's perspective |
 | cadc-tap.config.vaultSecretName | string | `"ppdbtap"` | Vault secret name: the final key in the vault path |
+| cadc-tap.config.voParquet | bool | `true` | Advertise VOParquet as a supported output format |
 | cadc-tap.ingress.path | string | `"ppdbtap"` | Ingress path that should be routed to this service |
 | cadc-tap.serviceAccount.name | string | `"ppdbtap"` | Name of the Kubernetes `ServiceAccount`, used for CloudSQL access |
 | cadc-tap.uws.database | string | `"ppdbtap"` | Database name |

--- a/applications/ppdbtap/values.yaml
+++ b/applications/ppdbtap/values.yaml
@@ -24,6 +24,9 @@ cadc-tap:
     # -- Whether Sentry is enabled in this environment
     sentryEnabled: false
 
+    # -- Advertise VOParquet as a supported output format
+    voParquet: true
+
   serviceAccount:
     # -- Name of the Kubernetes `ServiceAccount`, used for CloudSQL access
     name: "ppdbtap"

--- a/applications/tap/README.md
+++ b/applications/tap/README.md
@@ -17,6 +17,7 @@ IVOA TAP service
 | cadc-tap.config.sentryEnabled | bool | `false` | Whether Sentry is enabled in this environment |
 | cadc-tap.config.serviceName | string | `"tap"` | Name of the service from Gafaelfawr's perspective |
 | cadc-tap.config.vaultSecretName | string | `"tap"` | Vault secret name: the final key in the vault path |
+| cadc-tap.config.voParquet | bool | `true` | Advertise VOParquet as a supported output format |
 | cadc-tap.ingress.path | string | `"tap"` | Ingress path that should be routed to this service |
 | cadc-tap.serviceAccount.name | string | `"tap"` | Name of the Kubernetes `ServiceAccount`, used for CloudSQL access |
 | cadc-tap.tapSchema.database | string | `"tap"` | Database name |

--- a/applications/tap/values.yaml
+++ b/applications/tap/values.yaml
@@ -20,6 +20,9 @@ cadc-tap:
     outputLimit: "3221225472"
     outputLimitUnit: "byte"
 
+    # -- Advertise VOParquet as a supported output format
+    voParquet: true
+
   serviceAccount:
     # -- Name of the Kubernetes `ServiceAccount`, used for CloudSQL access
     name: "tap"

--- a/charts/cadc-tap/README.md
+++ b/charts/cadc-tap/README.md
@@ -25,7 +25,7 @@ IVOA TAP service
 | config.bigquery.dataset | string | None, must be set if backend is `bigquery` | BigQuery dataset name |
 | config.bigquery.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the TAP image |
 | config.bigquery.image.repository | string | `"ghcr.io/lsst-sqre/lsst-tap-service"` | TAP image to use |
-| config.bigquery.image.tag | string | `"3.17.0"` | Tag of TAP image to use |
+| config.bigquery.image.tag | string | `"3.18.0"` | Tag of TAP image to use |
 | config.bigquery.project | string | None, must be set if backend is `bigquery` | BigQuery project ID |
 | config.bigquery.schema | string | `""` | Schema name for table mappings (optional) |
 | config.database | string | `"dp02"` | Data Database name |
@@ -54,7 +54,7 @@ IVOA TAP service
 | config.qserv.host | string | `"mock-db:3306"` (the mock QServ) | QServ hostname:port to connect to |
 | config.qserv.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the TAP image |
 | config.qserv.image.repository | string | `"ghcr.io/lsst-sqre/lsst-tap-service"` | TAP image to use |
-| config.qserv.image.tag | string | `"3.17.0"` | Tag of TAP image to use |
+| config.qserv.image.tag | string | `"3.18.0"` | Tag of TAP image to use |
 | config.qserv.jdbcParams | string | `""` | Extra JDBC connection parameters |
 | config.qserv.passwordEnabled | bool | false | Whether the Qserv database is password protected |
 | config.sentryEnabled | bool | `false` | Whether Sentry is enabled in this environment |
@@ -64,6 +64,7 @@ IVOA TAP service
 | config.urlRewrite.enabled | bool | `true` | Whether it is enabled |
 | config.urlRewrite.rules | string | `"ivoa.ObsCore:access_url"` | String with a comma-separated list of schema.table:column rules |
 | config.vaultSecretName | string | `""` | Vault secret name, this is appended to the global path to find the vault secrets associated with this deployment. |
+| config.voParquet | bool | `false` | Whether to advertise VOParquet (application/vnd.apache.parquet) as a supported output format in the TAP capabilities. |
 | fullnameOverride | string | `"cadc-tap"` | Override the full name for resources (includes the release name) |
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
@@ -118,7 +119,7 @@ IVOA TAP service
 | uws.external.port | int | `5432` | Port of external PostgreSQL server |
 | uws.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the UWS database image |
 | uws.image.repository | string | `"ghcr.io/lsst-sqre/lsst-tap-uws-db"` | UWS database image to use |
-| uws.image.tag | string | `"3.17.0"` | Tag of UWS database image to use |
+| uws.image.tag | string | `"3.18.0"` | Tag of UWS database image to use |
 | uws.maxActive | int | `5` | Maximum active connections (maxIdle will be set to this value) |
 | uws.nodeSelector | object | `{}` | Node selection rules for the UWS database pod |
 | uws.podAnnotations | object | `{}` | Annotations for the UWS databse pod |

--- a/charts/cadc-tap/templates/tap-deployment.yaml
+++ b/charts/cadc-tap/templates/tap-deployment.yaml
@@ -191,6 +191,9 @@ spec:
                 {{- if .Values.config.maxRec }}
                 -Dtap.maxRec={{ .Values.config.maxRec }}
                 {{- end }}
+                {{- if .Values.config.voParquet }}
+                -Dtap.enableVOParquet=true
+                {{- end }}
                 -Dbase_url={{ .Values.global.baseUrl }}
                 -Dpath_prefix=/api/{{ .Values.ingress.path }}
                 -Dca.nrc.cadc.util.PropertiesReader.dir=/config/

--- a/charts/cadc-tap/values.yaml
+++ b/charts/cadc-tap/values.yaml
@@ -94,7 +94,7 @@ config:
       pullPolicy: "IfNotPresent"
 
       # -- Tag of TAP image to use
-      tag: "3.17.0"
+      tag: "3.18.0"
 
     # -- Whether the Qserv database is password protected
     # @default -- false
@@ -120,7 +120,7 @@ config:
       pullPolicy: "IfNotPresent"
 
       # -- Tag of TAP image to use
-      tag: "3.17.0"
+      tag: "3.18.0"
 
   # -- Address to a MySQL database containing TAP schema data
   tapSchemaAddress: "cadc-tap-schema-db:3306"
@@ -194,6 +194,10 @@ config:
   # -- Maximum row limit (MAXREC) enforced server-side.
   # Leave empty to use the default (100000000).
   maxRec: ""
+
+  # -- Whether to advertise VOParquet (application/vnd.apache.parquet) as a
+  # supported output format in the TAP capabilities.
+  voParquet: false
 
   # -- Rules for renaming Columns
   urlRewrite:
@@ -355,7 +359,7 @@ uws:
     pullPolicy: "IfNotPresent"
 
     # -- Tag of UWS database image to use
-    tag: "3.17.0"
+    tag: "3.18.0"
 
   # -- Resource limits and requests for the UWS database pod
   # @default -- See `values.yaml`


### PR DESCRIPTION
Adds a `voParquet` boolean parameter to the TAP service configuration. When enabled, it passes in a flag to the TAP service env variables which when enabled includes voParquet as an available format. Enable this flag for the `tap` & `ppdbtap` applications.