### PR TITLE
DM-55658: Deploy docverse packaging-restructure image on roundtable-dev

### DIFF
--- a/applications/docverse/README.md
+++ b/applications/docverse/README.md
@@ -49,6 +49,7 @@ Publish versioned docs
 | global.repertoireUrl | string | Set by Argo CD | Base URL for Repertoire discovery API |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the docverse image |
+| image.pythonModule | string | `"docverse_server"` | Top-level Python module of the server in this image. Images built after the DM-55658 packaging restructure use "docverse_server"; earlier images use "docverse". Must match the deployed image tag. |
 | image.repository | string | `"ghcr.io/lsst-sqre/docverse"` | Image to use in the docverse deployment |
 | image.tag | string | The appVersion of the chart | Tag of image to use |
 | ingress.annotations | object | `{}` | Additional annotations for the ingress rule |

--- a/applications/docverse/templates/maintenance-worker-deployment.yaml
+++ b/applications/docverse/templates/maintenance-worker-deployment.yaml
@@ -39,7 +39,7 @@ spec:
       containers:
         - name: "docverse-maintenance-worker"
           command: ["arq"]
-          args: ["docverse.worker.main.MaintenanceWorkerSettings"]
+          args: ["{{ .Values.image.pythonModule }}.worker.main.MaintenanceWorkerSettings"]
           env:
             {{- include "docverse.envVars" . | nindent 12 }}
             {{- include "docverse.kafkaEnvVars" . | nindent 12 }}

--- a/applications/docverse/templates/sync-worker-deployment.yaml
+++ b/applications/docverse/templates/sync-worker-deployment.yaml
@@ -39,7 +39,7 @@ spec:
       containers:
         - name: "docverse-sync-worker"
           command: ["arq"]
-          args: ["docverse.worker.main.KeeperSyncWorkerSettings"]
+          args: ["{{ .Values.image.pythonModule }}.worker.main.KeeperSyncWorkerSettings"]
           env:
             {{- include "docverse.envVars" . | nindent 12 }}
             {{- include "docverse.kafkaEnvVars" . | nindent 12 }}

--- a/applications/docverse/templates/worker-deployment.yaml
+++ b/applications/docverse/templates/worker-deployment.yaml
@@ -38,7 +38,7 @@ spec:
       containers:
         - name: "docverse-worker"
           command: ["arq"]
-          args: ["docverse.worker.main.WorkerSettings"]
+          args: ["{{ .Values.image.pythonModule }}.worker.main.WorkerSettings"]
           env:
             {{- include "docverse.envVars" . | nindent 12 }}
             {{- include "docverse.kafkaEnvVars" . | nindent 12 }}

--- a/applications/docverse/values-roundtable-dev.yaml
+++ b/applications/docverse/values-roundtable-dev.yaml
@@ -1,6 +1,6 @@
 image:
   pullPolicy: "Always"
-  tag: "tickets-DM-55551"
+  tag: "tickets-DM-55658"
 
 config:
   logLevel: "DEBUG"

--- a/applications/docverse/values.yaml
+++ b/applications/docverse/values.yaml
@@ -20,6 +20,11 @@ image:
   # @default -- The appVersion of the chart
   tag: null
 
+  # -- Top-level Python module of the server in this image. Images built
+  # after the DM-55658 packaging restructure use "docverse_server";
+  # earlier images use "docverse". Must match the deployed image tag.
+  pythonModule: "docverse_server"
+
 config:
   # -- Logging level
   logLevel: "INFO"


### PR DESCRIPTION
## Summary

- Points the `docverse` deployment on roundtable-dev at the `tickets-DM-55658` image, built from [lsst-sqre/docverse#485](https://github.com/lsst-sqre/docverse/pull/485) — the DM-55658 packaging restructure (server module `docverse` → `docverse_server`, client owns the `docverse` dist/import root).
- The arq worker Deployments passed the settings-module path as hardcoded container args (`docverse.worker.main.*Settings`); this is now a chart value `image.pythonModule` defaulting to `"docverse_server"`, recording the chart's coupling to the image layout. No environment needs the old value: docverse is not currently deployed on roundtable-prod.
- The API pod needs no chart change: it runs the image's own `start-service.sh`, which lsst-sqre/docverse#485 updates in lockstep.

## Validation steps

- `helm template` with the roundtable-dev values renders `args: ["docverse_server.worker.main.*Settings"]` for all three worker Deployments (verified locally).
- After sync on roundtable-dev, confirm the API pod and all three worker pods start cleanly and `GET /docverse/` reports the expected metadata.

## References

- Docverse PR: lsst-sqre/docverse#485
- PRD: lsst-sqre/docverse#484
- Jira: https://rubinobs.atlassian.net/browse/DM-55658