### PR TITLE
USDFSM-112: Add local ZFS /lscratch for USDF RSP notebooks

### DIFF
--- a/applications/nublado/values-usdfdev.yaml
+++ b/applications/nublado/values-usdfdev.yaml
@@ -115,6 +115,21 @@ controller:
         - secretName: "nublado-lab-secret"
           secretKey: "postgres-credentials.txt"
       standardInithome: false
+      # Make the per-user ZFS /lscratch PVC writable. The provisioner creates
+      # it as root:root 0755, and the lab runs as the user, so chown first.
+      initContainers:
+        - name: "lscratch-perms"
+          image:
+            repository: "ghcr.io/lsst-sqre/nublado"
+            tag: "15.1.0"
+          privileged: true
+          command:
+            - "/bin/sh"
+            - "-c"
+            - "chown \"${NUBLADO_UID}:${NUBLADO_GID}\" /lscratch && chmod 0700 /lscratch"
+          volumeMounts:
+            - containerPath: "/lscratch"
+              volumeName: "zfs-lscratch-storage"
       volumes:
         - name: "sdf-home"
           source:

--- a/applications/nublado/values-usdfdev.yaml
+++ b/applications/nublado/values-usdfdev.yaml
@@ -152,6 +152,15 @@ controller:
             resources:
               requests:
                 storage: "1Gi"
+        - name: "zfs-lscratch-storage"
+          source:
+            type: "persistentVolumeClaim"
+            storageClassName: "zfs-lscratch-storage"
+            accessModes:
+              - "ReadWriteMany"
+            resources:
+              requests:
+                storage: "10Gi"
       volumeMounts:
         - containerPath: "/home"
           volumeName: "sdf-home"
@@ -164,6 +173,8 @@ controller:
           volumeName: "sdf-data-rubin"
         - containerPath: "/scratch"
           volumeName: "sdf-scratch"
+        - containerPath: "/lscratch"
+          volumeName: "zfs-lscratch-storage"
 
 proxy:
   ingress:

--- a/applications/nublado/values-usdfdev.yaml
+++ b/applications/nublado/values-usdfdev.yaml
@@ -115,21 +115,6 @@ controller:
         - secretName: "nublado-lab-secret"
           secretKey: "postgres-credentials.txt"
       standardInithome: false
-      # Make the per-user ZFS /lscratch PVC writable. The provisioner creates
-      # it as root:root 0755, and the lab runs as the user, so chown first.
-      initContainers:
-        - name: "lscratch-perms"
-          image:
-            repository: "docker.io/library/busybox"
-            tag: "1.37.0"
-          privileged: true
-          command:
-            - "/bin/sh"
-            - "-c"
-            - "chown \"${NUBLADO_UID}:${NUBLADO_GID}\" /lscratch && chmod 0700 /lscratch"
-          volumeMounts:
-            - containerPath: "/lscratch"
-              volumeName: "zfs-lscratch-storage"
       volumes:
         - name: "sdf-home"
           source:
@@ -167,15 +152,13 @@ controller:
             resources:
               requests:
                 storage: "1Gi"
-        - name: "zfs-lscratch-storage"
+        # Node-local scratch on the kubelet disk (world-writable emptyDir).
+        # Soft size limit; wiped when the lab pod exits.
+        - name: "lscratch"
           source:
-            type: "persistentVolumeClaim"
-            storageClassName: "zfs-lscratch-storage"
-            accessModes:
-              - "ReadWriteMany"
-            resources:
-              requests:
-                storage: "10Gi"
+            type: "emptyDir"
+            medium: "disk"
+            size: "10Gi"
       volumeMounts:
         - containerPath: "/home"
           volumeName: "sdf-home"
@@ -189,7 +172,7 @@ controller:
         - containerPath: "/scratch"
           volumeName: "sdf-scratch"
         - containerPath: "/lscratch"
-          volumeName: "zfs-lscratch-storage"
+          volumeName: "lscratch"
 
 proxy:
   ingress:

