### PR TITLE
DM-55450: Pin squareone to tickets-DM-55450 image on data-dev

### DIFF
--- a/applications/squareone/Chart.yaml
+++ b/applications/squareone/Chart.yaml
@@ -9,8 +9,4 @@ maintainers:
   - name: jonathansick
     url: https://github.com/jonathansick
 
-# The default version tag of the squareone docker image
-# NOTE: temporarily pinned to the DM-55450 ticket branch image to exercise the
-# Semaphore 2.0 notifications API and the "Mark as unread" inbox UI on data-dev
-# (idfdev). Revert to a released version (e.g. "0.35.0") before merging this PR.
-appVersion: "tickets-DM-55450"
+appVersion: "0.35.1"

--- a/applications/squareone/Chart.yaml
+++ b/applications/squareone/Chart.yaml
@@ -9,4 +9,8 @@ maintainers:
   - name: jonathansick
     url: https://github.com/jonathansick
 
-appVersion: "0.35.0"
+# The default version tag of the squareone docker image
+# NOTE: temporarily pinned to the DM-55450 ticket branch image to exercise the
+# Semaphore 2.0 notifications API and the "Mark as unread" inbox UI on data-dev
+# (idfdev). Revert to a released version (e.g. "0.35.0") before merging this PR.
+appVersion: "tickets-DM-55450"


### PR DESCRIPTION
## Summary

Update Squareone to 0.35.1 with compatibility for Semaphore v2 API changes:

- User-notification list/detail endpoints moved under `/messages`
  (`GET /semaphore/v1/notifications/messages` and `.../messages/{id}`).
- New "Mark as unread" capability — `POST /semaphore/v1/notifications/unread`
  surfaced as a per-row and bulk action in the `/notifications` inbox.

## Validation

- `uv run phalanx application lint squareone` — passes for all environments.
- `uv run phalanx application template squareone idfdev` renders
  `image: "ghcr.io/lsst-sqre/squareone:tickets-DM-55450"`.
- Pre-commit hooks (yamllint, helm-docs, merge-conflict) pass; README
  unchanged (appVersion is not helm-docs-rendered).

## References

- squareone PR: lsst-sqre/squareone#549
- squareone release: https://github.com/lsst-sqre/squareone/releases/tag/squareone%400.35.1
- PRD: lsst-sqre/squareone#545
- Tasks: lsst-sqre/squareone#546, lsst-sqre/squareone#547, lsst-sqre/squareone#548
- Jira: https://rubinobs.atlassian.net/browse/DM-55450

