### PR TITLE
DM-55712: Remove leftover TAP qserv JDBC parameters for envs no longer using them

### DIFF
--- a/applications/tap/values-idfdemo.yaml
+++ b/applications/tap/values-idfdemo.yaml
@@ -15,11 +15,6 @@ cadc-tap:
     useVaultPassword: false
 
   config:
-    qserv:
-      host: "qserv-int.slac.stanford.edu:4090"
-      jdbcParams: "?enabledTLSProtocols=TLSv1.3"
-      passwordEnabled: true
-
     kafka:
       enabled: true
 

--- a/applications/tap/values-usdfdev.yaml
+++ b/applications/tap/values-usdfdev.yaml
@@ -14,11 +14,6 @@ cadc-tap:
     useVaultPassword: false
 
   config:
-    qserv:
-      host: "sdfqserv001.sdf.slac.stanford.edu:4090"
-      jdbcParams: "?enabledTLSProtocols=TLSv1.3"
-      passwordEnabled: true
-
     kafka:
       enabled: true
 

--- a/applications/tap/values-usdfint.yaml
+++ b/applications/tap/values-usdfint.yaml
@@ -14,11 +14,6 @@ cadc-tap:
     useVaultPassword: false
 
   config:
-    qserv:
-      host: "sdfqserv001.sdf.slac.stanford.edu:4090"
-      jdbcParams: "?enabledTLSProtocols=TLSv1.3"
-      passwordEnabled: true
-
     kafka:
       enabled: true
 

--- a/applications/tap/values-usdfprod.yaml
+++ b/applications/tap/values-usdfprod.yaml
@@ -14,11 +14,6 @@ cadc-tap:
     useVaultPassword: false
 
   config:
-    qserv:
-      host: "sdfqserv001.sdf.slac.stanford.edu:4040"
-      jdbcParams: "?enabledTLSProtocols=TLSv1.3"
-      passwordEnabled: true
-
     kafka:
       enabled: true
 


### PR DESCRIPTION
Change tap values for USDF and demo envs to remove leftover jdbc configuration that is no longer used.
Also, `qserv-password` can now be removed from the Vault "tap" app  secrets for those environments.