### PR TITLE
DM-55493: deploy hoverdrive 0.2.1

### DIFF
--- a/applications/hoverdrive/Chart.yaml
+++ b/applications/hoverdrive/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "0.2.0"
+appVersion: "0.2.1"
 description: Documentation links for VO.
 name: hoverdrive
 sources:


### PR DESCRIPTION
Bumps the `hoverdrive` application `appVersion` in `applications/hoverdrive/Chart.yaml` from `0.2.0` to `0.2.1`. The hoverdrive 0.2.1 release was just published.

```diff
-appVersion: "0.2.0"
+appVersion: "0.2.1"
```

Jira: [DM-55493](https://rubinobs.atlassian.net/browse/DM-55493)

**Do not merge yet.** Merging Phalanx auto-deploys to production. Merge only once the `0.2.1` image is confirmed available on GHCR.


[DM-55493]: https://rubinobs.atlassian.net/browse/DM-55493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