### PR TITLE
DM-55200: Wire Docverse metrics into Sasquatch on roundtable

### DIFF
--- a/applications/docverse/Chart.yaml
+++ b/applications/docverse/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "tickets-DM-55161"
+appVersion: "tickets-DM-55200"
 description: Publish versioned docs
 name: docverse
 sources:

--- a/applications/docverse/README.md
+++ b/applications/docverse/README.md
@@ -29,6 +29,10 @@ Publish versioned docs
 | config.maintenance.enabled | bool | `false` | Enable the maintenance worker that consumes the `docverse:maintenance-queue` arq queue. Requires the docverse image to provide `docverse.worker.main.MaintenanceWorkerSettings`. |
 | config.maintenance.gitRefAuditEnabled | bool | `false` | Whether to enable auditing the git ref lifecycle rule. Enabling this will cause docverse to make GitHub API calls to determine if the git ref associated with an edition still exists. |
 | config.maintenance.jobTimeoutSeconds | int | `3600` | Per-job timeout, in seconds, for maintenance-pool jobs (lifecycle evaluation and git ref audits). |
+| config.metrics.application | string | `"docverse"` | Name under which to log metrics. Generally there is no reason to change this. |
+| config.metrics.enabled | bool | `false` | Whether to enable sending application metrics events to Sasquatch over Kafka. When disabled, Docverse uses a no-op metrics manager. |
+| config.metrics.events.topicPrefix | string | `"lsst.square.metrics.events"` | Topic prefix for events. It may sometimes be useful to change this in development environments. |
+| config.metrics.schemaManager.registryUrl | string | Sasquatch in the local cluster | URL of the Confluent-compatible schema registry server |
 | config.pathPrefix | string | `"/docverse/api"` | URL path prefix |
 | config.reaperThresholds.buildProcessingSeconds | int | `28800` | Stuck-run reaper threshold, in seconds, for build_processing jobs. |
 | config.reaperThresholds.dashboardBuildSeconds | int | `1800` | Stuck-run reaper threshold, in seconds, for dashboard_build jobs. |

--- a/applications/docverse/templates/_helpers.tpl
+++ b/applications/docverse/templates/_helpers.tpl
@@ -103,3 +103,64 @@ Secret environment variables shared across all Docverse pods.
   value: {{ .Values.config.sentry.tracesSampleRate | quote }}
 {{- end }}
 {{- end }}
+
+{{/*
+Kafka connection environment variables for application-metrics publishing,
+sourced from the access-operator-minted docverse-kafka secret plus the static
+mount paths. Included only by the long-running metric-publishing pods (the API
+and the three worker pools) — deliberately NOT part of docverse.envVars, so the
+PreSync schema-update job never references the docverse-kafka secret (which the
+access operator only mints during the main sync wave). Self-gated on
+config.metrics.enabled.
+*/}}
+{{- define "docverse.kafkaEnvVars" -}}
+{{- if .Values.config.metrics.enabled }}
+- name: "KAFKA_BOOTSTRAP_SERVERS"
+  valueFrom:
+    secretKeyRef:
+      name: "docverse-kafka"
+      key: "bootstrapServers"
+- name: "KAFKA_SECURITY_PROTOCOL"
+  valueFrom:
+    secretKeyRef:
+      name: "docverse-kafka"
+      key: "securityProtocol"
+- name: "KAFKA_CLIENT_CERT_PATH"
+  value: "/etc/docverse-kafka/user.crt"
+- name: "KAFKA_CLIENT_KEY_PATH"
+  value: "/etc/docverse-kafka/user.key"
+- name: "KAFKA_CLUSTER_CA_PATH"
+  value: "/etc/docverse-kafka/ca.crt"
+{{- end }}
+{{- end }}
+
+{{/*
+Volume mounts for the Kafka client certificate material minted by the Strimzi
+access operator into the docverse-kafka secret. Included by every pod that
+publishes application metrics when config.metrics.enabled is true.
+*/}}
+{{- define "docverse.kafkaVolumeMounts" -}}
+- name: "kafka"
+  mountPath: "/etc/docverse-kafka/ca.crt"
+  readOnly: true
+  subPath: "ssl.truststore.crt"
+- name: "kafka"
+  mountPath: "/etc/docverse-kafka/user.crt"
+  readOnly: true
+  subPath: "ssl.keystore.crt"
+- name: "kafka"
+  mountPath: "/etc/docverse-kafka/user.key"
+  readOnly: true
+  subPath: "ssl.keystore.key"
+{{- end }}
+
+{{/*
+The Kafka client certificate volume sourced from the docverse-kafka secret.
+Included by every pod that publishes application metrics when
+config.metrics.enabled is true.
+*/}}
+{{- define "docverse.kafkaVolume" -}}
+- name: "kafka"
+  secret:
+    secretName: "docverse-kafka"
+{{- end }}

