### PR TITLE
DM-55593: Update USDAC/IDF configs for DP2 HiPS/MOC datasets

### DIFF
--- a/applications/portal/README.md
+++ b/applications/portal/README.md
@@ -15,6 +15,7 @@ Rubin Science Platform Portal Aspect
 | config.alertMessage | string | `nil` | If not null, display this alert to all users in a banner |
 | config.cleanupInterval | string | `"36h"` | How long results should be retained before being deleted |
 | config.debug | string | `"FALSE"` | Set to `TRUE` to enable service debugging |
+| config.hipsListUrl | string | `/api/hips/list` in the local Science Platform | URL for master list of Rubin-featured HiPS datasets |
 | config.hipsUrl | string | `/api/hips/images/color_gri` in the local Science Platform | URL for default HiPS map to be used for coverage displays |
 | config.livetap | string | `""` | Endpoint under `/api/` for the live TAP service on the instance, if present |
 | config.showUserInfo | string | `"true"` | Whether to show information about the logged-in user |

--- a/applications/portal/README.md
+++ b/applications/portal/README.md
@@ -15,7 +15,7 @@ Rubin Science Platform Portal Aspect
 | config.alertMessage | string | `nil` | If not null, display this alert to all users in a banner |
 | config.cleanupInterval | string | `"36h"` | How long results should be retained before being deleted |
 | config.debug | string | `"FALSE"` | Set to `TRUE` to enable service debugging |
-| config.hipsUrl | string | `/api/hips/images/color_gri` in the local Science Platform | URL for default HiPS service |
+| config.hipsUrl | string | `/api/hips/images/color_gri` in the local Science Platform | URL for default HiPS map to be used for coverage displays |
 | config.livetap | string | `""` | Endpoint under `/api/` for the live TAP service on the instance, if present |
 | config.showUserInfo | string | `"true"` | Whether to show information about the logged-in user |
 | config.ssotap | string | `""` | Endpoint under `/api/` for the DP0.3 SSO TAP service on the instance, if present |

--- a/applications/portal/README.md
+++ b/applications/portal/README.md
@@ -18,6 +18,7 @@ Rubin Science Platform Portal Aspect
 | config.hipsListUrl | string | `/api/hips/list` in the local Science Platform | URL for master list of Rubin-featured HiPS datasets |
 | config.hipsUrl | string | `/api/hips/images/color_gri` in the local Science Platform | URL for default HiPS map to be used for coverage displays |
 | config.livetap | string | `""` | Endpoint under `/api/` for the live TAP service on the instance, if present |
+| config.mocListUrl | string | `/api/hips/v2/dp2/dp2-moc-list.tbl` in the local Science Platform | URL for master list of Rubin-featured MOC datasets |
 | config.showUserInfo | string | `"true"` | Whether to show information about the logged-in user |
 | config.ssotap | string | `""` | Endpoint under `/api/` for the DP0.3 SSO TAP service on the instance, if present |
 | config.tapHistoryLimit | string | `"1000"` | Maximum number of recent TAP queries to show in history |

--- a/applications/portal/templates/statefulset.yaml
+++ b/applications/portal/templates/statefulset.yaml
@@ -48,7 +48,12 @@ spec:
             - name: "PROPS_alert__viewer__fits__service__url"
               value: "{{ .Values.global.baseUrl }}/api/alerts"
             - name: "PROPS_lsst__hips__masterUrl"
-              value: "{{ .Values.global.baseUrl }}/api/hips/list"
+               value: >-
+                {{- if .Values.config.hipsListUrl }}
+                       {{ .Values.config.hipsListUrl }}
+                {{- else }}
+                       {{ .Values.global.baseUrl }}/api/hips/list"
+                {{- end }}
             - name: "PROPS_lsst__moc__masterUrl"
               value: "{{ .Values.global.baseUrl }}/api/hips/v2/dp2/dp2-moc-list.tbl"
             - name: PROPS_job__cleanup__interval

--- a/applications/portal/templates/statefulset.yaml
+++ b/applications/portal/templates/statefulset.yaml
@@ -48,14 +48,19 @@ spec:
             - name: "PROPS_alert__viewer__fits__service__url"
               value: "{{ .Values.global.baseUrl }}/api/alerts"
             - name: "PROPS_lsst__hips__masterUrl"
-               value: >-
+              value: >-
                 {{- if .Values.config.hipsListUrl }}
                        {{ .Values.config.hipsListUrl }}
                 {{- else }}
