### PR TITLE
DM-51754: Update templatebot to 0.5.3

### DIFF
--- a/applications/templatebot/Chart.yaml
+++ b/applications/templatebot/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "0.5.2"
+appVersion: "0.5.3"
 description: Create new projects
 name: templatebot
 sources:


### PR DESCRIPTION
## Summary

- Bump the templatebot application's `appVersion` from 0.5.2 to 0.5.3 to deploy the latest [templatebot release](https://github.com/lsst-sqre/templatebot/releases/tag/0.5.3).

## Validation steps

- After merge and Argo CD sync, confirm templatebot is running the 0.5.3 image.

## References

- Jira: https://rubinobs.atlassian.net/browse/DM-51754