### PR TITLE
DM-55165: Add Chronograf and Kafdrop to service discovery

### DIFF
--- a/applications/repertoire/values.yaml
+++ b/applications/repertoire/values.yaml
@@ -310,6 +310,13 @@ config:
         name: "semaphore"
         template: "https://{{base_hostname}}/semaphore"
         openapi: "https://{{base_hostname}}/semaphore/openapi.json"
+    sasquatch:
+      - type: "ui"
+        name: "chronograf"
+        template: "https://{{base_hostname}}/chronograf"
+      - type: "ui"
+        name: "kafdrop"
+        template: "https://{{base_hostname}}/chronograf"
     sia:
       - type: "data"
         name: "sia"


### PR DESCRIPTION
Add UI service discovery entries for Chronograf and Kafdrop if Sasquatch is enabled. This is not strictly correct since either service could be disabled in the Sasquatch configuration, but we don't currently have a way to represent that in Repertoire.