### PR TITLE
DM-55425: Add auto scaling to ingester

### DIFF
--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -145,6 +145,15 @@ Rubin Observatory's telemetry service
 | trickster.resources.requests | object | `{"cpu":"100m","memory":"256Mi"}` | Kubernetes resource requests and limits for Trickster |
 | alert-brokers.cluster.name | string | `"sasquatch"` | Name of the Strimzi cluster. Synchronize this with the cluster name in the parent Prompt Kafka chart. |
 | alert-database.fullnameOverride | string | `""` | Override the full name for resources (includes the release name) |
+| alert-database.ingester.autoscaling.activationLagThreshold | string | `"10"` | Minimum lag per partition required to activate scaling from zero. Only relevant when minReplicaCount is 0. |
+| alert-database.ingester.autoscaling.consumerGroup | string | `"alertdb-ingester"` | Kafka consumer group to monitor for lag. Must match the consumer group used by the ingester application. |
+| alert-database.ingester.autoscaling.cooldownPeriod | int | `300` | Period to wait after the last trigger fires before scaling down (seconds). |
+| alert-database.ingester.autoscaling.enabled | bool | `true` | Enable KEDA-based autoscaling for the ingester. When enabled, KEDA manages the replica count based on Kafka consumer group lag. |
+| alert-database.ingester.autoscaling.lagThreshold | string | `"100"` | Target lag (messages) per partition that triggers scaling. |
+| alert-database.ingester.autoscaling.maxReplicaCount | int | `10` | Maximum number of replicas the ingester can scale to. |
+| alert-database.ingester.autoscaling.minReplicaCount | int | `3` | Minimum number of replicas. Set to 0 to allow scale-to-zero. |
+| alert-database.ingester.autoscaling.offsetResetPolicy | string | `"latest"` | Kafka offset reset policy for the KEDA scaler if the consumer group has no committed offset. |
+| alert-database.ingester.autoscaling.pollingInterval | int | `30` | How often KEDA checks Kafka consumer group lag (seconds). |
 | alert-database.ingester.image.pullPolicy | string | `"IfNotPresent"` |  |
 | alert-database.ingester.image.repository | string | `"lsstdm/alert_database_ingester"` |  |
 | alert-database.ingester.image.tag | string | `""` |  |
@@ -153,6 +162,7 @@ Rubin Observatory's telemetry service
 | alert-database.ingester.kafka.topic | list | `["alerts-simulated"]` | Name of the topic which will holds alert data. |
 | alert-database.ingester.kafka.user | string | `"alert-database-ingester"` | The username of the Kafka user identity used to connect to the broker. |
 | alert-database.ingester.logLevel | string | `"verbose"` | set the log level of the application. can be 'info', or 'debug', or anything else to suppress logging. |
+| alert-database.ingester.replicas | int | `1` | Number of static replicas when autoscaling is disabled. |
 | alert-database.ingester.s3.alertBucket | string | `"rubin-alert-archive"` |  |
 | alert-database.ingester.s3.endpointURL | string | `"https://sdfdatas3.slac.stanford.edu/"` |  |
 | alert-database.ingester.s3.schemaBucket | string | `"rubin-alert-archive"` |  |
@@ -160,6 +170,7 @@ Rubin Observatory's telemetry service
 | alert-database.ingester.s3.usdf | bool | `true` |  |
 | alert-database.ingester.schemaRegistryUrl | string | `"http://sasquatch-schema-registry.sasquatch:8081"` | URL of a schema registry instance |
 | alert-database.ingester.serviceAccountName | string | `"alert-database-ingester"` | The name of the Kubernetes ServiceAccount (*not* the Google Cloud IAM service account!) which is used by the alert database ingester. |
+| alert-database.ingester.terminationGracePeriodSeconds | int | `60` | Seconds Kubernetes waits after SIGTERM before sending SIGKILL. Should be long enough for the ingester to finish processing its current batch, commit offsets, and leave the Kafka consumer group cleanly. |
 | alert-database.ingress.annotations."nginx.ingress.kubernetes.io/rewrite-target" | string | `"/$2"` |  |
 | alert-database.ingress.enabled | bool | `false` | Whether to create an ingress |
 | alert-database.ingress.host | string | None, must be set if the ingress is enabled | Hostname for the ingress |

