### PR TITLE
Fix template for Repertoire cutout service

### DIFF
--- a/applications/repertoire/values.yaml
+++ b/applications/repertoire/values.yaml
@@ -385,7 +385,7 @@ config:
         datasets:
           - "dp02"
           - "dp1"
-        template: "https://{{{base_hostname}}/api/cutout"
+        template: "https://{{base_hostname}}/api/cutout"
         versions:
           soda-async-1.0:
             template: "https://{{base_hostname}}/api/cutout/jobs"


### PR DESCRIPTION
There was an extra brace in the Repertoire configuration.