### PR TITLE
DM-55384: Update times-square to 0.24.1

### DIFF
--- a/applications/times-square/Chart.yaml
+++ b/applications/times-square/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 type: application
 
 # The default version tag of the times-square docker image
-appVersion: "0.24.0"
+appVersion: "0.24.1"
 
 dependencies:
   - name: redis


### PR DESCRIPTION
## Summary

- Bumps the times-square appVersion from 0.24.0 to 0.24.1.
- This release fixes duplicate directory nodes in the GitHub pages contents tree when multiple pages share a multi-segment directory prefix (e.g. `sst/mtm1m3`), and includes the tox-to-nox development tooling migration and the `Factory` service-construction refactor.

## Validation steps

- [ ] After sync, confirm the times-square pods are running the 0.24.1 image and pass health checks.
- [ ] Request the `GET /times-square/v1/github` tree on an environment with nested GitHub-backed pages and confirm each directory appears exactly once.

## References

- Release: https://github.com/lsst-sqre/times-square/releases/tag/0.24.1
- Changelog: https://github.com/lsst-sqre/times-square/blob/main/CHANGELOG.md
- Times Square PR: lsst-sqre/times-square#142
- Jira: https://rubinobs.atlassian.net/browse/DM-55384

https://claude.ai/code/session_0125rf2HHX423MM9CMQnWPzF