### PR TITLE
DM-55299: Update Butler DP2 setup

### DIFF
--- a/applications/butler/templates/configmap-private.yaml
+++ b/applications/butler/templates/configmap-private.yaml
@@ -23,11 +23,21 @@ data:
 
   dp2.yaml: |
     datastore:
-      cls: lsst.daf.butler.datastores.fileDatastore.FileDatastore
-      name: dp2
-      records:
-        table: dp2_datastore_records
-      root: s3://butler-us-central1-dp2/dp2/
+      cls: lsst.daf.butler.datastores.chainedDatastore.ChainedDatastore
+      datastores:
+        - datastore:
+            cls: lsst.daf.butler.datastores.fileDatastore.FileDatastore
+            name: dp2
+            records:
+              table: dp2_datastore_records
+            root: s3://butler-us-central1-dp2/dp2/
+        - datastore:
+            cls: lsst.daf.butler.datastores.fileDatastore.FileDatastore
+            name: refcats
+            records:
+              table: refcats_datastore_records
+            root: s3://butler-us-central1-dp2/refcats/
+
     registry:
       db: {{ .Values.config.dp2PostgresUri }}
       temporary_tables: false
@@ -38,7 +48,7 @@ data:
         datastores: lsst.daf.butler.registry.bridge.monolithic.MonolithicDatastoreRegistryBridgeManager
         dimensions: lsst.daf.butler.registry.dimensions.static.StaticDimensionRecordStorageManager
         opaque: lsst.daf.butler.registry.opaque.ByNameOpaqueTableStorageManager
-      namespace: dm_55224
+      namespace: dp2_mini_dm_55293_try2
 
   prompt.yaml: |
     datastore:

--- a/environments/values-idfint.yaml
+++ b/environments/values-idfint.yaml
@@ -4,6 +4,7 @@ appOfAppsName: "science-platform"
 butlerServerRepositories:
   dp02: "https://data-int.lsst.cloud/api/butler/repo/dp02/butler.yaml"
   dp1: "https://data-int.lsst.cloud/api/butler/repo/dp1/butler.yaml"
+  dp2: "https://data-int.lsst.cloud/api/butler/repo/dp2/butler.yaml"
   prompt: "https://data-int.lsst.cloud/api/butler/repo/prompt/butler.yaml"
 gcp:
   projectId: "science-platform-int-dc5d"


### PR DESCRIPTION
Add an additional datastore location and point the DP2 Butler to an updated database that includes catalogs and refcats in addition to the images.