### PR TITLE
DM-55679: Add upload arq worker to qserv-kafka and upload configuration

### DIFF
--- a/applications/qserv-kafka/Chart.yaml
+++ b/applications/qserv-kafka/Chart.yaml
@@ -5,7 +5,7 @@ version: 1.0.0
 description: "Qserv Kafka bridge"
 sources:
   - "https://github.com/lsst-sqre/qserv-kafka"
-appVersion: 5.0.0
+appVersion: 5.0.1
 
 dependencies:
   - name: "redis"

--- a/applications/qserv-kafka/README.md
+++ b/applications/qserv-kafka/README.md
@@ -43,6 +43,8 @@ Qserv Kafka bridge
 | config.sentry.tracesSampleRate | float | `0` | The percentage of requests that should be traced. This should be a float between 0 and 1 |
 | config.slack.enabled | bool | `false` | Set to true to enable the Slack integration. If true, the slack-webhook secret must be provided. |
 | config.tapService | string | `"qserv"` | Name of the TAP service for which this Qserv Kafka instance is managing queries. This must match the name of the TAP service for the corresponding query quota in the Gafaelfawr configuration. |
+| config.uploadWorkerMaxJobs | int | `10` | Maximum number of arq jobs each upload worker can process simultaneously.. |
+| config.uploadWorkerTimeout | int | 900 (15 minutes) | How long to allow an upload worker to upload tables and submit the query to the backend before timing out, in seconds. |
 | frontend.affinity | object | `{}` | Affinity rules for the qserv-kafka frontend pod |
 | frontend.debug.disablePymalloc | bool | `false` |  |
 | frontend.debug.enabled | bool | `false` | Set to true to allow containers to run as root and to create and mount a debug PVC. Useful ro run debug containers to diagnose issues such as memory leaks. |
@@ -84,3 +86,10 @@ Qserv Kafka bridge
 | resultWorker.replicaCount | int | `1` | Number of result worker pods to start if autoscaling is disabled |
 | resultWorker.resources | object | See `values.yaml` | Resource limits and requests for the qserv-kafka worker pods |
 | resultWorker.tolerations | list | Tolerate GKE arm64 taint | Tolerations for the qserv-kafka worker pods |
+| uploadWorker.affinity | object | `{}` | Affinity rules for the qserv-kafka upload worker pods |
+| uploadWorker.allowRootDebug | bool | `false` | Whether to allow containers to run as root. Set to true to allow use of debug containers to diagnose issues such as memory leaks. |
+| uploadWorker.nodeSelector | object | `{}` | Node selection rules for the qserv-kafka upload worker pods |
+| uploadWorker.podAnnotations | object | `{}` | Annotations for the qserv-kafka upload worker pods |
+| uploadWorker.replicaCount | int | `1` | Number of upload worker pods to start |
+| uploadWorker.resources | object | See `values.yaml` | Resource limits and requests for the qserv-kafka upload worker pods |
+| uploadWorker.tolerations | list | Tolerate GKE arm64 taint | Tolerations for the qserv-kafka upload worker pods |

--- a/applications/qserv-kafka/templates/configmap.yaml
+++ b/applications/qserv-kafka/templates/configmap.yaml
@@ -41,6 +41,8 @@ data:
   QSERV_KAFKA_RESULT_TIMEOUT: {{ .Values.config.resultTimeout | quote }}
   QSERV_KAFKA_SLACK_ENABLED: {{ .Values.config.slack.enabled | quote }}
   QSERV_KAFKA_TAP_SERVICE: {{ .Values.config.tapService | quote }}
+  QSERV_KAFKA_UPLOAD_WORKER_MAX_JOBS: {{ .Values.config.uploadWorkerMaxJobs | quote }}
+  QSERV_KAFKA_UPLOAD_WORKER_TIMEOUT: {{ .Values.config.uploadWorkerTimeout | quote }}
   REPERTOIRE_BASE_URL: {{ .Values.global.repertoireUrl | quote }}
   SCHEMA_MANAGER_REGISTRY_URL: {{ .Values.config.metrics.schemaManager.registryUrl | quote }}
   SCHEMA_MANAGER_SUFFIX: {{ .Values.config.metrics.schemaManager.suffix | quote }}

