### PR TITLE
DM-55567: Add table mapping config option for the TAP applications

### DIFF
--- a/charts/cadc-tap/README.md
+++ b/charts/cadc-tap/README.md
@@ -58,6 +58,7 @@ IVOA TAP service
 | config.qserv.jdbcParams | string | `""` | Extra JDBC connection parameters |
 | config.qserv.passwordEnabled | bool | false | Whether the Qserv database is password protected |
 | config.qserv.schemaMappings | string | `""` | Schema name mappings: comma-separated list of user_schema:internal_schema pairs. Example: "dp1:dp1_pilot" dp1 queries execute against dp1_pilot. |
+| config.qserv.tableMappings | list | `[]` | Table name mappings for query rewriting Example: ["dp1.Object:dp1_pilot.Object"] rewrites references to dp1.Object so they query dp1_pilot.Object instead. |
 | config.sentryEnabled | bool | `false` | Whether Sentry is enabled in this environment |
 | config.serviceName | string | None, must be set | Name of the service from Gafaelfawr's perspective, used for metrics reporting |
 | config.tapSchemaAddress | string | `"cadc-tap-schema-db:3306"` | Address to a MySQL database containing TAP schema data |

--- a/charts/cadc-tap/templates/tap-deployment.yaml
+++ b/charts/cadc-tap/templates/tap-deployment.yaml
@@ -171,6 +171,9 @@ spec:
                 {{- if .Values.config.qserv.schemaMappings }}
                 -Dtap.schema.mappings={{ .Values.config.qserv.schemaMappings }}
                 {{- end }}
+                {{- if .Values.config.qserv.tableMappings }}
+                -Dtap.table.mappings={{ .Values.config.qserv.tableMappings | join "," }}
+                {{- end }}
                 {{- end }}
                 -Dgafaelfawr_url={{ .Values.global.baseUrl }}/auth/api/v1/user-info
                 -Dgcs_bucket={{ .Values.config.gcsBucket }}

--- a/charts/cadc-tap/values.yaml
+++ b/charts/cadc-tap/values.yaml
@@ -90,6 +90,11 @@ config:
     # Example: "dp1:dp1_pilot" dp1 queries execute against dp1_pilot.
     schemaMappings: ""
 
+    # -- Table name mappings for query rewriting
+    # Example: ["dp1.Object:dp1_pilot.Object"] rewrites references to
+    # dp1.Object so they query dp1_pilot.Object instead.
+    tableMappings: []
+
     image:
       # -- TAP image to use
       repository: "ghcr.io/lsst-sqre/lsst-tap-service"


### PR DESCRIPTION
Adds configuration option to the TAP applications for specifying a table mapping for use when we want a query to be rewritten to a different back end table name.