### PR TITLE
DM-55137: Configure USDF dev environment to use external PG for all TAP utility databases

### DIFF
--- a/applications/consdbtap/secrets-usdfdev.yaml
+++ b/applications/consdbtap/secrets-usdfdev.yaml
@@ -1,0 +1,4 @@
+tap-schema-admin-password:
+  description: >-
+    Admin password for the tap_schema_admin_consdbtap database account, used
+    by Repertoire to manage the TAP_SCHEMA schema.

--- a/applications/consdbtap/secrets.yaml
+++ b/applications/consdbtap/secrets.yaml
@@ -11,3 +11,11 @@ pgpassword:
   copy:
     application: exposurelog
     key: exposurelog_password
+tap-schema-password:
+  description: >-
+    Password for tap_schema database (CloudSQL or external PostgreSQL).
+  if: cadc-tap.tapSchema.useVaultPassword
+uws-db-password:
+  description: >-
+    Password for uws database (CloudSQL or external PostgreSQL).
+  if: cadc-tap.uws.useVaultPassword

--- a/applications/consdbtap/values-usdfdev.yaml
+++ b/applications/consdbtap/values-usdfdev.yaml
@@ -1,9 +1,19 @@
 cadc-tap:
   tapSchema:
-    image:
-      repository: "lsstsqre/tap-schema-usdf-dev-cdb"
-      tag: "tickets-OSW-1617"
-      pullPolicy: "Always"
+    type: "external"
+    database: "consdbtap"
+    username: "tap_schema_consdbtap"
+    useVaultPassword: true
+    external:
+      host: "rsp-db-ro.postgres-db"
+
+  uws:
+    type: "external"
+    database: "consdbtap"
+    username: "uws_consdbtap"
+    useVaultPassword: true
+    external:
+      host: "rsp-db-rw.postgres-db"
 
   config:
     datalinkPayloadUrl: "https://github.com/lsst/sdm_schemas/releases/download/w.2026.18/datalink-snippets.zip"

--- a/applications/livetap/secrets-usdfdev.yaml
+++ b/applications/livetap/secrets-usdfdev.yaml
@@ -1,0 +1,4 @@
+tap-schema-admin-password:
+  description: >-
+    Admin password for the tap_schema_admin_livetap database account, used by
+    Repertoire to manage the TAP_SCHEMA schema.

--- a/applications/livetap/secrets.yaml
+++ b/applications/livetap/secrets.yaml
@@ -6,3 +6,11 @@ pgpassword:
   description: >-
     Password to external PostgreSQL server that contains the live-updating
     ObsCore data.
+tap-schema-password:
+  description: >-
+    Password for tap_schema database (CloudSQL or external PostgreSQL).
+  if: cadc-tap.tapSchema.useVaultPassword
+uws-db-password:
+  description: >-
+    Password for uws database (CloudSQL or external PostgreSQL).
+  if: cadc-tap.uws.useVaultPassword

--- a/applications/livetap/values-usdfdev.yaml
+++ b/applications/livetap/values-usdfdev.yaml
@@ -1,4 +1,16 @@
 cadc-tap:
   tapSchema:
-    image:
-      repository: "lsstsqre/tap-schema-usdf-dev-livetap"
+    type: "external"
+    database: "livetap"
+    username: "tap_schema_livetap"
+    useVaultPassword: true
+    external:
+      host: "rsp-db-ro.postgres-db"
+
+  uws:
+    type: "external"
+    database: "livetap"
+    username: "uws_livetap"
+    useVaultPassword: true
+    external:
+      host: "rsp-db-rw.postgres-db"

--- a/applications/repertoire/secrets-usdfdev.yaml
+++ b/applications/repertoire/secrets-usdfdev.yaml
@@ -3,3 +3,11 @@ usdfdev_efd-password:
     InfluxDB password for the efdreader user for accessing the EFD database on
     usdf-dev. Clients will cache this secret locally in their client
     configuration, so changing it may be disruptive.
