### PR TITLE
DM-55317: Configure SIA on data-int for early DP2

### DIFF
--- a/applications/sia/values-idfint.yaml
+++ b/applications/sia/values-idfint.yaml
@@ -24,6 +24,12 @@ config:
       butler_type: "REMOTE"
       repository: "https://data-int.lsst.cloud/api/butler/repo/prompt/butler.yaml"
       datalink_url: "https://data-int.lsst.cloud/api/datalink/links?ID=ivo%3A%2F%2Forg.rubinobs%2Flsst-prompt%3Frepo%3Dprompt%26id%3D{id}"
+    - config: "https://raw.githubusercontent.com/lsst-dm/dax_obscore/refs/heads/main/configs/edp2.yaml"
+      label: "LSST.DP2"
+      name: "dp2"
+      butler_type: "REMOTE"
+      repository: "https://data-int.lsst.cloud/api/butler/repo/dp2/butler.yaml"
+      datalink_url: "https://data-int.lsst.cloud/api/datalink/links?ID=ivo%3A%2F%2Forg.rubinobs%2Flsst-dp2%3Frepo%3Ddp2%26id%3D{id}"
 
   enableSentry: true
   sentryTracesSampleRate: 1


### PR DESCRIPTION
Add an SIA endpoint for the "early" DP2 release on data-int.