### PR TITLE
DM-55225: Preview /api-aspect presentation on idfdev

### DIFF
--- a/applications/squareone/Chart.yaml
+++ b/applications/squareone/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
     url: https://github.com/jonathansick
 
 # The default version tag of the squareone docker image
-appVersion: "0.32.0"
+appVersion: "0.33.0"

--- a/applications/squareone/content/idfdev/api-aspect.mdx
+++ b/applications/squareone/content/idfdev/api-aspect.mdx
@@ -1,0 +1,14 @@
+# Rubin Science Platform APIs
+
+<Lede>Integrate Rubin data into your analysis tools with APIs.</Lede>
+
+To access APIs you need an [*access token*](/settings/tokens).
+See our guide [Creating user tokens](https://rsp.lsst.io/guides/auth/creating-user-tokens.html) to learn how to create tokens and use them in VO clients.
+
+## API endpoints
+
+<ApiEndpoints />
+
+## Documentation
+
+Learn more about the APIs in the [Rubin Science Platform API Aspect guide](https://rsp.lsst.io/guides/api/).

--- a/applications/squareone/values-idfdev.yaml
+++ b/applications/squareone/values-idfdev.yaml
@@ -1,8 +1,8 @@
 image:
   pullPolicy: Always
-  # Deploy the DM-55225 /api-aspect discovery skeleton branch image
-  # (squareone PR lsst-sqre/squareone#471) for preview on idfdev.
-  tag: "tickets-DM-55225-api-aspect-skeleton"
+  # Deploy the DM-55225 /api-aspect presentation branch image
+  # (squareone PR lsst-sqre/squareone#472) for preview on idfdev.
+  tag: "tickets-DM-55225-api-aspect-presentation"
 
 ingress:
   timesSquareScope: "exec:admin"

--- a/applications/squareone/values-idfdev.yaml
+++ b/applications/squareone/values-idfdev.yaml
@@ -1,8 +1,5 @@
 image:
   pullPolicy: Always
-  # Deploy the DM-55225 /api-aspect presentation branch image
-  # (squareone PR lsst-sqre/squareone#472) for preview on idfdev.
-  tag: "tickets-DM-55225-api-aspect-presentation"
 
 ingress:
   timesSquareScope: "exec:admin"

--- a/applications/squareone/values-idfdev.yaml
+++ b/applications/squareone/values-idfdev.yaml
@@ -1,5 +1,8 @@
 image:
   pullPolicy: Always
+  # Deploy the DM-55225 /api-aspect discovery skeleton branch image
+  # (squareone PR lsst-sqre/squareone#471) for preview on idfdev.
+  tag: "tickets-DM-55225-api-aspect-skeleton"
 
 ingress:
   timesSquareScope: "exec:admin"

--- a/applications/squareone/values-idfprod.yaml
+++ b/applications/squareone/values-idfprod.yaml
@@ -1,8 +1,5 @@
 replicaCount: 3
 
-image:
-  tag: "0.30.0" # hold back until 2026-02-26
-
 ingress:
   timesSquareScope: "exec:admin"
 


### PR DESCRIPTION
## Summary

- Update Squareone to release [0.33.0](https://github.com/lsst-sqre/squareone/releases/tag/squareone%400.33.0).
- Add a new `content/idfdev/api-aspect.mdx` that overrides **only idfdev** to embed the discovery-driven `<ApiEndpoints />` component in place of the hand-maintained endpoint bullets. Every other environment continues to fall back to the curated `idfprod` `api-aspect.mdx` (the chart's MDX fallback), so production content is unchanged.

> Note: the MDX component registered for the `/api-aspect` page is `<ApiEndpoints />` (the discovery-bound wrapper that renders the `ApiEndpointsList`); `ApiEndpointsList` itself is not registered for MDX, so `<ApiEndpoints />` is what the page uses.

## Validation steps

- After Argo CD syncs idfdev, confirm the squareone pod runs `ghcr.io/lsst-sqre/squareone:tickets-DM-55225-api-aspect-presentation`.
- Visit `https://data-dev.lsst.cloud/api-aspect` and confirm the **API endpoints** section renders the discovery-driven listing — one section per dataset (`dp1`/`dp02`/`dp03`), each service listed by name with its base URL — in place of the old static bullets.
- Confirm each dataset section shows a "Read the documentation" link to the dataset's docs site, and each curated service shows a book-icon link labeled with its standard (e.g. "IVOA TAP docs").
- Confirm the surrounding prose (token-access intro, Documentation link) still renders around the listing.
- Confirm a non-idfdev environment that falls back to idfprod content (e.g. idfint) still shows the curated static `/api-aspect` bullet list and its released image — i.e. this change is idfdev-only.

## References

- Jira: https://rubinobs.atlassian.net/browse/DM-55225
- squareone PR: lsst-sqre/squareone#472
