### PR TITLE
DM-55386: Deploy ook 0.24.0 with linkcheck bot-block handling

### DIFF
--- a/applications/ook/Chart.yaml
+++ b/applications/ook/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: ook
 version: 1.0.0
-appVersion: "0.23.0"
+appVersion: "0.24.0"
 description: >
   Ook is the librarian service for Rubin Observatory. Ook indexes
   documentation content into the Algolia search engine that powers the Rubin

--- a/applications/ook/README.md
+++ b/applications/ook/README.md
@@ -31,7 +31,9 @@ Ook is the librarian service for Rubin Observatory. Ook indexes documentation co
 | cloudsql.serviceAccount | string | `""` | The Google service account that has an IAM binding to the `ook` Kubernetes service accounts and has the `cloudsql.client` role |
 | config.algolia.documents_index | string | `"documents_dev"` | Name of the Algolia index for documents |
 | config.databaseUrl | string | `""` | Database URL |
+| config.linkcheck.blockedRecheckInterval | string | `"1h"` | Delay until the next recheck of a bot-blocked link, revisited at this near-term cadence because a block is inconclusive and tends to flap |
 | config.linkcheck.brokenMinAttempts | int | `3` | Minimum number of consecutive failed attempts before a previously-OK link is declared broken instead of failing |
+| config.linkcheck.brokenRecheckInterval | string | `"24h"` | Delay until the next recheck of a broken link, revisited at this slow cadence so a since-fixed link can heal without waiting to be resubmitted |
 | config.linkcheck.brokenThreshold | string | `"48h"` | Minimum span of consecutive failures before a previously-OK link is declared broken instead of failing |
 | config.linkcheck.checkRetention | string | `"30d"` | Age beyond which link-check submission records are purged by the scheduled linkcheck-recheck maintenance command |
 | config.linkcheck.freshnessTtl | string | `"24h"` | Age below which a URL's stored check result is considered fresh and is not rechecked on submission |
@@ -40,6 +42,7 @@ Ook is the librarian service for Rubin Observatory. Ook indexes documentation co
 | config.linkcheck.maxUrlsPerCheck | int | `1000` | Maximum number of unique canonical URLs accepted in a single link-check submission |
 | config.linkcheck.recheckIntervals | list | `["1h","4h","24h","48h"]` | Delays until the next recheck of a failing link, indexed by the number of consecutive failures so far |
 | config.linkcheck.requestTimeout | string | `"30s"` | Total timeout applied to each link-check HTTP request |
+| config.linkcheck.userAgent | string | `""` | Override for the User-Agent header sent on every link-check request. Leave empty to use Ook's built-in browser-prefixed hybrid default, which carries the running Ook version and repo URL |
 | config.logLevel | string | `"INFO"` | Logging level: "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL" |
 | config.migrateCountryCodes | bool | false to disable country code migration | Whether to migrate country codes in the database |
 | config.topics.ingest | string | `"lsst.square-events.ook.ingest"` | Kafka topic name for ingest events |

--- a/applications/ook/templates/configmap.yaml
+++ b/applications/ook/templates/configmap.yaml
@@ -19,5 +19,10 @@ data:
   OOK_LINKCHECK_BROKEN_THRESHOLD: {{ .Values.config.linkcheck.brokenThreshold | quote }}
   OOK_LINKCHECK_BROKEN_MIN_ATTEMPTS: {{ .Values.config.linkcheck.brokenMinAttempts | quote }}
   OOK_LINKCHECK_RECHECK_INTERVALS: {{ .Values.config.linkcheck.recheckIntervals | toJson | quote }}
+  OOK_LINKCHECK_BROKEN_RECHECK_INTERVAL: {{ .Values.config.linkcheck.brokenRecheckInterval | quote }}
+  OOK_LINKCHECK_BLOCKED_RECHECK_INTERVAL: {{ .Values.config.linkcheck.blockedRecheckInterval | quote }}
   OOK_LINKCHECK_CHECK_RETENTION: {{ .Values.config.linkcheck.checkRetention | quote }}
+  {{- with .Values.config.linkcheck.userAgent }}
+  OOK_LINKCHECK_USER_AGENT: {{ . | quote }}
+  {{- end }}
   ALGOLIA_DOCUMENT_INDEX: {{ .Values.config.algolia.documentIndex | quote }}

