### PR TITLE
DM-55387: Deploy Ook 0.25.0 with the intersphinx inventory cache

### DIFF
--- a/applications/gafaelfawr/values-roundtable-dev.yaml
+++ b/applications/gafaelfawr/values-roundtable-dev.yaml
@@ -38,6 +38,8 @@ config:
       Can access Docverse's as a user in an organization
     "exec:linkcheck": >-
       Can submit link-check requests to Ook
+    "write:intersphinx": >-
+      Can read and refresh Ook's cached intersphinx inventories
 
   groupMapping:
     "admin:userinfo":
@@ -67,6 +69,10 @@ config:
           organization: "lsst-sqre"
           team: "square"
     "exec:linkcheck":
+      - github:
+          organization: "lsst-sqre"
+          team: "square"
+    "write:intersphinx":
       - github:
           organization: "lsst-sqre"
           team: "square"

--- a/applications/gafaelfawr/values-roundtable-prod.yaml
+++ b/applications/gafaelfawr/values-roundtable-prod.yaml
@@ -38,6 +38,8 @@ config:
       Can access Docverse's as a user in an organization
     "exec:linkcheck": >-
       Can submit link-check requests to Ook
+    "write:intersphinx": >-
+      Can read and refresh Ook's cached intersphinx inventories
 
   groupMapping:
     "admin:userinfo":
@@ -70,6 +72,10 @@ config:
           organization: "lsst-sqre"
           team: "square"
     "exec:linkcheck":
+      - github:
+          organization: "lsst-sqre"
+          team: "square"
+    "write:intersphinx":
       - github:
           organization: "lsst-sqre"
           team: "square"

--- a/applications/ook/Chart.yaml
+++ b/applications/ook/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: ook
 version: 1.0.0
-appVersion: "0.24.0"
+appVersion: "0.25.0"
 description: >
   Ook is the librarian service for Rubin Observatory. Ook indexes
   documentation content into the Algolia search engine that powers the Rubin

--- a/applications/ook/README.md
+++ b/applications/ook/README.md
@@ -31,6 +31,9 @@ Ook is the librarian service for Rubin Observatory. Ook indexes documentation co
 | cloudsql.serviceAccount | string | `""` | The Google service account that has an IAM binding to the `ook` Kubernetes service accounts and has the `cloudsql.client` role |
 | config.algolia.documents_index | string | `"documents_dev"` | Name of the Algolia index for documents |
 | config.databaseUrl | string | `""` | Database URL |
+| config.intersphinx.activeWindow | string | `"30d"` | Active window for the intersphinx refresh job. The scheduled refresh only revalidates cached inventories requested by a client within this window; inventories last requested longer ago are skipped (not deleted) |
+| config.intersphinx.negativeTtl | string | `"5m"` | Negative-cache TTL for cold-miss intersphinx inventory fetch failures. A repeat request inside this window returns the error without re-contacting upstream |
+| config.intersphinx.ttl | string | `"1h"` | Freshness TTL for cached intersphinx inventories. An inventory fetched within this window is served as a fresh cache hit; an older one is served stale on the request path while the refresh job revalidates it |
 | config.linkcheck.blockedRecheckInterval | string | `"1h"` | Delay until the next recheck of a bot-blocked link, revisited at this near-term cadence because a block is inconclusive and tends to flap |
 | config.linkcheck.brokenMinAttempts | int | `3` | Minimum number of consecutive failed attempts before a previously-OK link is declared broken instead of failing |
 | config.linkcheck.brokenRecheckInterval | string | `"24h"` | Delay until the next recheck of a broken link, revisited at this slow cadence so a since-fixed link can heal without waiting to be resubmitted |
@@ -75,6 +78,14 @@ Ook is the librarian service for Rubin Observatory. Ook indexes documentation co
 | ingestUpdated.window | string | `"2d"` | Time window to look for updated documents (e.g. 1h, 2d, 3w). This must be set to a value greater than the cron schedule for the ingest-updated job. |
 | ingress.annotations | object | `{}` | Additional annotations to add to the ingress |
 | ingress.path | string | `"/ook"` | Path prefix where Squarebot is hosted |
