### PR TITLE
[DM-55296] Add obsforge application 

### DIFF
--- a/applications/obsforge/.helmignore
+++ b/applications/obsforge/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/applications/obsforge/Chart.yaml
+++ b/applications/obsforge/Chart.yaml
@@ -1,8 +1,19 @@
 apiVersion: v2
-appVersion: 0.1.0
-description: A metadata enrichment service for Rubin Observatory observations
 name: obsforge
-sources:
-- https://github.com/lsst-sqre/obsforge
 type: application
 version: 1.0.0
+description: A metadata enrichment service for Rubin Observatory observations
+sources:
+  - https://github.com/lsst-sqre/obsforge
+appVersion: 0.1.0
+
+dependencies:
+  - name: redis
+    version: 1.1.12
+    repository: https://lsst-sqre.github.io/charts/
+
+annotations:
+  phalanx.lsst.io/docs: |
+    - id: "SQR-115"
+      title: "ObsForge: A metadata enrichment service for Rubin Observatory observations"
+      url: "https://sqr-115.lsst.io/"

--- a/applications/obsforge/Chart.yaml
+++ b/applications/obsforge/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+appVersion: 0.1.0
+description: A metadata enrichment service for Rubin Observatory observations
+name: obsforge
+sources:
+- https://github.com/lsst-sqre/obsforge
+type: application
+version: 1.0.0

--- a/applications/obsforge/README.md
+++ b/applications/obsforge/README.md
@@ -11,10 +11,19 @@ A metadata enrichment service for Rubin Observatory observations
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules for the obsforge deployment pod |
+| config.arqMode | string | `"production"` | Mode for the arq queue dependency |
+| config.arqQueueName | string | `"arq:queue"` | Name of the arq queue used by ObsForge |
+| config.butlerLabel | string | `"prompt"` | Butler repository label used by worker enrichment |
+| config.butlerRepository | string | None, must be set | Prompt Butler repository path or URL for worker enrichment |
+| config.databaseUrl | string | None, must be set | PostgreSQL DSN for ObsForge durable state |
+| config.enrichmentMaxTries | int | `5` | Maximum arq attempts for an enrichment job |
 | config.logLevel | string | `"INFO"` | Logging level |
 | config.logProfile | string | `"production"` | Logging profile (`production` for JSON, `development` for human-friendly) |
+| config.obscoreConfig | string | None, must be set | Path or URL to the lsst.dax.obscore prompt.yaml config |
+| config.obscoreDatasetType | string | `"preliminary_visit_image"` | Dataset type selected from the ObsCore exporter config |
 | config.pathPrefix | string | `"/obsforge"` | URL path prefix |
 | config.slackAlerts | bool | `false` | Whether to send Slack alerts for unexpected failures |
+| config.updateSchema | bool | `false` | Whether to run Alembic schema migrations on install/upgrade |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.repertoireUrl | string | Set by Argo CD | Base URL for Repertoire discovery API |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
@@ -24,6 +33,30 @@ A metadata enrichment service for Rubin Observatory observations
 | ingress.annotations | object | `{}` | Additional annotations for the ingress rule |
 | nodeSelector | object | `{}` | Node selection rules for the obsforge deployment pod |
 | podAnnotations | object | `{}` | Annotations for the obsforge deployment pod |
+| redis.config.secretKey | string | `"redis-password"` | Key inside secret from which to get the Redis password |
+| redis.config.secretName | string | `"obsforge"` | Name of secret containing Redis password |
+| redis.persistence.accessMode | string | `"ReadWriteOnce"` | Access mode of storage to request |
+| redis.persistence.enabled | bool | `true` | Whether to persist Redis storage. Redis is arq transport state; keeping persistence enabled preserves queued and in-flight jobs across restarts. |
+| redis.persistence.size | string | `"100Mi"` | Amount of persistent storage to request |
+| redis.persistence.storageClass | string | `nil` | Class of storage to request |
+| redis.persistence.volumeClaimName | string | `nil` | Use an existing PVC, not dynamic provisioning. If this is set, the size, storageClass, and accessMode settings are ignored. |
+| redis.resources | object | See `values.yaml` | Resource limits and requests for the Redis pod |
+| redis.tolerations | list | `[]` | Tolerations for the Redis pod |
 | replicaCount | int | `1` | Number of web deployment pods to start |
 | resources | object | See `values.yaml` | Resource limits and requests for the obsforge deployment pod |
