### PR TITLE
DM-55537: Update SIA to 2.0.0

### DIFF
--- a/applications/sia/Chart.yaml
+++ b/applications/sia/Chart.yaml
@@ -1,11 +1,12 @@
 apiVersion: v2
-appVersion: 1.3.1
-description: Simple Image Access (SIA) IVOA Service using Butler
 name: sia
-sources:
-- https://github.com/lsst-sqre/sia
-type: application
 version: 1.0.0
+type: application
+description: "Simple Image Access (SIA) IVOA Service using Butler"
+sources:
+  - "https://github.com/lsst-sqre/sia"
+appVersion: 1.4.0
+
 annotations:
   phalanx.lsst.io/docs: |
     - id: "SQR-095"

--- a/applications/sia/Chart.yaml
+++ b/applications/sia/Chart.yaml
@@ -1,11 +1,12 @@
 apiVersion: v2
-appVersion: 1.3.1
-description: Simple Image Access (SIA) IVOA Service using Butler
 name: sia
-sources:
-- https://github.com/lsst-sqre/sia
-type: application
 version: 1.0.0
+type: application
+description: "Simple Image Access (SIA) IVOA Service using Butler"
+sources:
+  - "https://github.com/lsst-sqre/sia"
+appVersion: 2.0.0
+
 annotations:
   phalanx.lsst.io/docs: |
     - id: "SQR-095"

--- a/applications/sia/README.md
+++ b/applications/sia/README.md
@@ -35,4 +35,4 @@ Simple Image Access (SIA) IVOA Service using Butler
 | podAnnotations | object | `{}` | Annotations for the sia deployment pod |
 | replicaCount | int | `1` | Number of web deployment pods to start |
 | resources | object | See `values.yaml` | Resource limits and requests for the sia deployment pod |
-| tolerations | list | `[]` | Tolerations for the sia deployment pod |
+| tolerations | list | Tolerate GKE amd64 and arm64 taints | Tolerations for the sia deployment pod |

--- a/applications/sia/README.md
+++ b/applications/sia/README.md
@@ -12,7 +12,6 @@ Simple Image Access (SIA) IVOA Service using Butler
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules for the sia deployment pod |
 | config.butlerDataCollections | list | `[]` | List of data (Butler) Collections. Expected attributes: `config`, `label`, `name`, `butler_type`, `repository`, and `datalink_url` |
-| config.directButlerEnabled | bool | `false` | Whether direct butler access is enabled |
 | config.logLevel | string | `"INFO"` | Logging level |
 | config.logProfile | string | `"production"` | Logging profile (`production` for JSON, `development` for human-friendly) |
 | config.metrics.application | string | `"sia"` | Name under which to log metrics. Generally there is no reason to change this. |
@@ -21,7 +20,6 @@ Simple Image Access (SIA) IVOA Service using Butler
 | config.metrics.schemaManager.registryUrl | string | Sasquatch in the local cluster | URL of the Confluent-compatible schema registry server |
 | config.metrics.schemaManager.suffix | string | `""` | Suffix to add to all registered subjects. This is sometimes useful for experimentation during development. |
 | config.pathPrefix | string | `"/api/sia"` | URL path prefix |
-| config.pgUser | string | `"rubin"` | User to use from the PGPASSFILE if sia is using a direct Butler connection. |
 | config.sentry.enabled | bool | `false` | Set to true to enable the Sentry integration. |
 | config.sentry.tracesSampleRate | float | `0` | The percentage of requests that should be traced. This should be a float between 0 and 1. |
 | config.slackAlerts | bool | `false` | Whether to send alerts and status to Slack. |

--- a/applications/sia/README.md
+++ b/applications/sia/README.md
@@ -11,7 +11,7 @@ Simple Image Access (SIA) IVOA Service using Butler
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules for the sia deployment pod |
-| config.butlerDataCollections | list | `[]` | List of data (Butler) Collections Expected attributes: `config`, `label`, `name`, `butler_type`, `repository` & `datalink_url` |
+| config.butlerDataCollections | list | `[]` | List of data (Butler) Collections. Expected attributes: `config`, `label`, `name`, `butler_type`, `repository`, and `datalink_url` |
 | config.directButlerEnabled | bool | `false` | Whether direct butler access is enabled |
 | config.enableSentry | bool | `false` | Whether to send trace and telemetry information to Sentry. This traces every call and therefore should only be enabled in non-production environments. |
 | config.logLevel | string | `"INFO"` | Logging level |
@@ -22,18 +22,15 @@ Simple Image Access (SIA) IVOA Service using Butler
 | config.metrics.schemaManager.registryUrl | string | Sasquatch in the local cluster | URL of the Confluent-compatible schema registry server |
 | config.metrics.schemaManager.suffix | string | `""` | Suffix to add to all registered subjects. This is sometimes useful for experimentation during development. |
 | config.pathPrefix | string | `"/api/sia"` | URL path prefix |
-| config.pgUser | string | `"rubin"` | User to use from the PGPASSFILE if sia is using a direct Butler connection |
+| config.pgUser | string | `"rubin"` | User to use from the PGPASSFILE if sia is using a direct Butler connection. |
 | config.sentryTracesSampleRate | float | `0` |  |
 | config.slackAlerts | bool | `false` | Whether to send alerts and status to Slack. |
-| fullnameOverride | string | `""` | Override the full name for resources (includes the release name) |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the sia image |
 | image.repository | string | `"ghcr.io/lsst-sqre/sia"` | Image to use in the sia deployment |
 | image.tag | string | The appVersion of the chart | Tag of image to use |
 | ingress.annotations | object | `{}` | Additional annotations for the ingress rule |
-| ingress.path | string | `"/api/sia"` | Path prefix where app is hosted |
-| nameOverride | string | `""` | Override the base name for resources |
 | nodeSelector | object | `{}` | Node selection rules for the sia deployment pod |
 | podAnnotations | object | `{}` | Annotations for the sia deployment pod |
 | replicaCount | int | `1` | Number of web deployment pods to start |

--- a/applications/sia/README.md
+++ b/applications/sia/README.md
@@ -13,7 +13,6 @@ Simple Image Access (SIA) IVOA Service using Butler
 | affinity | object | `{}` | Affinity rules for the sia deployment pod |
 | config.butlerDataCollections | list | `[]` | List of data (Butler) Collections. Expected attributes: `config`, `label`, `name`, `butler_type`, `repository`, and `datalink_url` |
 | config.directButlerEnabled | bool | `false` | Whether direct butler access is enabled |
