### PR TITLE
DM-55625: Bump TAP version to 3.21.0

### DIFF
--- a/applications/ppdbtap/values-idfdev.yaml
+++ b/applications/ppdbtap/values-idfdev.yaml
@@ -25,8 +25,8 @@ cadc-tap:
       dataset: "ppdb_lsstcam"
       schema: "ppdb"
       image:
-        tag: "3.18.0"
-        imagePullPolicy: "Always"
+        tag: "tickets-DM-55648-release-3.21.0"
+        pullPolicy: "Always"
 
   cloudsql:
     enabled: true

--- a/applications/ppdbtap/values-idfdev.yaml
+++ b/applications/ppdbtap/values-idfdev.yaml
@@ -24,9 +24,6 @@ cadc-tap:
       project: "ppdb-dev-438721"
       dataset: "ppdb_lsstcam"
       schema: "ppdb"
-      image:
-        tag: "tickets-DM-55648-release-3.21.0"
-        pullPolicy: "Always"
 
   cloudsql:
     enabled: true

--- a/applications/ppdbtap/values-idfint.yaml
+++ b/applications/ppdbtap/values-idfint.yaml
@@ -25,8 +25,8 @@ cadc-tap:
       dataset: "ppdb_lsstcam"
       schema: "ppdb"
       image:
-        tag: "3.18.0"
-        imagePullPolicy: "Always"
+        tag: "tickets-DM-55648-release-3.21.0"
+        pullPolicy: "Always"
 
   cloudsql:
     enabled: true

--- a/applications/ppdbtap/values-idfint.yaml
+++ b/applications/ppdbtap/values-idfint.yaml
@@ -24,9 +24,6 @@ cadc-tap:
       project: "ppdb-prod"
       dataset: "ppdb_lsstcam"
       schema: "ppdb"
-      image:
-        tag: "tickets-DM-55648-release-3.21.0"
-        pullPolicy: "Always"
 
   cloudsql:
     enabled: true

--- a/applications/tap/values-idfdev.yaml
+++ b/applications/tap/values-idfdev.yaml
@@ -9,10 +9,6 @@ cadc-tap:
         - "ivoa.ObsCore:access_url"
         - "dp02_dc2_catalogs.ObsCore:access_url"
         - "dp1.ObsCore:access_url"
-    qserv:
-      image:
-        tag: "tickets-DM-55648-release-3.21.0"
-        pullPolicy: "Always"
 
   cloudsql:
     enabled: true

--- a/applications/tap/values-idfdev.yaml
+++ b/applications/tap/values-idfdev.yaml
@@ -9,6 +9,10 @@ cadc-tap:
         - "ivoa.ObsCore:access_url"
         - "dp02_dc2_catalogs.ObsCore:access_url"
         - "dp1.ObsCore:access_url"
+    qserv:
+      image:
+        tag: "tickets-DM-55648-release-3.21.0"
+        pullPolicy: "Always"
 
   cloudsql:
     enabled: true

--- a/charts/cadc-tap/README.md
+++ b/charts/cadc-tap/README.md
@@ -25,7 +25,7 @@ IVOA TAP service
 | config.bigquery.dataset | string | None, must be set if backend is `bigquery` | BigQuery dataset name |
 | config.bigquery.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the TAP image |
 | config.bigquery.image.repository | string | `"ghcr.io/lsst-sqre/lsst-tap-service"` | TAP image to use |
-| config.bigquery.image.tag | string | `"3.20.0"` | Tag of TAP image to use |
+| config.bigquery.image.tag | string | `"3.21.0"` | Tag of TAP image to use |
 | config.bigquery.project | string | None, must be set if backend is `bigquery` | BigQuery project ID |
 | config.bigquery.schema | string | `""` | Schema name for table mappings (optional) |
 | config.database | string | `"dp02"` | Data Database name |
@@ -57,11 +57,11 @@ IVOA TAP service
 | config.qserv.host | string | `"mock-db:3306"` (the mock QServ) | QServ hostname:port to connect to |
 | config.qserv.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the TAP image |
 | config.qserv.image.repository | string | `"ghcr.io/lsst-sqre/lsst-tap-service"` | TAP image to use |
