### PR TITLE
DM-55628: Enable schema and update DataLink configuration for EDP2 release

### DIFF
--- a/applications/datalinker/values-idfprod.yaml
+++ b/applications/datalinker/values-idfprod.yaml
@@ -2,3 +2,6 @@ config:
   metrics:
     enabled: true
   slackAlerts: true
+
+  # -- TAP configuration
+  tapMetadataUrl: "https://github.com/lsst/sdm_schemas/releases/download/EDP2-deploy-v1/datalink-columns.zip"

--- a/applications/repertoire/values-idfprod.yaml
+++ b/applications/repertoire/values-idfprod.yaml
@@ -3,6 +3,7 @@ config:
     - "dp02"
     - "dp03"
     - "dp1"
+    - "dp2"
     - "prompt"
   hips:
     legacy:
@@ -14,6 +15,11 @@ config:
     servers:
       tap:
         enabled: true
+        schemas:
+          - dp2
+          - dp1
+          - ivoa_obscore
+          - dp02_dc2
       ssotap:
         enabled: true
   useSubdomains:

--- a/applications/tap/values-idfprod.yaml
+++ b/applications/tap/values-idfprod.yaml
@@ -12,6 +12,8 @@ cadc-tap:
         - "dp02_dc2_catalogs.ObsCore:access_url"
         - "dp1.ObsCore:access_url"
 
+    datalinkPayloadUrl: "https://github.com/lsst/sdm_schemas/releases/download/EDP2-deploy-v1/datalink-snippets.zip"
+
   cloudsql:
     enabled: true
     instanceConnectionName: "science-platform-stable-6994:us-central1:science-platform-stable-0c29612b"


### PR DESCRIPTION
This adds the `dp2` schema in `repertoire` to `idfprod` for the EDP2 release and updates the DataLink configuration in `datalinker` and `tap` to use the assets from the `EDP2-deploy-v1` release tag.