### PR TITLE
DM-55167: Add director table information to TAP configuration for use with automated upload table partitioning

### DIFF
--- a/applications/qserv-kafka/values-idfdev.yaml
+++ b/applications/qserv-kafka/values-idfdev.yaml
@@ -1,6 +1,3 @@
-image:
-  pullPolicy: "Always"
-  tag: "t-DM-55501"
 config:
   logLevel: "DEBUG"
   metrics:

--- a/applications/qserv-kafka/values-idfdev.yaml
+++ b/applications/qserv-kafka/values-idfdev.yaml
@@ -1,3 +1,6 @@
+image:
+  pullPolicy: "Always"
+  tag: "tickets-DM-55168"
 config:
   logLevel: "DEBUG"
   metrics:

--- a/applications/qserv-kafka/values-idfdev.yaml
+++ b/applications/qserv-kafka/values-idfdev.yaml
@@ -1,6 +1,6 @@
 image:
   pullPolicy: "Always"
-  tag: "tickets-DM-55168"
+  tag: "t-DM-55501"
 config:
   logLevel: "DEBUG"
   metrics:

--- a/applications/tap/README.md
+++ b/applications/tap/README.md
@@ -16,6 +16,7 @@ IVOA TAP service
 | cadc-tap.config.outputLimitUnit | string | `"byte"` |  |
 | cadc-tap.config.sentryEnabled | bool | `false` | Whether Sentry is enabled in this environment |
 | cadc-tap.config.serviceName | string | `"tap"` | Name of the service from Gafaelfawr's perspective |
+| cadc-tap.config.uploadPartitionDirectors | list | `["dp1.Object:objectId","dp1.Source:sourceId","dp1.DiaObject:diaObjectId","dp2.Object:objectId","dp2.Source:sourceId","dp2.ShearObject:shearObjectId","dp2.IsolatedStarStellarMotions:isolated_star_id","dp2.DiaObject:diaObjectId"]` | Director tables for TAP_UPLOAD spatial partitioning |
 | cadc-tap.config.vaultSecretName | string | `"tap"` | Vault secret name: the final key in the vault path |
 | cadc-tap.config.voParquet | bool | `true` | Advertise VOParquet as a supported output format |
 | cadc-tap.ingress.path | string | `"tap"` | Ingress path that should be routed to this service |

--- a/applications/tap/values-idfdemo.yaml
+++ b/applications/tap/values-idfdemo.yaml
@@ -25,7 +25,10 @@ cadc-tap:
 
     urlRewrite:
       enabled: true
-      rules: "ivoa.ObsCore:access_url, dp02_dc2_catalogs.ObsCore:access_url, dp1.ObsCore:access_url"
+      rules:
+        - "ivoa.ObsCore:access_url"
+        - "dp02_dc2_catalogs.ObsCore:access_url"
+        - "dp1.ObsCore:access_url"
 
   cloudsql:
     enabled: true

--- a/applications/tap/values-idfdev.yaml
+++ b/applications/tap/values-idfdev.yaml
@@ -3,11 +3,6 @@ cadc-tap:
     kafka:
       enabled: true
 
-    qserv:
-      image:
-        pullPolicy: "Always"
-        tag: "tickets-DM-55169"
-
     urlRewrite:
       enabled: true
       rules:

--- a/applications/tap/values-idfdev.yaml
+++ b/applications/tap/values-idfdev.yaml
@@ -3,6 +3,12 @@ cadc-tap:
     kafka:
       enabled: true
 
+    uploadPartitionDirectors: "dp1.Object:objectId"
+    qserv:
+      image:
+        pullPolicy: "Always"
+        tag: "tickets-DM-55169"
+
     urlRewrite:
       enabled: true
       rules: "ivoa.ObsCore:access_url, dp02_dc2_catalogs.ObsCore:access_url, dp1.ObsCore:access_url"

--- a/applications/tap/values-idfdev.yaml
+++ b/applications/tap/values-idfdev.yaml
@@ -3,7 +3,6 @@ cadc-tap:
     kafka:
       enabled: true
 
-    uploadPartitionDirectors: "dp1.Object:objectId"
     qserv:
       image:
         pullPolicy: "Always"
@@ -11,7 +10,10 @@ cadc-tap:
 
     urlRewrite:
       enabled: true
-      rules: "ivoa.ObsCore:access_url, dp02_dc2_catalogs.ObsCore:access_url, dp1.ObsCore:access_url"
+      rules:
+        - "ivoa.ObsCore:access_url"
+        - "dp02_dc2_catalogs.ObsCore:access_url"
+        - "dp1.ObsCore:access_url"
 
   cloudsql:
     enabled: true