-| config.qserv.image.tag | string | `"3.20.0"` | Tag of TAP image to use |
+| config.qserv.image.tag | string | `"3.21.0"` | Tag of TAP image to use |
 | config.qserv.jdbcParams | string | `""` | Extra JDBC connection parameters |
 | config.qserv.passwordEnabled | bool | false | Whether the Qserv database is password protected |
 | config.qserv.schemaMappings | string | `""` | Schema name mappings: comma-separated list of user_schema:internal_schema pairs. Example: "dp1:dp1_pilot" dp1 queries execute against dp1_pilot. |
-| config.qserv.tableMappings | list | `[]` | Table name mappings for query rewriting (as visible:backend pairs). The visible name is the Felis/TAP_SCHEMA table The backend name is the actual Qserv / BigQuery table name. Example: ["dp1.Object:dp1_pilot.Object"] rewrites references to dp1.Object so they query dp1_pilot.Object instead. |
+| config.qserv.tableMappings | list | `[]` | Table name mappings for query rewriting (as visible:backend pairs). The visible name is the Felis / TAP_SCHEMA table The backend name is the actual Qserv / BigQuery table name. Example: ["dp1.Object:dp1_pilot.Object"] rewrites references to dp1.Object so they query dp1_pilot.Object instead. |
 | config.sentryEnabled | bool | `false` | Whether Sentry is enabled in this environment |
 | config.serviceName | string | None, must be set | Name of the service from Gafaelfawr's perspective, used for metrics reporting |
 | config.tapSchemaAddress | string | `"cadc-tap-schema-db:3306"` | Address to a MySQL database containing TAP schema data |
@@ -125,7 +125,7 @@ IVOA TAP service
 | uws.external.port | int | `5432` | Port of external PostgreSQL server |
 | uws.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the UWS database image |
 | uws.image.repository | string | `"ghcr.io/lsst-sqre/lsst-tap-uws-db"` | UWS database image to use |
-| uws.image.tag | string | `"3.20.0"` | Tag of UWS database image to use |
+| uws.image.tag | string | `"3.21.0"` | Tag of UWS database image to use |
 | uws.maxActive | int | `5` | Maximum active connections (maxIdle will be set to this value) |
 | uws.nodeSelector | object | `{}` | Node selection rules for the UWS database pod |
 | uws.podAnnotations | object | `{}` | Annotations for the UWS databse pod |

--- a/charts/cadc-tap/README.md
+++ b/charts/cadc-tap/README.md
@@ -42,6 +42,9 @@ IVOA TAP service
 | config.kafka.topics.jobDelete | string | `"lsst.tap.job-delete"` | Job Delete topic |
 | config.kafka.topics.jobRun | string | `"lsst.tap.job-run"` | Job Run topic |
 | config.kafka.topics.jobStatus | string | `"lsst.tap.job-status"` | Job Status topic |
+| config.maxDestruction | string | `""` | Maximum UWS job destruction time in seconds. Leave empty to use the default (604800, 1 week). |
+| config.maxExecutionDuration | string | `""` | Maximum execution duration for TAP queries in seconds. Also used for sizing the signed result upload URL's expiration Leave empty to use the default (14400, 4 hours). |
+| config.maxQuote | string | `""` | Maximum UWS job quote in seconds. Leave empty to use the default (86400, 24 hours). |
 | config.maxRec | string | `""` | Maximum row limit (MAXREC) enforced server-side. Leave empty to use the default (100000000). |
 | config.outputLimit | string | `""` | Output limit value for TAP queries advertised in capabilities. Leave empty to use the default (100000000). |
 | config.outputLimitUnit | string | `""` | Unit for the output limit: "byte" or "row". Leave empty to use the default ("row"). |
@@ -58,7 +61,7 @@ IVOA TAP service
 | config.qserv.jdbcParams | string | `""` | Extra JDBC connection parameters |
 | config.qserv.passwordEnabled | bool | false | Whether the Qserv database is password protected |
 | config.qserv.schemaMappings | string | `""` | Schema name mappings: comma-separated list of user_schema:internal_schema pairs. Example: "dp1:dp1_pilot" dp1 queries execute against dp1_pilot. |
