### PR TITLE
DM-55551: Deploy docverse API-polish image on roundtable-dev

### DIFF
--- a/applications/docverse/values-roundtable-dev.yaml
+++ b/applications/docverse/values-roundtable-dev.yaml
@@ -1,6 +1,6 @@
 image:
   pullPolicy: "Always"
-  tag: "tickets-DM-55550"
+  tag: "tickets-DM-55551"
 
 config:
   logLevel: "DEBUG"


### PR DESCRIPTION
## Summary

- Bump the `image.tag` override from `tickets-DM-55550` to `tickets-DM-55551` in `applications/docverse/values-roundtable-dev.yaml` to test the REST API contract polish (lsst-sqre/docverse#475) on roundtable-dev before release.
- `pullPolicy: Always` is already set on this environment, so restarts pick up rebuilt branch images.

## Validation steps

- Sync the `docverse` app on roundtable-dev in Argo CD and restart the Deployment so the branch image is pulled.
- `GET /docverse/openapi.json` has no `__`-mangled schema names or operationIds, serves `AdminOrganization` for admin org endpoints, and documents 403/404/409 error responses.
- Create endpoints (e.g. `POST /orgs/{org}/projects`) return 201 with a `Location` header equal to the body's `self_url`; enqueue endpoints return 202 with `Location` pointing at the org-scoped job URL.
- `POST /orgs/{org}/dashboard/rebuild` returns an object envelope `{"entries": [...]}` and a `Location` pointing at the org jobs collection.
- `GET /orgs` as a non-admin member returns only their orgs with effective roles; as a superadmin it returns all orgs.
- `PATCH /orgs/{org}/members/{member}` with `{"role": ...}` updates the role; `{"role": null}` returns 422.
- `PATCH /orgs/{org}/keeper-sync` with a partial body leaves omitted fields untouched; explicit nulls return 422.

## Teardown

- After testing, either revert this override on the next release or bump it again for the next ticket branch (this environment currently tracks branch images).

## References

- Jira: https://rubinobs.atlassian.net/browse/DM-55551
- Docverse PR: lsst-sqre/docverse#475

🤖 Generated with [Claude Code](https://claude.com/claude-code)