### PR TITLE
DM-55493: deploy squarebot 0.10.3

### DIFF
--- a/applications/squarebot/Chart.yaml
+++ b/applications/squarebot/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: squarebot
 version: 1.0.0
-appVersion: "0.10.2"
+appVersion: "0.10.3"
 description: Squarebot feeds events from services like Slack and GitHub into the SQuaRE Events Kafka message bus running on Roundtable. Backend apps like Templatebot and Unfurlbot can subscribe to these events and take domain-specific action.
 type: application
 home: https://squarebot.lsst.io/


### PR DESCRIPTION
Bumps the squarebot `appVersion` from `0.10.2` to `0.10.3` in `applications/squarebot/Chart.yaml`, deploying the newly published [squarebot 0.10.3](https://github.com/lsst-sqre/squarebot/releases/tag/0.10.3) release.

The GitHub release was just published, so the `0.10.3` image build may still be running.

**Merge once the `0.10.3` image is confirmed available on GHCR** ([ghcr.io/lsst-sqre/squarebot](https://github.com/lsst-sqre/squarebot/pkgs/container/squarebot)). Merging this PR auto-deploys to production.

Jira: [DM-55493](https://rubinobs.atlassian.net/browse/DM-55493)


[DM-55493]: https://rubinobs.atlassian.net/browse/DM-55493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