### PR TITLE
DM-55651: Deploy jira-data-proxy 1.0.1

### DIFF
--- a/applications/jira-data-proxy/Chart.yaml
+++ b/applications/jira-data-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "1.0.0"
+appVersion: "1.0.1"
 description: Jira API read-only proxy for Times Square users.
 name: jira-data-proxy
 sources:


### PR DESCRIPTION
## Summary

- Bump `jira-data-proxy` `appVersion` to 1.0.1, which fixes an SSRF in the proxy's upstream URL construction.
- `urljoin` returns its second argument unchanged when that argument is an absolute (`https://evil.example.org/`) or protocol-relative (`//evil.example.org/`) URL, and the proxied path comes straight from the request. Because the upstream GET attaches the Jira bot account's basic auth credentials, any authenticated caller could name a host of their choosing and have those credentials delivered to it — and use the service as an SSRF pivot to whatever the pod can reach. The joined URL is now refused with a 404 unless it stays within `JIRA_BASE_URL`.
- **This reaches production.** `jira-data-proxy` is deployed at `usdfprod` and `roundtable-prod` in addition to the three dev environments, and the chart resolves `image.tag` from `.Chart.AppVersion`, so all five environments move to 1.0.1 on sync. That is the intent — the fix should not sit in dev only.
- **Separately outstanding: the Jira bot account password should be rotated.** The exposure window is the service's entire deployed lifetime (in production since 2024-01), so the credential is best treated as potentially already disclosed. Deploying 1.0.1 closes the hole but does not undo any disclosure that already happened.

Verified before opening: `ghcr.io/lsst-sqre/jira-data-proxy:1.0.1` is published, `helm template` renders `ghcr.io/lsst-sqre/jira-data-proxy:1.0.1` for all five environments, `JIRA_BASE_URL` still carries the trailing slash the app's config validator requires, and `helm lint` passes.

## Validation steps

- After sync, confirm the pods are running 1.0.1 and healthy in each environment.
- Confirm ordinary proxying still works, e.g. `GET /jira-data-proxy/rest/api/2/issue/DM-55651` returns the issue JSON.
- Confirm `GET /jira-data-proxy/https://<host-you-control>/` returns 404 and that no request arrives at that host carrying an `Authorization: Basic` header. Repeat for the `//<host>/` and `https:%2F%2F<host>/` forms.
- Check the app logs for the `Refused a request that resolves outside of Jira` warning on those attempts.

## References

- Application PR: https://github.com/lsst-sqre/jira-data-proxy/pull/19
- Release: https://github.com/lsst-sqre/jira-data-proxy/releases/tag/1.0.1
- Jira: https://rubinobs.atlassian.net/browse/DM-55651