### PR TITLE
DM-55663: Bump uws.maxActive connections for TAP app on idfprod to 20

### DIFF
--- a/applications/tap/values-idfprod.yaml
+++ b/applications/tap/values-idfprod.yaml
@@ -19,3 +19,6 @@ cadc-tap:
     instanceConnectionName: "science-platform-stable-6994:us-central1:science-platform-stable-0c29612b"
     serviceAccount: "tap-service@science-platform-stable-6994.iam.gserviceaccount.com"
     database: "tap"
+
+  uws:
+    maxActive: 20


### PR DESCRIPTION
We've bumped the size of the CloudSQL instance on all idfs to one that allows 500 maxconnections, so here we increase the max connections for uws to ensure the pool is not exhausted