-| config.enableSentry | bool | `false` | Whether to send trace and telemetry information to Sentry. This traces every call and therefore should only be enabled in non-production environments. |
 | config.logLevel | string | `"INFO"` | Logging level |
 | config.logProfile | string | `"production"` | Logging profile (`production` for JSON, `development` for human-friendly) |
 | config.metrics.application | string | `"sia"` | Name under which to log metrics. Generally there is no reason to change this. |
@@ -23,8 +22,10 @@ Simple Image Access (SIA) IVOA Service using Butler
 | config.metrics.schemaManager.suffix | string | `""` | Suffix to add to all registered subjects. This is sometimes useful for experimentation during development. |
 | config.pathPrefix | string | `"/api/sia"` | URL path prefix |
 | config.pgUser | string | `"rubin"` | User to use from the PGPASSFILE if sia is using a direct Butler connection. |
-| config.sentryTracesSampleRate | float | `0` |  |
+| config.sentry.enabled | bool | `false` | Set to true to enable the Sentry integration. |
+| config.sentry.tracesSampleRate | float | `0` | The percentage of requests that should be traced. This should be a float between 0 and 1. |
 | config.slackAlerts | bool | `false` | Whether to send alerts and status to Slack. |
+| global.environmentName | string | Set by Argo CD Application | Name of the Phalanx environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the sia image |

--- a/applications/sia/README.md
+++ b/applications/sia/README.md
@@ -12,6 +12,7 @@ Simple Image Access (SIA) IVOA Service using Butler
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules for the sia deployment pod |
 | config.datasets | list | `["dp02","dp1"]` | List of datasets enabled in this environment. |
+| config.ivoidFormat | string | `"ivo://org.rubinobs/{dataset}/sia"` | Format string for the IVOID used for self-identification. This must contain a `dataset` variable that will be replaced with the label of the dataset. |
 | config.logLevel | string | `"INFO"` | Logging level |
 | config.logProfile | string | `"production"` | Logging profile (`production` for JSON, `development` for human-friendly) |
 | config.metrics.application | string | `"sia"` | Name under which to log metrics. Generally there is no reason to change this. |

--- a/applications/sia/README.md
+++ b/applications/sia/README.md
@@ -27,6 +27,7 @@ Simple Image Access (SIA) IVOA Service using Butler
 | config.slackAlerts | bool | `false` | Whether to send alerts and status to Slack. |
 | global.environmentName | string | Set by Argo CD Application | Name of the Phalanx environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
+| global.repertoireUrl | string | Set by Argo CD | Base URL for Repertoire discovery API |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the sia image |
 | image.repository | string | `"ghcr.io/lsst-sqre/sia"` | Image to use in the sia deployment |

--- a/applications/sia/README.md
+++ b/applications/sia/README.md
@@ -11,7 +11,7 @@ Simple Image Access (SIA) IVOA Service using Butler
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules for the sia deployment pod |
-| config.butlerDataCollections | list | `[]` | List of data (Butler) Collections. Expected attributes: `config`, `label`, `name`, `butler_type`, `repository`, and `datalink_url` |
+| config.datasets | list | `["dp02","dp1"]` | List of datasets enabled in this environment. |
 | config.logLevel | string | `"INFO"` | Logging level |
 | config.logProfile | string | `"production"` | Logging profile (`production` for JSON, `development` for human-friendly) |
 | config.metrics.application | string | `"sia"` | Name under which to log metrics. Generally there is no reason to change this. |
@@ -19,6 +19,7 @@ Simple Image Access (SIA) IVOA Service using Butler
 | config.metrics.events.topicPrefix | string | `"lsst.square.metrics.events"` | Topic prefix for events. It may sometimes be useful to change this in development environments. |
 | config.metrics.schemaManager.registryUrl | string | Sasquatch in the local cluster | URL of the Confluent-compatible schema registry server |
 | config.metrics.schemaManager.suffix | string | `""` | Suffix to add to all registered subjects. This is sometimes useful for experimentation during development. |
+| config.obscoreConfig | object | See `values.yaml` | ObsCore exporter configurations by dataset |
 | config.pathPrefix | string | `"/api/sia"` | URL path prefix |
 | config.sentry.enabled | bool | `false` | Set to true to enable the Sentry integration. |
 | config.sentry.tracesSampleRate | float | `0` | The percentage of requests that should be traced. This should be a float between 0 and 1. |

--- a/applications/sia/secrets.yaml
+++ b/applications/sia/secrets.yaml
@@ -24,4 +24,4 @@ slack-webhook:
 sentry-dsn:
   description: >-
     DSN URL to which Sentry trace and error logging will be sent.
-  if: config.enableSentry
+  if: config.sentry.enabled

--- a/applications/sia/secrets.yaml
+++ b/applications/sia/secrets.yaml
@@ -1,18 +1,3 @@
-"aws-credentials.ini":
-  if: config.directButlerEnabled
-  copy:
-    application: nublado
-    key: "aws-credentials.ini"
-"butler-gcs-idf-creds.json":
-  if: config.directButlerEnabled
-  copy:
-    application: nublado
-    key: "butler-gcs-idf-creds.json"
-"postgres-credentials.txt":
-  if: config.directButlerEnabled
-  copy:
-    application: nublado
-    key: "postgres-credentials.txt"
 slack-webhook:
   description: >-
     Slack web hook used to report internal errors to Slack. This secret may be

