### PR TITLE
DM-55230: Update turborepo-cache-proxy to 1.0.2

### DIFF
--- a/applications/turborepo-cache/README.md
+++ b/applications/turborepo-cache/README.md
@@ -32,7 +32,7 @@ Turborepo remote cache
 | proxy.config.pathPrefix | string | `"/turborepo-cache"` | URL path prefix for the proxy application |
 | proxy.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the proxy image |
 | proxy.image.repository | string | `"ghcr.io/lsst-sqre/turborepo-cache-proxy"` | Image to use for the proxy deployment |
-| proxy.image.tag | string | `"1.0.1"` | Tag of proxy image to use |
+| proxy.image.tag | string | `"1.0.2"` | Tag of proxy image to use |
 | proxy.nodeSelector | object | `{}` | Node selection rules for the proxy deployment pod |
 | proxy.podAnnotations | object | `{}` | Annotations for the proxy deployment pod |
 | proxy.replicaCount | int | `1` | Number of proxy deployment pods to start |

--- a/applications/turborepo-cache/values.yaml
+++ b/applications/turborepo-cache/values.yaml
@@ -63,7 +63,7 @@ proxy:
     pullPolicy: "IfNotPresent"
 
     # -- Tag of proxy image to use
-    tag: "1.0.1"
+    tag: "1.0.2"
 
   config:
     # -- Log level for the proxy application


### PR DESCRIPTION
## Summary

- Update the `turborepo-cache` proxy image tag from `1.0.1` to `1.0.2`.
- 1.0.2 fixes the proxy failing to start under the pod `securityContext` (`runAsUser: 1000`) with `exec /app/.venv/bin/uvicorn: permission denied`. The cause was a Python version mismatch in 1.0.1 (3.14 base image vs. a 3.13-pinned project) that left the virtualenv's interpreter symlink dangling; 1.0.2 targets Python 3.14 so the venv uses the interpreter present in the runtime image. See lsst-sqre/turborepo-cache-proxy#12.

## Validation steps

- After Argo CD syncs, confirm the `turborepo-cache` proxy pod reaches `Running` (no `CrashLoopBackOff` / `permission denied` in the proxy container logs).
- Confirm the proxy serves requests, e.g. the proxied Turborepo cache responds through the `/turborepo-cache/` prefix.

## References

- Image PR: lsst-sqre/turborepo-cache-proxy#12
- Jira: https://rubinobs.atlassian.net/browse/DM-55230