### PR TITLE
DM-55493: deploy turborepo-cache-proxy 1.0.3

### DIFF
--- a/applications/turborepo-cache/README.md
+++ b/applications/turborepo-cache/README.md
@@ -32,7 +32,7 @@ Turborepo remote cache
 | proxy.config.pathPrefix | string | `"/turborepo-cache"` | URL path prefix for the proxy application |
 | proxy.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the proxy image |
 | proxy.image.repository | string | `"ghcr.io/lsst-sqre/turborepo-cache-proxy"` | Image to use for the proxy deployment |
-| proxy.image.tag | string | `"1.0.2"` | Tag of proxy image to use |
+| proxy.image.tag | string | `"1.0.3"` | Tag of proxy image to use |
 | proxy.nodeSelector | object | `{}` | Node selection rules for the proxy deployment pod |
 | proxy.podAnnotations | object | `{}` | Annotations for the proxy deployment pod |
 | proxy.replicaCount | int | `1` | Number of proxy deployment pods to start |

--- a/applications/turborepo-cache/values.yaml
+++ b/applications/turborepo-cache/values.yaml
@@ -63,7 +63,7 @@ proxy:
     pullPolicy: "IfNotPresent"
 
     # -- Tag of proxy image to use
-    tag: "1.0.2"
+    tag: "1.0.3"
 
   config:
     # -- Log level for the proxy application


### PR DESCRIPTION
Bumps `proxy.image.tag` in `applications/turborepo-cache/values.yaml` from `1.0.2` to `1.0.3` (release just published).

- **YAML path:** `proxy.image.tag`
- **Before:** `    tag: "1.0.2"`
- **After:** `    tag: "1.0.3"`

Note: this app's deployed image tag lives in `values.yaml` at `proxy.image.tag`, not in `Chart.yaml` `appVersion`. `Chart.yaml` is unchanged. `applications/turborepo-cache/README.md` is also regenerated (helm-docs) to keep the values table in sync (`proxy.image.tag` row `1.0.2` -> `1.0.3`); no other keys, files, or apps touched.

Jira: https://rubinobs.atlassian.net/browse/DM-55493

**Do not merge until the 1.0.3 image is published on GHCR** (`ghcr.io/lsst-sqre/turborepo-cache-proxy:1.0.3`). Merging this PR auto-deploys to production.