+| schemaUpdate.affinity | object | `{}` | Affinity rules for the schema update job |
+| schemaUpdate.nodeSelector | object | `{}` | Node selection rules for the schema update job |
+| schemaUpdate.podAnnotations | object | `{}` | Annotations for the schema update job pod |
+| schemaUpdate.resources | object | See `values.yaml` | Resource limits and requests for the schema update job |
+| schemaUpdate.tolerations | list | `[]` | Tolerations for the schema update job |
 | tolerations | list | `[]` | Tolerations for the obsforge deployment pod |
+| worker.affinity | object | `{}` | Affinity rules for the obsforge worker pods |
+| worker.autoscaling.enabled | bool | `true` | Enable autoscaling of obsforge worker pods |
+| worker.autoscaling.maxReplicas | int | `10` | Maximum number of obsforge worker pods |
+| worker.autoscaling.minReplicas | int | `1` | Minimum number of obsforge worker pods |
+| worker.autoscaling.targetCPUUtilizationPercentage | int | `75` | Target CPU utilization of obsforge worker pods |
+| worker.nodeSelector | object | `{}` | Node selection rules for the obsforge worker pods |
+| worker.podAnnotations | object | `{}` | Annotations for the obsforge worker pods |
+| worker.replicaCount | int | `1` | Number of worker pods to start if autoscaling is disabled |
+| worker.resources | object | See `values.yaml` | Resource limits and requests for the obsforge worker pods |
+| worker.tolerations | list | `[]` | Tolerations for the obsforge worker pods |

--- a/applications/obsforge/README.md
+++ b/applications/obsforge/README.md
@@ -1,0 +1,29 @@
+# obsforge
+
+A metadata enrichment service for Rubin Observatory observations
+
+## Source Code
+
+* <https://github.com/lsst-sqre/obsforge>
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Affinity rules for the obsforge deployment pod |
+| config.logLevel | string | `"INFO"` | Logging level |
+| config.logProfile | string | `"production"` | Logging profile (`production` for JSON, `development` for human-friendly) |
+| config.pathPrefix | string | `"/obsforge"` | URL path prefix |
+| config.slackAlerts | bool | `false` | Whether to send Slack alerts for unexpected failures |
+| global.host | string | Set by Argo CD | Host name for ingress |
+| global.repertoireUrl | string | Set by Argo CD | Base URL for Repertoire discovery API |
+| global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
+| image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the obsforge image |
+| image.repository | string | `"ghcr.io/lsst-sqre/obsforge"` | Image to use in the obsforge deployment |
+| image.tag | string | The appVersion of the chart | Tag of image to use |
+| ingress.annotations | object | `{}` | Additional annotations for the ingress rule |
+| nodeSelector | object | `{}` | Node selection rules for the obsforge deployment pod |
+| podAnnotations | object | `{}` | Annotations for the obsforge deployment pod |
+| replicaCount | int | `1` | Number of web deployment pods to start |
+| resources | object | See `values.yaml` | Resource limits and requests for the obsforge deployment pod |
+| tolerations | list | `[]` | Tolerations for the obsforge deployment pod |

--- a/applications/obsforge/secrets.yaml
+++ b/applications/obsforge/secrets.yaml
@@ -1,0 +1,8 @@
+slack-webhook:
+  description: >-
+    Slack web hook used to report internal errors to Slack. This secret may be
+    changed at any time.
+  if: config.slackAlerts
+  copy:
+    application: mobu
+    key: app-alert-webhook

--- a/applications/obsforge/secrets.yaml
+++ b/applications/obsforge/secrets.yaml
@@ -1,3 +1,15 @@
+database-password:
+  description: >-
+    Password for the ObsForge PostgreSQL database. Changes must be coordinated
+    with the corresponding database deployment.
+redis-password:
+  description: >-
+    Password used to authenticate ObsForge to its internal Redis server,
+    deployed as part of the same Argo CD application. This secret can be
+    changed at any time, but both Redis and ObsForge pods must be restarted to
+    pick up the new value.
+  generate:
+    type: password
 slack-webhook:
   description: >-
     Slack web hook used to report internal errors to Slack. This secret may be

--- a/applications/obsforge/secrets.yaml
+++ b/applications/obsforge/secrets.yaml
@@ -2,6 +2,11 @@ database-password:
   description: >-
     Password for the ObsForge PostgreSQL database. Changes must be coordinated
     with the corresponding database deployment.
+butler-access-token:
+  description: >-
+    Access token used by the ObsForge worker when connecting to the remote
+    Butler repository for ObsCore enrichment. On the remote Butler environment,
+    create a service token for the bot-obsforge user with read:image scope.
 redis-password:
   description: >-
     Password used to authenticate ObsForge to its internal Redis server,

