### PR TITLE
DM-55623: Further update Repertoire configuration for DP2

### DIFF
--- a/applications/repertoire/README.md
+++ b/applications/repertoire/README.md
@@ -46,7 +46,7 @@ Service discovery
 | config.slackAlerts | bool | `false` | Whether to send Slack alerts for unexpected failures |
 | config.subdomainRules | object | See `values.yaml` | Rules for determining the expected URLs of deployed services that use a subdomain. See the [Repertoire documentation](https://repertoire.lsst.io/) for more information. |
 | config.tap.schemaSourceTemplate | string | GCS rubin-sdm-schemas-artifacts bucket | Template for schema artifact URLs (use {schemaVersion} placeholder) |
-| config.tap.schemaVersion | string | `"releases/w.2026.17"` | Default schema version for all TAP services (can be overridden per-app) |
+| config.tap.schemaVersion | string | `"releases/EDP2-deploy-v1"` | Default schema version for all TAP services (can be overridden per-app) |
 | config.tap.servers | object | See `values.yaml` | TAP Server configuration by application name. Configuration is used to populate & update the TAP_SCHEMA database for each enabled TAP application |
 | config.useSubdomains | list | `[]` | List of services that use subdomains instead of the main hostname. See the [Repertoire documentation](https://repertoire.lsst.io/) for more information. |
 | global.environmentName | string | Set by Argo CD | Name of the Phalanx environment |

--- a/applications/repertoire/values-idfint.yaml
+++ b/applications/repertoire/values-idfint.yaml
@@ -16,40 +16,10 @@ config:
     servers:
       tap:
         enabled: true
-        schemas:
-          - dp2
-          - dp1
-          - ivoa_obscore
-          - dp02_dc2
       ssotap:
         enabled: true
   useSubdomains:
     - "nublado"
-
-  rules:
-    sia:
-      - type: "data"
-        name: "sia"
-        datasets:
-          - "dp02"
-          - "dp1"
-          - "dp2"
-        template: "https://{{base_hostname}}/api/sia/{{dataset}}"
-        versions:
-          sia-query-2.0:
-            template: "https://{{base_hostname}}/api/sia/{{dataset}}/query"
-            ivoaStandardId: "ivo://ivoa.net/std/SIA#query-2.0"
-        openapi: "https://{{base_hostname}}/api/sia/openapi.json"
-        ivoaRegistry:
-          ivoaServiceType: "sia"
-          records:
-            dp1:
-              ivoid: "ivo://org.rubinobs/sia/lsst-dp1"
-              title: "Rubin Science Platform SIA Service (DP1)"
-              created: "2026-05-20T00:00:00"
-              description: >-
-                Simple Image Access v2 service for Data Preview 1, providing
-                image access to commissioning data from Rubin Observatory.
 
 cloudsql:
   enabled: true

--- a/applications/repertoire/values-idfprod.yaml
+++ b/applications/repertoire/values-idfprod.yaml
@@ -15,11 +15,6 @@ config:
     servers:
       tap:
         enabled: true
-        schemas:
-          - dp2
-          - dp1
-          - ivoa_obscore
-          - dp02_dc2
       ssotap:
         enabled: true
   useSubdomains:

--- a/applications/repertoire/values.yaml
+++ b/applications/repertoire/values.yaml
@@ -472,7 +472,7 @@ config:
   tap:
     # -- Default schema version for all TAP services (can be overridden
     # per-app)
-    schemaVersion: "releases/w.2026.17"
+    schemaVersion: "releases/EDP2-deploy-v1"
 
     # -- Template for schema artifact URLs (use {schemaVersion} placeholder)
     # @default -- GCS rubin-sdm-schemas-artifacts bucket

--- a/applications/repertoire/values.yaml
+++ b/applications/repertoire/values.yaml
@@ -347,6 +347,7 @@ config:
         datasets:
           - "dp02"
           - "dp1"
+          - "dp2"
         template: "https://{{base_hostname}}/api/sia/{{dataset}}"
         versions:
           sia-query-2.0:
@@ -486,24 +487,25 @@ config:
       tap:
         enabled: false
         schemas:
-          - dp1
-          - ivoa_obscore
-          - dp02_dc2
+          - "dp2"
+          - "dp1"
+          - "ivoa_obscore"
+          - "dp02_dc2"
         databaseUrl: "postgresql://tap@127.0.0.1:5432/tap"
         databasePasswordKey: "tap-database-password"
 
       ssotap:
         enabled: false
         schemas:
-          - dp03_10yr
-          - dp03_1yr
+          - "dp03_10yr"
+          - "dp03_1yr"
         databaseUrl: "postgresql://ssotap@127.0.0.1:5432/ssotap"
         databasePasswordKey: "ssotap-database-password"
 
       livetap:
         enabled: false
         schemas:
-          - oga_live_obscore
+          - "oga_live_obscore"
         databaseUrl: "postgresql://livetap@127.0.0.1:5432/livetap"
         databasePasswordKey: "livetap-database-password"
 


### PR DESCRIPTION
- Update the TAP schema version to the EDP2 release
- Simplify the configuration by moving DP2 values into `values-idfprod.yaml`