### PR TITLE
DM-55608b: Unlock DP2 Butler for end users

### DIFF
--- a/applications/butler/values-idfprod.yaml
+++ b/applications/butler/values-idfprod.yaml
@@ -15,7 +15,7 @@ config:
       authorized_groups: ["*"]
     dp2:
       config_uri: "file:///opt/lsst/butler/config/dp2.yaml"
-      authorized_groups: ["g_rubin"]
+      authorized_groups: ["*"]
   shareNubladoSecrets: false
   additionalS3EndpointUrls:
     slac: "https://sdfdatas3.slac.stanford.edu"


### PR DESCRIPTION
Remove the group restriction so that end-users in production can access DP2 Butler data.