### PR TITLE
DM-55549: Deploy Docverse time-ordered resource IDs image

### DIFF
--- a/applications/docverse/Chart.yaml
+++ b/applications/docverse/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "tickets-DM-55200"
+appVersion: "tickets-DM-55549"
 description: Publish versioned docs
 name: docverse
 sources:


### PR DESCRIPTION
## Summary

Bump the Docverse `appVersion` to `tickets-DM-55549`, deploying the time-ordered Crockford Base32 resource-ID work (Snowflake-style build/queue-job ID minting, Base32 public IDs for keeper-sync runs and tombstones, `binding_id` removal from the dashboard-template sync response).

The image includes two new Alembic revisions (`c7d8e9f0a1b2`, `d8e9f0a1b2c3`) that backfill `public_id` columns on `keeper_sync_runs` and `keeper_sync_state`; `config.updateSchema` is enabled on roundtable-dev, so the migration runs automatically on sync.

## Validation steps

- CI on the app PR is fully green (server, client, and worker suites; multi-arch container build).
- The `tickets-DM-55549` multi-arch image is published to ghcr.
- After merge and Argo CD sync on roundtable-dev: confirm the migration job applies both revisions, then spot-check that `GET /orgs/{org}/keeper-sync/runs/{run}` resolves runs by Base32 ID and newly created builds carry time-ordered IDs.

## References

- App PR: lsst-sqre/docverse#460
- PRD: lsst-sqre/docverse#448
- Jira: [DM-55549](https://rubinobs.atlassian.net/browse/DM-55549)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DM-55549]: https://rubinobs.atlassian.net/browse/DM-55549?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