### PR TITLE
DM-55570: Add a new Gafaelfawr scope write:obsforge

### DIFF
--- a/applications/gafaelfawr/values-idfdev.yaml
+++ b/applications/gafaelfawr/values-idfdev.yaml
@@ -80,6 +80,8 @@ config:
       - "g_users"
     "write:sasquatch":
       - "g_admins"
+    "write:obsforge":
+      - "g_admins"
 
   initialAdmins:
     - "adam"

--- a/applications/gafaelfawr/values-idfint.yaml
+++ b/applications/gafaelfawr/values-idfint.yaml
@@ -83,6 +83,8 @@ config:
       - "g_users"
     "write:sasquatch":
       - "g_admins"
+    "write:obsforge":
+      - "g_admins"
 
   initialAdmins:
     - "adam"

--- a/applications/gafaelfawr/values-idfprod.yaml
+++ b/applications/gafaelfawr/values-idfprod.yaml
@@ -100,6 +100,8 @@ config:
       - "g_users"
     "write:sasquatch":
       - "g_admins"
+    "write:obsforge":
+      - "g_admins"
 
   initialAdmins:
     - "adam"

--- a/applications/gafaelfawr/values.yaml
+++ b/applications/gafaelfawr/values.yaml
@@ -270,6 +270,8 @@ config:
       Service can send notifications to users and manage its notifications
     "write:sasquatch": >-
       Write access to the Sasquatch telemetry service
+    "write:obsforge": >-
+      Send notifications to ObsForge and register observations
     "user:token": >-
       Can create and modify user tokens
 


### PR DESCRIPTION
The Prompt publication service runs outside the RSP and needs to send notifications to ObsForge.
To grant access to the ObsForge external API we’ll use a new scope `write:obsforge`.
ObsForge is deployed on IDF so group mapping is needed only on those environments.
