### PR TITLE
DM-55120: Add Prompt Redis Stream Trim Cronjob

### DIFF
--- a/applications/prompt-redis/Chart.yaml
+++ b/applications/prompt-redis/Chart.yaml
@@ -12,3 +12,6 @@ dependencies:
 - name: redis-stream-exporter
   condition: redis-stream-exporter.enabled
   version: 1.0.0
+- name: redis-stream-trim
+  condition: redis-stream-trim.enabled
+  version: 1.0.0

--- a/applications/prompt-redis/README.md
+++ b/applications/prompt-redis/README.md
@@ -10,6 +10,7 @@ Redis cluster for prompt processing
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | redis-stream-exporter.resources | object | `{"limits":{"cpu":"1","memory":"2Gi"},"requests":{"cpu":"1","memory":"2Gi"}}` | Resource limits and requests for the Redis Stream Exporter |
 | redis-stream-exporter.sleepInterval | int | `5` | How long to sleep between redis stream exporter polling cycles |
+| redis-stream-trim.enabled | bool | `true` | Enabled Redis Stream trim cronjob |
 | redis.affinity | object | `{}` | Affinity rules for the persistent Redis pod |
 | redis.nodeSelector | object | `{}` | Node selection rules for the persistent Redis pod |
 | redis.persistence.accessMode | string | `"ReadWriteOnce"` | Access mode of storage to request |
@@ -31,3 +32,13 @@ Redis cluster for prompt processing
 | redis-stream-exporter.resources | object | See `values.yaml` | Kubernetes requests and limits for Redis Exporter |
 | redis-stream-exporter.sleepInterval | int | `10` | How long to sleep between redis stream exporter polling cycles |
 | redis-stream-exporter.tolerations | list | `[]` | Tolerations configuration |
+| redis-stream-trim.affinity | object | `{}` | Affinity configuration |
+| redis-stream-trim.cronSchedule | string | `"0 18 * * *"` |  |
+| redis-stream-trim.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
+| redis-stream-trim.image.repository | string | `"redis"` | Redis Stream Trim Docker image repository |
+| redis-stream-trim.image.tag | string | `"7-alpine"` | Redis Stream Trim image version |
+| redis-stream-trim.maxStreamLength | int | `1000` | Maximum Stream Length |
+| redis-stream-trim.nodeSelector | object | `{}` | Node selector configuration |
+| redis-stream-trim.replicaCount | int | `1` | Number of Redis Stream Trim pods to run in the deployment. |
+| redis-stream-trim.resources | object | See `values.yaml` | Kubernetes requests and limits for Redis Exporter |
+| redis-stream-trim.tolerations | list | `[]` | Tolerations configuration |

--- a/applications/prompt-redis/charts/redis-stream-trim/Chart.yaml
+++ b/applications/prompt-redis/charts/redis-stream-trim/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: redis-stream-trim
+version: 1.0.0
+description: A subchart to deploy a cronjob to trim events from Redis Streams
+appVersion: 1.0.0

--- a/applications/prompt-redis/charts/redis-stream-trim/README.md
+++ b/applications/prompt-redis/charts/redis-stream-trim/README.md
@@ -1,0 +1,18 @@
+# redis-stream-trim
+
+A subchart to deploy a cronjob to trim events from Redis Streams
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Affinity configuration |
+| cronSchedule | string | `"0 18 * * *"` |  |
+| image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
+| image.repository | string | `"redis"` | Redis Stream Trim Docker image repository |
+| image.tag | string | `"7-alpine"` | Redis Stream Trim image version |
+| maxStreamLength | int | `1000` | Maximum Stream Length |
+| nodeSelector | object | `{}` | Node selector configuration |
+| replicaCount | int | `1` | Number of Redis Stream Trim pods to run in the deployment. |
+| resources | object | See `values.yaml` | Kubernetes requests and limits for Redis Exporter |
+| tolerations | list | `[]` | Tolerations configuration |

