### PR TITLE
DM-55348: Fix cut and paste of gcloud commands

### DIFF
--- a/docs/environments/_summary.rst.jinja
+++ b/docs/environments/_summary.rst.jinja
@@ -81,7 +81,7 @@
 
 To obtain Kubernetes admin credentials for this cluster, run:
 
-.. prompt:: bash
+.. code:: bash
 
    gcloud container clusters get-credentials {{ env.gcp.cluster_name }} --project {{ env.gcp.project_id }} --region {{ env.gcp.region }}
 


### PR DESCRIPTION
The `gcloud` command to get credentials at the bottom of environment pages for environments hosted at Google had a broken copy to clipboard button because the sphinx-prompt extension didn't omit the prompt. Convert these to simple code blocks, which fixes the cut and paste behavior.