--- a/applications/nublado/values-usdfdev.yaml
+++ b/applications/nublado/values-usdfdev.yaml
@@ -120,8 +120,8 @@ controller:
       initContainers:
         - name: "lscratch-perms"
           image:
-            repository: "ghcr.io/lsst-sqre/nublado"
-            tag: "15.1.0"
+            repository: "docker.io/library/busybox"
+            tag: "1.37.0"
           privileged: true
           command:
             - "/bin/sh"

--- a/applications/nublado/values-usdfdev.yaml
+++ b/applications/nublado/values-usdfdev.yaml
@@ -152,13 +152,17 @@ controller:
             resources:
               requests:
                 storage: "1Gi"
-        # Node-local scratch on the kubelet disk (world-writable emptyDir).
-        # Soft size limit; wiped when the lab pod exits.
+        # Node-local ZFS scratch. RWO + lab pod fsGroup (Nublado) make the
+        # volume writable without a privileged init; keep NFS /scratch too.
         - name: "lscratch"
           source:
-            type: "emptyDir"
-            medium: "disk"
-            size: "10Gi"
+            type: "persistentVolumeClaim"
+            storageClassName: "zfs-lscratch-storage"
+            accessModes:
+              - "ReadWriteOnce"
+            resources:
+              requests:
+                storage: "10Gi"
       volumeMounts:
         - containerPath: "/home"
           volumeName: "sdf-home"

--- a/applications/nublado/values-usdfint.yaml
+++ b/applications/nublado/values-usdfint.yaml
@@ -150,6 +150,15 @@ controller:
             resources:
               requests:
                 storage: "1Gi"
+        - name: "zfs-lscratch-storage"
+          source:
+            type: "persistentVolumeClaim"
+            storageClassName: "zfs-lscratch-storage"
+            accessModes:
+              - "ReadWriteMany"
+            resources:
+              requests:
+                storage: "10Gi"
       volumeMounts:
         - containerPath: "/home"
           volumeName: "sdf-home"
@@ -162,6 +171,8 @@ controller:
           volumeName: "sdf-data-rubin"
         - containerPath: "/scratch"
           volumeName: "sdf-scratch"
+        - containerPath: "/lscratch"
+          volumeName: "zfs-lscratch-storage"
 
 proxy:
   ingress:

--- a/applications/nublado/values-usdfint.yaml
+++ b/applications/nublado/values-usdfint.yaml
@@ -113,21 +113,6 @@ controller:
         - secretName: "nublado-lab-secret"
           secretKey: "postgres-credentials.txt"
       standardInithome: false
-      # Make the per-user ZFS /lscratch PVC writable. The provisioner creates
-      # it as root:root 0755, and the lab runs as the user, so chown first.
-      initContainers:
-        - name: "lscratch-perms"
-          image:
-            repository: "docker.io/library/busybox"
-            tag: "1.37.0"
-          privileged: true
-          command:
-            - "/bin/sh"
-            - "-c"
-            - "chown \"${NUBLADO_UID}:${NUBLADO_GID}\" /lscratch && chmod 0700 /lscratch"
-          volumeMounts:
-            - containerPath: "/lscratch"
-              volumeName: "zfs-lscratch-storage"
       volumes:
         - name: "sdf-home"
           source:
@@ -165,15 +150,13 @@ controller:
             resources:
               requests:
                 storage: "1Gi"
-        - name: "zfs-lscratch-storage"
+        # Node-local scratch on the kubelet disk (world-writable emptyDir).
+        # Soft size limit; wiped when the lab pod exits.
+        - name: "lscratch"
           source:
-            type: "persistentVolumeClaim"
-            storageClassName: "zfs-lscratch-storage"
-            accessModes:
-              - "ReadWriteMany"
-            resources:
-              requests:
-                storage: "10Gi"
+            type: "emptyDir"
+            medium: "disk"
+            size: "10Gi"
       volumeMounts:
         - containerPath: "/home"
           volumeName: "sdf-home"
@@ -187,7 +170,7 @@ controller:
         - containerPath: "/scratch"
           volumeName: "sdf-scratch"
         - containerPath: "/lscratch"
