### PR TITLE
DM-55608: Deploy early DP2 Butler to production

### DIFF
--- a/applications/butler/values-idfprod.yaml
+++ b/applications/butler/values-idfprod.yaml
@@ -3,6 +3,8 @@ autoscaling:
 config:
   dp02PostgresUri: postgresql://butler@alloydb-dp.rsp-sql-stable.internal:5432/dp02
   dp1PostgresUri: postgresql://butler@alloydb-dp.rsp-sql-stable.internal:5432/dp1
+  dp2PostgresUri: postgresql://butler@alloydb-dp.rsp-sql-stable.internal:5432/dp2
+  dp2PostgresSchema: dp2_mini_dm_55598
   s3EndpointUrl: "https://storage.googleapis.com"
   repositories:
     dp02:
@@ -11,6 +13,9 @@ config:
     dp1:
       config_uri: "file:///opt/lsst/butler/config/dp1.yaml"
       authorized_groups: ["*"]
+    dp2:
+      config_uri: "file:///opt/lsst/butler/config/dp2.yaml"
+      authorized_groups: ["g_rubin"]
   shareNubladoSecrets: false
   additionalS3EndpointUrls:
     slac: "https://sdfdatas3.slac.stanford.edu"

--- a/applications/sia/values-idfprod.yaml
+++ b/applications/sia/values-idfprod.yaml
@@ -18,6 +18,12 @@ config:
       butler_type: "REMOTE"
       repository: "https://data.lsst.cloud/api/butler/repo/dp1/butler.yaml"
       datalink_url: "https://data.lsst.cloud/api/datalink/links?ID=ivo%3A%2F%2Forg.rubinobs%2Flsst-dp1%3Frepo%3Ddp1%26id%3D{id}"
+    - config: "https://raw.githubusercontent.com/lsst-dm/dax_obscore/refs/heads/main/configs/edp2.yaml"
+      label: "LSST.DP2"
+      name: "dp2"
+      butler_type: "REMOTE"
+      repository: "https://data.lsst.cloud/api/butler/repo/dp2/butler.yaml"
+      datalink_url: "https://data.lsst.cloud/api/datalink/links?ID=ivo%3A%2F%2Forg.rubinobs%2Flsst-dp2%3Frepo%3Ddp2%26id%3D{id}"
 
   enableSentry: true
   sentryTracesSampleRate: 0.1

--- a/environments/values-idfprod.yaml
+++ b/environments/values-idfprod.yaml
@@ -4,6 +4,7 @@ appOfAppsName: "science-platform"
 butlerServerRepositories:
   dp02: "https://data.lsst.cloud/api/butler/repo/dp02/butler.yaml"
   dp1: "https://data.lsst.cloud/api/butler/repo/dp1/butler.yaml"
+  dp2: "https://data.lsst.cloud/api/butler/repo/dp2/butler.yaml"
 gcp:
   projectId: "science-platform-stable-6994"
   region: "us-central1"


### PR DESCRIPTION
Deploy the "early" DP2 Butler data to the production Butler server.  Access is currently restricted to Rubin staff.