--- a/applications/tap/values-idfint.yaml
+++ b/applications/tap/values-idfint.yaml
@@ -9,7 +9,10 @@ cadc-tap:
 
     urlRewrite:
       enabled: true
-      rules: "ivoa.ObsCore:access_url, dp02_dc2_catalogs.ObsCore:access_url, dp1.ObsCore:access_url"
+      rules:
+        - "ivoa.ObsCore:access_url"
+        - "dp02_dc2_catalogs.ObsCore:access_url"
+        - "dp1.ObsCore:access_url"
 
   cloudsql:
     enabled: true

--- a/applications/tap/values-idfprod.yaml
+++ b/applications/tap/values-idfprod.yaml
@@ -7,7 +7,10 @@ cadc-tap:
 
     urlRewrite:
       enabled: true
-      rules: "ivoa.ObsCore:access_url, dp02_dc2_catalogs.ObsCore:access_url, dp1.ObsCore:access_url"
+      rules:
+        - "ivoa.ObsCore:access_url"
+        - "dp02_dc2_catalogs.ObsCore:access_url"
+        - "dp1.ObsCore:access_url"
 
   cloudsql:
     enabled: true

--- a/applications/tap/values-usdfdev.yaml
+++ b/applications/tap/values-usdfdev.yaml
@@ -24,7 +24,10 @@ cadc-tap:
 
     urlRewrite:
       enabled: true
-      rules: "ivoa.ObsCore:access_url, dp02_dc2_catalogs.ObsCore:access_url, dp1.ObsCore:access_url"
+      rules:
+        - "ivoa.ObsCore:access_url"
+        - "dp02_dc2_catalogs.ObsCore:access_url"
+        - "dp1.ObsCore:access_url"
 
     gcsBucket: "rubin:rubin-qserv"
     gcsBucketUrl: "https://s3dfrgw.slac.stanford.edu"

--- a/applications/tap/values-usdfint.yaml
+++ b/applications/tap/values-usdfint.yaml
@@ -24,7 +24,10 @@ cadc-tap:
 
     urlRewrite:
       enabled: true
-      rules: "ivoa.ObsCore:access_url, dp02_dc2_catalogs.ObsCore:access_url, dp1.ObsCore:access_url"
+      rules:
+        - "ivoa.ObsCore:access_url"
+        - "dp02_dc2_catalogs.ObsCore:access_url"
+        - "dp1.ObsCore:access_url"
 
     gcsBucket: "rubin:rubin-qserv"
     gcsBucketUrl: "https://s3dfrgw.slac.stanford.edu"

--- a/applications/tap/values-usdfprod.yaml
+++ b/applications/tap/values-usdfprod.yaml
@@ -24,7 +24,10 @@ cadc-tap:
 
     urlRewrite:
       enabled: true
-      rules: "ivoa.ObsCore:access_url, dp02_dc2_catalogs.ObsCore:access_url, dp1.ObsCore:access_url"
+      rules:
+        - "ivoa.ObsCore:access_url"
+        - "dp02_dc2_catalogs.ObsCore:access_url"
+        - "dp1.ObsCore:access_url"
 
     gcsBucket: "rubin:rubin-qserv"
     gcsBucketUrl: "https://s3dfrgw.slac.stanford.edu"

--- a/applications/tap/values.yaml
+++ b/applications/tap/values.yaml
@@ -23,6 +23,17 @@ cadc-tap:
     # -- Advertise VOParquet as a supported output format
     voParquet: true
 
+    # -- Director tables for TAP_UPLOAD spatial partitioning
+    uploadPartitionDirectors:
+      - "dp1.Object:objectId"
+      - "dp1.Source:sourceId"
+      - "dp1.DiaObject:diaObjectId"
+      - "dp2.Object:objectId"
+      - "dp2.Source:sourceId"
+      - "dp2.ShearObject:shearObjectId"
+      - "dp2.IsolatedStarStellarMotions:isolated_star_id"
+      - "dp2.DiaObject:diaObjectId"
+
   serviceAccount:
     # -- Name of the Kubernetes `ServiceAccount`, used for CloudSQL access
     name: "tap"

--- a/charts/cadc-tap/README.md
+++ b/charts/cadc-tap/README.md
@@ -60,10 +60,10 @@ IVOA TAP service
 | config.sentryEnabled | bool | `false` | Whether Sentry is enabled in this environment |
 | config.serviceName | string | None, must be set | Name of the service from Gafaelfawr's perspective, used for metrics reporting |
 | config.tapSchemaAddress | string | `"cadc-tap-schema-db:3306"` | Address to a MySQL database containing TAP schema data |
