### PR TITLE
DM-55165: Upgrade Repertoire to 2.0.0

### DIFF
--- a/applications/repertoire/Chart.yaml
+++ b/applications/repertoire/Chart.yaml
@@ -6,7 +6,7 @@ description: Service discovery
 home: "https://repertoire.lsst.io/"
 sources:
   - "https://github.com/lsst-sqre/repertoire"
-appVersion: 1.0.0
+appVersion: 2.0.0
 
 annotations:
   phalanx.lsst.io/docs: |

--- a/applications/repertoire/templates/ingress.yaml
+++ b/applications/repertoire/templates/ingress.yaml
@@ -27,8 +27,8 @@ template:
                   port:
                     number: 8080
             {{- if .Values.config.ivoaRegistry }}
-            - path: {{ .Values.config.ivoaRegistry.pathPrefix | quote }}
-              pathType: "Prefix"
+            - path: {{ .Values.config.ivoaRegistry.path | quote }}
+              pathType: "Exact"
               backend:
                 service:
                   name: "repertoire"

--- a/applications/repertoire/values-base.yaml
+++ b/applications/repertoire/values-base.yaml
@@ -6,4 +6,5 @@ config:
       username: "efdreader"
       passwordKey: "base_efd-password"
       schemaRegistry: "http://sasquatch-schema-registry.sasquatch:8081"
+      local: true
   slackAlerts: true

--- a/applications/repertoire/values-idfdev.yaml
+++ b/applications/repertoire/values-idfdev.yaml
@@ -14,6 +14,7 @@ config:
       username: "efdreader"
       passwordKey: "idfdev_efd-password"
       schemaRegistry: "http://sasquatch-schema-registry.sasquatch:8081"
+      local: true
   metrics:
     enabled: true
   slackAlerts: true

--- a/applications/repertoire/values-summit.yaml
+++ b/applications/repertoire/values-summit.yaml
@@ -6,6 +6,7 @@ config:
       username: "efdreader"
       passwordKey: "summit_efd-password"
       schemaRegistry: "http://sasquatch-schema-registry.sasquatch:8081"
+      local: true
     usdf_efd:
       url: "https://usdf-rsp.slac.stanford.edu/influxdb-enterprise-data/"
       database: "efd"

--- a/applications/repertoire/values-tucson-teststand.yaml
+++ b/applications/repertoire/values-tucson-teststand.yaml
@@ -6,4 +6,5 @@ config:
       username: "efdreader"
       passwordKey: "idfdev_efd-password"
       schemaRegistry: "http://sasquatch-schema-registry.sasquatch:8081"
+      local: true
   slackAlerts: true

--- a/applications/repertoire/values-usdfdev.yaml
+++ b/applications/repertoire/values-usdfdev.yaml
@@ -14,3 +14,4 @@ config:
       username: "efdreader"
       passwordKey: "usdfdev_efd-password"
       schemaRegistry: "http://sasquatch-schema-registry.sasquatch:8081"
+      local: true

--- a/applications/repertoire/values-usdfprod.yaml
+++ b/applications/repertoire/values-usdfprod.yaml
@@ -14,3 +14,4 @@ config:
       username: "efdreader"
       passwordKey: "usdf_efd-password"
       schemaRegistry: "http://sasquatch-schema-registry.sasquatch:8081"
+      local: true

--- a/applications/repertoire/values.yaml
+++ b/applications/repertoire/values.yaml
@@ -137,7 +137,7 @@ config:
     created: "2026-05-20T00:00:00"
     creator: "Vera C. Rubin Observatory"
     ivoid: "ivo://org.rubinobs/registry"
-    pathPrefix: "/discovery"
+    path: "/api/registry"
     repositoryName: "Rubin Science Platform IVOA Publishing Registry"
     rights: >-
       Restricted to authorized Rubin data rights holders. See


### PR DESCRIPTION
Serve the IVOA registry at `/api/registry` instead of at `/discovery/ivoa` to be consistent with the routes for the rest of the API aspect.