### PR TITLE
DM-55623: Add DP2 to Gafaelfawr's data rights mapping

### DIFF
--- a/applications/gafaelfawr/values-idfprod.yaml
+++ b/applications/gafaelfawr/values-idfprod.yaml
@@ -48,6 +48,7 @@ config:
         - "dp0.2"
         - "dp0.3"
         - "dp1"
+        - "dp2"
 
   # Enable metrics reporting.
   metrics:


### PR DESCRIPTION
Indicate that `g_users` has DP2 access.