--- a/applications/sasquatch/charts/alert-database/README.md
+++ b/applications/sasquatch/charts/alert-database/README.md
@@ -7,6 +7,15 @@ Archival database of alerts sent through the alert stream.
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | fullnameOverride | string | `""` | Override the full name for resources (includes the release name) |
+| ingester.autoscaling.activationLagThreshold | string | `"10"` | Minimum lag per partition required to activate scaling from zero. Only relevant when minReplicaCount is 0. |
+| ingester.autoscaling.consumerGroup | string | `"alertdb-ingester"` | Kafka consumer group to monitor for lag. Must match the consumer group used by the ingester application. |
+| ingester.autoscaling.cooldownPeriod | int | `300` | Period to wait after the last trigger fires before scaling down (seconds). |
+| ingester.autoscaling.enabled | bool | `true` | Enable KEDA-based autoscaling for the ingester. When enabled, KEDA manages the replica count based on Kafka consumer group lag. |
+| ingester.autoscaling.lagThreshold | string | `"100"` | Target lag (messages) per partition that triggers scaling. |
+| ingester.autoscaling.maxReplicaCount | int | `10` | Maximum number of replicas the ingester can scale to. |
+| ingester.autoscaling.minReplicaCount | int | `3` | Minimum number of replicas. Set to 0 to allow scale-to-zero. |
+| ingester.autoscaling.offsetResetPolicy | string | `"latest"` | Kafka offset reset policy for the KEDA scaler if the consumer group has no committed offset. |
+| ingester.autoscaling.pollingInterval | int | `30` | How often KEDA checks Kafka consumer group lag (seconds). |
 | ingester.image.pullPolicy | string | `"IfNotPresent"` |  |
 | ingester.image.repository | string | `"lsstdm/alert_database_ingester"` |  |
 | ingester.image.tag | string | `""` |  |
@@ -15,6 +24,7 @@ Archival database of alerts sent through the alert stream.
 | ingester.kafka.topic | list | `["alerts-simulated"]` | Name of the topic which will holds alert data. |
 | ingester.kafka.user | string | `"alert-database-ingester"` | The username of the Kafka user identity used to connect to the broker. |
 | ingester.logLevel | string | `"verbose"` | set the log level of the application. can be 'info', or 'debug', or anything else to suppress logging. |
+| ingester.replicas | int | `1` | Number of static replicas when autoscaling is disabled. |
 | ingester.s3.alertBucket | string | `"rubin-alert-archive"` |  |
 | ingester.s3.endpointURL | string | `"https://sdfdatas3.slac.stanford.edu/"` |  |
 | ingester.s3.schemaBucket | string | `"rubin-alert-archive"` |  |
@@ -22,6 +32,7 @@ Archival database of alerts sent through the alert stream.
 | ingester.s3.usdf | bool | `true` |  |
 | ingester.schemaRegistryUrl | string | `"http://sasquatch-schema-registry.sasquatch:8081"` | URL of a schema registry instance |
 | ingester.serviceAccountName | string | `"alert-database-ingester"` | The name of the Kubernetes ServiceAccount (*not* the Google Cloud IAM service account!) which is used by the alert database ingester. |
+| ingester.terminationGracePeriodSeconds | int | `60` | Seconds Kubernetes waits after SIGTERM before sending SIGKILL. Should be long enough for the ingester to finish processing its current batch, commit offsets, and leave the Kafka consumer group cleanly. |
 | ingress.annotations."nginx.ingress.kubernetes.io/rewrite-target" | string | `"/$2"` |  |
 | ingress.enabled | bool | `false` | Whether to create an ingress |
 | ingress.host | string | None, must be set if the ingress is enabled | Hostname for the ingress |