-| config.uploadPartitionDirectors | string | `""` | Comma-separated list of Qserv director tables for dependent upload partition detection. Format: database.table:idCol[,...] |
-| config.urlRewrite | object | `{"enabled":true,"rules":"ivoa.ObsCore:access_url"}` | Rules for renaming Columns |
+| config.uploadPartitionDirectors | list | `[]` | List of Qserv director tables for dependent upload partition detection. Format: ["database.table:idCol", ...] |
+| config.urlRewrite | object | `{"enabled":true,"rules":["ivoa.ObsCore:access_url"]}` | Rules for renaming Columns |
 | config.urlRewrite.enabled | bool | `true` | Whether it is enabled |
-| config.urlRewrite.rules | string | `"ivoa.ObsCore:access_url"` | String with a comma-separated list of schema.table:column rules |
+| config.urlRewrite.rules | list | `["ivoa.ObsCore:access_url"]` | List of schema.table:column rules for URL rewriting |
 | config.vaultSecretName | string | `""` | Vault secret name, this is appended to the global path to find the vault secrets associated with this deployment. |
 | config.voParquet | bool | `false` | Whether to advertise VOParquet (application/vnd.apache.parquet) as a supported output format in the TAP capabilities. |
 | fullnameOverride | string | `"cadc-tap"` | Override the full name for resources (includes the release name) |

--- a/charts/cadc-tap/README.md
+++ b/charts/cadc-tap/README.md
@@ -60,6 +60,7 @@ IVOA TAP service
 | config.sentryEnabled | bool | `false` | Whether Sentry is enabled in this environment |
 | config.serviceName | string | None, must be set | Name of the service from Gafaelfawr's perspective, used for metrics reporting |
 | config.tapSchemaAddress | string | `"cadc-tap-schema-db:3306"` | Address to a MySQL database containing TAP schema data |
+| config.uploadPartitionDirectors | string | `""` | Comma-separated list of Qserv director tables for dependent upload partition detection. Format: database.table:idCol[,...] |
 | config.urlRewrite | object | `{"enabled":true,"rules":"ivoa.ObsCore:access_url"}` | Rules for renaming Columns |
 | config.urlRewrite.enabled | bool | `true` | Whether it is enabled |
 | config.urlRewrite.rules | string | `"ivoa.ObsCore:access_url"` | String with a comma-separated list of schema.table:column rules |

--- a/charts/cadc-tap/README.md
+++ b/charts/cadc-tap/README.md
@@ -25,7 +25,7 @@ IVOA TAP service
 | config.bigquery.dataset | string | None, must be set if backend is `bigquery` | BigQuery dataset name |
 | config.bigquery.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the TAP image |
 | config.bigquery.image.repository | string | `"ghcr.io/lsst-sqre/lsst-tap-service"` | TAP image to use |
-| config.bigquery.image.tag | string | `"3.18.0"` | Tag of TAP image to use |
+| config.bigquery.image.tag | string | `"3.20.0"` | Tag of TAP image to use |
 | config.bigquery.project | string | None, must be set if backend is `bigquery` | BigQuery project ID |
 | config.bigquery.schema | string | `""` | Schema name for table mappings (optional) |
 | config.database | string | `"dp02"` | Data Database name |
@@ -54,7 +54,7 @@ IVOA TAP service
 | config.qserv.host | string | `"mock-db:3306"` (the mock QServ) | QServ hostname:port to connect to |
 | config.qserv.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the TAP image |
 | config.qserv.image.repository | string | `"ghcr.io/lsst-sqre/lsst-tap-service"` | TAP image to use |
-| config.qserv.image.tag | string | `"3.18.0"` | Tag of TAP image to use |
+| config.qserv.image.tag | string | `"3.20.0"` | Tag of TAP image to use |
 | config.qserv.jdbcParams | string | `""` | Extra JDBC connection parameters |
 | config.qserv.passwordEnabled | bool | false | Whether the Qserv database is password protected |
 | config.sentryEnabled | bool | `false` | Whether Sentry is enabled in this environment |
@@ -120,7 +120,7 @@ IVOA TAP service
 | uws.external.port | int | `5432` | Port of external PostgreSQL server |
 | uws.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the UWS database image |
 | uws.image.repository | string | `"ghcr.io/lsst-sqre/lsst-tap-uws-db"` | UWS database image to use |
-| uws.image.tag | string | `"3.18.0"` | Tag of UWS database image to use |
+| uws.image.tag | string | `"3.20.0"` | Tag of UWS database image to use |
 | uws.maxActive | int | `5` | Maximum active connections (maxIdle will be set to this value) |
 | uws.nodeSelector | object | `{}` | Node selection rules for the UWS database pod |
 | uws.podAnnotations | object | `{}` | Annotations for the UWS databse pod |

