### PR TITLE
DM-55348: Fix name of idfprod cluster

### DIFF
--- a/environments/values-idfprod.yaml
+++ b/environments/values-idfprod.yaml
@@ -7,7 +7,7 @@ butlerServerRepositories:
 gcp:
   projectId: "science-platform-stable-6994"
   region: "us-central1"
-  clusterName: "science-platform-stable"
+  clusterName: "rsp-prod"
 onepassword:
   connectUrl: "https://roundtable.lsst.cloud/1password"
   vaultTitle: "RSP data.lsst.cloud"


### PR DESCRIPTION
We have rebuilt the cluster and the GKE cluster is now called `rsp-prod`.