### PR TITLE
Add (soft)pod anti-affinity to love, envsys and simonyitel summit and BTS deployment.

### DIFF
--- a/applications/envsys/values-base.yaml
+++ b/applications/envsys/values-base.yaml
@@ -1,3 +1,16 @@
+x-pod-antiaffinity:
+  &pod-antiaffinity
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+            - key: csc-name
+              operator: Exists
+          topologyKey: kubernetes.io/hostname
+
 automatic-transfer-switch-ess309-sim:
   enabled: true
   classifier: ess309
@@ -5,6 +18,7 @@ automatic-transfer-switch-ess309-sim:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 309 --simulate
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -20,6 +34,7 @@ auxtel-ess201-sim:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 201 --simulate
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -35,6 +50,7 @@ auxtel-ess202-sim:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 202 --simulate
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -50,6 +66,7 @@ auxtel-ess308-sim:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 308 --simulate
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -65,6 +82,7 @@ auxtel-ess204-sim:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 204 --simulate
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -80,6 +98,7 @@ calibhill-ess301-sim:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 301 --simulate
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -95,6 +114,7 @@ camera-ess111-sim:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 111 --simulate
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -110,6 +130,7 @@ cleanroom-ess109-sim:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 109 --simulate
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -124,6 +145,7 @@ dimm1-sim:
     repository: ts-dockerhub.lsst.org/dimm
   env:
     RUN_ARG: 1 --simulate
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 25m
@@ -138,6 +160,7 @@ dimm2-sim:
     repository: ts-dockerhub.lsst.org/dimm
   env:
     RUN_ARG: 2 --simulate
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 26m
@@ -158,6 +181,7 @@ dream-sim:
     key: aws-access-key-id
   - name: AWS_SECRET_ACCESS_KEY
     key: aws-secret-access-key
+  <<: *pod-antiaffinity
   resources:
     limits:
       cpu: 200m
@@ -173,6 +197,7 @@ dsm1-sim:
   env:
     CSC_INDEX: 1
     RUN_ARG: --simulate 1 --state enabled
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 14m
@@ -188,6 +213,7 @@ dsm2-sim:
   env:
     CSC_INDEX: 2
     RUN_ARG: --simulate 2 --state enabled
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 10m
@@ -202,6 +228,7 @@ eas-sim:
     repository: ts-dockerhub.lsst.org/eas
   env:
     RUN_ARG: --simulate
+  <<: *pod-antiaffinity
   resources:
     limits:
       cpu: 750m
