### PR TITLE
DM-55115: Update noteburst to 0.27.0

### DIFF
--- a/applications/noteburst/Chart.yaml
+++ b/applications/noteburst/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: noteburst
 version: 1.0.0
-appVersion: "0.26.0"
+appVersion: "0.27.0"
 description: Noteburst is a notebook execution service for the Rubin Science Platform.
 type: application
 home: https://noteburst.lsst.io/


### PR DESCRIPTION
This version uses a fixed Nublado client that speaks the new protocol version and thus works with images built with jupyter-server-documents.