### PR TITLE
DM-55211: Update ook to 0.22.0

### DIFF
--- a/applications/ook/Chart.yaml
+++ b/applications/ook/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: ook
 version: 1.0.0
-appVersion: "0.21.0"
+appVersion: "tickets-DM-55211"
 description: >
   Ook is the librarian service for Rubin Observatory. Ook indexes
   documentation content into the Algolia search engine that powers the Rubin

--- a/applications/ook/Chart.yaml
+++ b/applications/ook/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: ook
 version: 1.0.0
-appVersion: "tickets-DM-55211"
+appVersion: "0.22.0"
 description: >
   Ook is the librarian service for Rubin Observatory. Ook indexes
   documentation content into the Algolia search engine that powers the Rubin


### PR DESCRIPTION
## Summary

- Set the `ook` chart `appVersion` to `tickets-DM-55211` to deploy the image built from the `tickets/DM-55211` branch of Ook (lsst-sqre/ook#228, author internal ID aliases) for testing on a development cluster.

This is a temporary deployment pin and should be reverted to a tagged release before merging to production.

## References

- Ook PR: lsst-sqre/ook#228
- Jira: https://rubinobs.atlassian.net/browse/DM-55211