--- a/applications/qserv-kafka/templates/upload-worker-deployment.yaml
+++ b/applications/qserv-kafka/templates/upload-worker-deployment.yaml
@@ -1,0 +1,79 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "qserv-kafka-upload-worker"
+  labels:
+    {{- include "qserv-kafka.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.uploadWorker.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "qserv-kafka.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: "upload-worker"
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.uploadWorker.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "qserv-kafka.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: "upload-worker"
+        qserv-kafka-redis-client: "true"
+    spec:
+      {{- with .Values.uploadWorker.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      automountServiceAccountToken: false
+      containers:
+        - name: "{{ .Chart.Name }}-upload-worker"
+          command:
+            - "arq"
+            - "qservkafka.workers.main.UploadWorkerSettings"
+          env:
+            {{- include "qserv-kafka.envVars" (dict "Values" .Values) | nindent 12 }}
+          envFrom:
+          - configMapRef:
+              name: "qserv-kafka"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          resources:
+            {{- toYaml .Values.uploadWorker.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: "kafka"
+              mountPath: "/etc/qserv-kafka/ca.crt"
+              readOnly: true
+              subPath: "ssl.truststore.crt"
+            - name: "kafka"
+              mountPath: "/etc/qserv-kafka/user.crt"
+              readOnly: true
+              subPath: "ssl.keystore.crt"
+            - name: "kafka"
+              mountPath: "/etc/qserv-kafka/user.key"
+              readOnly: true
+              subPath: "ssl.keystore.key"
+      {{- with .Values.uploadWorker.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ add .Values.config.uploadWorkerTimeout 10 }}
+      {{- with .Values.uploadWorker.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: {{ not .Values.uploadWorker.allowRootDebug }}
+        runAsUser: 1000
+        runAsGroup: 1000
+      volumes:
+        - name: "kafka"
+          secret:
+            secretName: "qserv-kafka-access"

--- a/applications/qserv-kafka/templates/upload-worker-networkpolicy.yaml
+++ b/applications/qserv-kafka/templates/upload-worker-networkpolicy.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: "qserv-kafka-upload-worker"
+  labels:
+    {{- include "qserv-kafka.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    # This policy controls inbound and outbound access to the upload workers.
+    matchLabels:
+      {{- include "qserv-kafka.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: "upload-worker"
+  policyTypes:
+    # Block all inbound access.
+    - Ingress

--- a/applications/qserv-kafka/values.yaml
+++ b/applications/qserv-kafka/values.yaml
@@ -140,6 +140,15 @@ config:
   # query quota in the Gafaelfawr configuration.
   tapService: "qserv"
 
+  # -- Maximum number of arq jobs each upload worker can process
+  # simultaneously..
+  uploadWorkerMaxJobs: 10
+
+  # -- How long to allow an upload worker to upload tables and submit the
+  # query to the backend before timing out, in seconds.
+  # @default -- 900 (15 minutes)
+  uploadWorkerTimeout: 900
+
 image:
   # -- Image to use in the qserv-kafka deployment
   repository: "ghcr.io/lsst-sqre/qserv-kafka"
@@ -284,6 +293,41 @@ resultWorker:
       memory: "145Mi"
 
   # -- Tolerations for the qserv-kafka worker pods
+  # @default -- Tolerate GKE arm64 taint
+  tolerations:
+    - key: "kubernetes.io/arch"
+      operator: "Equal"
+      value: "arm64"
+      effect: "NoSchedule"
+
+uploadWorker:
+  # -- Affinity rules for the qserv-kafka upload worker pods
+  affinity: {}
+
+  # -- Whether to allow containers to run as root. Set to true to allow use of
+  # debug containers to diagnose issues such as memory leaks.
+  allowRootDebug: false
+
+  # -- Node selection rules for the qserv-kafka upload worker pods
+  nodeSelector: {}
+
+  # -- Annotations for the qserv-kafka upload worker pods
+  podAnnotations: {}
+
+  # -- Number of upload worker pods to start
+  replicaCount: 1
+
+  # -- Resource limits and requests for the qserv-kafka upload worker pods
+  # @default -- See `values.yaml`
+  resources:
+    limits:
+      cpu: "250m"
+      memory: "300Mi"
+    requests:
+      cpu: "50m"
+      memory: "145Mi"
+
+  # -- Tolerations for the qserv-kafka upload worker pods
   # @default -- Tolerate GKE arm64 taint
   tolerations:
     - key: "kubernetes.io/arch"


### PR DESCRIPTION
This PR is part of the work to enable moving the part of the job upload request to the Qserv API in qserv-kafka to a separate path so that subsequent queries are not blocked.
 
## Changes
- Adds templates for an upload worker in qserv-kafka
- Add new configuration specific to uploads in qserv-kafka values (`uploadWorkerMaxJobs` and `uploadWorkerMaxJobs`)