@@ -217,6 +244,7 @@ epm-ess303-sim:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 303 --simulate
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -232,6 +260,7 @@ epm-generator-ess305-sim:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 305 --simulate
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 50m
@@ -247,6 +276,7 @@ epm-generator-ess306-sim:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 306 --simulate
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 50m
@@ -261,6 +291,7 @@ hvac-sim:
     repository: ts-dockerhub.lsst.org/hvac
   env:
     RUN_ARG: --state enabled --simulate
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 160m
@@ -276,6 +307,7 @@ louver-h1-ess441-sim:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 441 --simulate
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -291,6 +323,7 @@ louver-h1h2-ess442-sim:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 442 --simulate
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -306,6 +339,7 @@ louver-h2-ess443-sim:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 443 --simulate
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -321,6 +355,7 @@ m1m3-ess113-sim:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 113 --simulate
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -336,6 +371,7 @@ m1m3-ess114-sim:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 114 --simulate
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -351,6 +387,7 @@ m1m3-ess115-sim:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 115 --simulate
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -366,6 +403,7 @@ m1m3-ess116-sim:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 116 --simulate
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -381,6 +419,7 @@ m1m3-ess117-sim:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 117 --simulate
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -396,6 +435,7 @@ m2-ess106-sim:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 106 --simulate
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -411,6 +451,7 @@ m2-ess112-sim:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 112 --simulate
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -426,6 +467,7 @@ mtdome-ess404-sim:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 404 --simulate
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -441,6 +483,7 @@ mtdome-ess405-sim:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 405 --simulate
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -456,6 +499,7 @@ partsens-ess127-sim:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 127 --simulate
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -471,6 +515,7 @@ partsens-ess128-sim:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 128 --simulate
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -486,6 +531,7 @@ partsens-ess129-sim:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 129 --simulate
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -501,6 +547,7 @@ ringss-ess304-sim:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 304 --simulate
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -516,6 +563,7 @@ tea-ess123-sim:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 123 --simulate
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -531,6 +579,7 @@ tea-ess124-sim:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 124 --simulate
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -546,6 +595,7 @@ tea-ess125-sim:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 125 --simulate
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -561,6 +611,7 @@ tea-ess126-sim:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 126 --simulate
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -576,6 +627,7 @@ tma-ess121-sim:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 121 --simulate
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -591,6 +643,7 @@ tma-ess122-sim:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 122 --simulate
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -606,6 +659,7 @@ tma-ess104-sim:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 104 --simulate
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -621,6 +675,7 @@ tma-ess105-sim:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 105 --simulate
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -636,6 +691,7 @@ tma-ess110-sim:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 110 --simulate
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -651,6 +707,7 @@ ups-server-room1-ess310-sim:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 310 --simulate
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -666,6 +723,7 @@ ups-server-room2-ess311-sim:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 311 --simulate
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -682,6 +740,7 @@ weatherforecast:
   envSecrets:
   - name: METEOBLUE_API_KEY
     key: meteoblue-api-key
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 100m

--- a/applications/envsys/values-summit.yaml
+++ b/applications/envsys/values-summit.yaml
@@ -1,3 +1,16 @@
+x-pod-antiaffinity:
+  &pod-antiaffinity
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+            - key: csc-name
+              operator: Exists
+          topologyKey: kubernetes.io/hostname
+
 automatic-transfer-switch-ess309:
   enabled: true
   classifier: ess309
