### PR TITLE
DM-55493: deploy templatebot 0.5.4

### DIFF
--- a/applications/templatebot/Chart.yaml
+++ b/applications/templatebot/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "0.5.3"
+appVersion: "0.5.4"
 description: Create new projects
 name: templatebot
 sources:


### PR DESCRIPTION
Bumps the `templatebot` `appVersion` in `applications/templatebot/Chart.yaml` from `0.5.3` to `0.5.4`. The templatebot 0.5.4 release was just published.

- Jira: https://rubinobs.atlassian.net/browse/DM-55493

**Do not merge yet.** Merging this PR auto-deploys to production. Merge only once the `0.5.4` image is confirmed published on GHCR.