### PR TITLE
DM-55406: Update datalinker to 4.4.0

### DIFF
--- a/applications/datalinker/Chart.yaml
+++ b/applications/datalinker/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v2
 name: datalinker
 version: 1.0.0
-description: IVOA DataLink-based service and data discovery
+description: IVOA DataLink image matadata and location service
 sources:
   - "https://github.com/lsst-sqre/datalinker"
-appVersion: 4.3.0
+appVersion: 4.4.0
 
 annotations:
   phalanx.lsst.io/docs: |

--- a/applications/datalinker/README.md
+++ b/applications/datalinker/README.md
@@ -1,6 +1,6 @@
 # datalinker
 
-IVOA DataLink-based service and data discovery
+IVOA DataLink image matadata and location service
 
 ## Source Code
 
@@ -17,7 +17,6 @@ IVOA DataLink-based service and data discovery
 | config.sentry.enabled | bool | `false` | Whether to enable the Sentry integration |
 | config.slackAlerts | bool | `false` | Whether to send certain serious alerts to Slack |
 | config.tapMetadataUrl | string | `"https://github.com/lsst/sdm_schemas/releases/download/DP1-v1.2.0/datalink-columns.zip"` | URL containing TAP schema metadata used to construct queries |
-| global.butlerServerRepositories | string | Set by Argo CD | Butler repositories accessible via Butler server |
 | global.environmentName | string | Set by Argo CD | Name of the Phalanx environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.repertoireUrl | string | Set by Argo CD | Base URL for Repertoire discovery API |

--- a/applications/datalinker/README.md
+++ b/applications/datalinker/README.md
@@ -13,6 +13,11 @@ IVOA DataLink image matadata and location service
 | affinity | object | `{}` | Affinity rules for the datalinker deployment pod |
 | config.linksLifetime | string | `"1h"` | Lifetime of the `{links}` reply. Should be set to match the lifetime of links returned by the Butler server |
 | config.logLevel | string | `"INFO"` | Logging level |
+| config.metrics.application | string | `"datalinker"` | Name under which to log metrics. Generally there is no reason to change this. |
+| config.metrics.enabled | bool | `false` | Whether to enable sending metrics |
+| config.metrics.events.topicPrefix | string | `"lsst.square.metrics.events"` | Topic prefix for events. It may sometimes be useful to change this in development environments. |
+| config.metrics.schemaManager.registryUrl | string | Sasquatch in the local cluster | URL of the Confluent-compatible schema registry server |
+| config.metrics.schemaManager.suffix | string | `""` | Suffix to add to all registered subjects. This is sometimes useful for experimentation during development. |
 | config.pathPrefix | string | `"/api/datalink"` | URL path prefix for DataLink and related APIs |
 | config.sentry.enabled | bool | `false` | Whether to enable the Sentry integration |
 | config.slackAlerts | bool | `false` | Whether to send certain serious alerts to Slack |

--- a/applications/datalinker/templates/configmap.yaml
+++ b/applications/datalinker/templates/configmap.yaml
@@ -12,4 +12,9 @@ data:
   DATALINKER_TAP_METADATA_DIR: "/tmp/tap-metadata"
   DATALINKER_TAP_METADATA_URL: {{ .Values.config.tapMetadataUrl | quote }}
   {{- end }}
+  METRICS_APPLICATION: {{ .Values.config.metrics.application | quote }}
+  METRICS_ENABLED: {{ .Values.config.metrics.enabled | quote }}
+  METRICS_EVENTS_TOPIC_PREFIX: {{ .Values.config.metrics.events.topicPrefix | quote }}
   REPERTOIRE_BASE_URL: {{ .Values.global.repertoireUrl | quote }}
+  SCHEMA_MANAGER_REGISTRY_URL: {{ .Values.config.metrics.schemaManager.registryUrl | quote }}
+  SCHEMA_MANAGER_SUFFIX: {{ .Values.config.metrics.schemaManager.suffix | quote }}

--- a/applications/datalinker/templates/deployment.yaml
+++ b/applications/datalinker/templates/deployment.yaml
@@ -14,9 +14,9 @@ spec:
       annotations:
         # Force the pod to restart when the config map is updated.
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-      {{- with .Values.podAnnotations }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "datalinker.selectorLabels" . | nindent 8 }}
     spec:
