### PR TITLE
Review InfluxDB memory requests and limits on BTS

### DIFF
--- a/applications/sasquatch/values-base.yaml
+++ b/applications/sasquatch/values-base.yaml
@@ -118,10 +118,10 @@ influxdb:
     storageClass: rook-ceph-block
   resources:
     requests:
-      memory: 64Gi
+      memory: 32Gi
       cpu: 8
     limits:
-      memory: 64Gi
+      memory: 32Gi
       cpu: 8
 
 customInfluxDBIngress:


### PR DESCRIPTION
- InfluxDB Pod in Pending state after a Pod restart.
- Try reducing memory requests and limits from 64G to 32G to get the Pod scheduled.