### PR TITLE
DM-55579: Pin image of TAP service to 3.18.0 for ppdbtap on idfdev and idfint

### DIFF
--- a/applications/ppdbtap/values-idfdev.yaml
+++ b/applications/ppdbtap/values-idfdev.yaml
@@ -24,6 +24,9 @@ cadc-tap:
       project: "ppdb-dev-438721"
       dataset: "ppdb_lsstcam"
       schema: "ppdb"
+      image:
+        tag: "3.18.0"
+        imagePullPolicy: "Always"
 
   cloudsql:
     enabled: true

--- a/applications/ppdbtap/values-idfint.yaml
+++ b/applications/ppdbtap/values-idfint.yaml
@@ -24,6 +24,9 @@ cadc-tap:
       project: "ppdb-prod"
       dataset: "ppdb_lsstcam"
       schema: "ppdb"
+      image:
+        tag: "3.18.0"
+        imagePullPolicy: "Always"
 
   cloudsql:
     enabled: true


### PR DESCRIPTION
The reason for the pin is that there is a bug that showed up in 3.19.0 in an upgraded cadc package (cadc-tap-schema) which causes TAP_SCHEMA queries to fail on TAP service that use a MySQL TAP_SCHEMA database.
Currently this is what ppdbtap uses, so for now the temporary fix is to pin the version of TAP to the last one before the bug starte occuring, and the longer-term fix is to enable ppdbtap as a managed TAP service in Repertoire and then switch to the CloudSQL-based tap_schema