@@ -6,6 +19,7 @@ automatic-transfer-switch-ess309:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 309
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -22,6 +36,7 @@ auxtel-ess201:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 201
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 32m
@@ -38,6 +53,7 @@ auxtel-ess202:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 202
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 1
@@ -54,6 +70,7 @@ auxtel-ess308:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 308
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -70,6 +87,7 @@ auxtel-ess204:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 204
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -86,6 +104,7 @@ calibhill-ess301:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 301
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 30m
@@ -102,6 +121,7 @@ camera-ess111:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 111
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -118,6 +138,7 @@ cleanroom-ess109:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 109
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -133,6 +154,7 @@ dimm1:
     repository: ts-dockerhub.lsst.org/dimm
   env:
     RUN_ARG: 1
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 50m
@@ -148,6 +170,7 @@ dimm2:
     repository: ts-dockerhub.lsst.org/dimm
   env:
     RUN_ARG: 2
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 50m
@@ -168,6 +191,7 @@ dream:
     key: aws-access-key-id
   - name: AWS_SECRET_ACCESS_KEY
     key: aws-secret-access-key
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 70m
@@ -184,6 +208,7 @@ earthquake-ess302:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 302
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 70m
@@ -197,6 +222,7 @@ eas:
   image:
     revision: 6
     repository: ts-dockerhub.lsst.org/eas
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 120m
@@ -213,6 +239,7 @@ epm-ess303:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 303
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 500m
@@ -229,6 +256,7 @@ epm-generator-ess305:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 305
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 50m
@@ -245,6 +273,7 @@ epm-generator-ess306:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 306
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 50m
@@ -260,6 +289,7 @@ hvac:
     repository: ts-dockerhub.lsst.org/hvac
   env:
     RUN_ARG: --state enabled
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 200m
@@ -276,6 +306,7 @@ louver-h1-ess441:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 441
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -292,6 +323,7 @@ louver-h1h2-ess442:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 442
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -308,6 +340,7 @@ louver-h2-ess443:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 443
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -324,6 +357,7 @@ m1m3-ess113:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 113
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -340,6 +374,7 @@ m1m3-ess114:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 114
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -356,6 +391,7 @@ m1m3-ess115:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 115
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -372,6 +408,7 @@ m1m3-ess116:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 116
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -388,6 +425,7 @@ m1m3-ess117:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 117
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -404,6 +442,7 @@ m2-ess106:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 106
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -420,6 +459,7 @@ m2-ess112:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 112
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -436,6 +476,7 @@ mtdome-ess404:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 404
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 1
@@ -452,6 +493,7 @@ mtdome-ess405:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 405
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -468,6 +510,7 @@ partsens-ess127:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 127
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -484,6 +527,7 @@ partsens-ess128:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 128
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -500,6 +544,7 @@ partsens-ess129:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 129
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -520,6 +565,7 @@ ringss-ess304:
   envSecrets:
   - name: RINGSS_PASSWORD
     key: soar-ringss-db-password
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -536,6 +582,7 @@ tea-ess123:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 123
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -552,6 +599,7 @@ tea-ess124:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 124
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -568,6 +616,7 @@ tea-ess125:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 125
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -584,6 +633,7 @@ tea-ess126:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 126
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -600,6 +650,7 @@ tma-ess121:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 121
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -616,6 +667,7 @@ tma-ess122:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 122
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -632,6 +684,7 @@ tma-ess104:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 104
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 1
@@ -648,6 +701,7 @@ tma-ess105:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 105
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -664,6 +718,7 @@ tma-ess110:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 110
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -680,6 +735,7 @@ ups-server-room1-ess310:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 310
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -696,6 +752,7 @@ ups-server-room2-ess311:
     repository: ts-dockerhub.lsst.org/ess
   env:
     RUN_ARG: 311
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 19m
@@ -713,6 +770,7 @@ weatherforecast:
   envSecrets:
   - name: METEOBLUE_API_KEY
     key: meteoblue-api-key
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 100m

--- a/applications/love/values-base.yaml
+++ b/applications/love/values-base.yaml
@@ -1,3 +1,16 @@
+x-pod-antiaffinity:
+  &pod-antiaffinity
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+            - key: pod-template-hash
+              operator: Exists
+          topologyKey: kubernetes.io/hostname
+
 love-commander:
   image:
     repository: ts-dockerhub.lsst.org/love-commander
@@ -58,6 +71,7 @@ x-manager-producer:
     AUTH_LDAP_BIND_PASSWORD: auth-ldap-bind-password
     DB_PASS: db-pass
     REDIS_PASS: redis-pass
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 150m
@@ -209,6 +223,7 @@ love-nginx:
     storageClass: rook-ceph-block
     accessMode: ReadWriteOnce
     claimSize: 2Gi
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 50m
@@ -404,6 +419,7 @@ love-nginx:
 
 x-love-producer-envsys-resources:
   &love-producer-envsys-resources
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 50m
@@ -414,6 +430,7 @@ x-love-producer-envsys-resources:
 
 x-love-producer-scripqueue-resources:
   &love-producer-scripqueue-resources
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 50m
@@ -424,6 +441,7 @@ x-love-producer-scripqueue-resources:
 
 x-love-producer-vms-resources:
   &love-producer-vms-resources
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 50m
@@ -436,6 +454,7 @@ love-producer:
   image:
     repository: ts-dockerhub.lsst.org/love-producer
     pullPolicy: Always
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 15m

--- a/applications/love/values-summit.yaml
+++ b/applications/love/values-summit.yaml
@@ -1,3 +1,16 @@
+x-pod-antiaffinity:
+  &pod-antiaffinity
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+            - key: pod-template-hash
+              operator: Exists
+          topologyKey: kubernetes.io/hostname
+
 audio-broadcaster:
   image:
     repository: ts-dockerhub.lsst.org/audio_broadcaster
