### PR TITLE
Enable Herald of idfprod and add prompt dataset to repertoire config for prod

### DIFF
--- a/applications/repertoire/values-idfprod.yaml
+++ b/applications/repertoire/values-idfprod.yaml
@@ -3,6 +3,7 @@ config:
     - "dp02"
     - "dp03"
     - "dp1"
+    - "prompt"
   hips:
     legacy:
       dataset: "dp1"

--- a/environments/values-idfprod.yaml
+++ b/environments/values-idfprod.yaml
@@ -14,7 +14,7 @@ onepassword:
 vaultPathPrefix: "secret/phalanx/idfprod"
 
 applications:
-  herald: false
+  herald: true
   butler: true
   datalinker: true
   ghostwriter: true


### PR DESCRIPTION
Changes
- Set `herald: true` in environments/values-idfprod.yaml
- Add "prompt" to datasets list for `repertoire/values-idfprod.yaml`
