### PR TITLE
Update default Nublado image on idfint

### DIFF
--- a/applications/nublado/values-idfint.yaml
+++ b/applications/nublado/values-idfint.yaml
@@ -31,8 +31,8 @@ controller:
     images:
       numReleases: 0
       pin:
-        - "r30_0_10_rc2_rsp2979"
-      recommendedTag: "r30_0_10_rc2_rsp2979"
+        - "r30_0_10_rc3_rsp2984"
+      recommendedTag: "r30_0_10_rc3_rsp2984"
       source:
         type: "google"
         location: "us-central1"


### PR DESCRIPTION
Switch the default Nublado image on idfint to v30.0.10rc3.