### PR TITLE
DM-55532: Lower cell execution timeouts for mobu on idfint

### DIFF
--- a/applications/mobu/values-idfint.yaml
+++ b/applications/mobu/values-idfint.yaml
@@ -35,7 +35,7 @@ config:
       business:
         type: "NotebookRunnerCounting"
         options:
-          cell_execution_timeout: "1h"
+          cell_execution_timeout: "1000s"
           image:
             image_class: "latest-daily"
           repo_url: "https://github.com/lsst-sqre/phalanx-test.git"
@@ -58,7 +58,7 @@ config:
         type: "NotebookRunnerCounting"
         options:
           repo_url: "https://github.com/lsst-sqre/phalanx-test.git"
-          cell_execution_timeout: "1h"
+          cell_execution_timeout: "1000s"
           repo_ref: "main"
           execution_idle_time: 0
           idle_time: 300
@@ -75,7 +75,7 @@ config:
       business:
         type: "NotebookRunnerCounting"
         options:
-          cell_execution_timeout: "1h"
+          cell_execution_timeout: "1000s"
           repo_url: "https://github.com/lsst/tutorial-notebooks.git"
           repo_ref: "main"
           max_executions: 1


### PR DESCRIPTION
Based on Frossie's metrics research, 1000s should be sufficiently long that no valid cell execution will be caught. This should speed up finding issues with tutorial notebooks with DP2.