### PR TITLE
DM-55532: Pin Nublado prerelease on idfint

### DIFF
--- a/applications/nublado/values-idfint.yaml
+++ b/applications/nublado/values-idfint.yaml
@@ -29,6 +29,10 @@ controller:
         - containerPath: "/home"
           volumeName: "home"
     images:
+      numReleases: 0
+      pin:
+        - "r30_0_9_rc1_rsp2957"
+      recommended: "r30_0_9_rc1_rsp2957"
       source:
         type: "google"
         location: "us-central1"


### PR DESCRIPTION
We unfortunately have no way to tell the menu to display a pre-release normally, so instead set the releases to zero and make the new pre-release the recommended tag.