### PR TITLE
Update ingress-nginx controller image

### DIFF
--- a/applications/ingress-nginx/README.md
+++ b/applications/ingress-nginx/README.md
@@ -23,10 +23,10 @@ Ingress controller
 | ingress-nginx.controller.config.server-snippet | string | See `values.yaml` | Add additional per-server configuration used by Gafaelfawr to report errors from the authorization layer |
 | ingress-nginx.controller.config.ssl-redirect | string | `"true"` | Redirect all non-SSL access to SSL |
 | ingress-nginx.controller.config.use-forwarded-headers | string | `"true"` | Enable the `X-Forwarded-For` processing |
-| ingress-nginx.controller.image.digest | string | `nil` |  |
-| ingress-nginx.controller.image.digestChroot | string | `nil` |  |
+| ingress-nginx.controller.image.digest | string | `"sha256:ad37060a7aca08908bff09308f26e31b5eb4d155a8b77df65c926a4618078039"` |  |
+| ingress-nginx.controller.image.digestChroot | string | `"sha256:2dfeb83efdbf162a325a2bccd729104ddaf13da117c68f71f977c1dc868beabd"` |  |
 | ingress-nginx.controller.image.image | string | `"lsst-sqre/ingress-nginx-controller"` |  |
-| ingress-nginx.controller.image.pullPolicy | string | `"Always"` |  |
+| ingress-nginx.controller.image.pullPolicy | string | `"IfNotPresent"` |  |
 | ingress-nginx.controller.image.registry | string | `"ghcr.io"` |  |
 | ingress-nginx.controller.image.tag | string | `"v1.15.2-devsquare"` |  |
 | ingress-nginx.controller.metrics.enabled | bool | `true` | Enable metrics reporting via Prometheus |

--- a/applications/ingress-nginx/README.md
+++ b/applications/ingress-nginx/README.md
@@ -23,6 +23,12 @@ Ingress controller
 | ingress-nginx.controller.config.server-snippet | string | See `values.yaml` | Add additional per-server configuration used by Gafaelfawr to report errors from the authorization layer |
 | ingress-nginx.controller.config.ssl-redirect | string | `"true"` | Redirect all non-SSL access to SSL |
 | ingress-nginx.controller.config.use-forwarded-headers | string | `"true"` | Enable the `X-Forwarded-For` processing |
+| ingress-nginx.controller.image.digest | string | `nil` |  |
+| ingress-nginx.controller.image.digestChroot | string | `nil` |  |
+| ingress-nginx.controller.image.image | string | `"lsst-sqre/ingress-nginx-controller"` |  |
+| ingress-nginx.controller.image.pullPolicy | string | `"Always"` |  |
+| ingress-nginx.controller.image.registry | string | `"ghcr.io"` |  |
+| ingress-nginx.controller.image.tag | string | `"v1.15.2-devsquare"` |  |
 | ingress-nginx.controller.metrics.enabled | bool | `true` | Enable metrics reporting via Prometheus |
 | ingress-nginx.controller.podLabels | object | See `values.yaml` | Add labels used by `NetworkPolicy` objects to restrict access to the ingress and thus ensure that auth subrequest handlers run |
 | ingress-nginx.controller.resources | object | See `values.yaml` | Resource requests and limits for ingress-nginx controller |

--- a/applications/ingress-nginx/values.yaml
+++ b/applications/ingress-nginx/values.yaml
@@ -79,9 +79,9 @@ ingress-nginx:
       registry: ghcr.io
       image: lsst-sqre/ingress-nginx-controller
       tag: "v1.15.2-devsquare"
-      digest: null
-      digestChroot: null
-      pullPolicy: Always
+      digest: "sha256:ad37060a7aca08908bff09308f26e31b5eb4d155a8b77df65c926a4618078039"
+      digestChroot: "sha256:2dfeb83efdbf162a325a2bccd729104ddaf13da117c68f71f977c1dc868beabd"
+      pullPolicy: IfNotPresent
 
     metrics:
       # -- Enable metrics reporting via Prometheus

--- a/applications/ingress-nginx/values.yaml
+++ b/applications/ingress-nginx/values.yaml
@@ -75,6 +75,14 @@ ingress-nginx:
           return 403;
         }
 
+    image:
+      registry: ghcr.io
+      image: lsst-sqre/ingress-nginx-controller
+      tag: "v1.15.2-devsquare"
+      digest: null
+      digestChroot: null
+      pullPolicy: Always
+
     metrics:
       # -- Enable metrics reporting via Prometheus
       enabled: true


### PR DESCRIPTION
This bases ingress-nginx-controller on the custom SQuaRE build at https://github.com/lsst-sqre/ingress-nginx.

It removes almost all of the previous GitHub Actions; its only purpose is to replace the NGINX implementation at the heart of the controller with version 1.30.2, which is not vulnerable to CVE-2026-42945 .

README.md has been updated with instructions describing how to prepare a new release based on updated NGINX.

It is not intended to be a maintainable forward-looking solution.  It is a stopgap until we can migrate to the K8s Gateway API.