### PR TITLE
Update Click intersphinx URL to stable docs

### DIFF
--- a/docs/documenteer.toml
+++ b/docs/documenteer.toml
@@ -45,7 +45,7 @@ python_api_dir = "internals/api"
 rst_epilog_file = "_rst_epilog.rst"
 
 [sphinx.intersphinx.projects]
-click = "https://click.palletsprojects.com/en/8.1.x/"
+click = "https://click.palletsprojects.com/en/stable/"
 hvac = "https://hvac.readthedocs.io/en/stable/"
 python = "https://docs.python.org/3/"
 safir = "https://safir.lsst.io/"


### PR DESCRIPTION
## Summary

- Point the Click intersphinx mapping at `https://click.palletsprojects.com/en/stable/` instead of the retired `/en/8.1.x/` versioned path.
- Fixes the docs CI failure where the old URL (now just a redirect) was unreliable to fetch from GitHub Actions runners, causing an unreachable intersphinx inventory warning and an unresolvable `click.UsageError` cross-reference — both elevated to errors by `sphinx-build -W`.

## Validation steps

- Confirm `curl -sI https://click.palletsprojects.com/en/stable/objects.inv` returns 200 with the inventory payload.
- Confirm the docs CI job on this PR builds with no intersphinx or cross-reference warnings.