### PR TITLE
Reconfigure tutorial flocks on idfint

### DIFF
--- a/applications/mobu/values-idfint.yaml
+++ b/applications/mobu/values-idfint.yaml
@@ -76,25 +76,6 @@ config:
         type: "NotebookRunnerCounting"
         options:
           cell_execution_timeout: "1000s"
-          repo_url: "https://github.com/lsst/tutorial-notebooks.git"
-          repo_ref: "tickets/SP-3298"
-          max_executions: 1
-        restart: true
-    - name: "tutorial-adhoc"
-      # Designed to let us take an arbitrary tag and see whether tutorials
-      # pass on it. Just change the tag under options.image.tag.
-      count: 1
-      users:
-        - username: "bot-mobu-adhoc"
-      scopes:
-        - "exec:notebook"
-        - "exec:portal"
-        - "read:image"
-        - "read:tap"
-      business:
-        type: "NotebookRunnerCounting"
-        options:
-          cell_execution_timeout: "1h"
           image:
             image_class: "by-tag"
             tag: "exp_r30_0_10_rc1_rsp2975_nojsd"
@@ -102,6 +83,28 @@ config:
           repo_ref: "tickets/SP-3298"
           max_executions: 1
         restart: true
+    #- name: "tutorial-adhoc"
+    #  # Designed to let us take an arbitrary tag and see whether tutorials
+    #  # pass on it. Just change the tag under options.image.tag.
+    #  count: 1
+    #  users:
+    #    - username: "bot-mobu-adhoc"
+    #  scopes:
+    #    - "exec:notebook"
+    #    - "exec:portal"
+    #    - "read:image"
+    #    - "read:tap"
+    #  business:
+    #    type: "NotebookRunnerCounting"
+    #    options:
+    #      cell_execution_timeout: "1h"
+    #      image:
+    #        image_class: "by-tag"
+    #        tag: "exp_r30_0_10_rc1_rsp2975_nojsd"
+    #      repo_url: "https://github.com/lsst/tutorial-notebooks.git"
+    #      repo_ref: "main"
+    #      max_executions: 1
+    #    restart: true
     - name: "tap"
       count: 1
       users:


### PR DESCRIPTION
Run a single tutorial flock against the experimental with no jupyter-server-documents and against the DP2 testing branch.