### PR TITLE
DM-55550: Deploy docverse org-scoped jobs image on roundtable-dev

### DIFF
--- a/applications/docverse/values-roundtable-dev.yaml
+++ b/applications/docverse/values-roundtable-dev.yaml
@@ -1,5 +1,6 @@
 image:
   pullPolicy: "Always"
+  tag: "tickets-DM-55550"
 
 config:
   logLevel: "DEBUG"


### PR DESCRIPTION
## Summary

- Override `image.tag` to `tickets-DM-55550` in `applications/docverse/values-roundtable-dev.yaml` to test the org-scoped jobs API changes (lsst-sqre/docverse#465) on roundtable-dev before release.
- `pullPolicy: Always` is already set on this environment, so restarts pick up rebuilt branch images.

## Validation steps

- Sync the `docverse` app on roundtable-dev in Argo CD and restart the Deployment so the branch image is pulled.
- `GET /orgs/{org}/jobs` and `GET /orgs/{org}/jobs/{job}` respond for an org reader; `GET /queue/jobs/{job}` returns 404.
- The 202 envelopes from enqueue endpoints carry `job_id`/`job_url` pointing at `/orgs/{org}/jobs/{id}`.

## Teardown

- After testing, remove the `image.tag` override (revert this commit) so roundtable-dev returns to the chart's `appVersion` image.

## References

- Jira: https://rubinobs.atlassian.net/browse/DM-55550
- Docverse PR: lsst-sqre/docverse#465

🤖 Generated with [Claude Code](https://claude.com/claude-code)