### PR TITLE
DM-55224: Add Butler configuration for DP2 mini

### DIFF
--- a/applications/butler/README.md
+++ b/applications/butler/README.md
@@ -18,6 +18,7 @@ Server for Butler data abstraction service
 | config.additionalS3EndpointUrls | object | No additional URLs | Endpoint URLs for additional S3 services used by the Butler, as a mapping from profile name to URL. |
 | config.dp02PostgresUri | string | No configuration file for DP02 will be generated. | Postgres connection string pointing to the registry database hosting Data Preview 0.2 data. |
 | config.dp1PostgresUri | string | No configuration file for DP1 will be generated. | Postgres connection string pointing to the registry database hosting Data Preview 1 data. |
+| config.dp2PostgresUri | string | No configuration file for DP2 will be generated. | Postgres connection string pointing to the registry database hosting Data Preview 1 data. |
 | config.enableSentry | bool | `false` | True to enable capture of trace and other diagnostics to Sentry.io. |
 | config.pathPrefix | string | `"/api/butler"` | The prefix of the path portion of the URL where the Butler service will be exposed.  For example, if the service should be exposed at `https://data.lsst.cloud/api/butler`, this should be set to `/api/butler` |
 | config.pguser | string | Use values specified in per-repository Butler config files. | Postgres username used to connect to the Butler DB |

--- a/applications/butler/templates/configmap-private.yaml
+++ b/applications/butler/templates/configmap-private.yaml
@@ -21,6 +21,25 @@ data:
         opaque: lsst.daf.butler.registry.opaque.ByNameOpaqueTableStorageManager
       namespace: dm_51372
 
+  dp2.yaml: |
+    datastore:
+      cls: lsst.daf.butler.datastores.fileDatastore.FileDatastore
+      name: dp2
+      records:
+        table: dp2_datastore_records
+      root: s3://butler-us-central1-dp2/dp2/
+    registry:
+      db: {{ .Values.config.dp2PostgresUri }}
+      temporary_tables: false
+      managers:
+        attributes: lsst.daf.butler.registry.attributes.DefaultButlerAttributeManager
+        collections: lsst.daf.butler.registry.collections.synthIntKey.SynthIntKeyCollectionManager
+        datasets: lsst.daf.butler.registry.datasets.byDimensions.ByDimensionsDatasetRecordStorageManagerUUID
+        datastores: lsst.daf.butler.registry.bridge.monolithic.MonolithicDatastoreRegistryBridgeManager
+        dimensions: lsst.daf.butler.registry.dimensions.static.StaticDimensionRecordStorageManager
+        opaque: lsst.daf.butler.registry.opaque.ByNameOpaqueTableStorageManager
+      namespace: dm_55224
+
   prompt.yaml: |
     datastore:
       cls: lsst.daf.butler.datastores.chainedDatastore.ChainedDatastore

--- a/applications/butler/templates/configmap-public.yaml
+++ b/applications/butler/templates/configmap-public.yaml
@@ -16,4 +16,7 @@ data:
     dp1: "{{.Values.global.baseUrl}}{{.Values.config.pathPrefix}}/repo/dp1/butler.yaml"
     {{- if .Values.config.promptPostgresUri }}
     prompt: "{{.Values.global.baseUrl}}{{.Values.config.pathPrefix}}/repo/prompt/butler.yaml"
+    {{- end }}
+    {{- if .Values.config.dp2PostgresUri }}
+    dp2: "{{.Values.global.baseUrl}}{{.Values.config.pathPrefix}}/repo/dp2/butler.yaml"
     {{ end }}

--- a/applications/butler/values-idfint.yaml
+++ b/applications/butler/values-idfint.yaml
@@ -3,6 +3,7 @@ autoscaling:
 config:
   dp02PostgresUri: postgresql://butler@alloydb-dp.rsp-sql-int.internal:5432/dp02
   dp1PostgresUri: postgresql://butler@alloydb-dp.rsp-sql-int.internal:5432/dp1
+  dp2PostgresUri: postgresql://butler@alloydb-dp.rsp-sql-int.internal:5432/dp2
   promptPostgresUri: postgresql://butler@alloydb-butler-prompt.rsp-sql-int.internal:5432/prompt
   s3EndpointUrl: "https://storage.googleapis.com"
   repositories:
@@ -11,6 +12,9 @@ config:
       authorized_groups: ["*"]
     dp1:
       config_uri: "file:///opt/lsst/butler/config/dp1.yaml"
+      authorized_groups: ["*"]
+    dp2:
+      config_uri: "file:///opt/lsst/butler/config/dp2.yaml"
       authorized_groups: ["*"]
     prompt:
       config_uri: "file:///opt/lsst/butler/config/prompt.yaml"

--- a/applications/butler/values.yaml
+++ b/applications/butler/values.yaml
@@ -107,6 +107,11 @@ config:
   dp1PostgresUri: ""
 
   # -- Postgres connection string pointing to the registry database hosting
+  # Data Preview 1 data.
+  # @default -- No configuration file for DP2 will be generated.
+  dp2PostgresUri: ""
+
+  # -- Postgres connection string pointing to the registry database hosting
   # Prompt Data Products.
   # @default -- No configuration file for prompt will be generated.
   promptPostgresUri: ""


### PR DESCRIPTION
Set up an initial Butler configuration for the DP2 "mini" release.