### PR TITLE
DM-55587: Fix the qserv-kafka backend rest API timeout name and increase it to 60s

### DIFF
--- a/applications/qserv-kafka/README.md
+++ b/applications/qserv-kafka/README.md
@@ -10,6 +10,7 @@ Qserv Kafka bridge
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| config.backendApiTimeout | string | `"60s"` | Timeout for REST API calls in Safir `parse_timedelta` format. This includes time spent waiting for a connection if the maximum number of connections has been reached. |
 | config.consumerGroupId | string | `"qserv"` | Kafka consumer group ID |
 | config.jobCancelTopic | string | `"lsst.tap.job-delete"` | Kafka topic for query cancellation requests |
 | config.jobRunBatchSize | int | `10` | Maximum batch size for query execution requests. This should generally be the same as `qservRestMaxConnections`. |
@@ -31,7 +32,6 @@ Qserv Kafka bridge
 | config.qservPollInterval | string | `"1s"` | Interval at which Qserv is polled for query status in Safir `parse_timedelta` format |
 | config.qservRestMaxConnections | int | `15` | Maximum simultaneous connections to open to the REST API. This should be set to `jobRunBatchSize` plus some extra connections for the monitor and cancel jobs. |
 | config.qservRestSendApiVersion | bool | `true` | Whether to send the expected API version in REST API calls to Qserv |
-| config.qservRestTimeout | string | `"30s"` | Timeout for REST API calls in Safir `parse_timedelta` format. This includes time spent waiting for a connection if the maximum number of connections has been reached. |
 | config.qservRestUrl | string | None, must be set | URL to the Qserv REST API |
 | config.qservRestUsername | string | `nil` | Username for HTTP Basic Authentication for the Qserv REST API. If not null, the password will be assumed to be the same as the database password. |
 | config.qservRetryCount | int | `3` | How many times to retry after a Qserv API network failure |

--- a/applications/qserv-kafka/templates/configmap.yaml
+++ b/applications/qserv-kafka/templates/configmap.yaml
@@ -28,7 +28,7 @@ data:
   {{- if not .Values.config.qservRestSendApiVersion }}
   QSERV_KAFKA_QSERV_REST_SEND_API_VERSION: "false"
   {{- end }}
-  QSERV_KAFKA_QSERV_REST_TIMEOUT: {{ .Values.config.qservRestTimeout | quote }}
+  QSERV_KAFKA_BACKEND_API_TIMEOUT: {{ .Values.config.backendApiTimeout | quote }}
   QSERV_KAFKA_QSERV_REST_URL: {{ .Values.config.qservRestUrl | quote }}
   {{- if .Values.config.qservRestUsername }}
   QSERV_KAFKA_QSERV_REST_USERNAME: {{ .Values.config.qservRestUsername | quote }}

--- a/applications/qserv-kafka/values.yaml
+++ b/applications/qserv-kafka/values.yaml
@@ -102,7 +102,7 @@ config:
   # -- Timeout for REST API calls in Safir `parse_timedelta` format. This
   # includes time spent waiting for a connection if the maximum number of
   # connections has been reached.
-  qservRestTimeout: "30s"
+  backendApiTimeout: "60s"
 
   # -- URL to the Qserv REST API
   # @default -- None, must be set


### PR DESCRIPTION
The qserv-kafka app configuration has renamed `qserv_rest_timeout` to `backend_api_timeout` so update it the name.
Also increase the timeout to 60s. We are doing so because we've noticed increased mobu errors during Qserv API DELETE requests which often take more than 30s as they are synchronous.