### PR TITLE
DM-55386: Deploy ook 0.23.0 with the linkcheck service

### DIFF
--- a/applications/gafaelfawr/values-roundtable-dev.yaml
+++ b/applications/gafaelfawr/values-roundtable-dev.yaml
@@ -36,6 +36,8 @@ config:
       Can read and write to the Turborepo remote cache
     "exec:docverse": >-
       Can access Docverse's as a user in an organization
+    "exec:linkcheck": >-
+      Can submit link-check requests to Ook
 
   groupMapping:
     "admin:userinfo":
@@ -61,6 +63,10 @@ config:
           organization: "lsst-sqre"
           team: "friends"
     "exec:internal-tools":
+      - github:
+          organization: "lsst-sqre"
+          team: "square"
+    "exec:linkcheck":
       - github:
           organization: "lsst-sqre"
           team: "square"

--- a/applications/gafaelfawr/values-roundtable-prod.yaml
+++ b/applications/gafaelfawr/values-roundtable-prod.yaml
@@ -36,6 +36,8 @@ config:
       Can read and write to the Turborepo remote cache
     "exec:docverse": >-
       Can access Docverse's as a user in an organization
+    "exec:linkcheck": >-
+      Can submit link-check requests to Ook
 
   groupMapping:
     "admin:userinfo":
@@ -64,6 +66,10 @@ config:
           organization: "lsst-sqre"
           team: "friends"
     "exec:internal-tools":
+      - github:
+          organization: "lsst-sqre"
+          team: "square"
+    "exec:linkcheck":
       - github:
           organization: "lsst-sqre"
           team: "square"

--- a/applications/ook/Chart.yaml
+++ b/applications/ook/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: ook
 version: 1.0.0
-appVersion: "tickets-DM-55386"
+appVersion: "tickets-DM-55393"
 description: >
   Ook is the librarian service for Rubin Observatory. Ook indexes
   documentation content into the Algolia search engine that powers the Rubin

--- a/applications/ook/Chart.yaml
+++ b/applications/ook/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: ook
 version: 1.0.0
-appVersion: "tickets-DM-55393"
+appVersion: "0.23.0"
 description: >
   Ook is the librarian service for Rubin Observatory. Ook indexes
   documentation content into the Algolia search engine that powers the Rubin

--- a/applications/ook/Chart.yaml
+++ b/applications/ook/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: ook
 version: 1.0.0
-appVersion: "0.22.0"
+appVersion: "tickets-DM-55386"
 description: >
   Ook is the librarian service for Rubin Observatory. Ook indexes
   documentation content into the Algolia search engine that powers the Rubin

--- a/applications/ook/README.md
+++ b/applications/ook/README.md
@@ -31,9 +31,19 @@ Ook is the librarian service for Rubin Observatory. Ook indexes documentation co
 | cloudsql.serviceAccount | string | `""` | The Google service account that has an IAM binding to the `ook` Kubernetes service accounts and has the `cloudsql.client` role |
 | config.algolia.documents_index | string | `"documents_dev"` | Name of the Algolia index for documents |
 | config.databaseUrl | string | `""` | Database URL |
+| config.linkcheck.brokenMinAttempts | int | `3` | Minimum number of consecutive failed attempts before a previously-OK link is declared broken instead of failing |
+| config.linkcheck.brokenThreshold | string | `"48h"` | Minimum span of consecutive failures before a previously-OK link is declared broken instead of failing |
+| config.linkcheck.checkRetention | string | `"30d"` | Age beyond which link-check submission records are purged by the scheduled linkcheck-recheck maintenance command |
+| config.linkcheck.freshnessTtl | string | `"24h"` | Age below which a URL's stored check result is considered fresh and is not rechecked on submission |
+| config.linkcheck.hostInterval | string | `"1s"` | Minimum politeness interval between link-check requests to the same host |
+| config.linkcheck.maxConcurrency | int | `10` | Maximum number of concurrent link-check HTTP requests across all hosts |
+| config.linkcheck.maxUrlsPerCheck | int | `1000` | Maximum number of unique canonical URLs accepted in a single link-check submission |
+| config.linkcheck.recheckIntervals | list | `["1h","4h","24h","48h"]` | Delays until the next recheck of a failing link, indexed by the number of consecutive failures so far |
+| config.linkcheck.requestTimeout | string | `"30s"` | Total timeout applied to each link-check HTTP request |
 | config.logLevel | string | `"INFO"` | Logging level: "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL" |
 | config.migrateCountryCodes | bool | false to disable country code migration | Whether to migrate country codes in the database |
 | config.topics.ingest | string | `"lsst.square-events.ook.ingest"` | Kafka topic name for ingest events |