--- a/applications/obsforge/templates/_helpers.tpl
+++ b/applications/obsforge/templates/_helpers.tpl
@@ -36,6 +36,11 @@ Common environment variables from secrets
     secretKeyRef:
       name: "obsforge"
       key: "redis-password"
+- name: "OBSFORGE_BUTLER_ACCESS_TOKEN"
+  valueFrom:
+    secretKeyRef:
+      name: "obsforge"
+      key: "butler-access-token"
 {{- if .Values.config.slackAlerts }}
 - name: "OBSFORGE_SLACK_WEBHOOK"
   valueFrom:

--- a/applications/obsforge/templates/_helpers.tpl
+++ b/applications/obsforge/templates/_helpers.tpl
@@ -1,0 +1,23 @@
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "obsforge.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "obsforge.labels" -}}
+helm.sh/chart: {{ include "obsforge.chart" . }}
+{{ include "obsforge.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "obsforge.selectorLabels" -}}
+app.kubernetes.io/name: "obsforge"
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/applications/obsforge/templates/_helpers.tpl
+++ b/applications/obsforge/templates/_helpers.tpl
@@ -21,3 +21,26 @@ Selector labels
 app.kubernetes.io/name: "obsforge"
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Common environment variables from secrets
+*/}}
+{{- define "obsforge.envVars" -}}
+- name: "OBSFORGE_DATABASE_PASSWORD"
+  valueFrom:
+    secretKeyRef:
+      name: "obsforge"
+      key: "database-password"
+- name: "OBSFORGE_ARQ_QUEUE_PASSWORD"
+  valueFrom:
+    secretKeyRef:
+      name: "obsforge"
+      key: "redis-password"
+{{- if .Values.config.slackAlerts }}
+- name: "OBSFORGE_SLACK_WEBHOOK"
+  valueFrom:
+    secretKeyRef:
+      name: "obsforge"
+      key: "slack-webhook"
+{{- end }}
+{{- end }}

--- a/applications/obsforge/templates/configmap.yaml
+++ b/applications/obsforge/templates/configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "obsforge"
+  labels:
+    {{- include "obsforge.labels" . | nindent 4 }}
+data:
+  OBSFORGE_LOG_LEVEL: {{ .Values.config.logLevel | quote }}
+  OBSFORGE_LOG_PROFILE: {{ .Values.config.logProfile | quote }}
+  OBSFORGE_PATH_PREFIX: {{ .Values.config.pathPrefix | quote }}
+  REPERTOIRE_BASE_URL: {{ .Values.global.repertoireUrl | quote }}

--- a/applications/obsforge/templates/configmap.yaml
+++ b/applications/obsforge/templates/configmap.yaml
@@ -5,7 +5,17 @@ metadata:
   labels:
     {{- include "obsforge.labels" . | nindent 4 }}
 data:
+  OBSFORGE_ALEMBIC_CONFIG_PATH: "/app/alembic.ini"
+  OBSFORGE_ARQ_MODE: {{ .Values.config.arqMode | quote }}
+  OBSFORGE_ARQ_QUEUE_NAME: {{ .Values.config.arqQueueName | quote }}
+  OBSFORGE_ARQ_QUEUE_URL: "redis://obsforge-redis.{{ .Release.Namespace }}:6379/0"
+  OBSFORGE_BUTLER_LABEL: {{ .Values.config.butlerLabel | quote }}
+  OBSFORGE_BUTLER_REPOSITORY: {{ .Values.config.butlerRepository | quote }}
+  OBSFORGE_DATABASE_URL: {{ .Values.config.databaseUrl | quote }}
+  OBSFORGE_ENRICHMENT_MAX_TRIES: {{ .Values.config.enrichmentMaxTries | quote }}
   OBSFORGE_LOG_LEVEL: {{ .Values.config.logLevel | quote }}
   OBSFORGE_LOG_PROFILE: {{ .Values.config.logProfile | quote }}
+  OBSFORGE_OBSCORE_CONFIG: {{ .Values.config.obscoreConfig | quote }}
+  OBSFORGE_OBSCORE_DATASET_TYPE: {{ .Values.config.obscoreDatasetType | quote }}
   OBSFORGE_PATH_PREFIX: {{ .Values.config.pathPrefix | quote }}
   REPERTOIRE_BASE_URL: {{ .Values.global.repertoireUrl | quote }}

