### PR TITLE
DM-55161: Rename docverse lifecycle-eval arq pool to maintenance

### DIFF
--- a/applications/docverse/Chart.yaml
+++ b/applications/docverse/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "tickets-DM-55159"
+appVersion: "tickets-DM-55161"
 description: Publish versioned docs
 name: docverse
 sources:

--- a/applications/docverse/README.md
+++ b/applications/docverse/README.md
@@ -19,15 +19,23 @@ Publish versioned docs
 | cloudsql.resources | object | See `values.yaml` | Resource requests and limits for Cloud SQL Auth Proxy |
 | cloudsql.serviceAccount | string | `""` | The Google service account that has an IAM binding to the `docverse` Kubernetes service accounts and has the `cloudsql.client` role |
 | config.arqRedisUrl | string | Points to embedded Redis | URL for Redis arq queue database |
+| config.credentialKeyRotation | bool | `false` | Set true during a credential-encryption (Fernet) key rotation to deliver the retired key (DOCVERSE_CREDENTIAL_ENCRYPTION_KEY_RETIRED) to all pods so existing credentials can still be decrypted. Set back to false and remove the Vault key once all credentials have been re-encrypted. |
 | config.databaseUrl | string | `""` | Database URL for PostgreSQL |
 | config.githubAppId | string | `nil` | GitHub App ID for Docverse to use when accessing GitHub repositories. If not set, Docverse will operate in a limited mode without GitHub integration. |
 | config.keeperSync.enabled | bool | `false` | Enable the Keeper-sync worker that consumes the `docverse:sync-queue` arq queue. Requires the docverse image to provide `docverse.worker.main.KeeperSyncWorkerSettings`. |
+| config.keeperSync.jobTimeoutSeconds | int | `3600` | Per-job timeout, in seconds, for keeper-sync arq jobs. |
 | config.logLevel | string | `"INFO"` | Logging level |
 | config.logProfile | string | `"production"` | Logging profile (`production` for JSON, `development` for human-friendly) |
 | config.maintenance.enabled | bool | `false` | Enable the maintenance worker that consumes the `docverse:maintenance-queue` arq queue. Requires the docverse image to provide `docverse.worker.main.MaintenanceWorkerSettings`. |
 | config.maintenance.gitRefAuditEnabled | bool | `false` | Whether to enable auditing the git ref lifecycle rule. Enabling this will cause docverse to make GitHub API calls to determine if the git ref associated with an edition still exists. |
 | config.maintenance.jobTimeoutSeconds | int | `3600` | Per-job timeout, in seconds, for maintenance-pool jobs (lifecycle evaluation and git ref audits). |
 | config.pathPrefix | string | `"/docverse/api"` | URL path prefix |
+| config.reaperThresholds.buildProcessingSeconds | int | `28800` | Stuck-run reaper threshold, in seconds, for build_processing jobs. |
+| config.reaperThresholds.dashboardBuildSeconds | int | `1800` | Stuck-run reaper threshold, in seconds, for dashboard_build jobs. |
+| config.reaperThresholds.dashboardSyncSeconds | int | `21600` | Stuck-run reaper threshold, in seconds, for dashboard_sync jobs. |
+| config.reaperThresholds.keeperSyncSeconds | int | `21600` | Stuck-run reaper threshold, in seconds, for keeper-sync jobs. |
+| config.reaperThresholds.lifecycleSeconds | int | `21600` | Stuck-run reaper threshold, in seconds, for lifecycle_eval and git_ref_audit jobs (maintenance pool). |
+| config.reaperThresholds.publishEditionSeconds | int | `14400` | Stuck-run reaper threshold, in seconds, for publish_edition jobs. |
 | config.sentry.enabled | bool | `false` | Whether to send error reports and tracing data to Sentry. Requires the sentry-dsn secret to be set in Vault. |
 | config.sentry.tracesSampleRate | float | `0` | The percentage of requests that should be traced. This should be a float between 0 and 1. |
 | config.slackAlerts | bool | `false` | Whether to send Slack alerts for unexpected failures |

