### PR TITLE
DM-55463: Update qserv-kafka and bigquery-kafka to 5.0.0

### DIFF
--- a/applications/bigquery-kafka/Chart.yaml
+++ b/applications/bigquery-kafka/Chart.yaml
@@ -5,7 +5,7 @@ version: 1.0.0
 description: "BigQuery Kafka bridge"
 sources:
   - "https://github.com/lsst-sqre/qserv-kafka"
-appVersion: 4.5.0
+appVersion: 5.0.0
 
 dependencies:
   - name: "redis"

--- a/applications/qserv-kafka/Chart.yaml
+++ b/applications/qserv-kafka/Chart.yaml
@@ -5,7 +5,7 @@ version: 1.0.0
 description: "Qserv Kafka bridge"
 sources:
   - "https://github.com/lsst-sqre/qserv-kafka"
-appVersion: 4.4.0
+appVersion: 5.0.0
 
 dependencies:
   - name: "redis"


### PR DESCRIPTION
This release has improvements for temporary table uploads to Qserv and fixes for Qserv temporary table deletion and BINARY2 encoding error handling.