### PR TITLE
DM-55688: deploy templatebot 0.5.5

### DIFF
--- a/applications/templatebot/Chart.yaml
+++ b/applications/templatebot/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "0.5.4"
+appVersion: "0.5.5"
 description: Create new projects
 name: templatebot
 sources:


### PR DESCRIPTION
## Summary

- Bumps `applications/templatebot/Chart.yaml` `appVersion` from 0.5.4 to 0.5.5.

This is the deployment half of the templatebot monthly maintenance round. The 0.5.5 release is published and the image is in GHCR: `ghcr.io/lsst-sqre/templatebot:0.5.5` (multi-arch, linux/amd64 + linux/arm64, verified before opening this PR).

**0.5.5 carries a security fix.** It takes `gitpython` to 3.1.58, resolving four high-severity advisories, headlined by [GHSA-94p4-4cq8-9g67](https://github.com/advisories/GHSA-94p4-4cq8-9g67) (CVSS 7.5) — environment-variable exfiltration via a crafted URL passed to `Repo.create_remote()`. templatebot reaches that call during ordinary project creation, so this is a live code path rather than an unused one. Full notes: https://github.com/lsst-sqre/templatebot/releases/tag/0.5.5

## Scope

appVersion-only. `values.yaml` is untouched, and therefore no helm-docs `README.md` regeneration is needed (the helm-docs pre-commit hook was run and passed unchanged). One file, one line.

## Merging

**Please do not merge this on my behalf — @jonathansick will merge it himself**, since merging triggers the Argo sync and deploys templatebot to the environments per their sync policy.

## Validation steps

- After merge and sync, confirm the templatebot pod comes up healthy on the target environments and reports 0.5.5.
- Exercise a project-creation flow from Slack to confirm the gitpython upgrade did not disturb the clone/remote path (that path is what the security fix touches).

## References

- Release: https://github.com/lsst-sqre/templatebot/releases/tag/0.5.5
- Jira: https://rubinobs.atlassian.net/browse/DM-55688