--- a/applications/sia/templates/_helpers.tpl
+++ b/applications/sia/templates/_helpers.tpl
@@ -1,29 +1,4 @@
 {{/*
-Expand the name of the chart.
-*/}}
-{{- define "sia.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
-{{- end }}
-
-{{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
-*/}}
-{{- define "sia.fullname" -}}
-{{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
-{{- end }}
-{{- end }}
-
-{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "sia.chart" -}}
@@ -36,9 +11,6 @@ Common labels
 {{- define "sia.labels" -}}
 helm.sh/chart: {{ include "sia.chart" . }}
 {{ include "sia.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
@@ -49,4 +21,3 @@ Selector labels
 app.kubernetes.io/name: "sia"
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
-

--- a/applications/sia/templates/configmap.yaml
+++ b/applications/sia/templates/configmap.yaml
@@ -11,4 +11,3 @@ data:
   METRICS_ENABLED: {{ .Values.config.metrics.enabled | quote }}
   METRICS_APPLICATION: {{ .Values.config.metrics.application | quote }}
   SCHEMA_MANAGER_REGISTRY_URL: {{ .Values.config.metrics.schemaManager.registryUrl }}
-

--- a/applications/sia/templates/configmap.yaml
+++ b/applications/sia/templates/configmap.yaml
@@ -5,9 +5,9 @@ metadata:
   labels:
     {{- include "sia.labels" . | nindent 4 }}
 data:
-  SIA_LOG_LEVEL: {{ .Values.config.logLevel | quote }}
-  SIA_PATH_PREFIX: {{ .Values.config.pathPrefix | quote }}
-  SIA_PROFILE: {{ .Values.config.logProfile | quote }}
   METRICS_ENABLED: {{ .Values.config.metrics.enabled | quote }}
   METRICS_APPLICATION: {{ .Values.config.metrics.application | quote }}
   SCHEMA_MANAGER_REGISTRY_URL: {{ .Values.config.metrics.schemaManager.registryUrl }}
+  SIA_LOG_LEVEL: {{ .Values.config.logLevel | quote }}
+  SIA_LOG_PROFILE: {{ .Values.config.logProfile | quote }}
+  SIA_PATH_PREFIX: {{ .Values.config.pathPrefix | quote }}

--- a/applications/sia/templates/configmap.yaml
+++ b/applications/sia/templates/configmap.yaml
@@ -9,6 +9,7 @@ data:
   METRICS_APPLICATION: {{ .Values.config.metrics.application | quote }}
   SCHEMA_MANAGER_REGISTRY_URL: {{ .Values.config.metrics.schemaManager.registryUrl }}
   SIA_DATASETS: {{ .Values.config.datasets | toJson | quote }}
+  SIA_IVOID_FORMAT: {{ .Values.config.ivoidFormat | quote }}
   SIA_LOG_LEVEL: {{ .Values.config.logLevel | quote }}
   SIA_LOG_PROFILE: {{ .Values.config.logProfile | quote }}
   SIA_PATH_PREFIX: {{ .Values.config.pathPrefix | quote }}

--- a/applications/sia/templates/configmap.yaml
+++ b/applications/sia/templates/configmap.yaml
@@ -8,6 +8,8 @@ data:
   METRICS_ENABLED: {{ .Values.config.metrics.enabled | quote }}
   METRICS_APPLICATION: {{ .Values.config.metrics.application | quote }}
   SCHEMA_MANAGER_REGISTRY_URL: {{ .Values.config.metrics.schemaManager.registryUrl }}
+  SIA_DATASETS: {{ .Values.config.datasets | toJson | quote }}
   SIA_LOG_LEVEL: {{ .Values.config.logLevel | quote }}
   SIA_LOG_PROFILE: {{ .Values.config.logProfile | quote }}
   SIA_PATH_PREFIX: {{ .Values.config.pathPrefix | quote }}
+  SIA_OBSCORE_CONFIG: {{ .Values.config.obscoreConfig | toJson | quote }}

--- a/applications/sia/templates/configmap.yaml
+++ b/applications/sia/templates/configmap.yaml
@@ -7,6 +7,7 @@ metadata:
 data:
   METRICS_ENABLED: {{ .Values.config.metrics.enabled | quote }}
   METRICS_APPLICATION: {{ .Values.config.metrics.application | quote }}
+  REPERTOIRE_BASE_URL: {{ .Values.global.repertoireUrl | quote }}
   SCHEMA_MANAGER_REGISTRY_URL: {{ .Values.config.metrics.schemaManager.registryUrl }}
   SIA_DATASETS: {{ .Values.config.datasets | toJson | quote }}
   SIA_IVOID_FORMAT: {{ .Values.config.ivoidFormat | quote }}

--- a/applications/sia/templates/deployment.yaml
+++ b/applications/sia/templates/deployment.yaml
@@ -49,17 +49,6 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           env:
-            - name: "SIA_BUTLER_DATA_COLLECTIONS"
-              value: {{ .Values.config.butlerDataCollections | toJson | quote }}
-            - name: "SIA_ENVIRONMENT_NAME"
-              value: {{ .Values.global.host }}
-            {{- if .Values.config.slackAlerts }}
-            - name: "SIA_SLACK_WEBHOOK"
-              valueFrom:
-                secretKeyRef:
-                  name: "sia"
-                  key: "slack-webhook"
-            {{- end }}
             {{- if .Values.config.directButlerEnabled }}
             - name: "AWS_SHARED_CREDENTIALS_FILE"
               value: "/tmp/secrets/aws-credentials.ini"
@@ -69,15 +58,6 @@ spec:
               value: "/etc/butler/secrets/postgres-credentials.txt"
             - name: "GOOGLE_APPLICATION_CREDENTIALS"
               value: "/tmp/secrets/butler-gcs-idf-creds.json"
-            {{- end }}
-            {{- if .Values.config.enableSentry }}
-            - name: "SIA_SENTRY_DSN"
-              valueFrom:
-                secretKeyRef:
-                  name: "sia"
-                  key: "sentry-dsn"
-            - name: "SIA_SENTRY_TRACES_SAMPLE_RATE"
-              value: {{ .Values.config.sentryTracesSampleRate | quote }}
             {{- end }}
             {{- if .Values.config.metrics.enabled }}
             - name: "KAFKA_BOOTSTRAP_SERVERS"
@@ -97,19 +77,61 @@ spec:
             - name: "KAFKA_CLUSTER_CA_PATH"
               value: "/etc/sia-kafka/ca.crt"
             {{- end }}
+            - name: "SIA_BUTLER_DATA_COLLECTIONS"
+              value: {{ .Values.config.butlerDataCollections | toJson | quote }}
+            - name: "SIA_ENVIRONMENT_NAME"
+              value: {{ .Values.global.host }}
+            {{- if .Values.config.enableSentry }}
+            - name: "SIA_SENTRY_DSN"
+              valueFrom:
+                secretKeyRef:
+                  name: "sia"
+                  key: "sentry-dsn"
+            - name: "SIA_SENTRY_TRACES_SAMPLE_RATE"
+              value: {{ .Values.config.sentryTracesSampleRate | quote }}
+            {{- end }}
+            {{- if .Values.config.slackAlerts }}
+            - name: "SIA_SLACK_WEBHOOK"
+              valueFrom:
+                secretKeyRef:
+                  name: "sia"
+                  key: "slack-webhook"
+            {{- end }}
+            # Uvicorn keepalive timeout, in seconds. This should be longer
+            # than any keepalive timeouts on any downstream proxies. The
+            # keepalive timeout for ingress-nginx connections is 60s.
+            - name: "UVICORN_TIMEOUT_KEEP_ALIVE"
+              value: "61"
           envFrom:
             - configMapRef:
                 name: "sia"
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          ports:
-            - name: "http"
-              containerPort: 8080
-              protocol: "TCP"
+          lifecycle:
+            # Number of seconds k8s should wait before sending SIGTERM on
+            # graceful restarts/deployments/shutdowns. We need this because it
+            # takes ingress-nginx some time to configure itself to stop
+            # sending traffic to the pods scheduled for termination. If
+            # Uvicorn gets the SIGTERM and starts closing connections, we
+            # could end up with a TCP race condition if ingress-nginx still
+            # tries to send data over those connections.
+            #
+            # Note that terminationGracePeriodSeconds includes the time that
+            # is spent in the preStop hook. If you’re adding a preStop hook
+            # and your terminationGracePeriodSeconds is super fine-tuned, then
+            # you should update your terminationGracePeriodSeconds to add the
+            # amount of time you’ll be spending in your preStop hook.
+            preStop:
+              sleep:
+                seconds: 10
           livenessProbe:
             httpGet:
               path: /healthcheck
               port: http
+          ports:
+            - name: "http"
+              containerPort: 8080
+              protocol: "TCP"
           readinessProbe:
             httpGet:
               path: /healthcheck

--- a/applications/sia/templates/deployment.yaml
+++ b/applications/sia/templates/deployment.yaml
@@ -24,41 +24,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       automountServiceAccountToken: false
-      {{- if .Values.config.directButlerEnabled }}
-      initContainers:
-        - name: fix-secret-permissions
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
-          command:
-            - "/bin/sh"
-            - "-c"
-            - |
-              cp -RL /tmp/secrets-raw/* /etc/butler/secrets/
-              chmod 0400 /etc/butler/secrets/*
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - "all"
-          volumeMounts:
-            - name: "secrets"
-              mountPath: "/etc/butler/secrets"
-            - name: "secrets-raw"
-              mountPath: "/tmp/secrets-raw"
-      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           env:
-            {{- if .Values.config.directButlerEnabled }}
-            - name: "AWS_SHARED_CREDENTIALS_FILE"
-              value: "/tmp/secrets/aws-credentials.ini"
-            - name: "PGUSER"
-              value: {{ .Values.config.pgUser }}
-            - name: "PGPASSFILE"
-              value: "/etc/butler/secrets/postgres-credentials.txt"
-            - name: "GOOGLE_APPLICATION_CREDENTIALS"
-              value: "/tmp/secrets/butler-gcs-idf-creds.json"
-            {{- end }}
             {{- if .Values.config.metrics.enabled }}
             - name: "KAFKA_BOOTSTRAP_SERVERS"
               valueFrom:
@@ -126,8 +94,8 @@ spec:
                 seconds: 10
           livenessProbe:
             httpGet:
-              path: /healthcheck
-              port: http
+              path: "/healthcheck"
+              port: "http"
           ports:
             - name: "http"
               containerPort: 8080
@@ -153,11 +121,6 @@ spec:
               readOnly: true
               subPath: "ssl.keystore.key"
             {{- end }}
-            {{- if .Values.config.directButlerEnabled }}
-            - name: "secrets"
-              mountPath: "/etc/butler/secrets"
-              readOnly: true
-            {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -177,13 +140,6 @@ spec:
         - name: "kafka"
           secret:
             secretName: "sia-kafka"
-        {{- end }}
-        {{- if .Values.config.directButlerEnabled }}
-        - name: "secrets-raw"
-          secret:
-            secretName: "sia"
-        - name: "secrets"
-          emptyDir: {}
         {{- end }}
       securityContext:
         runAsNonRoot: true

--- a/applications/sia/templates/deployment.yaml
+++ b/applications/sia/templates/deployment.yaml
@@ -48,25 +48,6 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          envFrom:
-            - configMapRef:
-                name: "sia"
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          ports:
-            - name: "http"
-              containerPort: 8080
-              protocol: "TCP"
-          livenessProbe:
-            httpGet:
-              path: /healthcheck
-              port: http
-          readinessProbe:
-            httpGet:
-              path: /healthcheck
-              port: http
-          resources:
-            {{- toYaml .Values.resources | nindent 12 }}
           env:
             - name: "SIA_BUTLER_DATA_COLLECTIONS"
               value: {{ .Values.config.butlerDataCollections | toJson | quote }}
@@ -93,7 +74,7 @@ spec:
             - name: "SIA_SENTRY_DSN"
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "sia.fullname" . }}
+                  name: "sia"
                   key: "sentry-dsn"
             - name: "SIA_SENTRY_TRACES_SAMPLE_RATE"
               value: {{ .Values.config.sentryTracesSampleRate | quote }}
@@ -116,6 +97,25 @@ spec:
             - name: "KAFKA_CLUSTER_CA_PATH"
               value: "/etc/sia-kafka/ca.crt"
             {{- end }}
+          envFrom:
+            - configMapRef:
+                name: "sia"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: "http"
+              containerPort: 8080
+              protocol: "TCP"
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             {{- if .Values.config.metrics.enabled }}
             - name: "kafka"

--- a/applications/sia/templates/deployment.yaml
+++ b/applications/sia/templates/deployment.yaml
@@ -77,19 +77,19 @@ spec:
             - name: "KAFKA_CLUSTER_CA_PATH"
               value: "/etc/sia-kafka/ca.crt"
             {{- end }}
-            - name: "SIA_BUTLER_DATA_COLLECTIONS"
-              value: {{ .Values.config.butlerDataCollections | toJson | quote }}
-            - name: "SIA_ENVIRONMENT_NAME"
-              value: {{ .Values.global.host }}
-            {{- if .Values.config.enableSentry }}
-            - name: "SIA_SENTRY_DSN"
+            {{- if .Values.config.sentry.enabled }}
+            - name: "SENTRY_DSN"
               valueFrom:
                 secretKeyRef:
                   name: "sia"
                   key: "sentry-dsn"
-            - name: "SIA_SENTRY_TRACES_SAMPLE_RATE"
-              value: {{ .Values.config.sentryTracesSampleRate | quote }}
+            - name: "SENTRY_ENVIRONMENT"
+              value: {{ .Values.global.environmentName | quote }}
+            - name: "SENTRY_TRACES_SAMPLE_RATE"
+              value: {{ .Values.config.sentry.tracesSampleRate | quote }}
             {{- end }}
+            - name: "SIA_BUTLER_DATA_COLLECTIONS"
+              value: {{ .Values.config.butlerDataCollections | toJson | quote }}
             {{- if .Values.config.slackAlerts }}
             - name: "SIA_SLACK_WEBHOOK"
               valueFrom:

--- a/applications/sia/templates/deployment.yaml
+++ b/applications/sia/templates/deployment.yaml
@@ -56,8 +56,6 @@ spec:
             - name: "SENTRY_TRACES_SAMPLE_RATE"
               value: {{ .Values.config.sentry.tracesSampleRate | quote }}
             {{- end }}
-            - name: "SIA_BUTLER_DATA_COLLECTIONS"
-              value: {{ .Values.config.butlerDataCollections | toJson | quote }}
             {{- if .Values.config.slackAlerts }}
             - name: "SIA_SLACK_WEBHOOK"
               valueFrom:

--- a/applications/sia/templates/ingress-anonymous.yaml
+++ b/applications/sia/templates/ingress-anonymous.yaml
@@ -1,7 +1,7 @@
 apiVersion: gafaelfawr.lsst.io/v1alpha1
 kind: GafaelfawrIngress
 metadata:
-  name: {{ template "sia.fullname" . }}-anonymous
+  name: "sia-anonymous"
   labels:
     {{- include "sia.labels" . | nindent 4 }}
 config:
@@ -9,7 +9,7 @@ config:
     anonymous: true
 template:
   metadata:
-    name: {{ template "sia.fullname" . }}-anonymous
+    name: "sia-anonymous"
     {{- with .Values.ingress.annotations }}
     annotations:
       nginx.ingress.kubernetes.io/use-regex: "true"
@@ -20,24 +20,24 @@ template:
       - host: {{ .Values.global.host | quote }}
         http:
           paths:
-            - path: "{{ .Values.ingress.path }}/openapi.json"
+            - path: "{{ .Values.config.pathPrefix }}/openapi.json"
               pathType: "Exact"
               backend:
                 service:
-                  name: {{ template "sia.fullname" . }}
+                  name: "sia"
                   port:
                     number: 8080
-            - path: "{{ .Values.ingress.path }}/.+/capabilities"
+            - path: "{{ .Values.config.pathPrefix }}/.+/capabilities"
               pathType: "ImplementationSpecific"
               backend:
                 service:
-                  name: {{ template "sia.fullname" . }}
+                  name: "sia"
                   port:
                     number: 8080
-            - path: "{{ .Values.ingress.path }}/.+/availability"
+            - path: "{{ .Values.config.pathPrefix }}/.+/availability"
               pathType: "ImplementationSpecific"
               backend:
                 service:
-                  name: {{ template "sia.fullname" . }}
+                  name: "sia"
                   port:
                     number: 8080

--- a/applications/sia/templates/ingress.yaml
+++ b/applications/sia/templates/ingress.yaml
@@ -1,7 +1,7 @@
 apiVersion: gafaelfawr.lsst.io/v1alpha1
 kind: GafaelfawrIngress
 metadata:
-  name: {{ template "sia.fullname" . }}
+  name: "sia"
   labels:
     {{- include "sia.labels" . | nindent 4 }}
 config:
@@ -17,7 +17,7 @@ config:
         - "read:image"
 template:
   metadata:
-    name: {{ template "sia.fullname" . }}
+    name: "sia"
     annotations:
       nginx.ingress.kubernetes.io/proxy-connect-timeout: "1800"
       nginx.ingress.kubernetes.io/proxy-send-timeout: "1800"

--- a/applications/sia/values-idfdev.yaml
+++ b/applications/sia/values-idfdev.yaml
@@ -21,5 +21,6 @@ config:
       repository: "https://data-dev.lsst.cloud/api/butler/repo/dp1/butler.yaml"
       datalink_url: "https://data-dev.lsst.cloud/api/datalink/links?ID=ivo%3A%2F%2Forg.rubinobs%2Flsst-dp1%3Frepo%3Ddp1%26id%3D{id}"
 
-  enableSentry: true
-  sentryTracesSampleRate: 1
+  sentry:
+    enabled: true
+    tracesSampleRate: 1

--- a/applications/sia/values-idfdev.yaml
+++ b/applications/sia/values-idfdev.yaml
@@ -1,3 +1,7 @@
+image:
+  tag: "t-DM-55537"
+  pullPolicy: "Always"
+
 config:
   metrics:
     enabled: false

--- a/applications/sia/values-idfdev.yaml
+++ b/applications/sia/values-idfdev.yaml
@@ -17,5 +17,6 @@ config:
       repository: "https://data-dev.lsst.cloud/api/butler/repo/dp1/butler.yaml"
       datalink_url: "https://data-dev.lsst.cloud/api/datalink/links?ID=ivo%3A%2F%2Forg.rubinobs%2Flsst-dp1%3Frepo%3Ddp1%26id%3D{id}"
 
-  enableSentry: true
-  sentryTracesSampleRate: 1
+  sentry:
+    enabled: true
+    tracesSampleRate: 1

--- a/applications/sia/values-idfdev.yaml
+++ b/applications/sia/values-idfdev.yaml
@@ -6,21 +6,6 @@ config:
   metrics:
     enabled: false
 
-  # Data (Butler) Collections
-  butlerDataCollections:
-    - config: "https://raw.githubusercontent.com/lsst-dm/dax_obscore/refs/heads/main/configs/dp02.yaml"
-      label: "LSST.DP02"
-      name: "dp02"
-      butler_type: "REMOTE"
-      repository: "https://data-dev.lsst.cloud/api/butler/repo/dp02/butler.yaml"
-      datalink_url: "https://data-dev.lsst.cloud/api/datalink/links?ID=ivo%3A%2F%2Forg.rubinobs%2Flsst-dp02%3Frepo%3Ddp02%26id%3D{id}"
-    - config: "https://raw.githubusercontent.com/lsst-dm/dax_obscore/refs/heads/main/configs/dp1.yaml"
-      label: "LSST.DP1"
-      name: "dp1"
-      butler_type: "REMOTE"
-      repository: "https://data-dev.lsst.cloud/api/butler/repo/dp1/butler.yaml"
-      datalink_url: "https://data-dev.lsst.cloud/api/datalink/links?ID=ivo%3A%2F%2Forg.rubinobs%2Flsst-dp1%3Frepo%3Ddp1%26id%3D{id}"
-
   sentry:
     enabled: true
     tracesSampleRate: 1

--- a/applications/sia/values-idfdev.yaml
+++ b/applications/sia/values-idfdev.yaml
@@ -2,21 +2,6 @@ config:
   metrics:
     enabled: false
 
-  # Data (Butler) Collections
-  butlerDataCollections:
-    - config: "https://raw.githubusercontent.com/lsst-dm/dax_obscore/refs/heads/main/configs/dp02.yaml"
-      label: "LSST.DP02"
-      name: "dp02"
-      butler_type: "REMOTE"
-      repository: "https://data-dev.lsst.cloud/api/butler/repo/dp02/butler.yaml"
-      datalink_url: "https://data-dev.lsst.cloud/api/datalink/links?ID=ivo%3A%2F%2Forg.rubinobs%2Flsst-dp02%3Frepo%3Ddp02%26id%3D{id}"
-    - config: "https://raw.githubusercontent.com/lsst-dm/dax_obscore/refs/heads/main/configs/dp1.yaml"
-      label: "LSST.DP1"
-      name: "dp1"
-      butler_type: "REMOTE"
-      repository: "https://data-dev.lsst.cloud/api/butler/repo/dp1/butler.yaml"
-      datalink_url: "https://data-dev.lsst.cloud/api/datalink/links?ID=ivo%3A%2F%2Forg.rubinobs%2Flsst-dp1%3Frepo%3Ddp1%26id%3D{id}"
-
   sentry:
     enabled: true
     tracesSampleRate: 1

--- a/applications/sia/values-idfint.yaml
+++ b/applications/sia/values-idfint.yaml
@@ -31,5 +31,6 @@ config:
       repository: "https://data-int.lsst.cloud/api/butler/repo/dp2/butler.yaml"
       datalink_url: "https://data-int.lsst.cloud/api/datalink/links?ID=ivo%3A%2F%2Forg.rubinobs%2Flsst-dp2%3Frepo%3Ddp2%26id%3D{id}"
 
-  enableSentry: true
-  sentryTracesSampleRate: 1
+  sentry:
+    enabled: true
+    tracesSampleRate: 1

--- a/applications/sia/values-idfint.yaml
+++ b/applications/sia/values-idfint.yaml
@@ -1,35 +1,13 @@
 replicaCount: 4
 
 config:
+  datasets:
+    - "dp02"
+    - "dp1"
+    - "dp2"
+    - "prompt"
   metrics:
     enabled: true
-
-  # Data (Butler) Collections
-  butlerDataCollections:
-    - config: "https://raw.githubusercontent.com/lsst-dm/dax_obscore/refs/heads/main/configs/dp02.yaml"
-      label: "LSST.DP02"
-      name: "dp02"
-      butler_type: "REMOTE"
-      repository: "https://data-int.lsst.cloud/api/butler/repo/dp02/butler.yaml"
-      datalink_url: "https://data-int.lsst.cloud/api/datalink/links?ID=ivo%3A%2F%2Forg.rubinobs%2Flsst-dp02%3Frepo%3Ddp02%26id%3D{id}"
-    - config: "https://raw.githubusercontent.com/lsst-dm/dax_obscore/refs/heads/main/configs/dp1.yaml"
-      label: "LSST.DP1"
-      name: "dp1"
-      butler_type: "REMOTE"
-      repository: "https://data-int.lsst.cloud/api/butler/repo/dp1/butler.yaml"
-      datalink_url: "https://data-int.lsst.cloud/api/datalink/links?ID=ivo%3A%2F%2Forg.rubinobs%2Flsst-dp1%3Frepo%3Ddp1%26id%3D{id}"
-    - config: "https://raw.githubusercontent.com/lsst-dm/dax_obscore/refs/heads/main/configs/prompt.yaml"
-      label: "LSST.Prompt"
-      name: "prompt"
-      butler_type: "REMOTE"
-      repository: "https://data-int.lsst.cloud/api/butler/repo/prompt/butler.yaml"
-      datalink_url: "https://data-int.lsst.cloud/api/datalink/links?ID=ivo%3A%2F%2Forg.rubinobs%2Flsst-prompt%3Frepo%3Dprompt%26id%3D{id}"
-    - config: "https://raw.githubusercontent.com/lsst-dm/dax_obscore/refs/heads/main/configs/edp2.yaml"
-      label: "LSST.DP2"
-      name: "dp2"
-      butler_type: "REMOTE"
-      repository: "https://data-int.lsst.cloud/api/butler/repo/dp2/butler.yaml"
-      datalink_url: "https://data-int.lsst.cloud/api/datalink/links?ID=ivo%3A%2F%2Forg.rubinobs%2Flsst-dp2%3Frepo%3Ddp2%26id%3D{id}"
 
   sentry:
     enabled: true

--- a/applications/sia/values-idfint.yaml
+++ b/applications/sia/values-idfint.yaml
@@ -1,35 +1,12 @@
 replicaCount: 4
 
 config:
+  datasets:
+    - "dp02"
+    - "dp1"
+    - "dp2"
   metrics:
     enabled: true
-
-  # Data (Butler) Collections
-  butlerDataCollections:
-    - config: "https://raw.githubusercontent.com/lsst-dm/dax_obscore/refs/heads/main/configs/dp02.yaml"
-      label: "LSST.DP02"
-      name: "dp02"
-      butler_type: "REMOTE"
-      repository: "https://data-int.lsst.cloud/api/butler/repo/dp02/butler.yaml"
-      datalink_url: "https://data-int.lsst.cloud/api/datalink/links?ID=ivo%3A%2F%2Forg.rubinobs%2Flsst-dp02%3Frepo%3Ddp02%26id%3D{id}"
-    - config: "https://raw.githubusercontent.com/lsst-dm/dax_obscore/refs/heads/main/configs/dp1.yaml"
-      label: "LSST.DP1"
-      name: "dp1"
-      butler_type: "REMOTE"
-      repository: "https://data-int.lsst.cloud/api/butler/repo/dp1/butler.yaml"
-      datalink_url: "https://data-int.lsst.cloud/api/datalink/links?ID=ivo%3A%2F%2Forg.rubinobs%2Flsst-dp1%3Frepo%3Ddp1%26id%3D{id}"
-    - config: "https://raw.githubusercontent.com/lsst-dm/dax_obscore/refs/heads/main/configs/prompt.yaml"
-      label: "LSST.Prompt"
-      name: "prompt"
-      butler_type: "REMOTE"
-      repository: "https://data-int.lsst.cloud/api/butler/repo/prompt/butler.yaml"
-      datalink_url: "https://data-int.lsst.cloud/api/datalink/links?ID=ivo%3A%2F%2Forg.rubinobs%2Flsst-prompt%3Frepo%3Dprompt%26id%3D{id}"
-    - config: "https://raw.githubusercontent.com/lsst-dm/dax_obscore/refs/heads/main/configs/edp2.yaml"
-      label: "LSST.DP2"
-      name: "dp2"
-      butler_type: "REMOTE"
-      repository: "https://data-int.lsst.cloud/api/butler/repo/dp2/butler.yaml"
-      datalink_url: "https://data-int.lsst.cloud/api/datalink/links?ID=ivo%3A%2F%2Forg.rubinobs%2Flsst-dp2%3Frepo%3Ddp2%26id%3D{id}"
 
   sentry:
     enabled: true

--- a/applications/sia/values-idfprod.yaml
+++ b/applications/sia/values-idfprod.yaml
@@ -1,29 +1,12 @@
 replicaCount: 4
 
 config:
+  datasets:
+    - "dp02"
+    - "dp1"
+    - "dp2"
   metrics:
     enabled: true
-
-  # Data (Butler) Collections
-  butlerDataCollections:
-    - config: "https://raw.githubusercontent.com/lsst-dm/dax_obscore/refs/heads/main/configs/dp02.yaml"
-      label: "LSST.DP02"
-      name: "dp02"
-      butler_type: "REMOTE"
-      repository: "https://data.lsst.cloud/api/butler/repo/dp02/butler.yaml"
-      datalink_url: "https://data.lsst.cloud/api/datalink/links?ID=ivo%3A%2F%2Forg.rubinobs%2Flsst-dp02%3Frepo%3Ddp02%26id%3D{id}"
-    - config: "https://raw.githubusercontent.com/lsst-dm/dax_obscore/refs/heads/main/configs/dp1.yaml"
-      label: "LSST.DP1"
-      name: "dp1"
-      butler_type: "REMOTE"
-      repository: "https://data.lsst.cloud/api/butler/repo/dp1/butler.yaml"
-      datalink_url: "https://data.lsst.cloud/api/datalink/links?ID=ivo%3A%2F%2Forg.rubinobs%2Flsst-dp1%3Frepo%3Ddp1%26id%3D{id}"
-    - config: "https://raw.githubusercontent.com/lsst-dm/dax_obscore/refs/heads/main/configs/edp2.yaml"
-      label: "LSST.DP2"
-      name: "dp2"
-      butler_type: "REMOTE"
-      repository: "https://data.lsst.cloud/api/butler/repo/dp2/butler.yaml"
-      datalink_url: "https://data.lsst.cloud/api/datalink/links?ID=ivo%3A%2F%2Forg.rubinobs%2Flsst-dp2%3Frepo%3Ddp2%26id%3D{id}"
 
   sentry:
     enabled: true

--- a/applications/sia/values-idfprod.yaml
+++ b/applications/sia/values-idfprod.yaml
@@ -25,5 +25,6 @@ config:
       repository: "https://data.lsst.cloud/api/butler/repo/dp2/butler.yaml"
       datalink_url: "https://data.lsst.cloud/api/datalink/links?ID=ivo%3A%2F%2Forg.rubinobs%2Flsst-dp2%3Frepo%3Ddp2%26id%3D{id}"
 
-  enableSentry: true
-  sentryTracesSampleRate: 0.1
+  sentry:
+    enabled: true
+    tracesSampleRate: 0.1

--- a/applications/sia/values.yaml
+++ b/applications/sia/values.yaml
@@ -21,9 +21,6 @@ config:
   # `label`, `name`, `butler_type`, `repository`, and `datalink_url`
   butlerDataCollections: []
 
-  # -- Whether direct butler access is enabled
-  directButlerEnabled: false
-
   metrics:
     # -- Whether to enable sending metrics
     enabled: false
@@ -66,10 +63,6 @@ config:
 
   # -- Whether to send alerts and status to Slack.
   slackAlerts: false
-
-  # -- User to use from the PGPASSFILE if sia is using a direct Butler
-  # connection.
-  pgUser: "rubin"
 
 ingress:
   # -- Additional annotations for the ingress rule

--- a/applications/sia/values.yaml
+++ b/applications/sia/values.yaml
@@ -95,7 +95,16 @@ resources:
     memory: "32Gi"
 
 # -- Tolerations for the sia deployment pod
-tolerations: []
+# @default -- Tolerate GKE amd64 and arm64 taints
+tolerations:
+  - key: "kubernetes.io/arch"
+    operator: "Equal"
+    value: "amd64"
+    effect: "NoSchedule"
+  - key: "kubernetes.io/arch"
+    operator: "Equal"
+    value: "arm64"
+    effect: "NoSchedule"
 
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.

--- a/applications/sia/values.yaml
+++ b/applications/sia/values.yaml
@@ -2,12 +2,6 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-# -- Override the base name for resources
-nameOverride: ""
-
-# -- Override the full name for resources (includes the release name)
-fullnameOverride: ""
-
 # -- Number of web deployment pods to start
 replicaCount: 1
 
@@ -23,37 +17,17 @@ image:
   tag: ""
 
 config:
-  # -- Whether to send alerts and status to Slack.
-  slackAlerts: false
-
-  # -- Logging level
-  logLevel: "INFO"
-
-  # -- Logging profile (`production` for JSON, `development` for
-  # human-friendly)
-  logProfile: "production"
-
-  # -- URL path prefix
-  pathPrefix: "/api/sia"
+  # -- List of data (Butler) Collections. Expected attributes: `config`,
+  # `label`, `name`, `butler_type`, `repository`, and `datalink_url`
+  butlerDataCollections: []
 
   # -- Whether direct butler access is enabled
   directButlerEnabled: false
-
-  # -- List of data (Butler) Collections
-  # Expected attributes: `config`, `label`, `name`, `butler_type`, `repository` & `datalink_url`
-  butlerDataCollections: []
-
-  # -- User to use from the PGPASSFILE if sia is using a direct Butler
-  # connection
-  pgUser: "rubin"
 
   # -- Whether to send trace and telemetry information to Sentry. This traces
   # every call and therefore should only be enabled in non-production
   # environments.
   enableSentry: false
-
-  # Sentry tracing sample rate
-  sentryTracesSampleRate: 0.0
 
   metrics:
     # -- Whether to enable sending metrics
@@ -77,12 +51,29 @@ config:
       # for experimentation during development.
       suffix: ""
 
+  # -- Logging level
+  logLevel: "INFO"
+
+  # -- Logging profile (`production` for JSON, `development` for
+  # human-friendly)
+  logProfile: "production"
+
+  # -- URL path prefix
+  pathPrefix: "/api/sia"
+
+  # -- Whether to send alerts and status to Slack.
+  slackAlerts: false
+
+  # -- User to use from the PGPASSFILE if sia is using a direct Butler
+  # connection.
+  pgUser: "rubin"
+
+  # Sentry tracing sample rate.
+  sentryTracesSampleRate: 0.0
+
 ingress:
   # -- Additional annotations for the ingress rule
   annotations: {}
-
-  # -- Path prefix where app is hosted
-  path: "/api/sia"
 
 # -- Affinity rules for the sia deployment pod
 affinity: {}

--- a/applications/sia/values.yaml
+++ b/applications/sia/values.yaml
@@ -24,11 +24,6 @@ config:
   # -- Whether direct butler access is enabled
   directButlerEnabled: false
 
-  # -- Whether to send trace and telemetry information to Sentry. This traces
-  # every call and therefore should only be enabled in non-production
-  # environments.
-  enableSentry: false
-
   metrics:
     # -- Whether to enable sending metrics
     enabled: false
@@ -61,15 +56,20 @@ config:
   # -- URL path prefix
   pathPrefix: "/api/sia"
 
+  sentry:
+    # -- Set to true to enable the Sentry integration.
+    enabled: false
+
+    # -- The percentage of requests that should be traced. This should be a
+    # float between 0 and 1.
+    tracesSampleRate: 0.0
+
   # -- Whether to send alerts and status to Slack.
   slackAlerts: false
 
   # -- User to use from the PGPASSFILE if sia is using a direct Butler
   # connection.
   pgUser: "rubin"
-
-  # Sentry tracing sample rate.
-  sentryTracesSampleRate: 0.0
 
 ingress:
   # -- Additional annotations for the ingress rule
@@ -109,6 +109,10 @@ tolerations:
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:
+  # -- Name of the Phalanx environment
+  # @default -- Set by Argo CD Application
+  environmentName: null
+
   # -- Host name for ingress
   # @default -- Set by Argo CD
   host: null

--- a/applications/sia/values.yaml
+++ b/applications/sia/values.yaml
@@ -22,6 +22,11 @@ config:
     - "dp02"
     - "dp1"
 
+  # -- Format string for the IVOID used for self-identification. This must
+  # contain a `dataset` variable that will be replaced with the label of the
+  # dataset.
+  ivoidFormat: "ivo://org.rubinobs/{dataset}/sia"
+
   metrics:
     # -- Whether to enable sending metrics
     enabled: false

--- a/applications/sia/values.yaml
+++ b/applications/sia/values.yaml
@@ -17,9 +17,10 @@ image:
   tag: ""
 
 config:
-  # -- List of data (Butler) Collections. Expected attributes: `config`,
-  # `label`, `name`, `butler_type`, `repository`, and `datalink_url`
-  butlerDataCollections: []
+  # -- List of datasets enabled in this environment.
+  datasets:
+    - "dp02"
+    - "dp1"
 
   metrics:
     # -- Whether to enable sending metrics
@@ -49,6 +50,13 @@ config:
   # -- Logging profile (`production` for JSON, `development` for
   # human-friendly)
   logProfile: "production"
+
+  # -- ObsCore exporter configurations by dataset
+  # @default -- See `values.yaml`
+  obscoreConfig:
+    dp02: "https://raw.githubusercontent.com/lsst-dm/dax_obscore/refs/heads/main/configs/dp02.yaml"
+    dp1: "https://raw.githubusercontent.com/lsst-dm/dax_obscore/refs/heads/main/configs/dp1.yaml"
+    dp2: "https://raw.githubusercontent.com/lsst-dm/dax_obscore/refs/heads/main/configs/edp2.yaml"
 
   # -- URL path prefix
   pathPrefix: "/api/sia"

--- a/applications/sia/values.yaml
+++ b/applications/sia/values.yaml
@@ -17,9 +17,10 @@ image:
   tag: ""
 
 config:
-  # -- List of data (Butler) Collections. Expected attributes: `config`,
-  # `label`, `name`, `butler_type`, `repository`, and `datalink_url`
-  butlerDataCollections: []
+  # -- List of datasets enabled in this environment.
+  datasets:
+    - "dp02"
+    - "dp1"
 
   metrics:
     # -- Whether to enable sending metrics
@@ -49,6 +50,14 @@ config:
   # -- Logging profile (`production` for JSON, `development` for
   # human-friendly)
   logProfile: "production"
+
+  # -- ObsCore exporter configurations by dataset
+  # @default -- See `values.yaml`
+  obscoreConfig:
+    dp02: "https://raw.githubusercontent.com/lsst-dm/dax_obscore/refs/heads/main/configs/dp02.yaml"
+    dp1: "https://raw.githubusercontent.com/lsst-dm/dax_obscore/refs/heads/main/configs/dp1.yaml"
+    dp2: "https://raw.githubusercontent.com/lsst-dm/dax_obscore/refs/heads/main/configs/edp2.yaml"
+    prompt: "https://raw.githubusercontent.com/lsst-dm/dax_obscore/refs/heads/main/configs/prompt.yaml"
 
   # -- URL path prefix
   pathPrefix: "/api/sia"

--- a/applications/sia/values.yaml
+++ b/applications/sia/values.yaml
@@ -124,6 +124,10 @@ global:
   # @default -- Set by Argo CD
   host: null
 
+  # -- Base URL for Repertoire discovery API
+  # @default -- Set by Argo CD
+  repertoireUrl: null
+
   # -- Base path for Vault secrets
   # @default -- Set by Argo CD
   vaultSecretsPath: null

--- a/environments/templates/applications/rsp/sia.yaml
+++ b/environments/templates/applications/rsp/sia.yaml
@@ -26,10 +26,10 @@ spec:
     targetRevision: {{ or (index .Values "revisions" "sia") .Values.targetRevision | quote }}
     helm:
       parameters:
+        - name: "global.environmentName"
+          value: {{ .Values.name | quote }}
         - name: "global.host"
           value: {{ .Values.fqdn | quote }}
-        - name: "global.baseUrl"
-          value: "https://{{ .Values.fqdn }}"
         - name: "global.vaultSecretsPath"
           value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:

--- a/environments/templates/applications/rsp/sia.yaml
+++ b/environments/templates/applications/rsp/sia.yaml
@@ -30,6 +30,8 @@ spec:
           value: {{ .Values.name | quote }}
         - name: "global.host"
           value: {{ .Values.fqdn | quote }}
+        - name: "global.repertoireUrl"
+          value: "https://{{ .Values.fqdn }}/repertoire"
         - name: "global.vaultSecretsPath"
           value: {{ .Values.vaultPathPrefix | quote }}
       valueFiles:


### PR DESCRIPTION
This version uses service discovery instead of explicit configuration to find Butler and related metadata.

Remove `fullName` and `fullNameOverride` and hard-code object names following our current practice. Remove the separate ingress path prefix in favor of always using `config.pathPrefix`. Alphabetize the config settings and the deployment settings.