--- a/applications/sasquatch/charts/alert-database/templates/ingester-deployment.yaml
+++ b/applications/sasquatch/charts/alert-database/templates/ingester-deployment.yaml
@@ -5,7 +5,9 @@ metadata:
   labels:
     {{- include "alertDatabase.labels" . | nindent 4 }}
 spec:
-  replicas: 1
+  {{- if not .Values.ingester.autoscaling.enabled }}
+  replicas: {{ .Values.ingester.replicas | default 1 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "alertDatabase.ingesterSelectorLabels" . | nindent 6 }}
@@ -72,6 +74,7 @@ spec:
             secretName: sasquatch
         {{- end }}
       serviceAccountName: "{{ .Values.ingester.serviceAccountName }}"
+      terminationGracePeriodSeconds: {{ .Values.ingester.terminationGracePeriodSeconds }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/applications/sasquatch/charts/alert-database/templates/ingester-scaledobject.yaml
+++ b/applications/sasquatch/charts/alert-database/templates/ingester-scaledobject.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.ingester.autoscaling.enabled }}
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{ include "alertDatabase.ingesterName" . }}
+  labels:
+    {{- include "alertDatabase.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    name: {{ include "alertDatabase.ingesterName" . }}
+  pollingInterval: {{ .Values.ingester.autoscaling.pollingInterval }}
+  cooldownPeriod: {{ .Values.ingester.autoscaling.cooldownPeriod }}
+  minReplicaCount: {{ .Values.ingester.autoscaling.minReplicaCount }}
+  maxReplicaCount: {{ .Values.ingester.autoscaling.maxReplicaCount }}
+  triggers:
+    - type: kafka
+      metadata:
+        bootstrapServers: {{ .Values.ingester.kafka.cluster }}-kafka-bootstrap.{{ .Release.Namespace }}:{{ .Values.ingester.kafka.port }}
+        consumerGroup: {{ .Values.ingester.autoscaling.consumerGroup }}
+        topic: {{ range $i, $topic := .Values.ingester.kafka.topic }}{{if $i}},{{end}}{{$topic}}{{end}}
+        lagThreshold: {{ .Values.ingester.autoscaling.lagThreshold | quote }}
+        activationLagThreshold: {{ .Values.ingester.autoscaling.activationLagThreshold | quote }}
+        offsetResetPolicy: {{ .Values.ingester.autoscaling.offsetResetPolicy }}
+        tls: "enable"
+      authenticationRef:
+        name: {{ include "alertDatabase.ingesterName" . }}-kafka-auth
+{{- end }}

--- a/applications/sasquatch/charts/alert-database/templates/ingester-trigger-auth.yaml
+++ b/applications/sasquatch/charts/alert-database/templates/ingester-trigger-auth.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.ingester.autoscaling.enabled }}
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: {{ include "alertDatabase.ingesterName" . }}-kafka-auth
+  labels:
+    {{- include "alertDatabase.labels" . | nindent 4 }}
+spec:
+  secretTargetRef:
+    - parameter: ca
+      name: {{ .Values.ingester.kafka.cluster }}-cluster-ca-cert
+      key: ca.crt
+    - parameter: cert
+      name: {{ .Values.ingester.kafka.user }}
+      key: user.crt
+    - parameter: key
+      name: {{ .Values.ingester.kafka.user }}
+      key: user.key
+{{- end }}

--- a/applications/sasquatch/charts/alert-database/values.yaml
+++ b/applications/sasquatch/charts/alert-database/values.yaml
@@ -48,6 +48,46 @@ ingester:
   # anything else to suppress logging.
   logLevel: verbose
 