+tap-schema-admin-password:
+  description: >-
+    Admin password for the tap TAP_SCHEMA database, used by Repertoire to
+    manage the TAP_SCHEMA schema. Copied from the tap application's secret.
+  if: config.tap.servers.tap.enabled
+  copy:
+    application: tap
+    key: tap-schema-admin-password

--- a/applications/repertoire/secrets-usdfdev.yaml
+++ b/applications/repertoire/secrets-usdfdev.yaml
@@ -3,3 +3,38 @@ usdfdev_efd-password:
     InfluxDB password for the efdreader user for accessing the EFD database on
     usdf-dev. Clients will cache this secret locally in their client
     configuration, so changing it may be disruptive.
+tap-schema-admin-password:
+  description: >-
+    Admin password for the tap TAP_SCHEMA database, used by Repertoire to
+    manage the TAP_SCHEMA schema. Copied from the tap application's secret.
+  if: config.tap.servers.tap.enabled
+  copy:
+    application: tap
+    key: tap-schema-admin-password
+ssotap-schema-admin-password:
+  description: >-
+    Admin password for the ssotap TAP_SCHEMA database, used by Repertoire to
+    manage the TAP_SCHEMA schema. Copied from the ssotap application's
+    secret.
+  if: config.tap.servers.ssotap.enabled
+  copy:
+    application: ssotap
+    key: tap-schema-admin-password
+livetap-schema-admin-password:
+  description: >-
+    Admin password for the livetap TAP_SCHEMA database, used by Repertoire
+    to manage the TAP_SCHEMA schema. Copied from the livetap application's
+    secret.
+  if: config.tap.servers.livetap.enabled
+  copy:
+    application: livetap
+    key: tap-schema-admin-password
+consdbtap-schema-admin-password:
+  description: >-
+    Admin password for the consdbtap TAP_SCHEMA database, used by Repertoire
+    to manage the TAP_SCHEMA schema. Copied from the consdbtap application's
+    secret.
+  if: config.tap.servers.consdbtap.enabled
+  copy:
+    application: consdbtap
+    key: tap-schema-admin-password

--- a/applications/repertoire/secrets.yaml
+++ b/applications/repertoire/secrets.yaml
@@ -38,6 +38,15 @@ obsforgetap-database-password:
   copy:
     application: obsforgetap
     key: tap-schema-password
+consdbtap-database-password:
+  description: >-
+    Database password for the consdbtap service, used by repertoire to
+    manage the consdbtap TAP_SCHEMA. Copied from consdbtap application's
+    database-password.
+  if: config.tap.servers.consdbtap.enabled
+  copy:
+    application: consdbtap
+    key: tap-schema-password
 sentry-dsn:
   description: >-
     DSN URL to which Sentry trace and error logging will be sent.

--- a/applications/repertoire/templates/job-schema-update.yaml
+++ b/applications/repertoire/templates/job-schema-update.yaml
@@ -49,8 +49,6 @@ spec:
                 secretKeyRef:
                   name: "repertoire"
                   key: {{ $config.databasePasswordKey | quote }}
-            - name: "REPERTOIRE_DATABASE_USER"
-              value: {{ $config.databaseUser | quote }}
           image: "{{ $root.Values.image.repository }}:{{ $root.Values.image.tag | default $root.Chart.AppVersion }}"
           imagePullPolicy: {{ $root.Values.image.pullPolicy | quote }}
           {{- with $root.Values.schemaHook.resources }}

--- a/applications/repertoire/values-usdfdev.yaml
+++ b/applications/repertoire/values-usdfdev.yaml
@@ -7,6 +7,14 @@ config:
     - "live"
   hips:
     datasets: {}
+  tap:
+    schemaVersion: "w.2026.28"
+    schemaSourceTemplate: "https://github.com/lsst/sdm_schemas/archive/refs/tags/{version}.tar.gz"
+    servers:
+      tap:
+        enabled: true
+        databaseUrl: "postgresql://tap_schema_admin_tap@rsp-db-rw.postgres-db:5432/tap"
+        databasePasswordKey: "tap-schema-admin-password"
   influxdbDatabases:
     usdfdev_efd:
       url: "https://usdf-rsp-dev.slac.stanford.edu/influxdb/"

