### PR TITLE
DM-51754: Update Squarebot to 0.10.2 and unfurlbot to 0.5.1

### DIFF
--- a/applications/squarebot/Chart.yaml
+++ b/applications/squarebot/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: squarebot
 version: 1.0.0
-appVersion: "0.10.0"
+appVersion: "0.10.2"
 description: Squarebot feeds events from services like Slack and GitHub into the SQuaRE Events Kafka message bus running on Roundtable. Backend apps like Templatebot and Unfurlbot can subscribe to these events and take domain-specific action.
 type: application
 home: https://squarebot.lsst.io/

--- a/applications/templatebot/Chart.yaml
+++ b/applications/templatebot/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "0.5.1"
+appVersion: "0.5.2"
 description: Create new projects
 name: templatebot
 sources:

--- a/applications/unfurlbot/Chart.yaml
+++ b/applications/unfurlbot/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "0.5.0"
+appVersion: "0.5.1"
 description: Squarebot backend that unfurls Jira issues.
 name: unfurlbot
 sources:


### PR DESCRIPTION
## Summary

Bump two Squarebot-family applications to their latest releases for DM-51754. Both deployments default their image tag to `.Chart.AppVersion`, so these `appVersion` bumps are the only changes needed to roll out the new images.

- **Squarebot** `0.10.0` → `0.10.2` — deploys [Squarebot 0.10.2](https://github.com/lsst-sqre/squarebot/releases/tag/0.10.2) (`ghcr.io/lsst-sqre/squarebot:0.10.2`). Modernizes the repo onto a uv workspace on Python 3.14 and upgrades FastStream to the 0.7.x line (released as 0.10.1), plus a release-pipeline fix so the `rubin-squarebot` client publishes to PyPI from the new workspace layout (0.10.2).
- **unfurlbot** `0.5.0` → `0.5.1` — deploys [unfurlbot 0.5.1](https://github.com/lsst-sqre/unfurlbot/releases/tag/0.5.1) (`ghcr.io/lsst-sqre/unfurlbot:0.5.1`). Modernizes unfurlbot to the current SQuaRE archetype: Python 3.14, FastStream 0.7 (keeping the `KafkaRouter` + AsyncAPI design), Safir 15 / rubin-squarebot 0.10 and the other dependency floors, uv 0.11.21, refreshed pre-commit/ruff, and multiplatform (`linux/amd64` + `linux/arm64`) images.

There are no configuration or behavioral changes that affect either Phalanx deployment.

## References

- Squarebot release: https://github.com/lsst-sqre/squarebot/releases/tag/0.10.2
- unfurlbot release: https://github.com/lsst-sqre/unfurlbot/releases/tag/0.5.1
- Jira: https://rubinobs.atlassian.net/browse/DM-51754
