### PR TITLE
DM-55493: deploy unfurlbot 0.5.2

### DIFF
--- a/applications/unfurlbot/Chart.yaml
+++ b/applications/unfurlbot/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "0.5.1"
+appVersion: "0.5.2"
 description: Squarebot backend that unfurls Jira issues.
 name: unfurlbot
 sources:


### PR DESCRIPTION
Bump `applications/unfurlbot/Chart.yaml` `appVersion` from `0.5.1` to `0.5.2`. The unfurlbot 0.5.2 release was just published.

**Do not merge until the 0.5.2 image is available on GHCR** — merging this PR auto-deploys unfurlbot to production.

## Change

```diff
-appVersion: "0.5.1"
+appVersion: "0.5.2"
```

## References

- Jira: [DM-55493](https://rubinobs.atlassian.net/browse/DM-55493)


[DM-55493]: https://rubinobs.atlassian.net/browse/DM-55493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