+| intersphinxRefresh.affinity | object | `{}` | Affinity rules for Ook intersphinx-refresh pods |
+| intersphinxRefresh.enabled | bool | `false` | Enable the intersphinx-refresh job |
+| intersphinxRefresh.nodeSelector | object | `{}` | Node selection rules for Ook intersphinx-refresh pods |
+| intersphinxRefresh.podAnnotations | object | `{}` | Annotations for Ook intersphinx-refresh pods |
+| intersphinxRefresh.resources | object | `{}` | Resource limits and requests for Ook intersphinx-refresh pods |
+| intersphinxRefresh.schedule | string | `"15 * * * *"` | Cron schedule string for the ook intersphinx-refresh job (UTC) |
+| intersphinxRefresh.tolerations | list | `[]` | Tolerations for Ook intersphinx-refresh pods |
+| intersphinxRefresh.ttlSecondsAfterFinished | int | `86400` | Time (second) to keep a finished job before cleaning up |
 | linkcheckRecheck.affinity | object | `{}` | Affinity rules for Ook linkcheck-recheck pods |
 | linkcheckRecheck.enabled | bool | `false` | Enable the linkcheck-recheck job |
 | linkcheckRecheck.nodeSelector | object | `{}` | Node selection rules for Ook linkcheck-recheck pods |

--- a/applications/ook/templates/configmap.yaml
+++ b/applications/ook/templates/configmap.yaml
@@ -25,4 +25,7 @@ data:
   {{- with .Values.config.linkcheck.userAgent }}
   OOK_LINKCHECK_USER_AGENT: {{ . | quote }}
   {{- end }}
+  OOK_INTERSPHINX_TTL: {{ .Values.config.intersphinx.ttl | quote }}
+  OOK_INTERSPHINX_NEGATIVE_TTL: {{ .Values.config.intersphinx.negativeTtl | quote }}
+  OOK_INTERSPHINX_ACTIVE_WINDOW: {{ .Values.config.intersphinx.activeWindow | quote }}
   ALGOLIA_DOCUMENT_INDEX: {{ .Values.config.algolia.documentIndex | quote }}