+  # -- Seconds Kubernetes waits after SIGTERM before sending SIGKILL. Should
+  # be long enough for the ingester to finish processing its current batch,
+  # commit offsets, and leave the Kafka consumer group cleanly.
+  terminationGracePeriodSeconds: 60
+
+  # -- Number of static replicas when autoscaling is disabled.
+  replicas: 1
+
+  autoscaling:
+    # -- Enable KEDA-based autoscaling for the ingester. When enabled, KEDA
+    # manages the replica count based on Kafka consumer group lag.
+    enabled: true
+
+    # -- Minimum number of replicas. Set to 0 to allow scale-to-zero.
+    minReplicaCount: 3
+
+    # -- Maximum number of replicas the ingester can scale to.
+    maxReplicaCount: 10
+
+    # -- Target lag (messages) per partition that triggers scaling.
+    lagThreshold: "100"
+
+    # -- Minimum lag per partition required to activate scaling from zero.
+    # Only relevant when minReplicaCount is 0.
+    activationLagThreshold: "10"
+
+    # -- How often KEDA checks Kafka consumer group lag (seconds).
+    pollingInterval: 30
+
+    # -- Period to wait after the last trigger fires before scaling down (seconds).
+    cooldownPeriod: 300
+
+    # -- Kafka consumer group to monitor for lag. Must match the consumer
+    # group used by the ingester application.
+    consumerGroup: "alertdb-ingester"
+
+    # -- Kafka offset reset policy for the KEDA scaler if the consumer group
+    # has no committed offset.
+    offsetResetPolicy: "latest"
+
 server:
   image:
     repository: lsstdm/alert_database_server

--- a/applications/sasquatch/values-usdfdev-prompt-processing.yaml
+++ b/applications/sasquatch/values-usdfdev-prompt-processing.yaml
@@ -8,11 +8,6 @@ alert-brokers:
     - name: alerts-simulated
       partitions: 45
       replicas: 3
-    - name: lsst-alerts-v10.0
-      partitions: 45
-      replicas: 3
-      bytesRetained: "300000000000"
-      millisecondsRetained: "2629740000"
     - name: lsst-alerts-v11
       partitions: 45
       replicas: 3
@@ -93,7 +88,7 @@ alert-database:
   ingester:
     # The image can use either a tag or a digest to determine which is being used.
     image:
-      tag: v4.1.0
+      tag: v4.2.0
 
     logLevel: verbose
 
@@ -106,6 +101,19 @@ alert-database:
       topic:
         - lsst-alerts-v11
 
+    terminationGracePeriodSeconds: 60
+
+    autoscaling:
+      enabled: true
+      minReplicaCount: 1
+      maxReplicaCount: 20
+      lagThreshold: "100"
+      activationLagThreshold: "10"
+      pollingInterval: 30
+      cooldownPeriod: 900
+      consumerGroup: "alertdb-ingester"
+      offsetResetPolicy: "latest"
+
   ingress:
     enabled: true
     host: usdfdev-prompt-processing.slac.stanford.edu
@@ -114,7 +122,7 @@ alert-stream-schema-sync:
   enabled: true
   schemaSync:
     image:
-      tag: w.2026.19
+      tag: w.2026.28
 
 chronograf:
   enabled: false

--- a/applications/sasquatch/values-usdfprod-prompt-processing.yaml
+++ b/applications/sasquatch/values-usdfprod-prompt-processing.yaml
@@ -78,7 +78,7 @@ alert-database:
   ingester:
     # The image can use either a tag or a digest to determine which is being used.
     image:
-      tag: v4.1.0
+      tag: v4.2.0
 
     logLevel: verbose
 
@@ -91,6 +91,19 @@ alert-database:
       topic:
         - lsst-alerts-v11
 
+    terminationGracePeriodSeconds: 60
+
+    autoscaling:
+      enabled: true
+      minReplicaCount: 1
+      maxReplicaCount: 20
+      lagThreshold: "100"
+      activationLagThreshold: "10"
+      pollingInterval: 30
+      cooldownPeriod: 900
+      consumerGroup: "alertdb-ingester"
+      offsetResetPolicy: "latest"
+
   ingress:
     enabled: true
     host: usdfprod-prompt-processing.slac.stanford.edu
@@ -99,7 +112,7 @@ alert-stream-schema-sync:
   enabled: true
   schemaSync:
     image:
-      tag: w.2026.19
+      tag: w.2026.28
 
 chronograf:
   enabled: false


### PR DESCRIPTION
The ingester currently cannot read the alert stream fast enough for when we are at full capacity. We are adding auto scaling to help read out faster.