-| config.qserv.tableMappings | list | `[]` | Table name mappings for query rewriting Example: ["dp1.Object:dp1_pilot.Object"] rewrites references to dp1.Object so they query dp1_pilot.Object instead. |
+| config.qserv.tableMappings | list | `[]` | Table name mappings for query rewriting (as visible:backend pairs). The visible name is the Felis/TAP_SCHEMA table The backend name is the actual Qserv / BigQuery table name. Example: ["dp1.Object:dp1_pilot.Object"] rewrites references to dp1.Object so they query dp1_pilot.Object instead. |
 | config.sentryEnabled | bool | `false` | Whether Sentry is enabled in this environment |
 | config.serviceName | string | None, must be set | Name of the service from Gafaelfawr's perspective, used for metrics reporting |
 | config.tapSchemaAddress | string | `"cadc-tap-schema-db:3306"` | Address to a MySQL database containing TAP schema data |

--- a/charts/cadc-tap/templates/tap-deployment.yaml
+++ b/charts/cadc-tap/templates/tap-deployment.yaml
@@ -197,6 +197,15 @@ spec:
                 {{- if .Values.config.maxRec }}
                 -Dtap.maxRec={{ .Values.config.maxRec }}
                 {{- end }}
+                {{- if .Values.config.maxExecutionDuration }}
+                -Dtap.maxExecutionDuration={{ .Values.config.maxExecutionDuration }}
+                {{- end }}
+                {{- if .Values.config.maxDestruction }}
+                -Dtap.maxDestruction={{ .Values.config.maxDestruction }}
+                {{- end }}
+                {{- if .Values.config.maxQuote }}
+                -Dtap.maxQuote={{ .Values.config.maxQuote }}
+                {{- end }}
                 {{- if .Values.config.voParquet }}
                 -Dtap.enableVOParquet=true
                 {{- end }}

--- a/charts/cadc-tap/values.yaml
+++ b/charts/cadc-tap/values.yaml
@@ -105,7 +105,7 @@ config:
       pullPolicy: "IfNotPresent"
 
       # -- Tag of TAP image to use
-      tag: "3.20.0"
+      tag: "3.21.0"
 
     # -- Whether the Qserv database is password protected
     # @default -- false
@@ -131,7 +131,7 @@ config:
       pullPolicy: "IfNotPresent"
 
       # -- Tag of TAP image to use
-      tag: "3.20.0"
+      tag: "3.21.0"
 
   # -- Address to a MySQL database containing TAP schema data
   tapSchemaAddress: "cadc-tap-schema-db:3306"
@@ -388,7 +388,7 @@ uws:
     pullPolicy: "IfNotPresent"
 
     # -- Tag of UWS database image to use
-    tag: "3.20.0"
+    tag: "3.21.0"
 
   # -- Resource limits and requests for the UWS database pod
   # @default -- See `values.yaml`

--- a/charts/cadc-tap/values.yaml
+++ b/charts/cadc-tap/values.yaml
@@ -90,7 +90,9 @@ config:
     # Example: "dp1:dp1_pilot" dp1 queries execute against dp1_pilot.
     schemaMappings: ""
 
-    # -- Table name mappings for query rewriting
+    # -- Table name mappings for query rewriting (as visible:backend pairs).
+    # The visible name is the Felis / TAP_SCHEMA table
+    # The backend name is the actual Qserv / BigQuery table name.
     # Example: ["dp1.Object:dp1_pilot.Object"] rewrites references to
     # dp1.Object so they query dp1_pilot.Object instead.
     tableMappings: []
@@ -203,6 +205,19 @@ config:
   # -- Maximum row limit (MAXREC) enforced server-side.
   # Leave empty to use the default (100000000).
   maxRec: ""
+
+  # -- Maximum execution duration for TAP queries in seconds.
+  # Also used for sizing the signed result upload URL's expiration
+  # Leave empty to use the default (14400, 4 hours).
+  maxExecutionDuration: ""
+
+  # -- Maximum UWS job destruction time in seconds.
+  # Leave empty to use the default (604800, 1 week).
+  maxDestruction: ""
+
+  # -- Maximum UWS job quote in seconds.
+  # Leave empty to use the default (86400, 24 hours).
+  maxQuote: ""
 
   # -- Whether to advertise VOParquet (application/vnd.apache.parquet) as a
   # supported output format in the TAP capabilities.


### PR DESCRIPTION
## Changes:
- Update lsst-tap-service image  to version 3.21.0. The changes introduced can be found here: https://github.com/lsst-sqre/lsst-tap-service/compare/3.20.0...3.21.0
- Include optional parameters for specifying `maxExecutionDuration`, `maxDestruction` and `maxQuote` values to the TAP service, passed in as system env properties.