--- a/applications/prompt-redis/charts/redis-stream-trim/templates/_helpers.tpl
+++ b/applications/prompt-redis/charts/redis-stream-trim/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "redis-stream-trim.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "redis-stream-trim.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "redis-stream-trim.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "redis-stream-trim.labels" -}}
+helm.sh/chart: {{ include "redis-stream-trim.chart" . }}
+{{ include "redis-stream-trimselectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "redis-stream-trim.selectorLabels" -}}
+app.kubernetes.io/name: "redis-stream-trim"
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/applications/prompt-redis/charts/redis-stream-trim/templates/cronjob.yaml
+++ b/applications/prompt-redis/charts/redis-stream-trim/templates/cronjob.yaml
@@ -1,0 +1,57 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "redis-stream-trim.name" . }}
+spec:
+  schedule: {{ .Values.cronSchedule| toString | quote }}
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: 3600
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: redis-stream-trim
+            image:
+            image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+            imagePullPolicy: {{ .Values.image.pullPolicy }}
+            env:
+            - name: REDIS_HOST
+              value: prompt-redis.prompt-redis
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_STREAM
+              value: "instrument:lsstcam"
+            - name: MAX_STREAM_LEN
+              value: {{ .Values.maxStreamLength | toString | quote }}
+            command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+
+              # Export REDISCLI_AUTH so redis-cli reads it implicitly
+              if [ -n "$REDIS_PASSWORD" ]; then
+                export REDISCLI_AUTH="$REDIS_PASSWORD"
+              fi
+
+              echo "Starting Redis Stream Trimming Task"
+              echo "Target Stream: $REDIS_STREAM"
+              echo "Max Length Target: $MAX_STREAM_LEN"
+
+              # Check length BEFORE trim
+              BEFORE_LEN=$(redis-cli --raw -h "$REDIS_HOST" -p "$REDIS_PORT" XLEN "$REDIS_STREAM")
+              echo "Stream length BEFORE trimming: $BEFORE_LEN"
+
+              # Trim Redis Stream
+              TRIMMED=$(redis-cli --raw -h "$REDIS_HOST" -p "$REDIS_PORT" XTRIM "$REDIS_STREAM" MAXLEN "$MAX_STREAM_LEN")
+              echo "Entries removed by XTRIM: $TRIMMED"
+
+              # Check length AFTER trim
+              AFTER_LEN=$(redis-cli --raw -h "$REDIS_HOST" -p "$REDIS_PORT" XLEN "$REDIS_STREAM")
+              echo "Stream length AFTER trimming: $AFTER_LEN"
+
+              echo "Trimming Complete Successfully"

--- a/applications/prompt-redis/charts/redis-stream-trim/values.yaml
+++ b/applications/prompt-redis/charts/redis-stream-trim/values.yaml
@@ -1,0 +1,39 @@
+# Default values for Redis Stream Trim
+
+# -- Number of Redis Stream Trim pods to run in the deployment.
+replicaCount: 1
+
+image:
+  # -- Redis Stream Trim Docker image repository
+  repository: redis
+
+  # -- Image pull policy
+  pullPolicy: IfNotPresent
+
+  # -- Redis Stream Trim image version
+  tag: 7-alpine
+
+# Cron Schedule
+cronSchedule: "0 18 * * *"
+
+# -- Maximum Stream Length
+maxStreamLength: 1000
+
+# -- Kubernetes requests and limits for Redis Exporter
+# @default -- See `values.yaml`
+resources:
+  requests:
+    memory: "16Mi"
+    cpu: "10Mi"
+  limits:
+    memory: "64Mi"
+    cpu: "100Mi"
+
+# -- Node selector configuration
+nodeSelector: {}
+
+# -- Tolerations configuration
+tolerations: []
+
+# -- Affinity configuration
+affinity: {}

--- a/applications/prompt-redis/values.yaml
+++ b/applications/prompt-redis/values.yaml
@@ -58,6 +58,10 @@ redis-stream-exporter:
       cpu: "1"
       memory: "2Gi"
 
+redis-stream-trim:
+  # -- Enabled Redis Stream trim cronjob
+  enabled: true
+
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:


### PR DESCRIPTION
Add cronjob to automate the trim of the `instrument:lsstcam` Redis Stream.  Redis Streams has no automated way currently of trimming stream entries.