### PR TITLE
DM-55493: Deploy jira-data-proxy 1.0.2

### DIFF
--- a/applications/jira-data-proxy/Chart.yaml
+++ b/applications/jira-data-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "1.0.1"
+appVersion: "1.0.2"
 description: Jira API read-only proxy for Times Square users.
 name: jira-data-proxy
 sources:


### PR DESCRIPTION
Bumps `applications/jira-data-proxy/Chart.yaml` `appVersion` to [1.0.2](https://github.com/lsst-sqre/jira-data-proxy/releases/tag/1.0.2), released today. The `ghcr.io/lsst-sqre/jira-data-proxy:1.0.2` image is built and pushed.

Chart `appVersion` only — no `values.yaml` change, so no helm-docs regeneration. The shared `helm-docs.md.gotmpl` renders header, description, homepage, sources, and the values table; none of them read `appVersion`.

## What's in 1.0.2

The tail of the DM-55493 modernization. **No application behaviour changes** — the service's HTTP surface is untouched, and the safir 5 → 15 span moved zero application lines because every API it uses was unchanged across that span.

What *does* change in the deployed artifact is the interpreter and the build:

- **Python 3.14 on Debian bookworm**, up from 3.12 on bullseye (bullseye publishes no 3.14 slim image). This is the change worth watching on rollout.
- The image is built from `uv.lock` with the multi-stage `uv sync --frozen` pattern instead of pip and `requirements/*.txt`.
- Dependency floors raised: `safir>=15.1.1`, `fastapi>=0.141`, `starlette>=1.0.1`, `pydantic>=2.13`. The safir and starlette floors are what keep the CVE-2026-48710 fix required — the previous `safir>=5.0.0` was free to resolve a safir old enough to permit a vulnerable Starlette.

The SSRF fix (DM-55651) is **not** new here; it shipped in 1.0.1 and is already deployed.

## Deployment

Enabled in five environments: idfdev, roundtable-dev, roundtable-prod, usdfdev, usdfprod. They pick this up per their sync policy after merge.

Given that the interpreter changes, watching idfdev or roundtable-dev settle before prod syncs is the cheap check. The service is small — one `GET /{path:path}` proxy handler plus the internal metadata endpoint — so "pods healthy and a proxied request returns" covers it.