### PR TITLE
DM-55604: Update squareone to 0.37.1

### DIFF
--- a/applications/squareone/Chart.yaml
+++ b/applications/squareone/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
     url: https://github.com/jonathansick
 
 # The default version tag of the squareone docker image
-appVersion: "0.36.2"
+appVersion: "0.37.0"

--- a/applications/squareone/Chart.yaml
+++ b/applications/squareone/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
     url: https://github.com/jonathansick
 
 # The default version tag of the squareone docker image
-appVersion: "0.37.0"
+appVersion: "0.37.1"


### PR DESCRIPTION
## Summary

- Bump the squareone chart `appVersion` from 0.36.2 to 0.37.1 ([0.37.0 release notes](https://github.com/lsst-sqre/squareone/releases/tag/squareone%400.37.0), [0.37.1 release notes](https://github.com/lsst-sqre/squareone/releases/tag/squareone%400.37.1)).
- Squareone 0.37.0 delivers the first tranche of the Sentry error-reporting PRD (DM-55604), from squareone PR [#608](https://github.com/lsst-sqre/squareone/pull/608): a shared error-classification/reporting pattern (`@lsst-sqre/api-client-core`) applied to the semaphore broadcasts, repertoire discovery, and gafaelfawr auth queries plus the app data-layer catch sites, with an app-side `reportError` that captures to Sentry with site/package context tags behind a per-runtime dedupe window. Graceful-degradation fallbacks are unchanged.
- Squareone 0.37.1 adds the Next.js security patch (16.2.10 → 16.2.11) from squareone PR [#611](https://github.com/lsst-sqre/squareone/pull/611).
- Note: the pino→Sentry Logs bridge (squareone [#609](https://github.com/lsst-sqre/squareone/pull/609)) and the token-page/Times Square UI error states (squareone [#610](https://github.com/lsst-sqre/squareone/pull/610)) are **not** in this release — those PRs are still open and will ship in a subsequent version bump.
- The ghcr.io image `0.37.1` is published (amd64 + arm64); `phalanx application lint squareone` passes for all environments. No new configuration keys are required.

## Validation steps

- [ ] After Argo CD syncs squareone on idfdev, confirm the pod runs image tag `0.37.1` and the site loads normally (broadcasts banner, header login menu).
- [x] On `/admin/sentry` (idfdev), use the test buttons and confirm events arrive in the `rubin-observatory/squareone` Sentry project.
- [ ] Optionally, verify the DM-55599 scenario: a report-worthy failure from the broadcasts/discovery/auth endpoints produces a Sentry issue carrying `site`/`package` context tags, while the UI still degrades gracefully.

## References

- PRD: lsst-sqre/squareone#598
- Jira: https://rubinobs.atlassian.net/browse/DM-55604