### PR TITLE
DM-55489: Mostly remove read:alertdb scope

### DIFF
--- a/applications/gafaelfawr/values-usdfdev-prompt-processing.yaml
+++ b/applications/gafaelfawr/values-usdfdev-prompt-processing.yaml
@@ -6,7 +6,8 @@ redis:
     storageClass: "wekafs--sdf-k8s01"
 
 config:
-  databaseUrl: postgresql://gafaelfawr@gf-db-rw.gafaelfawr-db.svc.cluster.local/gafaelfawr
+  databaseUrl: "postgresql://gafaelfawr@gf-db-rw.gafaelfawr-db.svc.cluster.local/gafaelfawr"
+
   sentry:
     enabled: true
 
@@ -220,6 +221,9 @@ config:
     "write:sasquatch":
       - "rubinmgr"
       - "unix-admin"
+  knownScopes:
+    "read:alertdb": >-
+      Retrieve alert packets and schemas from the alert archive database
 
   initialAdmins:
     - "afausti"

--- a/applications/gafaelfawr/values-usdfprod-prompt-processing.yaml
+++ b/applications/gafaelfawr/values-usdfprod-prompt-processing.yaml
@@ -220,6 +220,9 @@ config:
     "write:sasquatch":
       - "rubinmgr"
       - "unix-admin"
+  knownScopes:
+    "read:alertdb": >-
+      Retrieve alert packets and schemas from the alert archive database
 
   initialAdmins:
     - "afausti"

--- a/applications/gafaelfawr/values.yaml
+++ b/applications/gafaelfawr/values.yaml
@@ -258,8 +258,6 @@ config:
       Use the Portal Aspect
     "exec:portal-admin": >-
       Read access to the Portal admin page
-    "read:alertdb": >-
-      Retrieve alert packets and schemas from the alert archive database
     "read:image": >-
       Retrieve images from project datasets
     "read:sasquatch": >-

--- a/applications/noteburst/README.md
+++ b/applications/noteburst/README.md
@@ -32,7 +32,7 @@ Noteburst is a notebook execution service for the Rubin Science Platform.
 | config.worker.keepAlive | string | `"hourly"` | Worker keep alive mode: "normal", "fast", "hourly", "daily", "disabled" |
 | config.worker.maxConcurrentJobs | int | `1` | Max number of concurrent notebook executions per worker |
 | config.worker.tokenLifetime | string | `"2419200"` | Worker token lifetime, in seconds. |
-| config.worker.tokenScopes | string | `"exec:notebook,read:image,read:tap,read:alertdb,read:sasquatch"` | Nublado2 worker account's token scopes as a comma-separated list. |
+| config.worker.tokenScopes | string | `"exec:notebook,read:image,read:tap,read:sasquatch"` | Nublado2 worker account's token scopes as a comma-separated list. |
 | config.worker.workerCount | int | `1` | Number of workers to run |
 | fullnameOverride | string | `""` | Override the full name for resources (includes the release name) |
 | global.baseUrl | string | Set by Argo CD | Base URL for the environment |

--- a/applications/noteburst/values.yaml
+++ b/applications/noteburst/values.yaml
@@ -180,7 +180,7 @@ config:
     tokenLifetime: "2419200"
 
     # -- Nublado2 worker account's token scopes as a comma-separated list.
-    tokenScopes: "exec:notebook,read:image,read:tap,read:alertdb,read:sasquatch"
+    tokenScopes: "exec:notebook,read:image,read:tap,read:sasquatch"
 
     # -- Nublado image stream to select: "recommended", "weekly" or "reference"
     imageSelector: "recommended"


### PR DESCRIPTION
This scope is only used for the alert-database service in sasquatch, which in turn is only used in the Prompt Processing environments. Its global existence was confusing people who were looking for the scope controlling access to Herald.

Remove it from the noteburst scopes, where it should not be needed, and move it from the global Gafaelfawr `knownScopes` configuration to the two specific clusters that use it.