--- a/charts/cadc-tap/templates/tap-deployment.yaml
+++ b/charts/cadc-tap/templates/tap-deployment.yaml
@@ -194,6 +194,9 @@ spec:
                 {{- if .Values.config.voParquet }}
                 -Dtap.enableVOParquet=true
                 {{- end }}
+                {{- if .Values.config.uploadPartitionDirectors }}
+                -Dupload.partition.directors={{ .Values.config.uploadPartitionDirectors }}
+                {{- end }}
                 -Dbase_url={{ .Values.global.baseUrl }}
                 -Dpath_prefix=/api/{{ .Values.ingress.path }}
                 -Dca.nrc.cadc.util.PropertiesReader.dir=/config/

--- a/charts/cadc-tap/templates/tap-deployment.yaml
+++ b/charts/cadc-tap/templates/tap-deployment.yaml
@@ -195,13 +195,13 @@ spec:
                 -Dtap.enableVOParquet=true
                 {{- end }}
                 {{- if .Values.config.uploadPartitionDirectors }}
-                -Dupload.partition.directors={{ .Values.config.uploadPartitionDirectors }}
+                -Dupload.partition.directors={{ .Values.config.uploadPartitionDirectors | join "," }}
                 {{- end }}
                 -Dbase_url={{ .Values.global.baseUrl }}
                 -Dpath_prefix=/api/{{ .Values.ingress.path }}
                 -Dca.nrc.cadc.util.PropertiesReader.dir=/config/
                 -Durl.rewrite.enabled={{ .Values.config.urlRewrite.enabled | default true }}
-                -Durl.rewrite.rules="{{ .Values.config.urlRewrite.rules | default "ivoa.ObsCore:access_url" }}"
+                -Durl.rewrite.rules="{{ .Values.config.urlRewrite.rules | default (list "ivoa.ObsCore:access_url") | join "," }}"
                 -Xmx{{ .Values.config.jvmMaxHeapSize }}
             - name: "CATALINA_BASE"
               value: "/var/lib/tomcat"

--- a/charts/cadc-tap/values.yaml
+++ b/charts/cadc-tap/values.yaml
@@ -199,6 +199,10 @@ config:
   # supported output format in the TAP capabilities.
   voParquet: false
 
+  # -- Comma-separated list of Qserv director tables for dependent upload
+  # partition detection.
+  uploadPartitionDirectors: ""
+
   # -- Rules for renaming Columns
   urlRewrite:
 

--- a/charts/cadc-tap/values.yaml
+++ b/charts/cadc-tap/values.yaml
@@ -94,7 +94,7 @@ config:
       pullPolicy: "IfNotPresent"
 
       # -- Tag of TAP image to use
-      tag: "3.18.0"
+      tag: "3.20.0"
 
     # -- Whether the Qserv database is password protected
     # @default -- false
@@ -120,7 +120,7 @@ config:
       pullPolicy: "IfNotPresent"
 
       # -- Tag of TAP image to use
-      tag: "3.18.0"
+      tag: "3.20.0"
 
   # -- Address to a MySQL database containing TAP schema data
   tapSchemaAddress: "cadc-tap-schema-db:3306"
@@ -364,7 +364,7 @@ uws:
     pullPolicy: "IfNotPresent"
 
     # -- Tag of UWS database image to use
-    tag: "3.18.0"
+    tag: "3.20.0"
 
   # -- Resource limits and requests for the UWS database pod
   # @default -- See `values.yaml`

--- a/charts/cadc-tap/values.yaml
+++ b/charts/cadc-tap/values.yaml
@@ -199,9 +199,9 @@ config:
   # supported output format in the TAP capabilities.
   voParquet: false
 
-  # -- Comma-separated list of Qserv director tables for dependent upload
-  # partition detection.
-  uploadPartitionDirectors: ""
+  # -- List of Qserv director tables for dependent upload partition detection.
+  # Format: ["database.table:idCol", ...]
+  uploadPartitionDirectors: []
 
   # -- Rules for renaming Columns
   urlRewrite:
@@ -209,8 +209,9 @@ config:
     # -- Whether it is enabled
     enabled: true
 
-    # -- String with a comma-separated list of schema.table:column rules
-    rules: "ivoa.ObsCore:access_url"
+    # -- List of schema.table:column rules for URL rewriting
+    rules:
+      - "ivoa.ObsCore:access_url"
 
 mockdb:
   # -- Spin up a container to pretend to be the database.


### PR DESCRIPTION
## Changes

- Add list of director tables for TAP_UPLOAD spatial partitioning. Stored as a yaml list in values and passed in as a tomcat env variable named `upload.partition.directors`.
- Change qserv image to the version that provides support for sending through the appropriate parameters
- Change urlRewrite rules to a yaml list