### PR TITLE
DM-55465: Release squareone 0.36.1 (PR-aware Times Square page fetch)

### DIFF
--- a/applications/squareone/Chart.yaml
+++ b/applications/squareone/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
     url: https://github.com/jonathansick
 
 # The default version tag of the squareone docker image
-appVersion: "0.36.0"
+appVersion: "0.36.1"


### PR DESCRIPTION
## Summary

Bump the squareone chart's `appVersion` from 0.36.0 to 0.36.1 (the image tag defaults to `appVersion`, so this deploys the new release everywhere).

Squareone 0.36.1 makes the Times Square page-metadata fetch PR-aware, so GitHub PR-preview pages (`/times-square/github-pr/...`) load again end-to-end: the notebook viewer, parameter form, live execution status, and download/edit links now work on PR-preview pages.

## Validation

- `phalanx application lint squareone` passes for all environments.
- `ghcr.io/lsst-sqre/squareone:0.36.1` is published and pullable.
- Post-merge: verify a Times Square GitHub PR-preview page renders on data-dev (idfdev) after Argo CD sync.

## References

- Release: https://github.com/lsst-sqre/squareone/releases/tag/squareone%400.36.1
- Squareone PR: lsst-sqre/squareone#586
- PRD: lsst-sqre/squareone#584
- Jira: [DM-55465](https://rubinobs.atlassian.net/browse/DM-55465)

[DM-55465]: https://rubinobs.atlassian.net/browse/DM-55465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