### PR TITLE
DM-55579: Move ppdbtap TAP_SCHEMA to the repertoire managed CloudSQL TAP_SCHEMA

### DIFF
--- a/applications/ppdbtap/values-idfdev.yaml
+++ b/applications/ppdbtap/values-idfdev.yaml
@@ -1,9 +1,9 @@
 cadc-tap:
   tapSchema:
-    image:
-      repository: "lsstsqre/tap-schema-idfint-ppdbtap"
-      tag: "tickets-DM-51914"
-      pullPolicy: "Always"
+    type: "cloudsql"
+    database: "ppdbtap"
+    username: "ppdbtap"
+    useVaultPassword: true
 
   config:
     backend: "bigquery"

--- a/applications/repertoire/secrets.yaml
+++ b/applications/repertoire/secrets.yaml
@@ -22,6 +22,14 @@ livetap-database-password:
   copy:
     application: livetap
     key: tap-schema-password
+ppdbtap-database-password:
+  description: >-
+    Database password for the ppdbtap service, used by repertoire to manage
+    the ppdbtap TAP_SCHEMA. Copied from ppdbtap application's database-password.
+  if: config.tap.servers.ppdbtap.enabled
+  copy:
+    application: ppdbtap
+    key: tap-schema-password
 sentry-dsn:
   description: >-
     DSN URL to which Sentry trace and error logging will be sent.

--- a/applications/repertoire/values-idfdev.yaml
+++ b/applications/repertoire/values-idfdev.yaml
@@ -25,6 +25,8 @@ config:
         enabled: true
       ssotap:
         enabled: true
+      ppdbtap:
+        enabled: true
   useSubdomains:
     - "nublado"
 

--- a/applications/repertoire/values.yaml
+++ b/applications/repertoire/values.yaml
@@ -510,6 +510,13 @@ config:
         databaseUrl: "postgresql://livetap@127.0.0.1:5432/livetap"
         databasePasswordKey: "livetap-database-password"
 
+      ppdbtap:
+        enabled: false
+        schemas:
+          - ppdb
+        databaseUrl: "postgresql://ppdbtap@127.0.0.1:5432/ppdbtap"
+        databasePasswordKey: "ppdbtap-database-password"
+
 cloudsql:
   # -- Enable the Cloud SQL Auth Proxy, used with Cloud SQL databases on
   # Google Cloud


### PR DESCRIPTION
This PR changes ppdbtap to run using the CloudSQL TAP_SCHEMA created & managed by repertoire

## Changes:
- Add `ppdbtap-database-password` secret to repertoire
- Add default ppdbtap tap configuration in base values.yaml
- Change ppdbtap TAP_SCHEMA configuration to use cloudsql approach
- Set ppdbtap enabled in repertoire for idfdev