### PR TITLE
DM-55532: Fix recommended tag setting on idfint

### DIFF
--- a/applications/nublado/values-idfint.yaml
+++ b/applications/nublado/values-idfint.yaml
@@ -32,7 +32,7 @@ controller:
       numReleases: 0
       pin:
         - "r30_0_9_rc1_rsp2957"
-      recommended: "r30_0_9_rc1_rsp2957"
+      recommendedTag: "r30_0_9_rc1_rsp2957"
       source:
         type: "google"
         location: "us-central1"


### PR DESCRIPTION
`recommendedTag`, not `recommended`, in the Nublado configuration.