### PR TITLE
DM-55384: Release squareone 0.36.0 (Times Square sidebar navigation)

### DIFF
--- a/applications/squareone/Chart.yaml
+++ b/applications/squareone/Chart.yaml
@@ -10,8 +10,4 @@ maintainers:
     url: https://github.com/jonathansick
 
 # The default version tag of the squareone docker image
-# NOTE: temporarily pinned to the DM-55384 ticket branch image to preview the
-# Times Square sidebar navigation work (icons, collapsible tree, ts_nav_focus
-# focus mode) on data-dev (idfdev). Revert to a released version
-# (e.g. "0.35.1") before merging this PR.
-appVersion: "tickets-DM-55384"
+appVersion: "0.36.0"

--- a/applications/squareone/Chart.yaml
+++ b/applications/squareone/Chart.yaml
@@ -9,4 +9,9 @@ maintainers:
   - name: jonathansick
     url: https://github.com/jonathansick
 
-appVersion: "0.35.1"
+# The default version tag of the squareone docker image
+# NOTE: temporarily pinned to the DM-55384 ticket branch image to preview the
+# Times Square sidebar navigation work (icons, collapsible tree, ts_nav_focus
+# focus mode) on data-dev (idfdev). Revert to a released version
+# (e.g. "0.35.1") before merging this PR.
+appVersion: "tickets-DM-55384"


### PR DESCRIPTION
## Summary

Update the squareone `appVersion` to the released [squareone 0.36.0](https://github.com/lsst-sqre/squareone/releases/tag/squareone%400.36.0), which ships the Times Square sidebar navigation work: per-node-type Lucide icons, a collapsible sidebar tree with a "Tree actions" menu (expand/collapse all, disabled when a no-op), kebab focus menus on container rows, and the linkable `ts_nav_focus` focus mode with an ancestor breadcrumb. It also includes client-side dedup of duplicate directory nodes in the GitHub contents tree (via `@lsst-sqre/times-square-client` 2.1.0).

This PR previously pinned `appVersion` to the `tickets-DM-55384` branch image as a [branch deployment](https://phalanx.lsst.io/developers/deploy-from-a-branch.html) for preview on data-dev (`idfdev`); that pin is now replaced with the released version, so it is ready to merge.

The chart's deployment template resolves the container tag as `image.tag | default .Chart.AppVersion`, and `image.tag` is empty, so setting `appVersion` in `Chart.yaml` is sufficient to pin the image.

## Validation steps

- `phalanx application lint squareone` passes for all environments.
- `phalanx application template squareone idfdev` renders the image as `ghcr.io/lsst-sqre/squareone:0.36.0` (tag verified present on ghcr).
- The sidebar features were previewed on `idfdev` via the earlier branch deployment of this PR (collapse/expand, kebab focus menus, `ts_nav_focus`).

## References

- lsst-sqre/squareone#535
- Release: https://github.com/lsst-sqre/squareone/releases/tag/squareone%400.36.0
- Jira: https://rubinobs.atlassian.net/browse/DM-55384