### PR TITLE
DM-55565: Increase Prompt Redis Exporter Resources

### DIFF
--- a/applications/prompt-redis/README.md
+++ b/applications/prompt-redis/README.md
@@ -8,6 +8,8 @@ Redis cluster for prompt processing
 |-----|------|---------|-------------|
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
+| redis-stream-exporter.resources | object | `{"limits":{"cpu":"1","memory":"2Gi"},"requests":{"cpu":"1","memory":"2Gi"}}` | Resource limits and requests for the Redis Stream Exporter |
+| redis-stream-exporter.sleepInterval | int | `5` | How long to sleep between redis stream exporter polling cycles |
 | redis.affinity | object | `{}` | Affinity rules for the persistent Redis pod |
 | redis.nodeSelector | object | `{}` | Node selection rules for the persistent Redis pod |
 | redis.persistence.accessMode | string | `"ReadWriteOnce"` | Access mode of storage to request |

--- a/applications/prompt-redis/values-usdfprod-prompt-processing.yaml
+++ b/applications/prompt-redis/values-usdfprod-prompt-processing.yaml
@@ -14,3 +14,11 @@ redis:
 redis-stream-exporter:
   enabled: true
   sleepInterval: 2
+
+  resources:
+    limits:
+      cpu: "1"
+      memory: "4Gi"
+    requests:
+      cpu: "1"
+      memory: "4Gi"

--- a/applications/prompt-redis/values.yaml
+++ b/applications/prompt-redis/values.yaml
@@ -44,6 +44,20 @@ redis:
   # -- Tolerations for the persistent Redis pod
   tolerations: []
 
+redis-stream-exporter:
+
+  # -- How long to sleep between redis stream exporter polling cycles
+  sleepInterval: 5
+
+  # -- Resource limits and requests for the Redis Stream Exporter
+  resources:
+    limits:
+      cpu: "1"
+      memory: "2Gi"
+    requests:
+      cpu: "1"
+      memory: "2Gi"
+
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:


### PR DESCRIPTION
Increase resources for production Redis Exporter resources due to out of memory kills.  Add missing resources and sleep interval to chart values file.  They were previously only defined in the sub chart.