### PR TITLE
Add ivoaRegistry ingress rule in repertoire

### DIFF
--- a/applications/repertoire/templates/ingress.yaml
+++ b/applications/repertoire/templates/ingress.yaml
@@ -26,3 +26,12 @@ template:
                   name: "repertoire"
                   port:
                     number: 8080
+            {{- if .Values.config.ivoaRegistry }}
+            - path: {{ .Values.config.ivoaRegistry.pathPrefix | quote }}
+              pathType: "Prefix"
+              backend:
+                service:
+                  name: "repertoire"
+                  port:
+                    number: 8080
+            {{- end }}


### PR DESCRIPTION
Adds /discovery (or whatever else is the configured base URL for our ivoa Registry) to the repertoire ingress