### PR TITLE
DM-55229: Add new notifications scopes

### DIFF
--- a/applications/gafaelfawr/values-idfdev.yaml
+++ b/applications/gafaelfawr/values-idfdev.yaml
@@ -55,6 +55,8 @@ config:
   groupMapping:
     "admin:jupyterlab":
       - "g_admins"
+    "admin:notifications":
+      - "g_admins"
     "admin:userinfo":
       - "g_admins"
     "exec:admin":

--- a/applications/gafaelfawr/values-idfint.yaml
+++ b/applications/gafaelfawr/values-idfint.yaml
@@ -60,6 +60,8 @@ config:
   groupMapping:
     "admin:jupyterlab":
       - "g_admins"
+    "admin:notifications":
+      - "g_admins"
     "admin:userinfo":
       - "g_admins"
     "exec:admin":

--- a/applications/gafaelfawr/values-idfprod.yaml
+++ b/applications/gafaelfawr/values-idfprod.yaml
@@ -71,6 +71,8 @@ config:
   groupMapping:
     "admin:jupyterlab":
       - "g_admins"
+    "admin:notifications":
+      - "g_admins"
     "admin:userinfo":
       - "g_admins"
     "exec:admin":

--- a/applications/gafaelfawr/values.yaml
+++ b/applications/gafaelfawr/values.yaml
@@ -242,6 +242,8 @@ config:
   knownScopes:
     "admin:jupyterlab": >-
       Can create and destroy labs for any user
+    "admin:notifications": >-
+      Can send and view all user notifications
     "admin:token": >-
       Can create and modify tokens for any user
     "admin:userinfo": >-
@@ -266,6 +268,8 @@ config:
       Execute SELECT queries in the TAP interface on project datasets
     "write:files": >-
       Write access to POSIX file space
+    "write:notifications": >-
+      Service can send notifications to users and manage its notifications
     "write:sasquatch": >-
       Write access to the Sasquatch telemetry service
     "user:token": >-


### PR DESCRIPTION
Add `admin:notifications` and `write:notifications` scopes. These will be used for the new Semaphore user notifications support.