@@ -25,6 +38,7 @@ audio-broadcaster:
   - name: tma1
     host: tma-rpi-audio01.cp.lsst.org
     port: 4444
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 5m
@@ -94,6 +108,7 @@ x-manager-producer:
     AUTH_LDAP_BIND_PASSWORD: auth-ldap-bind-password
     DB_PASS: db-pass
     REDIS_PASS: redis-pass
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 150m
@@ -251,6 +266,7 @@ love-nginx:
     storageClass: rook-ceph-block
     accessMode: ReadWriteOnce
     claimSize: 2Gi
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 120m
@@ -457,6 +473,7 @@ love-nginx:
 
 x-love-producer-envsys-resources:
   &love-producer-envsys-resources
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 70m
@@ -467,6 +484,7 @@ x-love-producer-envsys-resources:
 
 x-love-producer-scripqueue-resources:
   &love-producer-scripqueue-resources
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 200m
@@ -477,6 +495,7 @@ x-love-producer-scripqueue-resources:
 
 x-love-producer-vms-resources:
   &love-producer-vms-resources
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 50m
@@ -490,6 +509,7 @@ love-producer:
     revision: 3
     repository: ts-dockerhub.lsst.org/love-producer
     pullPolicy: Always
+  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 10m

--- a/applications/simonyitel/values-base.yaml
+++ b/applications/simonyitel/values-base.yaml
@@ -1,3 +1,16 @@
+x-pod-antiaffinity:
+  &pod-antiaffinity
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+            - key: csc-name
+              operator: Exists
+          topologyKey: kubernetes.io/hostname
+
 x-butler-secret:
   &butler-secret
   butlerSecret:
@@ -15,6 +28,7 @@ lasertracker1-sim:
     repository: ts-dockerhub.lsst.org/lasertracker
   env:
     RUN_ARG: 1 --simulate 2
+  <<: *pod-antiaffinity
   resources:
     limits:
       cpu: 200m
@@ -29,6 +43,7 @@ mtaircompressor1-sim:
     repository: ts-dockerhub.lsst.org/mtaircompressor
   env:
     RUN_ARG: 1 --simulate --state disabled
+  <<: *pod-antiaffinity
   resources:
     limits:
       cpu: 100m
@@ -43,6 +58,7 @@ mtaircompressor2-sim:
     repository: ts-dockerhub.lsst.org/mtaircompressor
   env:
     RUN_ARG: 2 --simulate --state disabled
+  <<: *pod-antiaffinity
   resources:
     limits:
       cpu: 100m
@@ -78,6 +94,7 @@ mtaos:
     readOnly: true
     server: nfs-obsenv.ls.lsst.org
     serverPath: /obs-env
+  <<: *pod-antiaffinity
   resources:
     limits:
       cpu: 1000m
@@ -93,6 +110,7 @@ mtcamhexapod-sim:
     repository: ts-dockerhub.lsst.org/mthexapod
   env:
     RUN_ARG: --simulate 1
+  <<: *pod-antiaffinity
   resources:
     limits:
       cpu: 500m
@@ -107,6 +125,7 @@ mtdome-sim:
     repository: ts-dockerhub.lsst.org/mtdome
   env:
     RUN_ARG: --simulate 1
+  <<: *pod-antiaffinity
   resources:
     limits:
       cpu: 1
@@ -118,6 +137,7 @@ mtdome-sim:
 mtdometrajectory:
   image:
     repository: ts-dockerhub.lsst.org/mtdometrajectory
+  <<: *pod-antiaffinity
   resources:
     limits:
       cpu: 250m
@@ -140,6 +160,7 @@ mtheaderservice:
     key: aws-access-key-id
   - name: AWS_SECRET_ACCESS_KEY
     key: aws-secret-access-key
+  <<: *pod-antiaffinity
   resources:
     limits:
       cpu: 2000m
