### PR TITLE
Revert "Temporarily grant access to lsst.sal namespace"

### DIFF
--- a/applications/sasquatch/charts/control-system/templates/kafka-users.yaml
+++ b/applications/sasquatch/charts/control-system/templates/kafka-users.yaml
@@ -92,14 +92,6 @@ spec:
         operations:
           - All
       - resource:
-          type: topic
-          name: "lsst.sal"
-          patternType: prefix
-        type: allow
-        host: "*"
-        operations:
-          - All
-      - resource:
           type: cluster
         operations:
           - Describe


### PR DESCRIPTION
This reverts commit 77a92720f8fe5febc0fdb363a1f4d21917271e77.