--- a/applications/obsforge/templates/deployment.yaml
+++ b/applications/obsforge/templates/deployment.yaml
@@ -1,0 +1,91 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "obsforge"
+  labels:
+    {{- include "obsforge.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "obsforge.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "obsforge.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      automountServiceAccountToken: false
+      containers:
+        - name: {{ .Chart.Name }}
+          env:
+            {{- if .Values.config.slackAlerts }}
+            - name: "OBSFORGE_SLACK_WEBHOOK"
+              valueFrom:
+                secretKeyRef:
+                  name: "obsforge"
+                  key: "slack-webhook"
+            {{- end }}
+            # Uvicorn keepalive timeout, in seconds. This should be longer
+            # than any keepalive timeouts on any downstream proxies. The
+            # keepalive timeout for ingress-nginx connections is 60s.
+            - name: "UVICORN_TIMEOUT_KEEP_ALIVE"
+              value: "61"
+          envFrom:
+            - configMapRef:
+                name: "obsforge"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          lifecycle:
+            # Number of seconds k8s should wait before sending SIGTERM on
+            # graceful restarts/deployments/shutdowns. We need this because it
+            # takes ingress-nginx some time to configure itself to stop
+            # sending traffic to the pods scheduled for termination. If
+            # Uvicorn gets the SIGTERM and starts closing connections, we
+            # could end up with a TCP race condition if ingress-nginx still
+            # tries to send data over those connections.
+            #
+            # Note that terminationGracePeriodSeconds includes the time that
+            # is spent in the preStop hook. If you’re adding a preStop hook
+            # and your terminationGracePeriodSeconds is super fine-tuned, then
+            # you should update your terminationGracePeriodSeconds to add the
+            # amount of time you’ll be spending in your preStop hook.
+            preStop:
+              sleep:
+                seconds: 10
+          ports:
+            - name: "http"
+              containerPort: 8080
+              protocol: "TCP"
+          readinessProbe:
+            httpGet:
+              path: "/"
+              port: "http"
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+            readOnlyRootFilesystem: true
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000

--- a/applications/obsforge/templates/deployment.yaml
+++ b/applications/obsforge/templates/deployment.yaml
@@ -9,6 +9,7 @@ spec:
   selector:
     matchLabels:
       {{- include "obsforge.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: "api"
   template:
     metadata:
       annotations:
@@ -18,6 +19,8 @@ spec:
         {{- end }}
       labels:
         {{- include "obsforge.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: "api"
+        obsforge-redis-client: "true"
     spec:
       {{- with .Values.affinity }}
       affinity:
@@ -27,13 +30,7 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           env:
-            {{- if .Values.config.slackAlerts }}
-            - name: "OBSFORGE_SLACK_WEBHOOK"
-              valueFrom:
-                secretKeyRef:
-                  name: "obsforge"
-                  key: "slack-webhook"
-            {{- end }}
+            {{- include "obsforge.envVars" . | nindent 12 }}
             # Uvicorn keepalive timeout, in seconds. This should be longer
             # than any keepalive timeouts on any downstream proxies. The
             # keepalive timeout for ingress-nginx connections is 60s.

--- a/applications/obsforge/templates/ingress.yaml
+++ b/applications/obsforge/templates/ingress.yaml
@@ -1,0 +1,30 @@
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
+metadata:
+  name: "obsforge"
+  labels:
+    {{- include "obsforge.labels" . | nindent 4 }}
+config:
+  scopes:
+    all:
+      - "write:obsforge"
+  service: "obsforge"
+template:
+  metadata:
+    name: "obsforge"
+    {{- with .Values.ingress.annotations }}
+    annotations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  spec:
+    rules:
+      - host: {{ required "global.host must be set" .Values.global.host | quote }}
+        http:
+          paths:
+            - path: {{ .Values.config.pathPrefix | quote }}
+              pathType: "Prefix"
+              backend:
+                service:
+                  name: "obsforge"
+                  port:
+                    number: 8080

--- a/applications/obsforge/templates/networkpolicy.yaml
+++ b/applications/obsforge/templates/networkpolicy.yaml
@@ -6,6 +6,7 @@ spec:
   podSelector:
     matchLabels:
       {{- include "obsforge.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: "api"
   policyTypes:
     - "Ingress"
   ingress:

--- a/applications/obsforge/templates/networkpolicy.yaml
+++ b/applications/obsforge/templates/networkpolicy.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: "obsforge"
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "obsforge.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - "Ingress"
+  ingress:
+    # Allow inbound access from pods (in any namespace) labeled
+    # gafaelfawr.lsst.io/ingress: true.
+    - from:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              gafaelfawr.lsst.io/ingress: "true"
+      ports:
+        - protocol: "TCP"
+          port: 8080

--- a/applications/obsforge/templates/schema-update-job.yaml
+++ b/applications/obsforge/templates/schema-update-job.yaml
@@ -1,0 +1,62 @@
+{{- if .Values.config.updateSchema }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "obsforge-schema-update"
+  annotations:
+    helm.sh/hook: "pre-install,pre-upgrade"
+    helm.sh/hook-delete-policy: "hook-succeeded"
+  labels:
+    {{- include "obsforge.labels" . | nindent 4 }}
+spec:
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.schemaUpdate.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "obsforge.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: "schema-update"
+        obsforge-redis-client: "true"
+    spec:
+      {{- with .Values.schemaUpdate.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      automountServiceAccountToken: false
+      containers:
+        - name: "obsforge-schema-update"
+          command:
+            - "obsforge"
+            - "update-schema"
+          env:
+            {{- include "obsforge.envVars" . | nindent 12 }}
+          envFrom:
+            - configMapRef:
+                name: "obsforge"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          resources:
+            {{- toYaml .Values.schemaUpdate.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+            readOnlyRootFilesystem: true
+      {{- with .Values.schemaUpdate.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      restartPolicy: "Never"
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+      {{- with .Values.schemaUpdate.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/applications/obsforge/templates/service.yaml
+++ b/applications/obsforge/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "obsforge"
+  labels:
+    {{- include "obsforge.labels" . | nindent 4 }}
+spec:
+  type: "ClusterIP"
+  ports:
+    - port: 8080
+      targetPort: "http"
+      protocol: "TCP"
+      name: "http"
+  selector:
+    {{- include "obsforge.selectorLabels" . | nindent 4 }}

--- a/applications/obsforge/templates/service.yaml
+++ b/applications/obsforge/templates/service.yaml
@@ -13,3 +13,4 @@ spec:
       name: "http"
   selector:
     {{- include "obsforge.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: "api"

--- a/applications/obsforge/templates/vault-secrets.yaml
+++ b/applications/obsforge/templates/vault-secrets.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.config.slackAlerts -}}
 apiVersion: ricoberger.de/v1alpha1
 kind: VaultSecret
 metadata:
@@ -8,4 +7,3 @@ metadata:
 spec:
   path: "{{ .Values.global.vaultSecretsPath }}/obsforge"
   type: Opaque
-{{- end }}

--- a/applications/obsforge/templates/vault-secrets.yaml
+++ b/applications/obsforge/templates/vault-secrets.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.config.slackAlerts -}}
+apiVersion: ricoberger.de/v1alpha1
+kind: VaultSecret
+metadata:
+  name: "obsforge"
+  labels:
+    {{- include "obsforge.labels" . | nindent 4 }}
+spec:
+  path: "{{ .Values.global.vaultSecretsPath }}/obsforge"
+  type: Opaque
+{{- end }}

--- a/applications/obsforge/templates/worker-deployment.yaml
+++ b/applications/obsforge/templates/worker-deployment.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "obsforge-worker"
+  labels:
+    {{- include "obsforge.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.worker.autoscaling.enabled }}
+  replicas: {{ .Values.worker.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "obsforge.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: "worker"
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.worker.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "obsforge.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: "worker"
+        obsforge-redis-client: "true"
+    spec:
+      {{- with .Values.worker.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      automountServiceAccountToken: false
+      containers:
+        - name: "obsforge-worker"
+          command:
+            - "arq"
+            - "obsforge.worker.main.WorkerSettings"
+          env:
+            {{- include "obsforge.envVars" . | nindent 12 }}
+          envFrom:
+            - configMapRef:
+                name: "obsforge"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          resources:
+            {{- toYaml .Values.worker.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+            readOnlyRootFilesystem: true
+      {{- with .Values.worker.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+      {{- with .Values.worker.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/applications/obsforge/templates/worker-hpa.yaml
+++ b/applications/obsforge/templates/worker-hpa.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.worker.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: "obsforge-worker"
+  labels:
+    {{- include "obsforge.labels" . | nindent 4 }}
+spec:
+  maxReplicas: {{ .Values.worker.autoscaling.maxReplicas }}
+  minReplicas: {{ .Values.worker.autoscaling.minReplicas }}
+  metrics:
+    {{- if .Values.worker.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: "cpu"
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.worker.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+  scaleTargetRef:
+    apiVersion: "apps/v1"
+    kind: "Deployment"
+    name: "obsforge-worker"
+{{- end }}

--- a/applications/obsforge/templates/worker-networkpolicy.yaml
+++ b/applications/obsforge/templates/worker-networkpolicy.yaml
@@ -1,0 +1,13 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: "obsforge-worker"
+  labels:
+    {{- include "obsforge.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "obsforge.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: "worker"
+  policyTypes:
+    - "Ingress"

--- a/applications/obsforge/values-idfdev.yaml
+++ b/applications/obsforge/values-idfdev.yaml
@@ -1,0 +1,11 @@
+image:
+  pullPolicy: "Always"
+  tag: tickets-DM-55184
+
+config:
+  databaseUrl: "postgresql://obsforge@obsforge-db-dev.slac.stanford.edu:5432/obsdb"
+  updateSchema: true
+  butlerRepository: "https://data-int.lsst.cloud/api/butler/repo/prompt/butler.yaml"
+  obscoreConfig: "https://raw.githubusercontent.com/lsst-dm/dax_obscore/refs/heads/main/configs/prompt.yaml"
+  logLevel: "DEBUG"
+  logProfile: "development"

--- a/applications/obsforge/values.yaml
+++ b/applications/obsforge/values.yaml
@@ -1,0 +1,66 @@
+# Default values for obsforge.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# -- Number of web deployment pods to start
+replicaCount: 1
+
+image:
+  # -- Image to use in the obsforge deployment
+  repository: "ghcr.io/lsst-sqre/obsforge"
+
+  # -- Pull policy for the obsforge image
+  pullPolicy: "IfNotPresent"
+
+  # -- Tag of image to use
+  # @default -- The appVersion of the chart
+  tag: null
+
+config:
+  # -- Logging level
+  logLevel: "INFO"
+
+  # -- Logging profile (`production` for JSON, `development` for
+  # human-friendly)
+  logProfile: "production"
+
+  # -- URL path prefix
+  pathPrefix: "/obsforge"
+
+  # -- Whether to send Slack alerts for unexpected failures
+  slackAlerts: false
+
+ingress:
+  # -- Additional annotations for the ingress rule
+  annotations: {}
+
+# -- Affinity rules for the obsforge deployment pod
+affinity: {}
+
+# -- Node selection rules for the obsforge deployment pod
+nodeSelector: {}
+
+# -- Annotations for the obsforge deployment pod
+podAnnotations: {}
+
+# -- Resource limits and requests for the obsforge deployment pod
+# @default -- See `values.yaml`
+resources: {}
+
+# -- Tolerations for the obsforge deployment pod
+tolerations: []
+
+# The following will be set by parameters injected by Argo CD and should not
+# be set in the individual environment values files.
+global:
+  # -- Host name for ingress
+  # @default -- Set by Argo CD
+  host: null
+
+  # -- Base URL for Repertoire discovery API
+  # @default -- Set by Argo CD
+  repertoireUrl: null
+
+  # -- Base path for Vault secrets
+  # @default -- Set by Argo CD
+  vaultSecretsPath: null

--- a/applications/obsforge/values.yaml
+++ b/applications/obsforge/values.yaml
@@ -17,6 +17,36 @@ image:
   tag: null
 
 config:
+  # -- PostgreSQL DSN for ObsForge durable state
+  # @default -- None, must be set
+  databaseUrl: null
+
+  # -- Mode for the arq queue dependency
+  arqMode: "production"
+
+  # -- Name of the arq queue used by ObsForge
+  arqQueueName: "arq:queue"
+
+  # -- Maximum arq attempts for an enrichment job
+  enrichmentMaxTries: 5
+
+  # -- Whether to run Alembic schema migrations on install/upgrade
+  updateSchema: false
+
+  # -- Butler repository label used by worker enrichment
+  butlerLabel: "prompt"
+
+  # -- Prompt Butler repository path or URL for worker enrichment
+  # @default -- None, must be set
+  butlerRepository: null
+
+  # -- Path or URL to the lsst.dax.obscore prompt.yaml config
+  # @default -- None, must be set
+  obscoreConfig: null
+
+  # -- Dataset type selected from the ObsCore exporter config
+  obscoreDatasetType: "preliminary_visit_image"
+
   # -- Logging level
   logLevel: "INFO"
 
@@ -49,6 +79,89 @@ resources: {}
 
 # -- Tolerations for the obsforge deployment pod
 tolerations: []
+
+worker:
+  # -- Affinity rules for the obsforge worker pods
+  affinity: {}
+
+  autoscaling:
+    # -- Enable autoscaling of obsforge worker pods
+    enabled: true
+
+    # -- Minimum number of obsforge worker pods
+    minReplicas: 1
+
+    # -- Maximum number of obsforge worker pods
+    maxReplicas: 10
+
+    # -- Target CPU utilization of obsforge worker pods
+    targetCPUUtilizationPercentage: 75
+
+  # -- Node selection rules for the obsforge worker pods
+  nodeSelector: {}
+
+  # -- Annotations for the obsforge worker pods
+  podAnnotations: {}
+
+  # -- Number of worker pods to start if autoscaling is disabled
+  replicaCount: 1
+
+  # -- Resource limits and requests for the obsforge worker pods
+  # @default -- See `values.yaml`
+  resources: {}
+
+  # -- Tolerations for the obsforge worker pods
+  tolerations: []
+
+schemaUpdate:
+  # -- Affinity rules for the schema update job
+  affinity: {}
+
+  # -- Node selection rules for the schema update job
+  nodeSelector: {}
+
+  # -- Annotations for the schema update job pod
+  podAnnotations: {}
+
+  # -- Resource limits and requests for the schema update job
+  # @default -- See `values.yaml`
+  resources: {}
+
+  # -- Tolerations for the schema update job
+  tolerations: []
+
+redis:
+  config:
+    # -- Name of secret containing Redis password
+    secretName: "obsforge"
+
+    # -- Key inside secret from which to get the Redis password
+    secretKey: "redis-password"
+
+  persistence:
+    # -- Whether to persist Redis storage. Redis is arq transport state; keeping
+    # persistence enabled preserves queued and in-flight jobs across restarts.
+    enabled: true
+
+    # -- Access mode of storage to request
+    accessMode: "ReadWriteOnce"
+
+    # -- Amount of persistent storage to request
+    size: "100Mi"
+
+    # -- Class of storage to request
+    storageClass: null
+
+    # -- Use an existing PVC, not dynamic provisioning. If this is set, the
+    # size, storageClass, and accessMode settings are ignored.
+    volumeClaimName: null
+
+  # -- Resource limits and requests for the Redis pod
+  # @default -- See `values.yaml`
+  resources: {}
+
+  # -- Tolerations for the Redis pod
+  tolerations: []
 
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.

--- a/docs/applications/obsforge/index.rst
+++ b/docs/applications/obsforge/index.rst
@@ -1,0 +1,16 @@
+.. px-app:: obsforge
+
+###########################################################################
+obsforge — A metadata enrichment service for Rubin Observatory observations
+###########################################################################
+
+.. jinja:: obsforge
+   :file: applications/_summary.rst.jinja
+
+Guides
+======
+
+.. toctree::
+   :maxdepth: 1
+
+   values

--- a/docs/applications/obsforge/values.md
+++ b/docs/applications/obsforge/values.md
@@ -1,0 +1,12 @@
+```{px-app-values} obsforge
+```
+
+# obsforge Helm values reference
+
+Helm values reference table for the {px-app}`obsforge` application.
+
+```{include} ../../../applications/obsforge/README.md
+---
+start-after: "## Values"
+---
+```

--- a/docs/applications/rsp.rst
+++ b/docs/applications/rsp.rst
@@ -21,6 +21,7 @@ Argo CD project: ``rsp``
    livetap/index
    noteburst/index
    nublado/index
+   obsforge/index
    portal/index
    ppdbtap/index
    qserv-kafka/index

--- a/docs/applications/rsp.rst
+++ b/docs/applications/rsp.rst
@@ -22,6 +22,7 @@ Argo CD project: ``rsp``
    livetap/index
    noteburst/index
    nublado/index
+   obsforge/index
    obsforgetap/index
    portal/index
    ppdbtap/index

--- a/environments/README.md
+++ b/environments/README.md
@@ -49,6 +49,7 @@
 | applications.noteburst | bool | `false` | Enable the noteburst application (required by times-square) |
 | applications.nublado | bool | `false` | Enable the nublado application (v3 of the Notebook Aspect) |
 | applications.nvr-control | bool | `false` | Enable the nvr-control application |
+| applications.obsforge | bool | `false` | Enable the obsforge application |
 | applications.obsloctap | bool | `false` | Enable the obsloctap application |
 | applications.obssys | bool | `false` | Enable the obssys control system application |
 | applications.onepassword-connect | bool | `false` | Enable the onepassword-connect application |

--- a/environments/README.md
+++ b/environments/README.md
@@ -50,6 +50,7 @@
 | applications.noteburst | bool | `false` | Enable the noteburst application (required by times-square) |
 | applications.nublado | bool | `false` | Enable the nublado application (v3 of the Notebook Aspect) |
 | applications.nvr-control | bool | `false` | Enable the nvr-control application |
+| applications.obsforge | bool | `false` | Enable the obsforge application |
 | applications.obsforgetap | bool | `false` | Enable the obsforgetap application |
 | applications.obsloctap | bool | `false` | Enable the obsloctap application |
 | applications.obssys | bool | `false` | Enable the obssys control system application |

--- a/environments/templates/applications/rsp/obsforge.yaml
+++ b/environments/templates/applications/rsp/obsforge.yaml
@@ -1,0 +1,42 @@
+{{- if (index .Values "applications" "obsforge") -}}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "obsforge"
+  {{- if .Values.defaultComputeClass }}
+  labels:
+    cloud.google.com/default-compute-class: {{ .Values.defaultComputeClass | quote }}
+  {{- end}}
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: "obsforge"
+  namespace: "argocd"
+  finalizers:
+    - "resources-finalizer.argocd.argoproj.io"
+spec:
+  destination:
+    namespace: "obsforge"
+    server: "https://kubernetes.default.svc"
+  project: "rsp"
+  source:
+    path: "applications/obsforge"
+    repoURL: {{ .Values.repoUrl | quote }}
+    targetRevision: {{ or (index .Values "revisions" "obsforge") .Values.targetRevision | quote }}
+    helm:
+      parameters:
+        - name: "global.baseUrl"
+          value: "https://{{ .Values.fqdn }}"
+        - name: "global.environmentName"
+          value: {{ .Values.name | quote }}
+        - name: "global.host"
+          value: {{ .Values.fqdn | quote }}
+        - name: "global.repertoireUrl"
+          value: "https://{{ .Values.fqdn }}/repertoire"
+        - name: "global.vaultSecretsPath"
+          value: {{ .Values.vaultPathPrefix | quote }}
+      valueFiles:
+        - "values.yaml"
+        - "values-{{ .Values.name }}.yaml"
+{{- end -}}

--- a/environments/values-idfdev.yaml
+++ b/environments/values-idfdev.yaml
@@ -29,6 +29,7 @@ applications:
   muster: true
   noteburst: true
   nublado: true
+  obsforge: true
   portal: true
   ppdbtap: true
   qserv-kafka: true

--- a/environments/values-idfdev.yaml
+++ b/environments/values-idfdev.yaml
@@ -30,6 +30,7 @@ applications:
   muster: true
   noteburst: true
   nublado: true
+  obsforge: true
   obsforgetap: true
   portal: true
   ppdbtap: true

--- a/environments/values.yaml
+++ b/environments/values.yaml
@@ -125,6 +125,9 @@ applications:
   # -- Enable the muster application
   muster: false
 
+  # -- Enable the obsforge application
+  obsforge: false
+
   # -- Enable the prompt-pub application
   prompt-pub: false
 

--- a/environments/values.yaml
+++ b/environments/values.yaml
@@ -128,6 +128,9 @@ applications:
   # -- Enable the muster application
   muster: false
 
+  # -- Enable the obsforge application
+  obsforge: false
+
   # -- Enable the obsforgetap application
   obsforgetap: false
 


### PR DESCRIPTION
This PR adds obsforge initial deployment. 
The application is  enabled on idfdev for the moment.

Dependencies:

- `prompt` butler,  available on IDF int only.
- `obsdb` PostgreSQL database at USDF. This is not ready yet, I'm waiting on access to that database to add the appropriate values to IDF int. 
- obsforge also depends on a new Gafaelfawr scope `write:obsforge` that needs to be added. 

Change summary:

- Added the Redis Helm dependency and Redis configuration, including persistent storage by default and generated Redis password.
- Added required ObsForge runtime configuration to the ConfigMap: database URL, arq mode/queue URL/queue name, enrichment retry count, Alembic config path, and worker ObsCore settings.
- Added Vault-backed secrets for PostgreSQL password, Redis password, and optional Slack webhook.
- Updated the API Deployment to use explicit secret env vars and Redis client labeling.
- Added API-specific component labels/selectors so the Service and API NetworkPolicy do not select worker pods.
- Added an optional Helm hook schema migration Job running obsforge update-schema.
- Added an obsforge-worker Deployment running arq obsforge.worker.main.WorkerSettings.
- Added worker autoscaling via HPA and a worker NetworkPolicy that denies inbound traffic.
- Updated the chart README values for the new config.
- Enable obsforge on idfdev.
- Add butler access token secret.