--- a/applications/repertoire/values-usdfdev.yaml
+++ b/applications/repertoire/values-usdfdev.yaml
@@ -13,6 +13,10 @@ config:
     servers:
       tap:
         enabled: true
+        schemas:
+          - "dp1"
+          - "ivoa_obscore"
+          - "dp02_dc2"
         databaseUrl: "postgresql://tap_schema_admin_tap@rsp-db-rw.postgres-db:5432/tap"
         databasePasswordKey: "tap-schema-admin-password"
       ssotap:

--- a/applications/repertoire/values-usdfdev.yaml
+++ b/applications/repertoire/values-usdfdev.yaml
@@ -7,6 +7,26 @@ config:
     - "live"
   hips:
     datasets: {}
+  tap:
+    schemaVersion: "w.2026.28"
+    schemaSourceTemplate: "https://github.com/lsst/sdm_schemas/archive/refs/tags/{version}.tar.gz"
+    servers:
+      tap:
+        enabled: true
+        databaseUrl: "postgresql://tap_schema_admin_tap@rsp-db-rw.postgres-db:5432/tap"
+        databasePasswordKey: "tap-schema-admin-password"
+      ssotap:
+        enabled: true
+        databaseUrl: "postgresql://tap_schema_admin_ssotap@rsp-db-rw.postgres-db:5432/ssotap"
+        databasePasswordKey: "ssotap-schema-admin-password"
+      livetap:
+        enabled: true
+        databaseUrl: "postgresql://tap_schema_admin_livetap@rsp-db-rw.postgres-db:5432/livetap"
+        databasePasswordKey: "livetap-schema-admin-password"
+      consdbtap:
+        enabled: true
+        databaseUrl: "postgresql://tap_schema_admin_consdbtap@rsp-db-rw.postgres-db:5432/consdbtap"
+        databasePasswordKey: "consdbtap-schema-admin-password"
   influxdbDatabases:
     usdfdev_efd:
       url: "https://usdf-rsp-dev.slac.stanford.edu/influxdb/"

--- a/applications/repertoire/values-usdfdev.yaml
+++ b/applications/repertoire/values-usdfdev.yaml
@@ -8,7 +8,7 @@ config:
   hips:
     datasets: {}
   tap:
-    schemaVersion: "w.2026.28"
+    schemaVersion: "w.2026.36"
     schemaSourceTemplate: "https://github.com/lsst/sdm_schemas/archive/refs/tags/{version}.tar.gz"
     servers:
       tap:

--- a/applications/repertoire/values.yaml
+++ b/applications/repertoire/values.yaml
@@ -524,6 +524,13 @@ config:
         databaseUrl: "postgresql://obsforgetap@127.0.0.1:5432/obsforgetap"
         databasePasswordKey: "obsforgetap-database-password"
 
+      consdbtap:
+        enabled: false
+        schemas:
+          - "efd"
+        databaseUrl: "postgresql://consdbtap@127.0.0.1:5432/consdbtap"
+        databasePasswordKey: "consdbtap-database-password"
+
 cloudsql:
   # -- Enable the Cloud SQL Auth Proxy, used with Cloud SQL databases on
   # Google Cloud

--- a/applications/repertoire/values.yaml
+++ b/applications/repertoire/values.yaml
@@ -527,7 +527,17 @@ config:
       consdbtap:
         enabled: false
         schemas:
-          - "efd"
+          - "cdb_latiss"
+          - "cdb_lsstcam"
+          - "cdb_lsstcomcam"
+          - "cdb_lsstcomcamsim"
+          - "cdb_startrackerfast"
+          - "cdb_startrackernarrow"
+          - "cdb_startrackerwide"
+          - "efd_latiss"
+          - "efd_lsstcam"
+          - "efd_lsstcomcam"
+
         databaseUrl: "postgresql://consdbtap@127.0.0.1:5432/consdbtap"
         databasePasswordKey: "consdbtap-database-password"
 