--- a/applications/docverse/README.md
+++ b/applications/docverse/README.md
@@ -22,10 +22,11 @@ Publish versioned docs
 | config.databaseUrl | string | `""` | Database URL for PostgreSQL |
 | config.githubAppId | string | `nil` | GitHub App ID for Docverse to use when accessing GitHub repositories. If not set, Docverse will operate in a limited mode without GitHub integration. |
 | config.keeperSync.enabled | bool | `false` | Enable the Keeper-sync worker that consumes the `docverse:sync-queue` arq queue. Requires the docverse image to provide `docverse.worker.main.KeeperSyncWorkerSettings`. |
-| config.lifecycleEval.enabled | bool | `false` | Enable the lifecycle-evaluation worker that consumes the `docverse:lifecycle-queue` arq queue. Requires the docverse image to provide `docverse.worker.main.LifecycleEvalWorkerSettings`. |
-| config.lifecycleEval.gitRefAuditEnabled | bool | `false` | Whether to enable auditing the git ref lifecycle rule. Enabling this will cause docverse to GitHub API calls to determine if the git ref associated with an edition still exists. |
 | config.logLevel | string | `"INFO"` | Logging level |
 | config.logProfile | string | `"production"` | Logging profile (`production` for JSON, `development` for human-friendly) |
+| config.maintenance.enabled | bool | `false` | Enable the maintenance worker that consumes the `docverse:maintenance-queue` arq queue. Requires the docverse image to provide `docverse.worker.main.MaintenanceWorkerSettings`. |
+| config.maintenance.gitRefAuditEnabled | bool | `false` | Whether to enable auditing the git ref lifecycle rule. Enabling this will cause docverse to make GitHub API calls to determine if the git ref associated with an edition still exists. |
+| config.maintenance.jobTimeoutSeconds | int | `3600` | Per-job timeout, in seconds, for maintenance-pool jobs (lifecycle evaluation and git ref audits). |
 | config.pathPrefix | string | `"/docverse/api"` | URL path prefix |
 | config.sentry.enabled | bool | `false` | Whether to send error reports and tracing data to Sentry. Requires the sentry-dsn secret to be set in Vault. |
 | config.sentry.tracesSampleRate | float | `0` | The percentage of requests that should be traced. This should be a float between 0 and 1. |
@@ -39,12 +40,12 @@ Publish versioned docs
 | image.repository | string | `"ghcr.io/lsst-sqre/docverse"` | Image to use in the docverse deployment |
 | image.tag | string | The appVersion of the chart | Tag of image to use |
 | ingress.annotations | object | `{}` | Additional annotations for the ingress rule |
-| lifecycleWorker.affinity | object | `{}` | Affinity rules for the lifecycle-eval worker pod |
-| lifecycleWorker.nodeSelector | object | `{}` | Node selection rules for the lifecycle-eval worker pod |
-| lifecycleWorker.podAnnotations | object | `{}` | Annotations for the lifecycle-eval worker pod |
-| lifecycleWorker.replicaCount | int | `1` | Number of lifecycle-eval worker pods to start |
-| lifecycleWorker.resources | object | See `values.yaml` | Resource limits and requests for the lifecycle-eval worker pod |
-| lifecycleWorker.tolerations | list | `[]` | Tolerations for the lifecycle-eval worker pod |
+| maintenanceWorker.affinity | object | `{}` | Affinity rules for the maintenance worker pod |
+| maintenanceWorker.nodeSelector | object | `{}` | Node selection rules for the maintenance worker pod |
+| maintenanceWorker.podAnnotations | object | `{}` | Annotations for the maintenance worker pod |
+| maintenanceWorker.replicaCount | int | `1` | Number of maintenance worker pods to start |
+| maintenanceWorker.resources | object | See `values.yaml` | Resource limits and requests for the maintenance worker pod |
+| maintenanceWorker.tolerations | list | `[]` | Tolerations for the maintenance worker pod |
 | nodeSelector | object | `{}` | Node selection rules for the docverse deployment pod |
 | podAnnotations | object | `{}` | Annotations for the docverse deployment pod |
 | redis.affinity | object | `{}` | Affinity rules for the Redis pod |

