### PR TITLE
DM-55187: Change IVOA registry default pathPrefix to /api

### DIFF
--- a/applications/repertoire/templates/ingress.yaml
+++ b/applications/repertoire/templates/ingress.yaml
@@ -27,7 +27,7 @@ template:
                   port:
                     number: 8080
             {{- if .Values.config.ivoaRegistry }}
-            - path: {{ .Values.config.ivoaRegistry.pathPrefix | quote }}
+            - path: "{{ .Values.config.ivoaRegistry.pathPrefix }}/registry"
               pathType: "Prefix"
               backend:
                 service:

--- a/applications/repertoire/values.yaml
+++ b/applications/repertoire/values.yaml
@@ -137,7 +137,7 @@ config:
     created: "2026-05-20T00:00:00"
     creator: "Vera C. Rubin Observatory"
     ivoid: "ivo://org.rubinobs/registry"
-    pathPrefix: "/discovery"
+    pathPrefix: "/api"
     repositoryName: "Rubin Science Platform IVOA Publishing Registry"
     rights: >-
       Restricted to authorized Rubin data rights holders. See


### PR DESCRIPTION
Target of this PR is to allow moving the publishing registry path to `/api/registry` instead of  `/discovery/ivoa`.