@@ -170,6 +191,7 @@ mtheaderservice-sim:
     readOnly: false
     server: nfs-project.ls.lsst.org
     serverPath: /project
+  <<: *pod-antiaffinity
   resources:
     limits:
       cpu: 2000m
@@ -187,6 +209,7 @@ mtm1m3-sim:
     LSST_KAFKA_CMDEVT_FLUSH_MS: 0
     LSST_KAFKA_MAX_QUEUE_MSG: 200
     LSST_KAFKA_MAX_QUEUE_MS: 100
+  <<: *pod-antiaffinity
   resources:
     limits:
       cpu: 1
@@ -199,6 +222,7 @@ mtm1m3ts-sim:
   enabled: true
   image:
     repository: ts-dockerhub.lsst.org/mtm1m3ts_sim
+  <<: *pod-antiaffinity
   resources:
     limits:
       cpu: 400m
@@ -214,6 +238,7 @@ mtm2hexapod-sim:
     repository: ts-dockerhub.lsst.org/mthexapod
   env:
     RUN_ARG: --simulate 2
+  <<: *pod-antiaffinity
   resources:
     limits:
       cpu: 400m
@@ -228,6 +253,7 @@ mtm2-hwsim:
     repository: ts-dockerhub.lsst.org/m2
   env:
     RUN_ARG: --host m2-crio-simulator.ls.lsst.org
+  <<: *pod-antiaffinity
   resources:
     limits:
       cpu: 850m
@@ -242,6 +268,7 @@ mtmount-sim:
     repository: ts-dockerhub.lsst.org/mtmount
   env:
     RUN_ARG: --simulate
+  <<: *pod-antiaffinity
   resources:
     limits:
       cpu: 500m
@@ -263,6 +290,7 @@ mtoods:
   - lfa-credentials.ini
   - oods-lsstcam-credentials.ini
   <<: *butler-secret
+  <<: *pod-antiaffinity
   resources:
     limits:
       cpu: 1
@@ -335,6 +363,7 @@ wfoods:
   - lfa-credentials.ini
   - oods-lsstcam-credentials.ini
   <<: *butler-secret
+  <<: *pod-antiaffinity
   resources:
     limits:
       cpu: 1
@@ -396,6 +425,7 @@ mtptg:
     TELESCOPE: MT
     LSST_KAFKA_TLM_FLUSH_MS: 0
     LSST_KAFKA_CMDEVT_FLUSH_MS: 0
+  <<: *pod-antiaffinity
   resources:
     limits:
       cpu: 1200m
@@ -410,6 +440,7 @@ mtrotator-sim:
     repository: ts-dockerhub.lsst.org/mtrotator
   env:
     RUN_ARG: --simulate
+  <<: *pod-antiaffinity
   resources:
     limits:
       cpu: 400m
@@ -424,6 +455,7 @@ mtvms-camera-rotator-sim:
     repository: ts-dockerhub.lsst.org/vms_sim
   env:
     RUN_ARG: CameraRotator
+  <<: *pod-antiaffinity
   resources:
     limits:
       cpu: 250m
@@ -438,6 +470,7 @@ mtvms-m1m3-sim:
     repository: ts-dockerhub.lsst.org/vms_sim
   env:
     RUN_ARG: M1M3
+  <<: *pod-antiaffinity
   resources:
     limits:
       cpu: 250m
@@ -452,6 +485,7 @@ mtvms-m2-sim:
     repository: ts-dockerhub.lsst.org/vms_sim
   env:
     RUN_ARG: M2
+  <<: *pod-antiaffinity
   resources:
     limits:
       cpu: 250m

--- a/applications/simonyitel/values-summit.yaml
+++ b/applications/simonyitel/values-summit.yaml
@@ -1,3 +1,16 @@
+x-pod-antiaffinity:
+  &pod-antiaffinity
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+            - key: csc-name
+              operator: Exists
+          topologyKey: kubernetes.io/hostname
+
 x-butler-secret:
   &butler-secret
   butlerSecret:
