### PR TITLE
Deploy Squareone 0.34.0

### DIFF
--- a/applications/squareone/Chart.yaml
+++ b/applications/squareone/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
     url: https://github.com/jonathansick
 
 # The default version tag of the squareone docker image
-appVersion: "0.33.0"
+appVersion: "0.34.0"


### PR DESCRIPTION
Bump the squareone chart `appVersion` from `0.33.0` to `0.34.0` to deploy the [`squareone@0.34.0`](https://github.com/lsst-sqre/squareone/releases/tag/squareone%400.34.0) release.

No environment values files override the image tag (`values.yaml` uses `tag: ""`, which defaults to `appVersion`), so this single change rolls the release out everywhere squareone is deployed.

## Release highlights

- Admin user notifications UI: new `/admin/notifications` listing, `/admin/notifications/[id]` detail, and `/admin/notifications/new` compose pages (gated by `exec:admin` + `admin:notifications` scope).
- Resolve the Semaphore service URL via Repertoire service discovery instead of the static `semaphoreUrl` config field; `semaphoreUrl` is now deprecated but retained for config-validation compatibility.
- "Learn more about quotas" docs link on the `/settings/quotas` page (derived from `docsBaseUrl`, no Phalanx change required).
- Dependency/security updates resolving Dependabot advisories.

Full notes: https://github.com/lsst-sqre/squareone/releases/tag/squareone%400.34.0