-          volumeName: "zfs-lscratch-storage"
+          volumeName: "lscratch"
 
 proxy:
   ingress:

--- a/applications/nublado/values-usdfint.yaml
+++ b/applications/nublado/values-usdfint.yaml
@@ -118,8 +118,8 @@ controller:
       initContainers:
         - name: "lscratch-perms"
           image:
-            repository: "ghcr.io/lsst-sqre/nublado"
-            tag: "15.1.0"
+            repository: "docker.io/library/busybox"
+            tag: "1.37.0"
           privileged: true
           command:
             - "/bin/sh"

--- a/applications/nublado/values-usdfint.yaml
+++ b/applications/nublado/values-usdfint.yaml
@@ -113,6 +113,21 @@ controller:
         - secretName: "nublado-lab-secret"
           secretKey: "postgres-credentials.txt"
       standardInithome: false
+      # Make the per-user ZFS /lscratch PVC writable. The provisioner creates
+      # it as root:root 0755, and the lab runs as the user, so chown first.
+      initContainers:
+        - name: "lscratch-perms"
+          image:
+            repository: "ghcr.io/lsst-sqre/nublado"
+            tag: "15.1.0"
+          privileged: true
+          command:
+            - "/bin/sh"
+            - "-c"
+            - "chown \"${NUBLADO_UID}:${NUBLADO_GID}\" /lscratch && chmod 0700 /lscratch"
+          volumeMounts:
+            - containerPath: "/lscratch"
+              volumeName: "zfs-lscratch-storage"
       volumes:
         - name: "sdf-home"
           source:

--- a/applications/nublado/values-usdfint.yaml
+++ b/applications/nublado/values-usdfint.yaml
@@ -150,13 +150,17 @@ controller:
             resources:
               requests:
                 storage: "1Gi"
-        # Node-local scratch on the kubelet disk (world-writable emptyDir).
-        # Soft size limit; wiped when the lab pod exits.
+        # Node-local ZFS scratch. RWO + lab pod fsGroup (Nublado) make the
+        # volume writable without a privileged init; keep NFS /scratch too.
         - name: "lscratch"
           source:
-            type: "emptyDir"
-            medium: "disk"
-            size: "10Gi"
+            type: "persistentVolumeClaim"
+            storageClassName: "zfs-lscratch-storage"
+            accessModes:
+              - "ReadWriteOnce"
+            resources:
+              requests:
+                storage: "10Gi"
       volumeMounts:
         - containerPath: "/home"
           volumeName: "sdf-home"

--- a/applications/nublado/values-usdfprod.yaml
+++ b/applications/nublado/values-usdfprod.yaml
@@ -150,6 +150,15 @@ controller:
             resources:
               requests:
                 storage: "1Gi"
+        - name: "zfs-lscratch-storage"
+          source:
+            type: "persistentVolumeClaim"
+            storageClassName: "zfs-lscratch-storage"
+            accessModes:
+              - "ReadWriteMany"
+            resources:
+              requests:
+                storage: "10Gi"
       volumeMounts:
         - containerPath: "/home"
           volumeName: "sdf-home"
@@ -162,6 +171,8 @@ controller:
           volumeName: "sdf-data-rubin"
         - containerPath: "/scratch"
           volumeName: "sdf-scratch"
+        - containerPath: "/lscratch"
+          volumeName: "zfs-lscratch-storage"
 
 proxy:
   ingress:

--- a/applications/nublado/values-usdfprod.yaml
+++ b/applications/nublado/values-usdfprod.yaml
@@ -113,21 +113,6 @@ controller:
         - secretName: "nublado-lab-secret"
           secretKey: "postgres-credentials.txt"
       standardInithome: false