--- a/applications/ook/templates/cronjob-intersphinx-refresh.yaml
+++ b/applications/ook/templates/cronjob-intersphinx-refresh.yaml
@@ -1,0 +1,83 @@
+{{- if .Values.intersphinxRefresh.enabled -}}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: "ook-intersphinx-refresh"
+  labels:
+    {{- include "ook.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "intersphinx-refresh"
+    app.kubernetes.io/part-of: "ook"
+spec:
+  schedule: {{ .Values.intersphinxRefresh.schedule | quote }}
+  concurrencyPolicy: "Forbid"
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      ttlSecondsAfterFinished: {{ .Values.intersphinxRefresh.ttlSecondsAfterFinished }}
+      template:
+        metadata:
+          {{- with .Values.intersphinxRefresh.podAnnotations }}
+          annotations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          labels:
+            {{- include "ook.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: "intersphinx-refresh"
+            app.kubernetes.io/part-of: "ook"
+        spec:
+          restartPolicy: "Never"
+          {{- if or .Values.cloudsql.enabled }}
+          serviceAccountName: "ook"
+          {{- else }}
+          automountServiceAccountToken: false
+          {{- end }}
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+          containers:
+            - name: {{ .Chart.Name }}
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              command:
+                - "ook"
+                - "refresh-intersphinx"
+              resources:
+                {{- toYaml .Values.resources | nindent 16 }}
+              envFrom:
+                - configMapRef:
+                    name: "ook"
+              env:
+                {{- include "ook.envVars" (dict "Chart" .Chart "Release" .Release "Values" .Values) | nindent 16 }}
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - "all"
+                readOnlyRootFilesystem: true
+              volumeMounts:
+                {{- include "ook.volumeMounts" (dict "Chart" .Chart "Release" .Release "Values" .Values) | nindent 16 }}
+          {{- if .Values.cloudsql.enabled }}
+          initContainers:
+            {{- include "ook.cloudsqlSidecar" . | nindent 12 }}
+          {{- end }}
+          {{with .Values.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumes:
+            {{- include "ook.volumes" (dict "Chart" .Chart "Release" .Release "Values" .Values) | nindent 12 }}
+{{- end }}

--- a/applications/ook/templates/ingress.yaml
+++ b/applications/ook/templates/ingress.yaml
@@ -151,3 +151,40 @@ template:
                   name: "ook"
                   port:
                     number: {{ .Values.service.port }}
+
+---
+# The intersphinx inventory cache API requires the write:intersphinx scope
+# (delegated to the documentation toolchain via OOK_TOKEN). This covers
+# GET /ook/intersphinx/inventory, which serves cached Sphinx objects.inv
+# inventories and, on a cold miss, fetches and stores the origin inventory.
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
+metadata:
+  name: "ook-intersphinx"
+  labels:
+    {{- include "ook.labels" . | nindent 4 }}
+config:
+  loginRedirect: false
+  scopes:
+    all:
+      - "write:intersphinx"
+  service: "ook"
+template:
+  metadata:
+    name: "ook-intersphinx"
+    {{- with .Values.ingress.annotations }}
+    annotations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  spec:
+    rules:
+      - host: {{ required "global.host must be set" .Values.global.host | quote }}
+        http:
+          paths:
+            - path: "{{ .Values.ingress.path }}/intersphinx/inventory"
+              pathType: "Prefix"
+              backend:
+                service:
+                  name: "ook"
+                  port:
+                    number: {{ .Values.service.port }}

--- a/applications/ook/values-roundtable-dev.yaml
+++ b/applications/ook/values-roundtable-dev.yaml
@@ -1,11 +1,3 @@
-image:
-  # Deploy the branch image built from lsst-sqre/ook#298 (DM-55600) to test
-  # the intersphinx inventory cache service with ETag/304 revalidation
-  # (lsst-sqre/ook#284 merged to main plus lsst-sqre/ook#294). Remove this
-  # override once the feature ships in a tagged release.
-  tag: "tickets-DM-55600"
-  pullPolicy: Always
-
 config:
   logLevel: "DEBUG"
   databaseUrl: "postgresql://ook@localhost/ook"

--- a/applications/ook/values-roundtable-dev.yaml
+++ b/applications/ook/values-roundtable-dev.yaml
@@ -1,8 +1,9 @@
 image:
-  # Deploy the branch image built from lsst-sqre/ook#284 (DM-55387) to test
-  # the intersphinx inventory cache service. Remove this override once the
-  # feature ships in a tagged release.
-  tag: "tickets-DM-55387"
+  # Deploy the branch image built from lsst-sqre/ook#298 (DM-55600) to test
+  # the intersphinx inventory cache service with ETag/304 revalidation
+  # (lsst-sqre/ook#284 merged to main plus lsst-sqre/ook#294). Remove this
+  # override once the feature ships in a tagged release.
+  tag: "tickets-DM-55600"
   pullPolicy: Always
 
 config:

--- a/applications/ook/values-roundtable-dev.yaml
+++ b/applications/ook/values-roundtable-dev.yaml
@@ -1,4 +1,8 @@
 image:
+  # Deploy the branch image built from lsst-sqre/ook#284 (DM-55387) to test
+  # the intersphinx inventory cache service. Remove this override once the
+  # feature ships in a tagged release.
+  tag: "tickets-DM-55387"
   pullPolicy: Always
 
 config:
@@ -20,6 +24,10 @@ ingestUpdated:
 linkcheckRecheck:
   enabled: true
   schedule: "45 4 * * *"
+
+intersphinxRefresh:
+  enabled: true
+  schedule: "15 * * * *"
 
 ingestLsstTexmf:
   enabled: true

--- a/applications/ook/values-roundtable-prod.yaml
+++ b/applications/ook/values-roundtable-prod.yaml
@@ -15,6 +15,9 @@ ingestUpdated:
 linkcheckRecheck:
   enabled: true
   schedule: "45 4 * * *"
+intersphinxRefresh:
+  enabled: true
+  schedule: "15 * * * *"
 ingestLsstTexmf:
   enabled: true
 

--- a/applications/ook/values.yaml
+++ b/applications/ook/values.yaml
@@ -148,6 +148,23 @@ config:
     # scheduled linkcheck-recheck maintenance command
     checkRetention: "30d"
 
+  intersphinx:
+    # -- Freshness TTL for cached intersphinx inventories. An inventory
+    # fetched within this window is served as a fresh cache hit; an older one
+    # is served stale on the request path while the refresh job revalidates
+    # it
+    ttl: "1h"
+
+    # -- Negative-cache TTL for cold-miss intersphinx inventory fetch
+    # failures. A repeat request inside this window returns the error without
+    # re-contacting upstream
+    negativeTtl: "5m"
+
+    # -- Active window for the intersphinx refresh job. The scheduled refresh
+    # only revalidates cached inventories requested by a client within this
+    # window; inventories last requested longer ago are skipped (not deleted)
+    activeWindow: "30d"
+
 audit:
   # -- Enable the audit job
   enabled: true
@@ -228,6 +245,31 @@ linkcheckRecheck:
   tolerations: []
 
   # -- Affinity rules for Ook linkcheck-recheck pods
+  affinity: {}
+
+intersphinxRefresh:
+  # -- Enable the intersphinx-refresh job
+  enabled: false
+
+  # -- Cron schedule string for the ook intersphinx-refresh job (UTC)
+  schedule: "15 * * * *"
+
+  # -- Time (second) to keep a finished job before cleaning up
+  ttlSecondsAfterFinished: 86400
+
+  # -- Resource limits and requests for Ook intersphinx-refresh pods
+  resources: {}
+
+  # -- Annotations for Ook intersphinx-refresh pods
+  podAnnotations: {}
+
+  # -- Node selection rules for Ook intersphinx-refresh pods
+  nodeSelector: {}
+
+  # -- Tolerations for Ook intersphinx-refresh pods
+  tolerations: []
+
+  # -- Affinity rules for Ook intersphinx-refresh pods
   affinity: {}
 
 ingestLsstTexmf:


### PR DESCRIPTION
## Summary

Deploy **Ook 0.25.0**, which ships the new **intersphinx inventory cache**
service, and enable the feature on **roundtable-prod**.

Ook becomes a caching proxy for Sphinx `objects.inv` inventories: a new
`GET /ook/intersphinx/inventory?url=…` endpoint serves cached inventories
(fetching synchronously on a cold miss, serving stale copies when upstreams
are down) with **ETag/304 revalidation** — a strong SHA-256 `ETag` on every
200 and `If-None-Match` → `304 Not Modified` support — and an
`ook refresh-intersphinx` CronJob proactively revalidates stale-but-active
inventories with conditional GETs. See PRDs lsst-sqre/ook#236 (cache
service) and lsst-sqre/ook#294 (ETag/304).

The feature was validated on roundtable-dev with branch images
(`tickets-DM-55387`, then `tickets-DM-55600`), including an end-to-end
smoke test of the ETag/304 contract through the Gafaelfawr ingress.

## What this PR does

**Chart-level plumbing (environment-agnostic, disabled by default):**

- `ook-intersphinx` `GafaelfawrIngress` protecting `GET /ook/intersphinx/inventory`
  with the new `write:intersphinx` scope.
- `ook-intersphinx-refresh` `CronJob` running `ook refresh-intersphinx`
  (mirrors `linkcheck-recheck`; `intersphinxRefresh.enabled` defaults to `false`).
- `OOK_INTERSPHINX_*` ConfigMap wiring and `config.intersphinx` /
  `intersphinxRefresh` values defaults (TTL 1h, negative TTL 5m, active window 30d).

**Release deploy:**

- Bump `Chart.yaml` `appVersion` to **0.25.0**.
- Remove the roundtable-dev `image.tag`/`pullPolicy` branch-image override —
  dev now tracks the released appVersion like prod.

**Per-environment enablement (both roundtable-dev and roundtable-prod):**

- Enable the `intersphinx-refresh` CronJob (hourly at :15).
- Register the `write:intersphinx` scope in Gafaelfawr (mapped to the
  `lsst-sqre/square` team).

The `intersphinx_inventory` Alembic migration (`c2a2c14c0e60`) runs
automatically via the existing schema-update job (`config.updateSchema: true`
on both environments); it has already been applied on roundtable-dev.

## How to deploy / validate (Argo CD)

After merging, on **roundtable-prod** (dev updates the same way, minus the
scope/migration novelty):

1. **gafaelfawr** → Sync (registers the `write:intersphinx` scope) before the
   ook ingress references it.
2. **ook** → Sync; the schema-update job applies migration `c2a2c14c0e60` and
   the Deployment rolls to 0.25.0.
3. Smoke-test with a token carrying `write:intersphinx`:
   `GET https://roundtable.lsst.cloud/ook/intersphinx/inventory?url=<objects.inv URL>`
   — expect 200 with `Age` and a quoted SHA-256 `ETag`; repeat with
   `If-None-Match: <that ETag>` — expect an empty-body `304 Not Modified`.
4. Confirm the `ook-intersphinx-refresh` CronJob is scheduled and runs cleanly.

On roundtable-dev, reset the Argo CD target revision back to `main` and sync
(it had been pointed at this branch for the branch-image testing).

## References

- PRDs: lsst-sqre/ook#236 (cache service), lsst-sqre/ook#294 (ETag/304)
- Ook implementation PRs: lsst-sqre/ook#284, lsst-sqre/ook#298 (both merged)
- Release: https://github.com/lsst-sqre/ook/releases/tag/0.25.0
- Jira: [DM-55387], [DM-55600]
- Companion client PRDs: lsst-sqre/documenteer#318, lsst-sqre/documenteer#342


[DM-55387]: https://rubinobs.atlassian.net/browse/DM-55387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DM-55600]: https://rubinobs.atlassian.net/browse/DM-55600
