### PR TITLE
Fix typo in repertoire values comment on use of schemaVersion

### DIFF
--- a/applications/repertoire/README.md
+++ b/applications/repertoire/README.md
@@ -45,7 +45,7 @@ Service discovery
 | config.sentry.enabled | bool | `false` | Whether to enable the Sentry integration |
 | config.slackAlerts | bool | `false` | Whether to send Slack alerts for unexpected failures |
 | config.subdomainRules | object | See `values.yaml` | Rules for determining the expected URLs of deployed services that use a subdomain. See the [Repertoire documentation](https://repertoire.lsst.io/) for more information. |
-| config.tap.schemaSourceTemplate | string | GCS rubin-sdm-schemas-artifacts bucket | Template for schema artifact URLs (use {schemaVersion} placeholder) |
+| config.tap.schemaSourceTemplate | string | GCS rubin-sdm-schemas-artifacts bucket | Template for schema artifact URLs (use {version} placeholder) |
 | config.tap.schemaVersion | string | `"releases/EDP2-deploy-v2"` | Default schema version for all TAP services (can be overridden per-app) |
 | config.tap.servers | object | See `values.yaml` | TAP Server configuration by application name. Configuration is used to populate & update the TAP_SCHEMA database for each enabled TAP application |
 | config.useSubdomains | list | `[]` | List of services that use subdomains instead of the main hostname. See the [Repertoire documentation](https://repertoire.lsst.io/) for more information. |

--- a/applications/repertoire/values.yaml
+++ b/applications/repertoire/values.yaml
@@ -475,7 +475,7 @@ config:
     # per-app)
     schemaVersion: "releases/EDP2-deploy-v2"
 
-    # -- Template for schema artifact URLs (use {schemaVersion} placeholder)
+    # -- Template for schema artifact URLs (use {version} placeholder)
     # @default -- GCS rubin-sdm-schemas-artifacts bucket
     schemaSourceTemplate: "gs://rubin-sdm-schemas-artifacts/{version}/schemas.tar.gz"
 


### PR DESCRIPTION
Change `schemaVersion` to `version` in repertoire values.yaml