-      # Make the per-user ZFS /lscratch PVC writable. The provisioner creates
-      # it as root:root 0755, and the lab runs as the user, so chown first.
-      initContainers:
-        - name: "lscratch-perms"
-          image:
-            repository: "docker.io/library/busybox"
-            tag: "1.37.0"
-          privileged: true
-          command:
-            - "/bin/sh"
-            - "-c"
-            - "chown \"${NUBLADO_UID}:${NUBLADO_GID}\" /lscratch && chmod 0700 /lscratch"
-          volumeMounts:
-            - containerPath: "/lscratch"
-              volumeName: "zfs-lscratch-storage"
       volumes:
         - name: "sdf-home"
           source:
@@ -165,15 +150,13 @@ controller:
             resources:
               requests:
                 storage: "1Gi"
-        - name: "zfs-lscratch-storage"
+        # Node-local scratch on the kubelet disk (world-writable emptyDir).
+        # Soft size limit; wiped when the lab pod exits.
+        - name: "lscratch"
           source:
-            type: "persistentVolumeClaim"
-            storageClassName: "zfs-lscratch-storage"
-            accessModes:
-              - "ReadWriteMany"
-            resources:
-              requests:
-                storage: "10Gi"
+            type: "emptyDir"
+            medium: "disk"
+            size: "10Gi"
       volumeMounts:
         - containerPath: "/home"
           volumeName: "sdf-home"
@@ -187,7 +170,7 @@ controller:
         - containerPath: "/scratch"
           volumeName: "sdf-scratch"
         - containerPath: "/lscratch"
-          volumeName: "zfs-lscratch-storage"
+          volumeName: "lscratch"
 
 proxy:
   ingress:

--- a/applications/nublado/values-usdfprod.yaml
+++ b/applications/nublado/values-usdfprod.yaml
@@ -118,8 +118,8 @@ controller:
       initContainers:
         - name: "lscratch-perms"
           image:
-            repository: "ghcr.io/lsst-sqre/nublado"
-            tag: "15.1.0"
+            repository: "docker.io/library/busybox"
+            tag: "1.37.0"
           privileged: true
           command:
             - "/bin/sh"

--- a/applications/nublado/values-usdfprod.yaml
+++ b/applications/nublado/values-usdfprod.yaml
@@ -113,6 +113,21 @@ controller:
         - secretName: "nublado-lab-secret"
           secretKey: "postgres-credentials.txt"
       standardInithome: false
+      # Make the per-user ZFS /lscratch PVC writable. The provisioner creates
+      # it as root:root 0755, and the lab runs as the user, so chown first.
+      initContainers:
+        - name: "lscratch-perms"
+          image:
+            repository: "ghcr.io/lsst-sqre/nublado"
+            tag: "15.1.0"
+          privileged: true
+          command:
+            - "/bin/sh"
+            - "-c"
+            - "chown \"${NUBLADO_UID}:${NUBLADO_GID}\" /lscratch && chmod 0700 /lscratch"
+          volumeMounts:
+            - containerPath: "/lscratch"
+              volumeName: "zfs-lscratch-storage"
       volumes:
         - name: "sdf-home"
           source:

--- a/applications/nublado/values-usdfprod.yaml
+++ b/applications/nublado/values-usdfprod.yaml
@@ -150,13 +150,17 @@ controller:
             resources:
               requests:
                 storage: "1Gi"
-        # Node-local scratch on the kubelet disk (world-writable emptyDir).
-        # Soft size limit; wiped when the lab pod exits.
+        # Node-local ZFS scratch. RWO + lab pod fsGroup (Nublado) make the
+        # volume writable without a privileged init; keep NFS /scratch too.
         - name: "lscratch"
           source:
-            type: "emptyDir"
-            medium: "disk"
-            size: "10Gi"
+            type: "persistentVolumeClaim"
+            storageClassName: "zfs-lscratch-storage"
+            accessModes:
+              - "ReadWriteOnce"
+            resources:
+              requests:
+                storage: "10Gi"
       volumeMounts:
         - containerPath: "/home"
           volumeName: "sdf-home"


### PR DESCRIPTION
Mount zfs-lscratch-storage at /lscratch alongside existing NFS /scratch so labs get fast node-local scratch without breaking shared scratch users. Sized PVCs at 10Gi.