--- a/applications/docverse/templates/configmap.yaml
+++ b/applications/docverse/templates/configmap.yaml
@@ -30,3 +30,9 @@ data:
   DOCVERSE_PUBLISH_EDITION_REAPER_THRESHOLD_SECONDS: {{ .Values.config.reaperThresholds.publishEditionSeconds | quote }}
   DOCVERSE_BUILD_PROCESSING_REAPER_THRESHOLD_SECONDS: {{ .Values.config.reaperThresholds.buildProcessingSeconds | quote }}
   DOCVERSE_DASHBOARD_SYNC_REAPER_THRESHOLD_SECONDS: {{ .Values.config.reaperThresholds.dashboardSyncSeconds | quote }}
+  {{- if .Values.config.metrics.enabled }}
+  METRICS_ENABLED: "true"
+  METRICS_APPLICATION: {{ .Values.config.metrics.application | quote }}
+  METRICS_EVENTS_TOPIC_PREFIX: {{ .Values.config.metrics.events.topicPrefix | quote }}
+  SCHEMA_MANAGER_REGISTRY_URL: {{ .Values.config.metrics.schemaManager.registryUrl | quote }}
+  {{- end }}

--- a/applications/docverse/templates/deployment.yaml
+++ b/applications/docverse/templates/deployment.yaml
@@ -36,6 +36,7 @@ spec:
         - name: {{ .Chart.Name }}
           env:
             {{- include "docverse.envVars" . | nindent 12 }}
+            {{- include "docverse.kafkaEnvVars" . | nindent 12 }}
             # Uvicorn keepalive timeout, in seconds. This should be longer
             # than any keepalive timeouts on any downstream proxies. The
             # keepalive timeout for ingress-nginx connections is 60s.
@@ -79,6 +80,10 @@ spec:
               drop:
                 - "all"
             readOnlyRootFilesystem: true
+          {{- if .Values.config.metrics.enabled }}
+          volumeMounts:
+            {{- include "docverse.kafkaVolumeMounts" . | nindent 12 }}
+          {{- end }}
       {{- if .Values.cloudsql.enabled }}
       initContainers:
         {{- include "docverse.cloudsqlSidecar" . | nindent 8 }}
@@ -95,3 +100,7 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
         runAsGroup: 1000
+      {{- if .Values.config.metrics.enabled }}
+      volumes:
+        {{- include "docverse.kafkaVolume" . | nindent 8 }}
+      {{- end }}

--- a/applications/docverse/templates/job-schema-update.yaml
+++ b/applications/docverse/templates/job-schema-update.yaml
@@ -47,6 +47,13 @@ spec:
                 name: "docverse"
           env:
             {{- include "docverse.envVars" . | nindent 12 }}
+            # Alembic-only job: never publish metrics. Override the shared
+            # configmap's METRICS_ENABLED so Configuration() builds the no-op
+            # metrics manager instead of a Kafka one (this job has no Kafka
+            # wiring and runs as a PreSync hook before the docverse-kafka
+            # secret is minted).
+            - name: "METRICS_ENABLED"
+              value: "false"
       {{- if .Values.cloudsql.enabled }}
       initContainers:
         {{- include "docverse.cloudsqlSidecar" . | nindent 8 }}

--- a/applications/docverse/templates/kafka-access.yaml
+++ b/applications/docverse/templates/kafka-access.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.config.metrics.enabled -}}
+apiVersion: access.strimzi.io/v1alpha1
+kind: KafkaAccess
+metadata:
+  name: "docverse-kafka"
+  labels:
+    {{- include "docverse.labels" . | nindent 4 }}
+spec:
+  kafka:
+    name: "sasquatch"
+    namespace: "sasquatch"
+    listener: "tls"
+  user:
+    kind: "KafkaUser"
+    apiGroup: "kafka.strimzi.io"
+    name: "app-metrics-docverse"
+    namespace: "sasquatch"
+{{- end }}

--- a/applications/docverse/templates/maintenance-worker-deployment.yaml
+++ b/applications/docverse/templates/maintenance-worker-deployment.yaml
@@ -42,6 +42,7 @@ spec:
           args: ["docverse.worker.main.MaintenanceWorkerSettings"]
           env:
             {{- include "docverse.envVars" . | nindent 12 }}
