### PR TITLE
DM-55115: Update mobu to the latest version

### DIFF
--- a/applications/mobu/Chart.yaml
+++ b/applications/mobu/Chart.yaml
@@ -5,4 +5,4 @@ description: "Continuous integration testing"
 home: https://mobu.lsst.io/
 sources:
   - "https://github.com/lsst-sqre/mobu"
-appVersion: 19.0.0
+appVersion: 19.1.0


### PR DESCRIPTION
This version picks up a change to the Nublado client to speak the new JupyterLab WebSocket protocol.