### PR TITLE
DM-55230: Update ducktors turborepo-remote-cache to 2.11.1

### DIFF
--- a/applications/turborepo-cache/Chart.yaml
+++ b/applications/turborepo-cache/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2.6.1 # version of turborepo-remote-cache; set proxy version in values.yaml
+appVersion: 2.11.1 # version of turborepo-remote-cache; set proxy version in values.yaml
 description: Turborepo remote cache
 name: turborepo-cache
 sources:


### PR DESCRIPTION
## Summary

Bump the third-party **ducktors/turborepo-remote-cache** image from **2.6.1 → 2.11.1** (latest, released 2026-05-23). Set via `applications/turborepo-cache/Chart.yaml` `appVersion`, which `cache.image.tag: null` inherits.

This is the cache backend only — separate from the proxy 1.0.1 bump in #6580 so the two can be reviewed/rolled independently.

## Changelog review (2.6.1 → 2.11.1)

Scanned the upstream changelog against our config surface (`AUTH_MODE=static`, `STORAGE_PROVIDER=google-cloud-storage`, `STORAGE_PATH`, `TURBO_TOKEN`, port 3000, `/v8/artifacts/status` probe, non-root uid 100, read-only rootfs). **No breaking changes** to any of those. New features are all opt-in (AUTH_MODE=none, artifact signature keys, read-only mode, local-cache cleanup endpoint, configurable `HOST` which defaults to `0.0.0.0`).

Two things to watch:
- **`BODY_LIMIT`** env var with a new default (v2.11.0) — controls max artifact upload size; we inherit the default. Can pin later if large artifacts are rejected.
- Runtime base image moved **Node 20-alpine → Node 24** (v2.8.3) — internal, but worth confirming on dev given our `readOnlyRootFilesystem` + `runAsUser: 100`.

## Deployment / testing

**Recommend rolling to roundtable-dev first** to smoke-test the Node 24 runtime and large-artifact uploads before prod. Merging deploys per environment sync policy.

## References

- Jira: DM-55230
- Upstream: https://github.com/ducktors/turborepo-remote-cache/releases
- Related: #6580 (proxy 1.0.1)