@@ -23,6 +36,7 @@ ccheaderservice:
     key: aws-access-key-id
   - name: AWS_SECRET_ACCESS_KEY
     key: aws-secret-access-key
+  <<: *pod-antiaffinity
   resources:
     limits:
       cpu: 1000m
@@ -52,6 +66,7 @@ ccheaderservice-sim:
     readOnly: true
     server: nfs-scratch.cp.lsst.org
     serverPath: /scratch/header_service
+  <<: *pod-antiaffinity
   resources:
     limits:
       cpu: 1000m
@@ -74,6 +89,7 @@ ccoods:
   - lfa-credentials.ini
   - oods-lsstcam-credentials.ini
   <<: *butler-secret
+  <<: *pod-antiaffinity
   resources:
     limits:
       cpu: 100m
@@ -137,6 +153,7 @@ gcheaderservice101:
     key: aws-access-key-id
   - name: AWS_SECRET_ACCESS_KEY
     key: aws-secret-access-key
+  <<: *pod-antiaffinity
   resources:
     limits:
       cpu: 2000m
@@ -159,6 +176,7 @@ gcheaderservice102:
     key: aws-access-key-id
   - name: AWS_SECRET_ACCESS_KEY
     key: aws-secret-access-key
+  <<: *pod-antiaffinity
   resources:
     limits:
       cpu: 2000m
@@ -181,6 +199,7 @@ gcheaderservice103:
     key: aws-access-key-id
   - name: AWS_SECRET_ACCESS_KEY
     key: aws-secret-access-key
+  <<: *pod-antiaffinity
   resources:
     limits:
       cpu: 2000m
@@ -196,6 +215,7 @@ lasertracker1:
     repository: ts-dockerhub.lsst.org/lasertracker
   env:
     RUN_ARG: 1
+  <<: *pod-antiaffinity
   resources:
     limits:
       cpu: 300m
@@ -211,6 +231,7 @@ mtaircompressor1:
     repository: ts-dockerhub.lsst.org/mtaircompressor
   env:
     RUN_ARG: 1 --state disabled
+  <<: *pod-antiaffinity
   resources:
     limits:
       cpu: 100m
@@ -226,6 +247,7 @@ mtaircompressor2:
     repository: ts-dockerhub.lsst.org/mtaircompressor
   env:
     RUN_ARG: 2 --state disabled
+  <<: *pod-antiaffinity
   resources:
     limits:
       cpu: 100m
@@ -271,6 +293,7 @@ mtaos:
     readOnly: true
     server: nfs-obs-env.cp.lsst.org
     serverPath: /obs-env
+  <<: *pod-antiaffinity
   resources:
     limits:
       cpu: 12000m
@@ -293,6 +316,7 @@ mtcamhexapod:
     readOnly: true
     server: nfs-obs-env.cp.lsst.org
     serverPath: /obs-env
+  <<: *pod-antiaffinity
   resources:
     limits:
       cpu: 500m
@@ -309,6 +333,7 @@ mtcamhexapod-sim:
     repository: ts-dockerhub.lsst.org/mthexapod
   env:
     RUN_ARG: --simulate 1
+  <<: *pod-antiaffinity
   resources:
     limits:
       cpu: 500m
@@ -322,6 +347,7 @@ mtdome:
   image:
     revision: 0
     repository: ts-dockerhub.lsst.org/mtdome
+  <<: *pod-antiaffinity
   resources:
     limits:
       cpu: 900m
@@ -337,6 +363,7 @@ mtdome-sim:
     repository: ts-dockerhub.lsst.org/mtdome
   env:
     RUN_ARG: --simulate 1
+  <<: *pod-antiaffinity
   resources:
     limits:
       cpu: 900m
@@ -349,6 +376,7 @@ mtdometrajectory:
   image:
     revision: 0
     repository: ts-dockerhub.lsst.org/mtdometrajectory