--- a/applications/docverse/secrets.yaml
+++ b/applications/docverse/secrets.yaml
@@ -4,6 +4,12 @@ DOCVERSE_CREDENTIAL_ENCRYPTION_KEY:
     secret will invalidate all existing encrypted credentials.
   generate:
     type: fernet-key
+DOCVERSE_CREDENTIAL_ENCRYPTION_KEY_RETIRED:
+  description: >-
+    Previous Fernet key, provided only during a credential-encryption key
+    rotation so credentials encrypted under the old key can still be decrypted.
+    Remove after all credentials have been re-encrypted.
+  if: config.credentialKeyRotation
 DOCVERSE_DATABASE_PASSWORD:
   description: >-
     Password for the PostgreSQL database used by Docverse.

--- a/applications/docverse/templates/_helpers.tpl
+++ b/applications/docverse/templates/_helpers.tpl
@@ -60,6 +60,13 @@ Secret environment variables shared across all Docverse pods.
     secretKeyRef:
       name: "docverse"
       key: "DOCVERSE_CREDENTIAL_ENCRYPTION_KEY"
+{{- if .Values.config.credentialKeyRotation }}
+- name: "DOCVERSE_CREDENTIAL_ENCRYPTION_KEY_RETIRED"
+  valueFrom:
+    secretKeyRef:
+      name: "docverse"
+      key: "DOCVERSE_CREDENTIAL_ENCRYPTION_KEY_RETIRED"
+{{- end }}
 - name: "DOCVERSE_DATABASE_PASSWORD"
   valueFrom:
     secretKeyRef:

--- a/applications/docverse/templates/configmap.yaml
+++ b/applications/docverse/templates/configmap.yaml
@@ -23,3 +23,10 @@ data:
   {{- end }}
   DOCVERSE_GIT_REF_AUDIT_ENABLED: {{ .Values.config.maintenance.gitRefAuditEnabled | quote }}
   DOCVERSE_MAINTENANCE_JOB_TIMEOUT_SECONDS: {{ .Values.config.maintenance.jobTimeoutSeconds | quote }}
+  DOCVERSE_KEEPER_SYNC_JOB_TIMEOUT_SECONDS: {{ .Values.config.keeperSync.jobTimeoutSeconds | quote }}
+  DOCVERSE_KEEPER_SYNC_REAPER_THRESHOLD_SECONDS: {{ .Values.config.reaperThresholds.keeperSyncSeconds | quote }}
+  DOCVERSE_LIFECYCLE_REAPER_THRESHOLD_SECONDS: {{ .Values.config.reaperThresholds.lifecycleSeconds | quote }}
+  DOCVERSE_DASHBOARD_BUILD_REAPER_THRESHOLD_SECONDS: {{ .Values.config.reaperThresholds.dashboardBuildSeconds | quote }}
+  DOCVERSE_PUBLISH_EDITION_REAPER_THRESHOLD_SECONDS: {{ .Values.config.reaperThresholds.publishEditionSeconds | quote }}
+  DOCVERSE_BUILD_PROCESSING_REAPER_THRESHOLD_SECONDS: {{ .Values.config.reaperThresholds.buildProcessingSeconds | quote }}
+  DOCVERSE_DASHBOARD_SYNC_REAPER_THRESHOLD_SECONDS: {{ .Values.config.reaperThresholds.dashboardSyncSeconds | quote }}

--- a/applications/docverse/templates/configmap.yaml
+++ b/applications/docverse/templates/configmap.yaml
@@ -21,4 +21,5 @@ data:
   {{- if .Values.config.githubAppId }}
   DOCVERSE_GITHUB_APP_ID: {{ .Values.config.githubAppId | quote }}
   {{- end }}
-  DOCVERSE_GIT_REF_AUDIT_ENABLED: {{ .Values.config.lifecycleEval.gitRefAuditEnabled | quote }}
+  DOCVERSE_GIT_REF_AUDIT_ENABLED: {{ .Values.config.maintenance.gitRefAuditEnabled | quote }}
+  DOCVERSE_MAINTENANCE_JOB_TIMEOUT_SECONDS: {{ .Values.config.maintenance.jobTimeoutSeconds | quote }}

