### PR TITLE
DM-53296: Deploy Squareone 0.36.2

### DIFF
--- a/applications/squareone/Chart.yaml
+++ b/applications/squareone/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
     url: https://github.com/jonathansick
 
 # The default version tag of the squareone docker image
-appVersion: "0.36.1"
+appVersion: "0.36.2"


### PR DESCRIPTION
## Summary

Deploys Squareone 0.36.2 to the RSP by bumping the `squareone` chart's `appVersion` from `0.36.1` to `0.36.2`.

Squareone 0.36.2 is a patch release focused on accessibility and responsive layout:

- **Accessibility (WCAG):** a "Skip to main content" link and a single root `<main>` landmark on every page; named header/footer/sidebar/Times Square navigation and broadcast-banner `<aside>` landmarks; and persistent ARIA live regions so broadcast banners are announced to screen readers.
- **Responsive layout:** every route now reflows without horizontal scroll at a 320px viewport (WCAG 1.4.10), the Times Square sidebar layout stacks on narrow viewports, and the header user menu stays visible when the nav collapses. The shared desktop breakpoint moved to `66rem` to fix a layout break in the ~960–1056px range.
- **Dev tooling:** a development mock for the Gafaelfawr per-user tokens API (production builds unaffected).

Release notes: https://github.com/lsst-sqre/squareone/releases/tag/squareone%400.36.2

## Validation

- `phalanx application lint squareone` passes across all environments.
- Docker image `ghcr.io/lsst-sqre/squareone:0.36.2` published by the squareone release workflow.

## References

DM-53296
