### PR TITLE
DM-55135: Deploy squareone 0.32.0 with /admin ingress

### DIFF
--- a/applications/squareone/Chart.yaml
+++ b/applications/squareone/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
     url: https://github.com/jonathansick
 
 # The default version tag of the squareone docker image
-appVersion: "tickets-DM-55172"
+appVersion: "0.32.0"

--- a/applications/squareone/Chart.yaml
+++ b/applications/squareone/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
     url: https://github.com/jonathansick
 
 # The default version tag of the squareone docker image
-appVersion: "tickets-DM-55135"
+appVersion: "tickets-DM-55172"

--- a/applications/squareone/Chart.yaml
+++ b/applications/squareone/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
     url: https://github.com/jonathansick
 
 # The default version tag of the squareone docker image
-appVersion: "0.31.0"
+appVersion: "tickets-DM-55135"

--- a/applications/squareone/README.md
+++ b/applications/squareone/README.md
@@ -49,6 +49,7 @@ Squareone is the homepage UI for the Rubin Science Platform.
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy (tip: use Always for development) |
 | image.repository | string | `"ghcr.io/lsst-sqre/squareone"` | Squareone Docker image repository |
 | image.tag | string | Chart's appVersion | Overrides the image tag. |
+| ingress.adminScope | string | `"exec:admin"` | Scope required for the /admin UI |
 | ingress.annotations | object | `{}` | Additional annotations to add to the ingress |
 | ingress.enabled | bool | `true` | Enable ingress |
 | ingress.timesSquareScope | string | `"exec:notebook"` | Scope required for /times-square UI |

--- a/applications/squareone/templates/ingress-admin.yaml
+++ b/applications/squareone/templates/ingress-admin.yaml
@@ -1,0 +1,31 @@
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
+metadata:
+  name: {{ template "squareone.fullname" . }}-admin
+  labels:
+    {{- include "squareone.labels" . | nindent 4 }}
+config:
+  loginRedirect: true
+  scopes:
+    all:
+      - {{ .Values.ingress.adminScope | quote }}
+  service: "squareone"
+template:
+  metadata:
+    name: {{ template "squareone.fullname" . }}-admin
+    {{- with .Values.ingress.annotations }}
+    annotations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  spec:
+    rules:
+      - host: {{ required "global.host must be set" .Values.global.host | quote }}
+        http:
+          paths:
+            - path: "/admin"
+              pathType: "Prefix"
+              backend:
+                service:
+                  name: {{ template "squareone.fullname" . }}
+                  port:
+                    number: 80

--- a/applications/squareone/values.yaml
+++ b/applications/squareone/values.yaml
@@ -33,6 +33,9 @@ ingress:
   # -- Scope required for /times-square UI
   timesSquareScope: "exec:notebook"
 
+  # -- Scope required for the /admin UI
+  adminScope: "exec:admin"
+
 # -- Resource requests and limits for Squareone pods
 # @default -- see `values.yaml`
 resources:


### PR DESCRIPTION
## Summary

- Point the squareone chart's `appVersion` at the `tickets-DM-55135` image so environments can preview the new `/admin` section from squareone PR #429.
- Add a `GafaelfawrIngress` for the `/admin` path prefix requiring the `exec:admin` scope, gating the admin UI at the ingress as defense-in-depth alongside squareone's client-side scope check.
- Make the admin scope configurable via a new `ingress.adminScope` value (default `exec:admin`), mirroring the existing `ingress.timesSquareScope` pattern.

## Validation steps

- Sync the chart in a dev environment and confirm a `GafaelfawrIngress` named `squareone-admin` is created for the `/admin` prefix with `scopes.all: ["exec:admin"]`.
- As a user **with** the `exec:admin` scope, visit `/admin` and confirm it loads (redirecting to `/admin/sentry`).
- As a user **without** `exec:admin`, visit `/admin` and confirm Gafaelfawr denies access at the ingress (403), independent of squareone's in-app gate.
- Confirm the unauthenticated `/` ingress and the `/times-square` ingress continue to route normally (the longer `/admin` prefix wins for admin routes only).
- Confirm the deployed pods run the `tickets-DM-55135` image tag.

## References

- Squareone PR: lsst-sqre/squareone#429
- Jira: https://rubinobs.atlassian.net/browse/DM-55135