### PR TITLE
DM-55622: Update datalinker to 4.4.1

### DIFF
--- a/applications/datalinker/Chart.yaml
+++ b/applications/datalinker/Chart.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 description: IVOA DataLink image matadata and location service
 sources:
   - "https://github.com/lsst-sqre/datalinker"
-appVersion: 4.4.0
+appVersion: 4.4.1
 
 annotations:
   phalanx.lsst.io/docs: |


### PR DESCRIPTION
This release only fixes human-readable text in the links and service descriptor for the cutout service to remove references to afw.