### PR TITLE
DM-55230: Update turborepo-cache-proxy to 1.0.1

### DIFF
--- a/applications/turborepo-cache/README.md
+++ b/applications/turborepo-cache/README.md
@@ -32,7 +32,7 @@ Turborepo remote cache
 | proxy.config.pathPrefix | string | `"/turborepo-cache"` | URL path prefix for the proxy application |
 | proxy.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the proxy image |
 | proxy.image.repository | string | `"ghcr.io/lsst-sqre/turborepo-cache-proxy"` | Image to use for the proxy deployment |
-| proxy.image.tag | string | `"1.0.0"` | Tag of proxy image to use |
+| proxy.image.tag | string | `"1.0.1"` | Tag of proxy image to use |
 | proxy.nodeSelector | object | `{}` | Node selection rules for the proxy deployment pod |
 | proxy.podAnnotations | object | `{}` | Annotations for the proxy deployment pod |
 | proxy.replicaCount | int | `1` | Number of proxy deployment pods to start |

--- a/applications/turborepo-cache/values.yaml
+++ b/applications/turborepo-cache/values.yaml
@@ -63,7 +63,7 @@ proxy:
     pullPolicy: "IfNotPresent"
 
     # -- Tag of proxy image to use
-    tag: "1.0.0"
+    tag: "1.0.1"
 
   config:
     # -- Log level for the proxy application


### PR DESCRIPTION
## Summary

Bump the turborepo-cache-proxy image to **1.0.1** (this month's maintenance release: dependency refresh + Python 3.14 base image).

- `applications/turborepo-cache/values.yaml`: `proxy.image.tag` `1.0.0` → `1.0.1`
- `README.md` regenerated by helm-docs.

The `proxy.image.tag` default applies to both `roundtable-dev` and `roundtable-prod` (neither env file overrides it). Chart `appVersion` (2.6.1) is the ducktors turborepo-remote-cache version and is unchanged.

## Deployment

Merging deploys per the environment sync policy (roundtable-dev, roundtable-prod). The 1.0.1 image is built/pushed by the [GitHub release](https://github.com/lsst-sqre/turborepo-cache-proxy/releases/tag/1.0.1).

## References

- Jira: DM-55230
- Release: https://github.com/lsst-sqre/turborepo-cache-proxy/releases/tag/1.0.1