### PR TITLE
Increase qserv-kafka batch size on idfint

### DIFF
--- a/applications/qserv-kafka/values-idfint.yaml
+++ b/applications/qserv-kafka/values-idfint.yaml
@@ -1,4 +1,5 @@
 config:
+  jobRunBatchSize: 50
   logLevel: "DEBUG"
   metrics:
     enabled: true
@@ -7,6 +8,7 @@ config:
   slack:
     enabled: true
   qservDatabaseUrl: "mysql+asyncmy://qsmaster@134.79.23.230:4040/"
+  qservRestMaxConnections: 55
   qservRestSendApiVersion: false
   qservRestUrl: "https://134.79.23.230:4048/"
   qservRestUsername: "qsmaster"


### PR DESCRIPTION
Increase both the qserv-kafka batch size and the httpx connection pool on idfint, since that Qserv should be able to handle additional parallelism.