--- a/applications/docverse/templates/maintenance-worker-deployment.yaml
+++ b/applications/docverse/templates/maintenance-worker-deployment.yaml
@@ -1,33 +1,33 @@
-{{- if .Values.config.lifecycleEval.enabled }}
+{{- if .Values.config.maintenance.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: "docverse-lifecycle-worker"
+  name: "docverse-maintenance-worker"
   annotations:
     argocd.argoproj.io/sync-wave: "2"
   labels:
     {{- include "docverse.labels" . | nindent 4 }}
-    app.kubernetes.io/component: "lifecycle-worker"
+    app.kubernetes.io/component: "maintenance-worker"
     docverse-redis-client: "true"
 spec:
-  replicas: {{ .Values.lifecycleWorker.replicaCount }}
+  replicas: {{ .Values.maintenanceWorker.replicaCount }}
   selector:
     matchLabels:
       {{- include "docverse.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/component: "lifecycle-worker"
+      app.kubernetes.io/component: "maintenance-worker"
   template:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-        {{- with .Values.lifecycleWorker.podAnnotations }}
+        {{- with .Values.maintenanceWorker.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
       labels:
         {{- include "docverse.selectorLabels" . | nindent 8 }}
-        app.kubernetes.io/component: "lifecycle-worker"
+        app.kubernetes.io/component: "maintenance-worker"
         docverse-redis-client: "true"
     spec:
-      {{- with .Values.lifecycleWorker.affinity }}
+      {{- with .Values.maintenanceWorker.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -37,9 +37,9 @@ spec:
       automountServiceAccountToken: false
       {{- end }}
       containers:
-        - name: "docverse-lifecycle-worker"
+        - name: "docverse-maintenance-worker"
           command: ["arq"]
-          args: ["docverse.worker.main.LifecycleEvalWorkerSettings"]
+          args: ["docverse.worker.main.MaintenanceWorkerSettings"]
           env:
             {{- include "docverse.envVars" . | nindent 12 }}
           envFrom:
@@ -48,7 +48,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           resources:
-            {{- toYaml .Values.lifecycleWorker.resources | nindent 12 }}
+            {{- toYaml .Values.maintenanceWorker.resources | nindent 12 }}
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -59,11 +59,11 @@ spec:
       initContainers:
         {{- include "docverse.cloudsqlSidecar" . | nindent 8 }}
       {{- end }}
-      {{- with .Values.lifecycleWorker.nodeSelector }}
+      {{- with .Values.maintenanceWorker.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.lifecycleWorker.tolerations }}
+      {{- with .Values.maintenanceWorker.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/applications/docverse/values-roundtable-dev.yaml
+++ b/applications/docverse/values-roundtable-dev.yaml
@@ -10,7 +10,7 @@ config:
     - "jonathansick"
   keeperSync:
     enabled: true
-  lifecycleEval:
+  maintenance:
     enabled: true
     gitRefAuditEnabled: true
   sentry:

--- a/applications/docverse/values.yaml
+++ b/applications/docverse/values.yaml
@@ -67,14 +67,18 @@ config:
     # provide `docverse.worker.main.KeeperSyncWorkerSettings`.
     enabled: false
 
-  lifecycleEval:
-    # -- Enable the lifecycle-evaluation worker that consumes the
-    # `docverse:lifecycle-queue` arq queue. Requires the docverse image to
-    # provide `docverse.worker.main.LifecycleEvalWorkerSettings`.
+  maintenance:
+    # -- Enable the maintenance worker that consumes the
+    # `docverse:maintenance-queue` arq queue. Requires the docverse image to
+    # provide `docverse.worker.main.MaintenanceWorkerSettings`.
     enabled: false
 
+    # -- Per-job timeout, in seconds, for maintenance-pool jobs (lifecycle
+    # evaluation and git ref audits).
+    jobTimeoutSeconds: 3600
+
     # -- Whether to enable auditing the git ref lifecycle rule.
-    # Enabling this will cause docverse to GitHub API calls to determine
+    # Enabling this will cause docverse to make GitHub API calls to determine
     # if the git ref associated with an edition still exists.
     gitRefAuditEnabled: false
 
@@ -139,11 +143,11 @@ syncWorker:
   # -- Tolerations for the Keeper-sync worker pod
   tolerations: []
 
-lifecycleWorker:
-  # -- Number of lifecycle-eval worker pods to start
+maintenanceWorker:
+  # -- Number of maintenance worker pods to start
   replicaCount: 1
 
-  # -- Resource limits and requests for the lifecycle-eval worker pod
+  # -- Resource limits and requests for the maintenance worker pod
   # @default -- See `values.yaml`
   resources:
     limits:
@@ -153,16 +157,16 @@ lifecycleWorker:
       cpu: "50m"
       memory: "128Mi"
 
-  # -- Affinity rules for the lifecycle-eval worker pod
+  # -- Affinity rules for the maintenance worker pod
   affinity: {}
 
-  # -- Node selection rules for the lifecycle-eval worker pod
+  # -- Node selection rules for the maintenance worker pod
   nodeSelector: {}
 
-  # -- Annotations for the lifecycle-eval worker pod
+  # -- Annotations for the maintenance worker pod
   podAnnotations: {}
 
-  # -- Tolerations for the lifecycle-eval worker pod
+  # -- Tolerations for the maintenance worker pod
   tolerations: []
 
 # -- Tolerations for the docverse deployment pod

--- a/applications/docverse/values.yaml
+++ b/applications/docverse/values.yaml
@@ -67,6 +67,9 @@ config:
     # provide `docverse.worker.main.KeeperSyncWorkerSettings`.
     enabled: false
 
+    # -- Per-job timeout, in seconds, for keeper-sync arq jobs.
+    jobTimeoutSeconds: 3600
+
   maintenance:
     # -- Enable the maintenance worker that consumes the
     # `docverse:maintenance-queue` arq queue. Requires the docverse image to
@@ -81,6 +84,27 @@ config:
     # Enabling this will cause docverse to make GitHub API calls to determine
     # if the git ref associated with an edition still exists.
     gitRefAuditEnabled: false
+
+  # -- Set true during a credential-encryption (Fernet) key rotation to deliver
+  # the retired key (DOCVERSE_CREDENTIAL_ENCRYPTION_KEY_RETIRED) to all pods so
+  # existing credentials can still be decrypted. Set back to false and remove the
+  # Vault key once all credentials have been re-encrypted.
+  credentialKeyRotation: false
+
+  reaperThresholds:
+    # -- Stuck-run reaper threshold, in seconds, for keeper-sync jobs.
+    keeperSyncSeconds: 21600
+    # -- Stuck-run reaper threshold, in seconds, for lifecycle_eval and
+    # git_ref_audit jobs (maintenance pool).
+    lifecycleSeconds: 21600
+    # -- Stuck-run reaper threshold, in seconds, for dashboard_build jobs.
+    dashboardBuildSeconds: 1800
+    # -- Stuck-run reaper threshold, in seconds, for publish_edition jobs.
+    publishEditionSeconds: 14400
+    # -- Stuck-run reaper threshold, in seconds, for build_processing jobs.
+    buildProcessingSeconds: 28800
+    # -- Stuck-run reaper threshold, in seconds, for dashboard_sync jobs.
+    dashboardSyncSeconds: 21600
 
 ingress:
   # -- Additional annotations for the ingress rule


### PR DESCRIPTION
## Summary

- Update the docverse chart to match the application's backwards-incompatible rename of the lifecycle-eval arq worker pool to "maintenance" (`LifecycleEvalWorkerSettings` → `MaintenanceWorkerSettings`, `docverse:lifecycle-queue` → `docverse:maintenance-queue`). The worker Deployment, its container args, names, and component labels all move to `maintenance-worker`.
- Rename the `config.lifecycleEval` and top-level `lifecycleWorker` value blocks to `config.maintenance` / `maintenanceWorker`, and expose a new `config.maintenance.jobTimeoutSeconds` (default `3600`) wired into the ConfigMap as `DOCVERSE_MAINTENANCE_JOB_TIMEOUT_SECONDS`.
- Bump `appVersion` to `tickets-DM-55161` so roundtable-dev pulls an image that actually provides `MaintenanceWorkerSettings` (the `ghcr.io/lsst-sqre/docverse:tickets-DM-55161` image is already published).
- Expose the remaining per-environment docverse operator tunables that `config.py` already supports but the chart could not set:
  - `config.keeperSync.jobTimeoutSeconds` (default `3600`), the sibling of the maintenance job timeout, wired to `DOCVERSE_KEEPER_SYNC_JOB_TIMEOUT_SECONDS`.
  - A uniform `config.reaperThresholds` block for the six stuck-run reaper thresholds (keeper-sync, lifecycle/git-ref-audit, dashboard_build, publish_edition, build_processing, dashboard_sync), wired into the ConfigMap as the matching `DOCVERSE_*_REAPER_THRESHOLD_SECONDS` env vars. Defaults match `config.py` (`21600`/`21600`/`1800`/`14400`/`28800`/`21600`).
- Add a `config.credentialKeyRotation` gate (default `false`) plus a manually-provided `DOCVERSE_CREDENTIAL_ENCRYPTION_KEY_RETIRED` secret and a conditional `secretKeyRef` env in `docverse.envVars`, so the previous Fernet key can be delivered to all pods during a credential-encryption key rotation and removed afterward.

## Validation steps

- `helm template docverse applications/docverse -f applications/docverse/values.yaml -f applications/docverse/values-roundtable-dev.yaml --set global.host=example.org --set global.vaultSecretsPath=secret/k8s --set global.repertoireUrl=https://example.org/repertoire` renders a `docverse-maintenance-worker` Deployment with `args: ["docverse.worker.main.MaintenanceWorkerSettings"]`, component label `maintenance-worker`, and a ConfigMap containing `DOCVERSE_MAINTENANCE_JOB_TIMEOUT_SECONDS: "3600"` and `DOCVERSE_GIT_REF_AUDIT_ENABLED: "true"`.
- `grep -rn -i "lifecycleeval\|lifecycle-worker\|lifecycleWorker\|LifecycleEvalWorkerSettings\|lifecycle-queue" applications/docverse/` returns nothing.
- Default render (`helm template docverse applications/docverse --set global.host=example.org --set global.vaultSecretsPath=secret/k8s --set global.repertoireUrl=https://example.org/repertoire`) emits all seven new `DOCVERSE_*` env vars with the `config.py` defaults (`DOCVERSE_KEEPER_SYNC_JOB_TIMEOUT_SECONDS: "3600"`, reaper thresholds `"21600"`/`"21600"`/`"1800"`/`"14400"`/`"28800"`/`"21600"`), and `DOCVERSE_CREDENTIAL_ENCRYPTION_KEY_RETIRED` is absent.
- Adding `--set config.credentialKeyRotation=true` renders the `DOCVERSE_CREDENTIAL_ENCRYPTION_KEY_RETIRED` `secretKeyRef` env on every pod that includes `docverse.envVars` (API + each enabled worker pool + schema-update job).
- `helm lint applications/docverse` passes; `helm-docs` regenerates the README cleanly (yamllint + helm-docs pre-commit hooks pass).
- `grep -roh "DOCVERSE_[A-Z_]*" applications/docverse/templates/ | sort -u` — the only `config.py` fields intentionally not exposed are `DOCVERSE_NAME`, `DOCVERSE_ALEMBIC_CONFIG_PATH`, `DOCVERSE_ARQ_MODE`, `DOCVERSE_ARQ_QUEUE_NAME`, and `DOCVERSE_ARQ_REDIS_PASSWORD`.
- After sync to roundtable-dev, confirm the `docverse-maintenance-worker` pod starts cleanly (no missing-class crash) and consumes the `docverse:maintenance-queue`.

## References

- Jira: https://rubinobs.atlassian.net/browse/DM-55161
