### PR TITLE
DM-55623: Exclude the sasquatch notebook from idfint and idfprod

### DIFF
--- a/applications/mobu/values-idfint.yaml
+++ b/applications/mobu/values-idfint.yaml
@@ -36,6 +36,10 @@ config:
         type: "NotebookRunnerCounting"
         options:
           cell_execution_timeout: "1000s"
+          collection_rules:
+            - type: exclude_union_of
+              patterns:
+                - "sasquatch.ipynb"
           image:
             image_class: "latest-daily"
           repo_url: "https://github.com/lsst-sqre/phalanx-test.git"
@@ -58,6 +62,10 @@ config:
         type: "NotebookRunnerCounting"
         options:
           cell_execution_timeout: "1000s"
+          collection_rules:
+            - type: exclude_union_of
+              patterns:
+                - "sasquatch.ipynb"
           execution_idle_time: 0
           idle_time: 300
           repo_ref: "main"

--- a/applications/mobu/values-idfprod.yaml
+++ b/applications/mobu/values-idfprod.yaml
@@ -36,6 +36,10 @@ config:
         type: "NotebookRunnerCounting"
         options:
           cell_execution_timeout: "1h"
+          collection_rules:
+            - type: exclude_union_of
+              patterns:
+                - "sasquatch.ipynb"
           repo_url: "https://github.com/lsst-sqre/phalanx-test.git"
           repo_ref: "main"
           execution_idle_time: 0


### PR DESCRIPTION
This requires a local database to run currently, and there are none registered in service discovery for those environments until we register the metrics databases.