### PR TITLE
DM-55598: Switch data-int Butler DB to new release

### DIFF
--- a/applications/butler/README.md
+++ b/applications/butler/README.md
@@ -18,7 +18,8 @@ Server for Butler data abstraction service
 | config.additionalS3EndpointUrls | object | No additional URLs | Endpoint URLs for additional S3 services used by the Butler, as a mapping from profile name to URL. |
 | config.dp02PostgresUri | string | No configuration file for DP02 will be generated. | Postgres connection string pointing to the registry database hosting Data Preview 0.2 data. |
 | config.dp1PostgresUri | string | No configuration file for DP1 will be generated. | Postgres connection string pointing to the registry database hosting Data Preview 1 data. |
-| config.dp2PostgresUri | string | No configuration file for DP2 will be generated. | Postgres connection string pointing to the registry database hosting Data Preview 1 data. |
+| config.dp2PostgresSchema | string | Must be set. | Name of the Postgres schema holding the current Butler database for Data Preview 2. |
+| config.dp2PostgresUri | string | No configuration file for DP2 will be generated. | Postgres connection string pointing to the registry database hosting Data Preview 2 data. |
 | config.enableSentry | bool | `false` | True to enable capture of trace and other diagnostics to Sentry.io. |
 | config.pathPrefix | string | `"/api/butler"` | The prefix of the path portion of the URL where the Butler service will be exposed.  For example, if the service should be exposed at `https://data.lsst.cloud/api/butler`, this should be set to `/api/butler` |
 | config.pguser | string | Use values specified in per-repository Butler config files. | Postgres username used to connect to the Butler DB |

--- a/applications/butler/templates/configmap-private.yaml
+++ b/applications/butler/templates/configmap-private.yaml
@@ -48,7 +48,7 @@ data:
         datastores: lsst.daf.butler.registry.bridge.monolithic.MonolithicDatastoreRegistryBridgeManager
         dimensions: lsst.daf.butler.registry.dimensions.static.StaticDimensionRecordStorageManager
         opaque: lsst.daf.butler.registry.opaque.ByNameOpaqueTableStorageManager
-      namespace: dp2_mini_dm_55560
+      namespace: {{ .Values.config.dp2PostgresSchema }}
 
   prompt.yaml: |
     datastore:

--- a/applications/butler/values-idfint.yaml
+++ b/applications/butler/values-idfint.yaml
@@ -4,6 +4,7 @@ config:
   dp02PostgresUri: postgresql://butler@alloydb-dp.rsp-sql-int.internal:5432/dp02
   dp1PostgresUri: postgresql://butler@alloydb-dp.rsp-sql-int.internal:5432/dp1
   dp2PostgresUri: postgresql://butler@alloydb-dp.rsp-sql-int.internal:5432/dp2
+  dp2PostgresSchema: dp2_mini_dm_55598
   promptPostgresUri: postgresql://butler@alloydb-butler-prompt.rsp-sql-int.internal:5432/prompt
   s3EndpointUrl: "https://storage.googleapis.com"
   repositories:

--- a/applications/butler/values.yaml
+++ b/applications/butler/values.yaml
@@ -107,9 +107,14 @@ config:
   dp1PostgresUri: ""
 
   # -- Postgres connection string pointing to the registry database hosting
-  # Data Preview 1 data.
+  # Data Preview 2 data.
   # @default -- No configuration file for DP2 will be generated.
   dp2PostgresUri: ""
+
+  # -- Name of the Postgres schema holding the current Butler database for
+  # Data Preview 2.
+  # @default -- Must be set.
+  dp2PostgresSchema: ""
 
   # -- Postgres connection string pointing to the registry database hosting
   # Prompt Data Products.


### PR DESCRIPTION
Update the Butler DB on `data-int` to the hopefully-final release of "early" DP2.