-                       {{ .Values.global.baseUrl }}/api/hips/list"
+                       {{ .Values.global.baseUrl }}/api/hips/list
                 {{- end }}
             - name: "PROPS_lsst__moc__masterUrl"
-              value: "{{ .Values.global.baseUrl }}/api/hips/v2/dp2/dp2-moc-list.tbl"
+              value: >-
+                {{- if .Values.config.mocListUrl }}
+                       {{ .Values.config.mocListUrl }}
+                {{- else }}
+                       {{ .Values.global.baseUrl }}/api/hips/v2/dp2/dp2-moc-list.tbl
+                {{- end }}
             - name: PROPS_job__cleanup__interval
               value: "120"
             - name: PROPS_OP_searchActionsCmdMask_0

--- a/applications/portal/values-idfint.yaml
+++ b/applications/portal/values-idfint.yaml
@@ -12,7 +12,7 @@ config:
         size: "20Gi"
         storageClass: "standard-rwo"
   ssotap: "ssotap"
-  hipsUrl: "https://data-int.lsst.cloud/api/hips/v2/dp1/deep_coadd/band_r"
+  hipsUrl: "https://data-int.lsst.cloud/api/hips/v2/dp2/color_gri"
 
 redis:
   persistence:

--- a/applications/portal/values-idfint.yaml
+++ b/applications/portal/values-idfint.yaml
@@ -12,6 +12,7 @@ config:
         size: "20Gi"
         storageClass: "standard-rwo"
   ssotap: "ssotap"
+  hipsListUrl: "https://data-int.lsst.cloud/api/hips/v2/dp2/list"
   hipsUrl: "https://data-int.lsst.cloud/api/hips/v2/dp2/color_gri"
 
 redis:

--- a/applications/portal/values-idfprod.yaml
+++ b/applications/portal/values-idfprod.yaml
@@ -12,7 +12,7 @@ config:
         size: "40Gi"
         storageClass: "standard-rwo"
   ssotap: "ssotap"
-  hipsUrl: "https://data.lsst.cloud/api/hips/v2/dp1/deep_coadd/band_r"
+  hipsUrl: "https://data.lsst.cloud/api/hips/v2/dp2/color_gri"
 
 redis:
   persistence:

--- a/applications/portal/values-idfprod.yaml
+++ b/applications/portal/values-idfprod.yaml
@@ -12,6 +12,7 @@ config:
         size: "40Gi"
         storageClass: "standard-rwo"
   ssotap: "ssotap"
+  hipsListUrl: "https://data.lsst.cloud/api/hips/v2/dp2/list"
   hipsUrl: "https://data.lsst.cloud/api/hips/v2/dp2/color_gri"
 
 redis:

--- a/applications/portal/values.yaml
+++ b/applications/portal/values.yaml
@@ -61,6 +61,10 @@ config:
   # -- How long results should be retained before being deleted
   cleanupInterval: "36h"
 
+  # -- URL for master list of Rubin-featured HiPS datasets
+  # @default -- `/api/hips/list` in the local Science Platform
+  hipsListUrl: ""
+
   # -- URL for default HiPS map to be used for coverage displays
   # @default -- `/api/hips/images/color_gri` in the local Science Platform
   hipsUrl: ""

--- a/applications/portal/values.yaml
+++ b/applications/portal/values.yaml
@@ -69,6 +69,10 @@ config:
   # @default -- `/api/hips/images/color_gri` in the local Science Platform
   hipsUrl: ""
 
+  # -- URL for master list of Rubin-featured MOC datasets
+  # @default -- `/api/hips/v2/dp2/dp2-moc-list.tbl` in the local Science Platform
+  mocListUrl: ""
+
   # -- Whether to show information about the logged-in user
   showUserInfo: "true"
 

--- a/applications/portal/values.yaml
+++ b/applications/portal/values.yaml
@@ -61,7 +61,7 @@ config:
   # -- How long results should be retained before being deleted
   cleanupInterval: "36h"
 
-  # -- URL for default HiPS service
+  # -- URL for default HiPS map to be used for coverage displays
   # @default -- `/api/hips/images/color_gri` in the local Science Platform
   hipsUrl: ""
 


### PR DESCRIPTION
Main tasks:

- Use DP2 color HiPS for coverage
- Make HiPS list phalanx-configurable
- Use DP2 HiPS list for idfprod and idfint

Also, clarify that the phalanx property involved does in fact control the coverage HiPS