### PR TITLE
Reduce Nublado max pod age on idfint and idfprod

### DIFF
--- a/applications/nublado/values-idfint.yaml
+++ b/applications/nublado/values-idfint.yaml
@@ -128,7 +128,8 @@ hub:
 
 jupyterhub:
   cull:
-    timeout: 90000 # 25hrs
+    timeout: 90000  # 25 hours
+    maxAge: 432000  # 5 days
   hub:
     config:
       JupyterHub:

--- a/applications/nublado/values-idfprod.yaml
+++ b/applications/nublado/values-idfprod.yaml
@@ -106,7 +106,8 @@ hub:
 
 jupyterhub:
   cull:
-    timeout: 90000  # 25hrs
+    timeout: 90000  # 25 hours
+    maxAge: 432000  # 5 days
 
   hub:
     config:


### PR DESCRIPTION
Reduce the max pod age to five days, after which it will be killed whether idle or not.