### PR TITLE
Temporarily grant access to lsst.sal namespace

### DIFF
--- a/applications/sasquatch/charts/control-system/templates/kafka-users.yaml
+++ b/applications/sasquatch/charts/control-system/templates/kafka-users.yaml
@@ -92,6 +92,14 @@ spec:
         operations:
           - All
       - resource:
+          type: topic
+          name: "lsst.sal"
+          patternType: prefix
+        type: allow
+        host: "*"
+        operations:
+          - All
+      - resource:
           type: cluster
         operations:
           - Describe


### PR DESCRIPTION
- For testing at BTS the camera kafka user requires access to write to lsst.sal namespace