### PR TITLE
DM-55474: Add Repertoire to service discovery

### DIFF
--- a/applications/repertoire/values.yaml
+++ b/applications/repertoire/values.yaml
@@ -310,10 +310,18 @@ config:
         datasets:
           - "prompt"
         template: "https://{{base_hostname}}/api/ppdbtap"
+    repertoire:
+      - type: "internal"
+        name: "repertoire"
+        template: "https://{{base_hostname}}/repertoire"
+        openapi: "https://{{base_hostname}}/repertoire/openapi.json"
     semaphore:
       - type: "internal"
         name: "semaphore"
         template: "https://{{base_hostname}}/semaphore"
+        versions:
+          v1:
+            template: "https://{{base_hostname}}/semaphore/v1"
         openapi: "https://{{base_hostname}}/semaphore/openapi.json"
     sasquatch:
       - type: "ui"


### PR DESCRIPTION
Add Repertoire itself to service discovery. This isn't useful for services directly, but it will be helpful once the Phalanx docs build generates static service discovery information for each environment. It will allow other documentation to publish the root URL for the Repertoire API.

Add `v1` for the Semaphore API since Semaphore uses versioned APIs.