+| config.topics.linkcheck | string | `"lsst.square-events.ook.linkcheck"` | Kafka topic name for link-check execution requests |
 | config.updateSchema | bool | false to disable schema upgrades | Whether to run the database migration job |
 | fullnameOverride | string | `""` | Override the full name for resources (includes the release name) |
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |
@@ -62,6 +72,14 @@ Ook is the librarian service for Rubin Observatory. Ook indexes documentation co
 | ingestUpdated.window | string | `"2d"` | Time window to look for updated documents (e.g. 1h, 2d, 3w). This must be set to a value greater than the cron schedule for the ingest-updated job. |
 | ingress.annotations | object | `{}` | Additional annotations to add to the ingress |
 | ingress.path | string | `"/ook"` | Path prefix where Squarebot is hosted |
+| linkcheckRecheck.affinity | object | `{}` | Affinity rules for Ook linkcheck-recheck pods |
+| linkcheckRecheck.enabled | bool | `false` | Enable the linkcheck-recheck job |
+| linkcheckRecheck.nodeSelector | object | `{}` | Node selection rules for Ook linkcheck-recheck pods |
+| linkcheckRecheck.podAnnotations | object | `{}` | Annotations for Ook linkcheck-recheck pods |
+| linkcheckRecheck.resources | object | `{}` | Resource limits and requests for Ook linkcheck-recheck pods |
+| linkcheckRecheck.schedule | string | `"45 4 * * *"` | Cron schedule string for the ook linkcheck-recheck job (UTC) |
+| linkcheckRecheck.tolerations | list | `[]` | Tolerations for Ook linkcheck-recheck pods |
+| linkcheckRecheck.ttlSecondsAfterFinished | int | `86400` | Time (second) to keep a finished job before cleaning up |
 | nameOverride | string | `""` | Override the base name for resources |
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` | Annotations for API and worker pods |

--- a/applications/ook/templates/configmap.yaml
+++ b/applications/ook/templates/configmap.yaml
@@ -10,4 +10,14 @@ data:
   SAFIR_PROFILE: "production"
   OOK_DATABASE_URL: {{ required "config.databaseUrl must be set" .Values.config.databaseUrl | quote }}
   OOK_INGEST_KAFKA_TOPIC: {{ .Values.config.topics.ingest | quote }}
+  OOK_LINKCHECK_KAFKA_TOPIC: {{ .Values.config.topics.linkcheck | quote }}
+  OOK_LINKCHECK_REQUEST_TIMEOUT: {{ .Values.config.linkcheck.requestTimeout | quote }}
+  OOK_LINKCHECK_MAX_CONCURRENCY: {{ .Values.config.linkcheck.maxConcurrency | quote }}
+  OOK_LINKCHECK_HOST_INTERVAL: {{ .Values.config.linkcheck.hostInterval | quote }}
+  OOK_LINKCHECK_FRESHNESS_TTL: {{ .Values.config.linkcheck.freshnessTtl | quote }}
+  OOK_LINKCHECK_MAX_URLS_PER_CHECK: {{ .Values.config.linkcheck.maxUrlsPerCheck | quote }}
+  OOK_LINKCHECK_BROKEN_THRESHOLD: {{ .Values.config.linkcheck.brokenThreshold | quote }}
+  OOK_LINKCHECK_BROKEN_MIN_ATTEMPTS: {{ .Values.config.linkcheck.brokenMinAttempts | quote }}
+  OOK_LINKCHECK_RECHECK_INTERVALS: {{ .Values.config.linkcheck.recheckIntervals | toJson | quote }}
+  OOK_LINKCHECK_CHECK_RETENTION: {{ .Values.config.linkcheck.checkRetention | quote }}
   ALGOLIA_DOCUMENT_INDEX: {{ .Values.config.algolia.documentIndex | quote }}

--- a/applications/ook/templates/cronjob-linkcheck-recheck.yaml
+++ b/applications/ook/templates/cronjob-linkcheck-recheck.yaml
@@ -1,0 +1,83 @@
+{{- if .Values.linkcheckRecheck.enabled -}}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: "ook-linkcheck-recheck"
+  labels:
+    {{- include "ook.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "linkcheck-recheck"
+    app.kubernetes.io/part-of: "ook"
+spec:
+  schedule: {{ .Values.linkcheckRecheck.schedule | quote }}
+  concurrencyPolicy: "Forbid"
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      ttlSecondsAfterFinished: {{ .Values.linkcheckRecheck.ttlSecondsAfterFinished }}
+      template:
+        metadata:
+          {{- with .Values.linkcheckRecheck.podAnnotations }}
+          annotations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          labels:
+            {{- include "ook.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: "linkcheck-recheck"
+            app.kubernetes.io/part-of: "ook"
+        spec:
+          restartPolicy: "Never"
+          {{- if or .Values.cloudsql.enabled }}
+          serviceAccountName: "ook"
+          {{- else }}
+          automountServiceAccountToken: false
+          {{- end }}
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+          containers:
+            - name: {{ .Chart.Name }}
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              command:
+                - "ook"
+                - "linkcheck-recheck"
+              resources:
+                {{- toYaml .Values.resources | nindent 16 }}
+              envFrom:
+                - configMapRef:
+                    name: "ook"
+              env:
+                {{- include "ook.envVars" (dict "Chart" .Chart "Release" .Release "Values" .Values) | nindent 16 }}
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - "all"
+                readOnlyRootFilesystem: true
+              volumeMounts:
+                {{- include "ook.volumeMounts" (dict "Chart" .Chart "Release" .Release "Values" .Values) | nindent 16 }}
+          {{- if .Values.cloudsql.enabled }}
+          initContainers:
+            {{- include "ook.cloudsqlSidecar" . | nindent 12 }}
+          {{- end }}
+          {{with .Values.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumes:
+            {{- include "ook.volumes" (dict "Chart" .Chart "Release" .Release "Values" .Values) | nindent 12 }}
+{{- end }}

--- a/applications/ook/templates/ingress.yaml
+++ b/applications/ook/templates/ingress.yaml
@@ -1,5 +1,8 @@
 ---
-# Ook endpoints default to anonymous scope
+# Ook endpoints default to anonymous scope. This includes the OpenAPI spec
+# at /ook/openapi.json, which must stay unauthenticated so that API clients
+# can read it (only the Swagger browser at /ook/docs requires a login, via
+# the ook-apibrowser ingress below).
 apiVersion: gafaelfawr.lsst.io/v1alpha1
 kind: GafaelfawrIngress
 metadata:
@@ -103,6 +106,45 @@ template:
         http:
           paths:
             - path: "{{ .Values.ingress.path }}/ingest"
+              pathType: "Prefix"
+              backend:
+                service:
+                  name: "ook"
+                  port:
+                    number: {{ .Values.service.port }}
+
+---
+# The link-check submit-and-poll API requires the exec:linkcheck scope
+# (delegated to documentation CI via OOK_TOKEN). This covers POST
+# /ook/linkcheck/checks and GET /ook/linkcheck/checks/{id}; the submitting
+# client polls its own check with the same token. The other linkcheck read
+# endpoints (/ook/linkcheck/urls and /ook/linkcheck/projects/...) remain
+# anonymous via the catch-all ook ingress.
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
+metadata:
+  name: "ook-linkcheck"
+  labels:
+    {{- include "ook.labels" . | nindent 4 }}
+config:
+  loginRedirect: false
+  scopes:
+    all:
+      - "exec:linkcheck"
+  service: "ook"
+template:
+  metadata:
+    name: "ook-linkcheck"
+    {{- with .Values.ingress.annotations }}
+    annotations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  spec:
+    rules:
+      - host: {{ required "global.host must be set" .Values.global.host | quote }}
+        http:
+          paths:
+            - path: "{{ .Values.ingress.path }}/linkcheck/checks"
               pathType: "Prefix"
               backend:
                 service:

--- a/applications/ook/values-roundtable-dev.yaml
+++ b/applications/ook/values-roundtable-dev.yaml
@@ -17,6 +17,10 @@ audit:
 ingestUpdated:
   enabled: false
 
+linkcheckRecheck:
+  enabled: true
+  schedule: "45 4 * * *"
+
 ingestLsstTexmf:
   enabled: true
 

--- a/applications/ook/values-roundtable-prod.yaml
+++ b/applications/ook/values-roundtable-prod.yaml
@@ -12,6 +12,9 @@ ingestUpdated:
   enabled: true
   window: "2d"
   schedule: "30 3 * * *"
+linkcheckRecheck:
+  enabled: true
+  schedule: "45 4 * * *"
 ingestLsstTexmf:
   enabled: true
 

--- a/applications/ook/values.yaml
+++ b/applications/ook/values.yaml
@@ -88,9 +88,52 @@ config:
     # -- Kafka topic name for ingest events
     ingest: "lsst.square-events.ook.ingest"
 
+    # -- Kafka topic name for link-check execution requests
+    linkcheck: "lsst.square-events.ook.linkcheck"
+
   algolia:
     # -- Name of the Algolia index for documents
     documents_index: "documents_dev"
+
+  linkcheck:
+    # -- Total timeout applied to each link-check HTTP request
+    requestTimeout: "30s"
+
+    # -- Maximum number of concurrent link-check HTTP requests across all
+    # hosts
+    maxConcurrency: 10
+
+    # -- Minimum politeness interval between link-check requests to the same
+    # host
+    hostInterval: "1s"
+
+    # -- Age below which a URL's stored check result is considered fresh and
+    # is not rechecked on submission
+    freshnessTtl: "24h"
+
+    # -- Maximum number of unique canonical URLs accepted in a single
+    # link-check submission
+    maxUrlsPerCheck: 1000
+
+    # -- Minimum span of consecutive failures before a previously-OK link is
+    # declared broken instead of failing
+    brokenThreshold: "48h"
+
+    # -- Minimum number of consecutive failed attempts before a previously-OK
+    # link is declared broken instead of failing
+    brokenMinAttempts: 3
+
+    # -- Delays until the next recheck of a failing link, indexed by the
+    # number of consecutive failures so far
+    recheckIntervals:
+      - "1h"
+      - "4h"
+      - "24h"
+      - "48h"
+
+    # -- Age beyond which link-check submission records are purged by the
+    # scheduled linkcheck-recheck maintenance command
+    checkRetention: "30d"
 
 audit:
   # -- Enable the audit job
@@ -147,6 +190,31 @@ ingestUpdated:
   tolerations: []
 
   # -- Affinity rules for Ook audit pods
+  affinity: {}
+
+linkcheckRecheck:
+  # -- Enable the linkcheck-recheck job
+  enabled: false
+
+  # -- Cron schedule string for the ook linkcheck-recheck job (UTC)
+  schedule: "45 4 * * *"
+
+  # -- Time (second) to keep a finished job before cleaning up
+  ttlSecondsAfterFinished: 86400
+
+  # -- Resource limits and requests for Ook linkcheck-recheck pods
+  resources: {}
+
+  # -- Annotations for Ook linkcheck-recheck pods
+  podAnnotations: {}
+
+  # -- Node selection rules for Ook linkcheck-recheck pods
+  nodeSelector: {}
+
+  # -- Tolerations for Ook linkcheck-recheck pods
+  tolerations: []
+
+  # -- Affinity rules for Ook linkcheck-recheck pods
   affinity: {}
 
 ingestLsstTexmf:

--- a/applications/sasquatch/charts/square-events/templates/ook-topics.yaml
+++ b/applications/sasquatch/charts/square-events/templates/ook-topics.yaml
@@ -11,3 +11,16 @@ spec:
   config:
     # http://kafka.apache.org/documentation/#topicconfigs
     retention.ms: 604800000  # 1 week
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: "lsst.square-events.ook.linkcheck"
+  labels:
+    strimzi.io/cluster: {{ .Values.cluster.name }}
+spec:
+  partitions: 4
+  replicas: 3
+  config:
+    # http://kafka.apache.org/documentation/#topicconfigs
+    retention.ms: 604800000  # 1 week

--- a/applications/sasquatch/charts/square-events/templates/ook-user.yaml
+++ b/applications/sasquatch/charts/square-events/templates/ook-user.yaml
@@ -29,6 +29,15 @@ spec:
         host: "*"
       - resource:
           type: topic
+          name: "lsst.square-events.ook.linkcheck"
+          patternType: literal
+        operations:
+          - "Describe"
+          - "Read"
+          - "Write"
+        host: "*"
+      - resource:
+          type: topic
           name: "lsst.square-events.squarebot.slack.app.mention"
           patternType: literal
         type: allow


### PR DESCRIPTION
## Summary

- Deploys the **ook 0.23.0 release** ([release notes](https://github.com/lsst-sqre/ook/releases/tag/0.23.0)) by setting the chart appVersion. The release carries both features this branch was staged for: link-check-as-a-service (DM-55386, lsst-sqre/ook#263) and the bibliography hardening with time-ordered resource IDs (DM-55393, lsst-sqre/ook#283). The branch was originally validated on roundtable-dev with branch-deployment images (`tickets-DM-55386`, then `tickets-DM-55393`); the appVersion now pins the released tag.
- Adds `config.linkcheck` chart values (timeouts, concurrency, politeness, freshness TTL, URL cap, retry-ladder thresholds, check retention) wired into the ook ConfigMap as `OOK_LINKCHECK_*` env vars, plus the `ook-linkcheck-recheck` daily maintenance CronJob (mirroring `ingest-updated`), enabled on roundtable-dev and roundtable-prod.
- Provisions the `lsst.square-events.ook.linkcheck` Kafka topic and ook user ACL in sasquatch square-events; adds the new `exec:linkcheck` Gafaelfawr scope (with square-team group mapping) on both roundtable environments and an `ook-linkcheck` GafaelfawrIngress protecting `/ook/linkcheck/checks`; documents that `/ook/openapi.json` stays anonymous via the catch-all ook ingress.

> [!IMPORTANT]
> Ook 0.23.0's pre-deployment `updateSchema` job runs a one-time data migration (`cf936213314d`) that **re-mints every resource ID** in creation order — resource IDs and URLs issued by earlier ook releases are invalid after the sync (deliberate; no external consumers hold resource IDs yet). The release also changes `POST /ook/ingest/resources/documents` to return per-item results.

## Validation steps

- [ ] Branch-deploy to roundtable-dev: point the ook Argo CD app at `tickets/DM-55386` and sync ook, gafaelfawr, and sasquatch (square-events).
- [ ] Confirm the `lsst.square-events.ook.linkcheck` KafkaTopic and updated ook KafkaUser ACL exist in the sasquatch namespace.
- [ ] Fetch `https://roundtable-dev.lsst.cloud/ook/openapi.json` without a token and confirm it returns the spec anonymously.
- [ ] `POST /ook/linkcheck/checks` without a token returns 401/403; with an `exec:linkcheck` token returns 202 + Location, and polling the Location shows the check completing with per-URL statuses.
- [ ] Confirm anonymous reads work on `GET /ook/linkcheck/urls?url=...` and `GET /ook/linkcheck/projects/{slug}/links`.
- [ ] Confirm the `ook-linkcheck-recheck` CronJob exists and a manually-triggered run (`kubectl create job --from=cronjob/ook-linkcheck-recheck ...`) completes cleanly.
- [ ] With the 0.23.0 image: confirm the `updateSchema` job applies migrations `cf936213314d`, `3b66bd60b53f`, and `20144e072aa7`, and that `GET /ook/resources` lists resources with re-minted IDs in creation order and no dangling contributor/relation references.
- [ ] Re-POST a document to `/ook/ingest/resources/documents` and confirm the per-item response reports `updated` with an unchanged resource ID.

## References

- PRD: lsst-sqre/ook#235 (linkcheck), lsst-sqre/ook#238 (bibliography hardening)
- Implementation PRs: lsst-sqre/ook#263, lsst-sqre/ook#283
- Release: https://github.com/lsst-sqre/ook/releases/tag/0.23.0
- Jira: https://rubinobs.atlassian.net/browse/DM-55386, https://rubinobs.atlassian.net/browse/DM-55393

https://claude.ai/code/session_015ZnykDXGQZuUPYBhDxBvSS
