### PR TITLE
DM-55290: Add user-notifications config keys to squareone chart

### DIFF
--- a/applications/squareone/Chart.yaml
+++ b/applications/squareone/Chart.yaml
@@ -9,8 +9,4 @@ maintainers:
   - name: jonathansick
     url: https://github.com/jonathansick
 
-# The default version tag of the squareone docker image
-# NOTE: temporarily pinned to the DM-55290 ticket branch image to exercise the
-# user-notifications UI on data-dev (idfdev). Revert to a released version
-# (e.g. "0.34.0") before merging this PR.
-appVersion: "tickets-DM-55290-notifications-ui"
+appVersion: "0.35.0"

--- a/applications/squareone/Chart.yaml
+++ b/applications/squareone/Chart.yaml
@@ -10,4 +10,7 @@ maintainers:
     url: https://github.com/jonathansick
 
 # The default version tag of the squareone docker image
-appVersion: "0.34.0"
+# NOTE: temporarily pinned to the DM-55290 ticket branch image to exercise the
+# user-notifications UI on data-dev (idfdev). Revert to a released version
+# (e.g. "0.34.0") before merging this PR.
+appVersion: "tickets-DM-55290-notifications-ui"

--- a/applications/squareone/README.md
+++ b/applications/squareone/README.md
@@ -22,6 +22,7 @@ Squareone is the homepage UI for the Rubin Science Platform.
 | config.docsBaseUrl | string | `"https://rsp.lsst.io"` | Base URL for user documentation (excludes trailing slash) |
 | config.enableAppsMenu | bool | `false` | Enable the App menu |
 | config.enableSentry | bool | `false` | Enable Sentry |
+| config.enableUserNotifications | bool | `false` | Enable the user-facing notifications UI: the unread badge in the header user menu and the /notifications inbox and detail pages. Requires semaphoreUrl to be set for the underlying Semaphore API. |
 | config.headerLogoAlt | string | `"Logo"` | Alternative text for header logo for accessibility |
 | config.headerLogoData | string | null uses Squareone's default built-in logo | Base64-encoded image data for header logo (without data URL prefix). Must be used with headerLogoMimeType. Used only if both headerLogoUrl and headerLogoFile are null. |
 | config.headerLogoFile | string | null uses Squareone's default built-in logo | Filename of a logo image in the content/{environment}/ directory (e.g., "header-logo.png"). The file will be base64-encoded automatically. Used only if headerLogoUrl is null. Supported formats: .png, .jpg, .jpeg, .svg, .webp, .gif. Note: unlike MDX files, logo files do NOT fall back to idfprod if not found in the environment directory. |
@@ -40,6 +41,7 @@ Squareone is the homepage UI for the Rubin Science Platform.
 | config.siteDescription | string | See `values.yaml` | Site description, used in meta tags |
 | config.siteName | string | `"Rubin Science Platform"` | Name of the site, used in the title and meta tags. |
 | config.timesSquareUrl | string | null disables the Times Square integration | URL to the Times Square (parameterized notebooks) API service. |
+| config.userNotificationsPollIntervalSeconds | int | `300` | Background polling cadence, in seconds, for the unread notification count in the header user menu. Only relevant when enableUserNotifications is true. |
 | fullnameOverride | string | `""` | Overrides the full name for resources (includes the release name) |
 | global.baseUrl | string | Set by Argo CD Application | Base URL for the environment |
 | global.environmentName | string | Set by Argo CD Application | Name of the Phalanx environment |

--- a/applications/squareone/templates/configmap.yaml
+++ b/applications/squareone/templates/configmap.yaml
@@ -16,6 +16,8 @@ data:
     {{- if .Values.config.semaphoreUrl }}
     semaphoreUrl: {{ .Values.config.semaphoreUrl | quote }}
     {{- end}}
+    enableUserNotifications: {{ .Values.config.enableUserNotifications }}
+    userNotificationsPollIntervalSeconds: {{ .Values.config.userNotificationsPollIntervalSeconds }}
     {{- if .Values.config.timesSquareUrl }}
     timesSquareUrl: {{ .Values.config.timesSquareUrl | quote }}
     {{- end}}

--- a/applications/squareone/values-idfdev.yaml
+++ b/applications/squareone/values-idfdev.yaml
@@ -8,6 +8,7 @@ config:
   siteName: "Rubin Science Platform @ data-dev"
   docsBaseUrl: "https://rsp.lsst.io/v/idfdev"
   semaphoreUrl: "https://data-dev.lsst.cloud/semaphore"
+  enableUserNotifications: true
   timesSquareUrl: "https://data-dev.lsst.cloud/times-square/api"
   coManageRegistryUrl: "https://id-dev.lsst.cloud"
   plausibleDomain: "data-dev.lsst.cloud"

--- a/applications/squareone/values.yaml
+++ b/applications/squareone/values.yaml
@@ -89,6 +89,15 @@ config:
   # @default -- null disables the Semaphore integration
   semaphoreUrl: null
 
+  # -- Enable the user-facing notifications UI: the unread badge in the header
+  # user menu and the /notifications inbox and detail pages. Requires
+  # semaphoreUrl to be set for the underlying Semaphore API.
+  enableUserNotifications: false
+
+  # -- Background polling cadence, in seconds, for the unread notification count
+  # in the header user menu. Only relevant when enableUserNotifications is true.
+  userNotificationsPollIntervalSeconds: 300
+
   # -- URL to the Times Square (parameterized notebooks) API service.
   # @default -- null disables the Times Square integration
   timesSquareUrl: null


### PR DESCRIPTION
## Summary

- Mirror squareone's `enableUserNotifications` (default `false`) and `userNotificationsPollIntervalSeconds` (default `300`) config keys into the Phalanx chart, and surface both into the runtime ConfigMap, so the notifications UI can be controlled per environment (PRD §Config).
- Defaults to disabled; **enabled on data-dev (idfdev)** so the UI can be exercised there ahead of release. No other environment enables it.
- ⚠️ Temporarily pins the chart `appVersion` to the `tickets-DM-55290-notifications-ui` image so the branch build runs on data-dev. The `appVersion` commit must be reverted to a released version (e.g. `0.34.0`) before this PR merges.

## Validation steps

- `phalanx application template squareone idfdev` renders `enableUserNotifications: true` and `userNotificationsPollIntervalSeconds: 300`.
- `phalanx application template squareone <other-env>` renders `enableUserNotifications: false`.
- After Argo CD syncs data-dev to this branch, confirm squareone runs the `tickets-DM-55290-notifications-ui` image and the header unread badge + `/notifications` pages appear.

## References

- Closes lsst-sqre/squareone#505
- PRD: lsst-sqre/squareone#495
- Jira: https://rubinobs.atlassian.net/browse/DM-55290