@@ -34,6 +34,24 @@ spec:
                 secretKeyRef:
                   name: "datalinker"
                   key: "slack-webhook"
+            {{- end }}
+            {{- if .Values.config.metrics.enabled }}
+            - name: "KAFKA_BOOTSTRAP_SERVERS"
+              valueFrom:
+                secretKeyRef:
+                  name: "datalinker-kafka"
+                  key: "bootstrapServers"
+            - name: "KAFKA_CLIENT_CERT_PATH"
+              value: "/etc/datalinker-kafka/user.crt"
+            - name: "KAFKA_CLIENT_KEY_PATH"
+              value: "/etc/datalinker-kafka/user.key"
+            - name: "KAFKA_CLUSTER_CA_PATH"
+              value: "/etc/datalinker-kafka/ca.crt"
+            - name: "KAFKA_SECURITY_PROTOCOL"
+              valueFrom:
+                secretKeyRef:
+                  name: "datalinker-kafka"
+                  key: "securityProtocol"
             {{- end }}
             {{- if .Values.config.sentry.enabled }}
             - name: "SENTRY_DSN"
@@ -92,6 +110,20 @@ spec:
           volumeMounts:
             - name: "tmp"
               mountPath: "/tmp"
+            {{- if .Values.config.metrics.enabled }}
+            - name: "kafka"
+              mountPath: "/etc/datalinker-kafka/ca.crt"
+              readOnly: true
+              subPath: "ssl.truststore.crt"
+            - name: "kafka"
+              mountPath: "/etc/datalinker-kafka/user.crt"
+              readOnly: true
+              subPath: "ssl.keystore.crt"
+            - name: "kafka"
+              mountPath: "/etc/datalinker-kafka/user.key"
+              readOnly: true
+              subPath: "ssl.keystore.key"
+            {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -109,3 +141,8 @@ spec:
         - name: "tmp"
           emptyDir:
             medium: "Memory"
+        {{- if .Values.config.metrics.enabled }}
+        - name: "kafka"
+          secret:
+            secretName: "datalinker-kafka"
+        {{- end }}

--- a/applications/datalinker/templates/deployment.yaml
+++ b/applications/datalinker/templates/deployment.yaml
@@ -28,8 +28,6 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           env:
-            - name: "DAF_BUTLER_REPOSITORIES"
-              value: {{ .Values.global.butlerServerRepositories | b64dec | quote }}
             {{- if .Values.config.slackAlerts }}
             - name: "DATALINKER_SLACK_WEBHOOK"
               valueFrom:

--- a/applications/datalinker/templates/kafka-access.yaml
+++ b/applications/datalinker/templates/kafka-access.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.config.metrics.enabled -}}
+apiVersion: access.strimzi.io/v1alpha1
+kind: KafkaAccess
+metadata:
+  name: "datalinker-kafka"
+  labels:
+    {{- include "datalinker.labels" . | nindent 4 }}
+spec:
+  kafka:
+    name: "sasquatch"
+    namespace: "sasquatch"
+    listener: "tls"
+  user:
+    kind: "KafkaUser"
+    apiGroup: "kafka.strimzi.io"
+    name: "app-metrics-datalinker"
+    namespace: "sasquatch"
+{{- end }}

--- a/applications/datalinker/values-idfdev.yaml
+++ b/applications/datalinker/values-idfdev.yaml
@@ -1,3 +1,5 @@
 config:
   logLevel: "DEBUG"
+  metrics:
+    enabled: true
   slackAlerts: true

--- a/applications/datalinker/values-idfint.yaml
+++ b/applications/datalinker/values-idfint.yaml
@@ -1,2 +1,4 @@
 config:
+  metrics:
+    enabled: true
   slackAlerts: true

--- a/applications/datalinker/values-idfprod.yaml
+++ b/applications/datalinker/values-idfprod.yaml
@@ -1,2 +1,4 @@
 config:
+  metrics:
+    enabled: true
   slackAlerts: true

--- a/applications/datalinker/values.yaml
+++ b/applications/datalinker/values.yaml
@@ -70,10 +70,6 @@ tolerations:
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:
-  # -- Butler repositories accessible via Butler server
-  # @default -- Set by Argo CD
-  butlerServerRepositories: null
-
   # -- Name of the Phalanx environment
   # @default -- Set by Argo CD
   environmentName: null

