### PR TITLE
DM-54973: Add schemaMappings parameter to TAP configuration

### DIFF
--- a/charts/cadc-tap/README.md
+++ b/charts/cadc-tap/README.md
@@ -57,6 +57,7 @@ IVOA TAP service
 | config.qserv.image.tag | string | `"3.17.0"` | Tag of TAP image to use |
 | config.qserv.jdbcParams | string | `""` | Extra JDBC connection parameters |
 | config.qserv.passwordEnabled | bool | false | Whether the Qserv database is password protected |
+| config.qserv.schemaMappings | string | `""` | Schema name mappings: comma-separated list of user_schema:internal_schema pairs. Example: "dp1:dp1_pilot" dp1 queries execute against dp1_pilot. |
 | config.sentryEnabled | bool | `false` | Whether Sentry is enabled in this environment |
 | config.serviceName | string | None, must be set | Name of the service from Gafaelfawr's perspective, used for metrics reporting |
 | config.tapSchemaAddress | string | `"cadc-tap-schema-db:3306"` | Address to a MySQL database containing TAP schema data |

--- a/charts/cadc-tap/templates/tap-deployment.yaml
+++ b/charts/cadc-tap/templates/tap-deployment.yaml
@@ -168,6 +168,9 @@ spec:
                 -Dqservuser.driverClassName=com.mysql.cj.jdbc.Driver
                 -Dqservuser.url=jdbc:mysql://{{ .Values.config.qserv.host }}/{{ .Values.config.qserv.jdbcParams }}
                 -Dqservuser.maxActive=100
+                {{- if .Values.config.qserv.schemaMappings }}
+                -Dtap.schema.mappings={{ .Values.config.qserv.schemaMappings }}
+                {{- end }}
                 {{- end }}
                 -Dgafaelfawr_url={{ .Values.global.baseUrl }}/auth/api/v1/user-info
                 -Dgcs_bucket={{ .Values.config.gcsBucket }}

--- a/charts/cadc-tap/values.yaml
+++ b/charts/cadc-tap/values.yaml
@@ -86,6 +86,10 @@ config:
     # -- Extra JDBC connection parameters
     jdbcParams: ""
 
+    # -- Schema name mappings: comma-separated list of user_schema:internal_schema pairs.
+    # Example: "dp1:dp1_pilot" dp1 queries execute against dp1_pilot.
+    schemaMappings: ""
+
     image:
       # -- TAP image to use
       repository: "ghcr.io/lsst-sqre/lsst-tap-service"


### PR DESCRIPTION
## Changes
- Add schemaMappings parameter to cadc-tap values file that gets passed in as a tomcat environment variable to the TAP service. When enabled this parameter gets used to rename the target schema alias with the actual schema name in the database in the translated SQL query.