### PR TITLE
DM-55623: Enable DP2 on idfprod

### DIFF
--- a/applications/hips/values-idfdev.yaml
+++ b/applications/hips/values-idfdev.yaml
@@ -5,6 +5,9 @@ config:
     dp1:
       bucketName: "static-us-central1-dp1-hips"
       objectPrefix: "DM-51494"
+    dp2:
+      bucketName: "static-us-central1-dp2-hips"
+      objectPrefix: "DM-55402/dp2x1"
   defaultBucketKey: "dp02"
   gcsProject: "data-curation-prod-fbdb"
   serviceAccount: "crawlspace-hips@science-platform-dev-7696.iam.gserviceaccount.com"

--- a/applications/hips/values-idfprod.yaml
+++ b/applications/hips/values-idfprod.yaml
@@ -7,6 +7,9 @@ config:
     dp1:
       bucketName: "static-us-central1-dp1-hips"
       objectPrefix: "DM-51494"
+    dp2:
+      bucketName: "static-us-central1-dp2-hips"
+      objectPrefix: "DM-55402/dp2x1"
   defaultBucketKey: "dp02"
   gcsProject: "data-curation-prod-fbdb"
   serviceAccount: "crawlspace-hips@science-platform-stable-6994.iam.gserviceaccount.com"

--- a/applications/repertoire/values-idfdev.yaml
+++ b/applications/repertoire/values-idfdev.yaml
@@ -3,6 +3,7 @@ config:
     - "dp02"
     - "dp03"
     - "dp1"
+    - "dp2"
     - "prompt"
   hips:
     legacy:

--- a/applications/repertoire/values-idfint.yaml
+++ b/applications/repertoire/values-idfint.yaml
@@ -6,16 +6,6 @@ config:
     - "dp2"
     - "prompt"
   hips:
-    datasets:
-      dp2:
-        paths:
-          - "color_gri"
-          - "color_u"
-          - "color_g"
-          - "color_r"
-          - "color_i"
-          - "color_z"
-          - "color_y"
     legacy:
       dataset: "dp1"
   metrics:

--- a/applications/repertoire/values-idfprod.yaml
+++ b/applications/repertoire/values-idfprod.yaml
@@ -3,6 +3,7 @@ config:
     - "dp02"
     - "dp03"
     - "dp1"
+    - "dp2"
     - "prompt"
   hips:
     legacy:

--- a/applications/repertoire/values.yaml
+++ b/applications/repertoire/values.yaml
@@ -105,6 +105,15 @@ config:
           - "deep_coadd/band_i"
           - "deep_coadd/band_z"
           - "deep_coadd/band_y"
+      dp2:
+        paths:
+          - "color_gri"
+          - "color_u"
+          - "color_g"
+          - "color_r"
+          - "color_i"
+          - "color_z"
+          - "color_y"
 
     legacy:
       # -- If set, specifies the dataset that should be shown at the legacy


### PR DESCRIPTION
Add DP2 to the supported datasets for Repertoire on idfprod and move the HiPS configuration for DP2 to the main `values.yaml`. Add the HiPS bucket and prefix for DP2 to the hips application on idfdev and idfprod.