### PR TITLE
OSW-2418: Update EAS CSC to c44r6.

### DIFF
--- a/applications/envsys/values-summit.yaml
+++ b/applications/envsys/values-summit.yaml
@@ -207,7 +207,7 @@ earthquake-ess302:
 eas:
   enabled: true
   image:
-    revision: 2
+    revision: 6
     repository: ts-dockerhub.lsst.org/eas
     pullPolicy: Always
   resources:


### PR DESCRIPTION
Changes to EAS are:

1. **daytime control of louvers** - if a louver is opened manually by an observer, then EAS will command the louver to be partially opened if facing the sun, or fully opened otherwise. The position of the sun relative to the dome is monitored, and louver positions are continuously updated.
2. **m1m3 heater/fan setpoint clamped** - the m1m3 setpoint will be constrained to be within a configurable margin of the median m1m3 thermal sensor reading, defaulting to -0.4°C/+0.2°C.