### PR TITLE
DM-55245: Rebuild docs on repertoire values changes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -120,9 +120,10 @@ jobs:
               - "applications/*/values.yaml"
               - "applications/argocd/values-*.yaml"
               - "applications/gafaelfawr/values-*.yaml"
+              - "applications/repertoire/values-*.yaml"
               - "environments/values-*.yaml"
-              - "requirements/*.txt"
               - "src/phalanx/**"
+              - "uv.lock"
             docs-specific:
               - "docs/**"
             minikube:


### PR DESCRIPTION
## Summary

- The `docs` paths-filter in `.github/workflows/ci.yaml` gates rebuilds of the static documentation, including the Repertoire discovery JSON published at `https://phalanx.lsst.io/discovery/environments/{env}.json`. It only watched per-environment values files for `argocd` and `gafaelfawr`, so a change touching only `applications/repertoire/values-{env}.yaml` did not trigger a docs rebuild and the published discovery JSON could go stale.
- Add `applications/repertoire/values-*.yaml` to the `docs` filter so per-environment Repertoire config changes regenerate the discovery data. This matters now that rsp.lsst.io builds its per-environment docs from this JSON, including on scheduled rebuilds.
- Replace the stale `requirements/*.txt` entry (the `requirements/` directory no longer exists now that dependencies are managed with uv) with `uv.lock`, matching the `minikube` filter.

## Validation steps

- Open a PR touching only `applications/repertoire/values-idfdev.yaml` and confirm the `docs` job runs.
- Open a PR touching only `uv.lock` and confirm the `docs` job runs.

## References

- Closes #6711
- Jira: https://rubinobs.atlassian.net/browse/DM-55245