--- a/applications/ook/values-roundtable-prod.yaml
+++ b/applications/ook/values-roundtable-prod.yaml
@@ -1,3 +1,7 @@
+image:
+  pullPolicy: Always
+  tag: "tickets-DM-55386-linkcheck-bot-blocks"
+
 config:
   databaseUrl: "postgresql://ook@localhost/ook"
   algolia:

--- a/applications/ook/values-roundtable-prod.yaml
+++ b/applications/ook/values-roundtable-prod.yaml
@@ -4,6 +4,12 @@ image:
 
 config:
   databaseUrl: "postgresql://ook@localhost/ook"
+  linkcheck:
+    # Temporarily shortened from the 24h default for the DM-55386
+    # bot-block investigation so resubmitted checks re-fetch URLs
+    # instead of serving stored results. Revert with the image
+    # override at teardown.
+    freshnessTtl: "5m"
   algolia:
     documentIndex: "document_dev"
   updateSchema: true

--- a/applications/ook/values-roundtable-prod.yaml
+++ b/applications/ook/values-roundtable-prod.yaml
@@ -1,15 +1,5 @@
-image:
-  pullPolicy: Always
-  tag: "tickets-DM-55386-linkcheck-bot-blocks"
-
 config:
   databaseUrl: "postgresql://ook@localhost/ook"
-  linkcheck:
-    # Temporarily shortened from the 24h default for the DM-55386
-    # bot-block investigation so resubmitted checks re-fetch URLs
-    # instead of serving stored results. Revert with the image
-    # override at teardown.
-    freshnessTtl: "5m"
   algolia:
     documentIndex: "document_dev"
   updateSchema: true

--- a/applications/ook/values.yaml
+++ b/applications/ook/values.yaml
@@ -107,6 +107,11 @@ config:
     # host
     hostInterval: "1s"
 
+    # -- Override for the User-Agent header sent on every link-check request.
+    # Leave empty to use Ook's built-in browser-prefixed hybrid default, which
+    # carries the running Ook version and repo URL
+    userAgent: ""
+
     # -- Age below which a URL's stored check result is considered fresh and
     # is not rechecked on submission
     freshnessTtl: "24h"
@@ -130,6 +135,14 @@ config:
       - "4h"
       - "24h"
       - "48h"
+
+    # -- Delay until the next recheck of a broken link, revisited at this slow
+    # cadence so a since-fixed link can heal without waiting to be resubmitted
+    brokenRecheckInterval: "24h"
+
+    # -- Delay until the next recheck of a bot-blocked link, revisited at this
+    # near-term cadence because a block is inconclusive and tends to flap
+    blockedRecheckInterval: "1h"
 
     # -- Age beyond which link-check submission records are purged by the
     # scheduled linkcheck-recheck maintenance command


### PR DESCRIPTION
## Summary

Deploys ook 0.24.0 to production, shipping the linkcheck bot-protection and transient-server handling from [ook PR #288](https://github.com/lsst-sqre/ook/pull/288) (DM-55386):

- Descriptive browser-prefixed hybrid `User-Agent` and browser-like `Accept` headers on every linkcheck request, so Cloudflare bot-protection heuristics stop returning 403 on production link checks. The User-Agent is configurable via `config.linkcheck.userAgent`.
- A new `blocked` link status for Cloudflare bot-protection 403s and transient HTTP 429/503 conditions, distinguished from confirmed breakage so documenteer users don't chase false broken-link warnings.
- New recheck-cadence knobs wired into the chart configmap: `config.linkcheck.brokenRecheckInterval` (default 24h) and `config.linkcheck.blockedRecheckInterval` (default 1h), plus the `OOK_LINKCHECK_USER_AGENT` override.

Bumps `appVersion` to the released `0.24.0` tag so roundtable-prod runs the released image under the default pull policy. The temporary roundtable-prod branch-deploy overrides from the DM-55386 investigation — the image `pullPolicy: Always` / branch tag and the shortened linkcheck `freshnessTtl` — have been reverted, returning ook to a standard production deployment stance.

## References

- ook release: https://github.com/lsst-sqre/ook/releases/tag/0.24.0
- ook PR: https://github.com/lsst-sqre/ook/pull/288
- PRD: https://github.com/lsst-sqre/ook/issues/235
- Jira: https://rubinobs.atlassian.net/browse/DM-55386