--- a/applications/datalinker/values.yaml
+++ b/applications/datalinker/values.yaml
@@ -27,6 +27,28 @@ config:
   # -- Logging level
   logLevel: "INFO"
 
+  metrics:
+    # -- Whether to enable sending metrics
+    enabled: false
+
+    # -- Name under which to log metrics. Generally there is no reason to
+    # change this.
+    application: "datalinker"
+
+    events:
+      # -- Topic prefix for events. It may sometimes be useful to change this
+      # in development environments.
+      topicPrefix: "lsst.square.metrics.events"
+
+    schemaManager:
+      # -- URL of the Confluent-compatible schema registry server
+      # @default -- Sasquatch in the local cluster
+      registryUrl: "http://sasquatch-schema-registry.sasquatch.svc.cluster.local:8081"
+
+      # -- Suffix to add to all registered subjects. This is sometimes useful
+      # for experimentation during development.
+      suffix: ""
+
   # -- URL path prefix for DataLink and related APIs
   pathPrefix: "/api/datalink"
 

--- a/applications/sasquatch/charts/app-metrics/values.yaml
+++ b/applications/sasquatch/charts/app-metrics/values.yaml
@@ -7,6 +7,10 @@
 # for the structure of this value.
 # @default -- See `values.yaml`
 globalAppConfig:
+  bigquerykafka:
+    influxTags:
+      - "username"
+      - "queue"
   docverse:
     influxTags:
       - "organization"
@@ -19,6 +23,9 @@ globalAppConfig:
       - "ci_platform"
       - "success"
       - "github_repository"
+  datalinker:
+    influxTags:
+      - "username"
   gafaelfawr:
     influxTags:
       - "service"
@@ -43,10 +50,6 @@ globalAppConfig:
   nublado:
     influxTags:
       - "username"
-  bigquerykafka:
-    influxTags:
-      - "username"
-      - "queue"
   qservkafka:
     influxTags:
       - "username"

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -147,6 +147,7 @@ app-metrics:
   enabled: true
   apps:
     - bigquerykafka
+    - datalinker
     - gafaelfawr
     - herald
     - mobu

--- a/applications/sasquatch/values-idfint.yaml
+++ b/applications/sasquatch/values-idfint.yaml
@@ -103,6 +103,7 @@ app-metrics:
   enabled: true
   apps:
     - bigquerykafka
+    - datalinker
     - gafaelfawr
     - herald
     - mobu

--- a/applications/sasquatch/values-idfprod.yaml
+++ b/applications/sasquatch/values-idfprod.yaml
@@ -84,6 +84,7 @@ chronograf:
 app-metrics:
   enabled: true
   apps:
+    - datalinker
     - gafaelfawr
     - herald
     - mobu

--- a/docs/applications/datalinker/index.rst
+++ b/docs/applications/datalinker/index.rst
@@ -4,13 +4,13 @@
 datalinker — IVOA DataLink service
 ##################################
 
-datalinker provides various facilities for discovering and referring to data products and services within the Rubin Science Platform.
-It is primarily based on the IVOA DataLink standard, but also provides some related service discovery facilities beyond the scope of that standard.
-
-Most significantly, datalinker is used to retrieve images referenced in the results of an ObsTAP search.
+datalinker is used to retrieve images referenced in the results of an ObsTAP search.
 It does this by returning a DataLink response for the image that includes a signed URL, allowing direct image download from the underlying data store.
+Included in that response are service descriptors for any related services for acting on that image.
 
-It also provides the HiPS list service, which collects the property files of HiPS data sets served by :px-app:`hips` and returns them with appropriate URLs, and implements a variety of "microservice" endpoints that rewrite simple service-descriptor-friendly APIs into redirects to other RSP services.
+Currently, datalinker also provides several small redirect-only services to run TAP queries.
+These are referenced in DataLink descriptors added to TAP results by the TAP service, and are used by clients to perform related TAP queries for a row of TAP results.
+These services will eventually be moved into a separate service.
 
 .. jinja:: datalinker
    :file: applications/_summary.rst.jinja


### PR DESCRIPTION
This release adds metrics support and uses service discovery to locate the Butler server. Also update the service documentation, since the role of datalinker has changed since we introduced Repertoire.