+            {{- include "docverse.kafkaEnvVars" . | nindent 12 }}
           envFrom:
             - configMapRef:
                 name: "docverse"
@@ -55,6 +56,10 @@ spec:
               drop:
                 - "all"
             readOnlyRootFilesystem: true
+          {{- if .Values.config.metrics.enabled }}
+          volumeMounts:
+            {{- include "docverse.kafkaVolumeMounts" . | nindent 12 }}
+          {{- end }}
       {{- if .Values.cloudsql.enabled }}
       initContainers:
         {{- include "docverse.cloudsqlSidecar" . | nindent 8 }}
@@ -71,4 +76,8 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
         runAsGroup: 1000
+      {{- if .Values.config.metrics.enabled }}
+      volumes:
+        {{- include "docverse.kafkaVolume" . | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/applications/docverse/templates/sync-worker-deployment.yaml
+++ b/applications/docverse/templates/sync-worker-deployment.yaml
@@ -42,6 +42,7 @@ spec:
           args: ["docverse.worker.main.KeeperSyncWorkerSettings"]
           env:
             {{- include "docverse.envVars" . | nindent 12 }}
+            {{- include "docverse.kafkaEnvVars" . | nindent 12 }}
           envFrom:
             - configMapRef:
                 name: "docverse"
@@ -55,6 +56,10 @@ spec:
               drop:
                 - "all"
             readOnlyRootFilesystem: true
+          {{- if .Values.config.metrics.enabled }}
+          volumeMounts:
+            {{- include "docverse.kafkaVolumeMounts" . | nindent 12 }}
+          {{- end }}
       {{- if .Values.cloudsql.enabled }}
       initContainers:
         {{- include "docverse.cloudsqlSidecar" . | nindent 8 }}
@@ -71,4 +76,8 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
         runAsGroup: 1000
+      {{- if .Values.config.metrics.enabled }}
+      volumes:
+        {{- include "docverse.kafkaVolume" . | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/applications/docverse/templates/worker-deployment.yaml
+++ b/applications/docverse/templates/worker-deployment.yaml
@@ -41,6 +41,7 @@ spec:
           args: ["docverse.worker.main.WorkerSettings"]
           env:
             {{- include "docverse.envVars" . | nindent 12 }}
+            {{- include "docverse.kafkaEnvVars" . | nindent 12 }}
           envFrom:
             - configMapRef:
                 name: "docverse"
@@ -54,6 +55,10 @@ spec:
               drop:
                 - "all"
             readOnlyRootFilesystem: true
+          {{- if .Values.config.metrics.enabled }}
+          volumeMounts:
+            {{- include "docverse.kafkaVolumeMounts" . | nindent 12 }}
+          {{- end }}
       {{- if .Values.cloudsql.enabled }}
       initContainers:
         {{- include "docverse.cloudsqlSidecar" . | nindent 8 }}
@@ -70,3 +75,7 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
         runAsGroup: 1000
+      {{- if .Values.config.metrics.enabled }}
+      volumes:
+        {{- include "docverse.kafkaVolume" . | nindent 8 }}
+      {{- end }}

--- a/applications/docverse/values-roundtable-dev.yaml
+++ b/applications/docverse/values-roundtable-dev.yaml
@@ -15,6 +15,8 @@ config:
     gitRefAuditEnabled: true
   sentry:
     enabled: true
+  metrics:
+    enabled: true
 
 cloudsql:
   enabled: true

--- a/applications/docverse/values.yaml
+++ b/applications/docverse/values.yaml
@@ -43,6 +43,25 @@ config:
     # float between 0 and 1.
     tracesSampleRate: 0.0
 
+  metrics:
+    # -- Whether to enable sending application metrics events to Sasquatch
+    # over Kafka. When disabled, Docverse uses a no-op metrics manager.
+    enabled: false
+
+    # -- Name under which to log metrics. Generally there is no reason to
+    # change this.
+    application: "docverse"
+
+    events:
+      # -- Topic prefix for events. It may sometimes be useful to change this
+      # in development environments.
+      topicPrefix: "lsst.square.metrics.events"
+
+    schemaManager:
+      # -- URL of the Confluent-compatible schema registry server
+      # @default -- Sasquatch in the local cluster
+      registryUrl: "http://sasquatch-schema-registry.sasquatch.svc.cluster.local:8081"
+
   # -- Database URL for PostgreSQL
   databaseUrl: ""
 

--- a/applications/sasquatch/charts/app-metrics/values.yaml
+++ b/applications/sasquatch/charts/app-metrics/values.yaml
@@ -7,6 +7,18 @@
 # for the structure of this value.
 # @default -- See `values.yaml`
 globalAppConfig:
+  docverse:
+    influxTags:
+      - "organization"
+      - "project"
+      - "action"
+      - "edition_kind"
+      - "trigger"
+      - "role"
+      - "principal_type"
+      - "ci_platform"
+      - "success"
+      - "github_repository"
   gafaelfawr:
     influxTags:
       - "service"

--- a/applications/sasquatch/values-roundtable-dev.yaml
+++ b/applications/sasquatch/values-roundtable-dev.yaml
@@ -92,6 +92,7 @@ app-metrics:
   enabled: true
   apps:
     - gafaelfawr
+    - docverse
 
 squareEvents:
   enabled: true


### PR DESCRIPTION
## Summary

- Wire the `docverse` chart so its long-running pods (the API plus all three worker pools) publish safir application-metrics events ([SQR-112](https://sqr-112.lsst.io/#application-metrics)) to Sasquatch over Kafka, mirroring the gafaelfawr pattern: a `config.metrics` block, a `KafkaAccess` (`docverse-kafka`) that the Strimzi access operator turns into a Kafka client secret, `KAFKA_*`/`METRICS_*` env, and the Kafka cert volume/mounts — all gated on `metrics.enabled` and turned on for roundtable-dev.
- Register `docverse` in the Sasquatch `app-metrics` subchart (promoting `organization`, `project`, `action`, `edition_kind`, `trigger`, `role`, `principal_type`, `ci_platform`, `success`, `github_repository` to InfluxDB tags) and add `docverse` to `app-metrics.apps` on roundtable-dev. This registers the `lsst.square.metrics.events.docverse` topic, the `app-metrics-docverse` KafkaUser, and the Telegraf consumer against the InfluxDB OSS storage pipeline that #6570 (DM-55214) stood up on roundtable-dev.
- Bump the `docverse` chart `appVersion` to `tickets-DM-55200` so the deployed image carries the application-side metrics work (lsst-sqre/docverse#439).

This PR is scoped to **roundtable-dev only**. The Sasquatch storage pipeline (InfluxDB + Telegraf + Chronograf) is no longer stood up here — #6570 activated it on roundtable-dev. roundtable-prod is deferred until its Sasquatch pipeline is activated separately; enabling docverse metrics there would require activating the `app-metrics` subchart and storage pipeline on prod first.

The work is committed in three atomic changesets: the Docverse app-metrics registration, the Docverse publish wiring, and the appVersion bump.

### Notes for reviewers

- The `KAFKA_*` connection vars deliberately live in a deployment-only helper (`docverse.kafkaEnvVars`) rather than the shared `docverse.envVars`. The PreSync `schema-update` Job also includes `docverse.envVars` and runs before the `docverse-kafka` secret is minted (main sync wave), so putting the secret refs in the shared helper would deadlock the first deploy on a missing `secretKeyRef`. For the same reason the Job pins `METRICS_ENABLED=false`, overriding the shared configmap, so its `Configuration()` builds the no-op metrics manager (the `docverse-admin` CLI loads `Configuration` at import).

### Operational prerequisites

- `docverse-kafka` is auto-generated by the Strimzi access operator — no Vault entry needed.

## Validation steps

- `phalanx application template docverse roundtable-dev` and `phalanx application template sasquatch roundtable-dev` both render cleanly; the docverse render carries the `KafkaAccess`, `METRICS_*` env, and Kafka cert volumes (with the schema-update Job pinned to `METRICS_ENABLED=false`), and the sasquatch render materializes the `lsst.square.metrics.events.docverse` KafkaTopic, the `app-metrics-docverse` KafkaUser, and the Telegraf consumer with the docverse influxTags (gafaelfawr preserved).
- After Argo CD syncs roundtable-dev, confirm the `docverse-kafka` secret exists (minted by the access operator) and that the `lsst.square.metrics.events.docverse` KafkaTopic and `app-metrics-docverse` KafkaUser were created in the `sasquatch` namespace.
- Trigger a Docverse event end-to-end (e.g. upload a build / publish an edition) and watch it land on `lsst.square.metrics.events.docverse` in Kafdrop, then appear in the `lsst.square.metrics` InfluxDB database and in Chronograf — with `project`/`github_repository`/`action`/etc. materialized as tags and counts/`elapsed` as fields.

## References

- Jira: https://rubinobs.atlassian.net/browse/DM-55200
- Application-side work: lsst-sqre/docverse#439
- Sasquatch roundtable-dev metrics infrastructure: #6570 (DM-55214)
