### PR TITLE
Set a quota on herald in idfprod

### DIFF
--- a/applications/gafaelfawr/values-idfprod.yaml
+++ b/applications/gafaelfawr/values-idfprod.yaml
@@ -57,6 +57,7 @@ config:
   quota:
     default:
       api:
+        herald: 250
         hips: 1000
         sia: 70
         tap: 1000


### PR DESCRIPTION
This service is hybrid, so put an API quota on it to keep from hammering SLAC.