### PR TITLE
DM-55403: Update DP2 HiPS maps

### DIFF
--- a/applications/hips/values-idfint.yaml
+++ b/applications/hips/values-idfint.yaml
@@ -9,7 +9,7 @@ config:
       objectPrefix: "DM-51494"
     dp2:
       bucketName: "static-us-central1-dp2-hips"
-      objectPrefix: "DM-55402"
+      objectPrefix: "DM-55402/dp2x1"
   defaultBucketKey: "dp02"
   gcsProject: "data-curation-prod-fbdb"
   serviceAccount: "crawlspace-hips@science-platform-int-dc5d.iam.gserviceaccount.com"

--- a/applications/repertoire/values-idfint.yaml
+++ b/applications/repertoire/values-idfint.yaml
@@ -9,7 +9,7 @@ config:
     datasets:
       dp2:
         paths:
-          - "cosmost2/color_gri"
+          - "color_gri"
     legacy:
       dataset: "dp1"
   metrics:


### PR DESCRIPTION
Hide more of the directory structure and switch to the `dp2x1` directory, which has the (hopefully final) maps.