### PR TITLE
DM-55467: Update times-square to 0.25.0

### DIFF
--- a/applications/times-square/Chart.yaml
+++ b/applications/times-square/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 type: application
 
 # The default version tag of the times-square docker image
-appVersion: "0.24.1"
+appVersion: "0.25.0"
 
 dependencies:
   - name: redis


### PR DESCRIPTION
## Summary

Bump the times-square chart `appVersion` from 0.24.1 to **0.25.0**, deploying the new release to every environment that follows the chart default (idfdev, idfint, idfprod, usdfdev, usdfprod).

Release notes: https://github.com/lsst-sqre/times-square/releases/tag/0.25.0

Highlights of 0.25.0:

- **Fixes the stuck scheduled page on usdfprod** (DM-55467): recurring schedules that terminate by `count` now survive the storage round trip, and the affected page resumes scheduling on the first `schedule_runs` tick after deploy — no data migration needed.
- The run scheduler skips pages with un-evaluatable schedules with a single warning instead of an error-level Sentry event every 5 minutes.
- The GitHub configs check validates sidecar run schedules at ingest time.
- Terminal execution-failure results on `htmlstatus` and the SSE stream (DM-55470), with new optional settings `TS_EXECUTION_FAILURE_LIFETIME` and `TS_HTTP_CLIENT_TIMEOUT` (both have defaults; no values changes required).
- Transient GitHub API errors during check-run setup are retried (DM-55466).

Note: `idfdemo` pins `image.tag: tickets-DM-52819` in `values-idfdemo.yaml`, so it deliberately stays on that branch build and is not affected by this bump.

## Post-deploy verification (usdfprod)

- Confirm page `33f4908ff5284ab6a566988af62ca37a` gets a next scheduled run.
- Confirm the Sentry issue (`AttributeError: 'NoneType' object has no attribute 'tzinfo'`, env usdfprod) stops receiving new events.

## References

- Jira: [DM-55467](https://rubinobs.atlassian.net/browse/DM-55467)
- PRD: lsst-sqre/times-square#147


[DM-55467]: https://rubinobs.atlassian.net/browse/DM-55467?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