--- a/applications/ssotap/secrets-usdfdev.yaml
+++ b/applications/ssotap/secrets-usdfdev.yaml
@@ -1,0 +1,4 @@
+tap-schema-admin-password:
+  description: >-
+    Admin password for the tap_schema_admin_ssotap database account, used by
+    Repertoire to manage the TAP_SCHEMA schema.

--- a/applications/ssotap/values-usdfdev.yaml
+++ b/applications/ssotap/values-usdfdev.yaml
@@ -1,14 +1,16 @@
 cadc-tap:
   tapSchema:
-    image:
-      repository: "lsstsqre/tap-schema-usdf-dev-sso"
-    type: "containerized"
-    database: "TAP_SCHEMA"
-    username: "TAP_SCHEMA"
-    useVaultPassword: false
+    type: "external"
+    database: "ssotap"
+    username: "tap_schema_ssotap"
+    useVaultPassword: true
+    external:
+      host: "rsp-db-ro.postgres-db"
 
   uws:
-    type: "containerized"
-    database: "postgres"
-    username: "postgres"
-    useVaultPassword: false
+    type: "external"
+    database: "ssotap"
+    username: "uws_ssotap"
+    useVaultPassword: true
+    external:
+      host: "rsp-db-rw.postgres-db"

--- a/applications/tap/secrets-usdfdev.yaml
+++ b/applications/tap/secrets-usdfdev.yaml
@@ -1,0 +1,4 @@
+tap-schema-admin-password:
+  description: >-
+    Admin password for the tap_schema_admin_tap database account, used by
+    Repertoire to manage the TAP_SCHEMA schema.

--- a/applications/tap/values-usdfdev.yaml
+++ b/applications/tap/values-usdfdev.yaml
@@ -1,17 +1,19 @@
 cadc-tap:
   tapSchema:
-    image:
-      repository: "lsstsqre/tap-schema-usdf-dev-tap"
-    type: "containerized"
-    database: "TAP_SCHEMA"
-    username: "TAP_SCHEMA"
-    useVaultPassword: false
+    type: "external"
+    database: "tap"
+    username: "tap_schema_tap"
+    useVaultPassword: true
+    external:
+      host: "rsp-db-ro.postgres-db"
 
   uws:
-    type: "containerized"
-    database: "postgres"
-    username: "postgres"
-    useVaultPassword: false
+    type: "external"
+    database: "tap"
+    username: "uws_tap"
+    useVaultPassword: true
+    external:
+      host: "rsp-db-rw.postgres-db"
 
   config:
     qserv:

--- a/applications/tap/values-usdfdev.yaml
+++ b/applications/tap/values-usdfdev.yaml
@@ -1,17 +1,19 @@
 cadc-tap:
   tapSchema:
-    image:
-      repository: "lsstsqre/tap-schema-usdf-dev-tap"
-    type: "containerized"
-    database: "TAP_SCHEMA"
-    username: "TAP_SCHEMA"
-    useVaultPassword: false
+    type: "external"
+    database: "tap"
+    username: "tap_schema_tap"
+    useVaultPassword: true
+    external:
+      host: "rsp-db-ro.postgres-db"
 
   uws:
-    type: "containerized"
-    database: "postgres"
-    username: "postgres"
-    useVaultPassword: false
+    type: "external"
+    database: "tap"
+    username: "uws_tap"
+    useVaultPassword: true
+    external:
+      host: "rsp-db-rw.postgres-db"
 
   config:
     kafka:


### PR DESCRIPTION
Configures all tap applications for `usdf-dev` to use external postgres for  the UWS and TAP_SCHEMA databases.
In the process updates repertoire configuration which now manages TAP_SCHEMA updates for those apps.

In the changes there is also a minor correction to repertoire's job update helm hook to remove a user env var that is obsolete.