### PR TITLE
DM-55466: Add HTTP client timeout setting for times-square

### DIFF
--- a/applications/times-square/README.md
+++ b/applications/times-square/README.md
@@ -31,6 +31,7 @@ An API service for managing and rendering parameterized Jupyter notebooks.
 | config.htmlKeyMigration.dryRun | bool | `true` | Whether to run the HTML key migration job as a dry-run only |
 | config.htmlKeyMigration.enabled | bool | `false` | Whether to run the HTML key migration job as a pre-install/upgrade hook |
 | config.htmlKeyMigration.page | string | `""` | The name of the page to migrate, if set |
+| config.httpClientTimeout | string | `"30"` | Timeout for the shared HTTP client used for all outbound requests (GitHub API and Noteburst) in seconds |
 | config.logLevel | string | `"INFO"` | Logging level: "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL" |
 | config.name | string | `"times-square"` | Name of the service. |
 | config.nbstripoutMigration.dryRun | bool | `false` | Whether to run the nbstripout migration job as a dry-run only |

--- a/applications/times-square/templates/configmap.yaml
+++ b/applications/times-square/templates/configmap.yaml
@@ -19,4 +19,5 @@ data:
   TS_GITHUB_ORGS: {{ .Values.config.githubOrgs | quote }}
   TS_CHECK_RUN_TIMEOUT: {{ .Values.config.githubCheckRunTimeout | quote }}
   TS_DEFAULT_EXECUTION_TIMEOUT: {{ .Values.config.defaultExecutionTimeout | quote }}
+  TS_HTTP_CLIENT_TIMEOUT: {{ .Values.config.httpClientTimeout | quote }}
   TS_SENTRY_TRACES_SAMPLE_RATE: {{ .Values.config.sentryTracesSampleRate | quote }}

--- a/applications/times-square/values.yaml
+++ b/applications/times-square/values.yaml
@@ -151,6 +151,10 @@ config:
   # -- Default execution timeout for notebooks in seconds
   defaultExecutionTimeout: "300" # 5 minutes
 
+  # -- Timeout for the shared HTTP client used for all outbound requests
+  # (GitHub API and Noteburst) in seconds
+  httpClientTimeout: "30"
+
   # Sentry tracing sample rate
   sentryTracesSampleRate: 0.0
 


### PR DESCRIPTION
## Summary

- Add a `config.httpClientTimeout` values setting to the times-square application chart, mapped to the `TS_HTTP_CLIENT_TIMEOUT` environment variable in the ConfigMap.
- This supports the new configurable shared-HTTP-client timeout added to times-square in lsst-sqre/times-square#162, which raises the outbound request timeout (GitHub API and Noteburst) from httpx's implicit 5-second default to a configurable 30 seconds.

## Validation steps

- After the next times-square release is deployed, sync times-square in Argo CD on a dev environment and confirm the ConfigMap includes `TS_HTTP_CLIENT_TIMEOUT: "30"`.
- Confirm the times-square API and worker pods restart cleanly with the new environment variable.

## References

- Application change: lsst-sqre/times-square#162
- Jira: https://rubinobs.atlassian.net/browse/DM-55466