+  <<: *pod-antiaffinity
   resources:
     limits:
       cpu: 250m
@@ -371,6 +399,7 @@ mtheaderservice:
     key: aws-access-key-id
   - name: AWS_SECRET_ACCESS_KEY
     key: aws-secret-access-key
+  <<: *pod-antiaffinity
   resources:
     limits:
       cpu: 2000m
@@ -387,6 +416,7 @@ mtm1m3-sim:
   env:
     LSST_KAFKA_TLM_FLUSH_MS: 0
     LSST_KAFKA_CMDEVT_FLUSH_MS: 0
+  <<: *pod-antiaffinity
   resources:
     limits:
       cpu: 1000m
@@ -399,6 +429,7 @@ mtm2:
   image:
     revision: 0
     repository: ts-dockerhub.lsst.org/m2
+  <<: *pod-antiaffinity
   resources:
     limits:
       cpu: 850m
@@ -414,6 +445,7 @@ mtm2-sim:
     repository: ts-dockerhub.lsst.org/m2
   env:
     RUN_ARG: --simulate
+  <<: *pod-antiaffinity
   resources:
     limits:
       cpu: 850m
@@ -436,6 +468,7 @@ mtm2hexapod:
     readOnly: true
     server: nfs-obs-env.cp.lsst.org
     serverPath: /obs-env
+  <<: *pod-antiaffinity
   resources:
     limits:
       cpu: 400m
@@ -452,6 +485,7 @@ mtm2hexapod-sim:
     repository: ts-dockerhub.lsst.org/mthexapod
   env:
     RUN_ARG: --simulate 2
+  <<: *pod-antiaffinity
   resources:
     limits:
       cpu: 400m
@@ -465,6 +499,7 @@ mtmount:
   image:
     revision: 6
     repository: ts-dockerhub.lsst.org/mtmount
+  <<: *pod-antiaffinity
   resources:
     limits:
       cpu: 2
@@ -480,6 +515,7 @@ mtmount-ccw-only:
     repository: ts-dockerhub.lsst.org/mtmount
   env:
     CCW_ONLY: yes
+  <<: *pod-antiaffinity
   resources:
     limits:
       cpu: 2
@@ -495,6 +531,7 @@ mtmount-sim:
     repository: ts-dockerhub.lsst.org/mtmount
   env:
     RUN_ARG: --simulate
+  <<: *pod-antiaffinity
   resources:
     limits:
       cpu: 500m
@@ -517,6 +554,7 @@ mtoods:
   - lfa-credentials.ini
   - oods-lsstcam-credentials.ini
   <<: *butler-secret
+  <<: *pod-antiaffinity
   resources:
     limits:
       cpu: 1500m
@@ -579,6 +617,7 @@ mtptg:
     TELESCOPE: MT
     LSST_KAFKA_TLM_FLUSH_MS: 0
     LSST_KAFKA_CMDEVT_FLUSH_MS: 0
+  <<: *pod-antiaffinity
   resources:
     limits:
       cpu: 1200m
@@ -591,6 +630,7 @@ mtrotator:
   image:
     revision: 1
     repository: ts-dockerhub.lsst.org/mtrotator
+  <<: *pod-antiaffinity
   resources:
     limits:
       cpu: 1
@@ -606,6 +646,7 @@ mtrotator-sim:
     repository: ts-dockerhub.lsst.org/mtrotator
   env:
     RUN_ARG: --simulate
+  <<: *pod-antiaffinity
   resources:
     limits:
       cpu: 400m
@@ -628,6 +669,7 @@ wfoods:
   - lfa-credentials.ini
   - oods-lsstcam-credentials.ini
   <<: *butler-secret
+  <<: *pod-antiaffinity
   resources:
     limits:
       cpu: 500m


### PR DESCRIPTION
These updates aim to improve the Kubernetes scheduling of these systems pods and try to prevent them from landing all on the same node as we were experiencing at the summit and BTS.