### PR TITLE
[DM-55707] Add obsforgetap application

### DIFF
--- a/applications/obsforgetap/.helmignore
+++ b/applications/obsforgetap/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/applications/obsforgetap/Chart.yaml
+++ b/applications/obsforgetap/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: obsforgetap
+version: 1.0.0
+description: ObsForge TAP service
+sources:
+  - https://github.com/lsst-sqre/tap-postgres
+  - https://github.com/opencadc/tap
+
+dependencies:
+  - name: cadc-tap
+    version: 1.0.0
+    repository: "file://../../charts/cadc-tap"

--- a/applications/obsforgetap/README.md
+++ b/applications/obsforgetap/README.md
@@ -1,0 +1,38 @@
+# obsforgetap
+
+ObsForge TAP service
+
+## Source Code
+
+* <https://github.com/lsst-sqre/tap-postgres>
+* <https://github.com/opencadc/tap>
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| cadc-tap.config.backend | string | `"pg"` | What type of backend? |
+| cadc-tap.config.pg.database | string | `"obsdb"` | Postgres database to connect to |
+| cadc-tap.config.pg.host | string | None, must be set | Postgres hostname:port to connect to |
+| cadc-tap.config.pg.username | string | `"obsforge"` | Postgres username to use to connect |
+| cadc-tap.config.sentryEnabled | bool | `false` | Whether Sentry is enabled in this environment |
+| cadc-tap.config.serviceName | string | `"obsforgetap"` | Name of the service from Gafaelfawr's perspective |
+| cadc-tap.config.vaultSecretName | string | `"obsforgetap"` | Vault secret name: the final key in the vault path |
+| cadc-tap.ingress.path | string | `"obsforgetap"` | Ingress path that should be routed to this service |
+| cadc-tap.serviceAccount.name | string | `"obsforgetap"` | Name of the Kubernetes `ServiceAccount`, used for CloudSQL access |
+| cadc-tap.tapSchema.database | string | `"obsforgetap"` | Database name |
+| cadc-tap.tapSchema.tapadm | object | `{"maxActive":2}` | Connection pool configuration for jdbc/tapadm |
+| cadc-tap.tapSchema.tapadm.maxActive | int | `2` | Maximum active connections (maxIdle will be set to this value) |
+| cadc-tap.tapSchema.tapuser | object | `{"maxActive":5}` | Connection pool configuration for jdbc/tapuser (query planning and tap_upload) |
+| cadc-tap.tapSchema.tapuser.maxActive | int | `5` | Maximum active connections (maxIdle will be set to this value) |
+| cadc-tap.tapSchema.type | string | "cloudsql" | Database backend type: "containerized", "cloudsql", or "external" |
+| cadc-tap.tapSchema.useVaultPassword | bool | `true` | Whether the TAP_SCHEMA database requires a password in Vault (true for cloudsql/external) |
+| cadc-tap.tapSchema.username | string | `"obsforgetap"` | Database username |
+| cadc-tap.uws.database | string | `"obsforgetap"` | Database name |
+| cadc-tap.uws.maxActive | int | `8` | Maximum active connections (maxIdle will be set to this value) |
+| cadc-tap.uws.type | string | `"cloudsql"` | Database backend type: "containerized", "cloudsql", or "external" |
+| cadc-tap.uws.useVaultPassword | bool | `true` | Whether the UWS database requires a password in Vault (true for cloudsql/external) |
+| cadc-tap.uws.username | string | `"obsforgetap"` | Database username |
+| global.baseUrl | string | Set by Argo CD | Base URL for the environment |
+| global.host | string | Set by Argo CD | Host name for ingress |
+| global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |

--- a/applications/obsforgetap/secrets.yaml
+++ b/applications/obsforgetap/secrets.yaml
@@ -1,0 +1,15 @@
+"google_creds.json":
+  description: >-
+    Google service account credentials used to write async job output to
+    Google Cloud Storage.
+pgpassword:
+  description: >-
+    Password to external PostgreSQL server that contains the ObsForge data.
+tap-schema-password:
+  description: >-
+    Password for tap_schema database (CloudSQL or external PostgreSQL).
+  if: cadc-tap.tapSchema.useVaultPassword
+uws-db-password:
+  description: >-
+    Password for uws database (CloudSQL or external PostgreSQL).
+  if: cadc-tap.uws.useVaultPassword

--- a/applications/obsforgetap/templates/_helpers.tpl
+++ b/applications/obsforgetap/templates/_helpers.tpl
@@ -1,0 +1,23 @@
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "obsforgetap.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "obsforgetap.labels" -}}
+helm.sh/chart: {{ include "obsforgetap.chart" . }}
+{{ include "obsforgetap.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "obsforgetap.selectorLabels" -}}
+app.kubernetes.io/name: "obsforgetap"
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/applications/obsforgetap/values-idfdev.yaml
+++ b/applications/obsforgetap/values-idfdev.yaml
@@ -1,0 +1,19 @@
+cadc-tap:
+  resources:
+    requests:
+      cpu: "1.0"
+      memory: "2Gi"
+    limits:
+      cpu: "4.0"
+      memory: "8Gi"
+
+  config:
+    jvmMaxHeapSize: 7G
+    pg:
+      host: "obsforge-db-dev.slac.stanford.edu:5432"
+
+  cloudsql:
+    enabled: true
+    instanceConnectionName: "science-platform-dev-7696:us-central1:science-platform-dev-e9e11de2"
+    serviceAccount: "obsforgetap@science-platform-dev-7696.iam.gserviceaccount.com"
+    database: "obsforgetap"

--- a/applications/obsforgetap/values-idfdev.yaml
+++ b/applications/obsforgetap/values-idfdev.yaml
@@ -1,0 +1,19 @@
+cadc-tap:
+  resources:
+    requests:
+      cpu: "1.0"
+      memory: "2Gi"
+    limits:
+      cpu: "4.0"
+      memory: "8Gi"
+
+  config:
+    jvmMaxHeapSize: 7G
+    pg:
+      host: "obsforge-db-dev.slac.stanford.edu:5432"
+
+  cloudsql:
+    enabled: true
+    instanceConnectionName: "science-platform-dev-7696:us-central1:science-platform-dev-e9e11de2"
+    serviceAccount: "obsforgetap@science-platform-dev-7696.iam.gserviceaccount.com"
+    database: "obsforge"

--- a/applications/obsforgetap/values.yaml
+++ b/applications/obsforgetap/values.yaml
@@ -1,0 +1,88 @@
+cadc-tap:
+  ingress:
+    # -- Ingress path that should be routed to this service
+    path: "obsforgetap"
+
+  config:
+    # -- What type of backend?
+    backend: "pg"
+
+    # -- Name of the service from Gafaelfawr's perspective
+    serviceName: "obsforgetap"
+
+    # -- Whether Sentry is enabled in this environment
+    sentryEnabled: false
+
+    pg:
+      # -- Postgres hostname:port to connect to
+      # @default -- None, must be set
+      host: ""
+
+      # -- Postgres database to connect to
+      database: "obsdb"
+
+      # -- Postgres username to use to connect
+      username: "obsforge"
+
+    # -- Vault secret name: the final key in the vault path
+    vaultSecretName: "obsforgetap"
+
+  serviceAccount:
+    # -- Name of the Kubernetes `ServiceAccount`, used for CloudSQL access
+    name: "obsforgetap"
+
+  tapSchema:
+    # -- Database backend type: "containerized", "cloudsql", or "external"
+    # @default -- "cloudsql"
+    type: "cloudsql"
+
+    # -- Database name
+    database: "obsforgetap"
+
+    # -- Database username
+    username: "obsforgetap"
+
+    # -- Whether the TAP_SCHEMA database requires a password in Vault (true for cloudsql/external)
+    useVaultPassword: true
+
+    # -- Connection pool configuration for jdbc/tapadm
+    tapadm:
+      # -- Maximum active connections (maxIdle will be set to this value)
+      maxActive: 2
+
+    # -- Connection pool configuration for jdbc/tapuser (query planning and tap_upload)
+    tapuser:
+      # -- Maximum active connections (maxIdle will be set to this value)
+      maxActive: 5
+
+  uws:
+    # -- Database backend type: "containerized", "cloudsql", or "external"
+    type: "cloudsql"
+
+    # -- Database name
+    database: "obsforgetap"
+
+    # -- Database username
+    username: "obsforgetap"
+
+    # -- Whether the UWS database requires a password in Vault (true for cloudsql/external)
+    useVaultPassword: true
+
+    # -- Connection pool configuration
+    # -- Maximum active connections (maxIdle will be set to this value)
+    maxActive: 8
+
+# The following will be set by parameters injected by Argo CD and should not
+# be set in the individual environment values files.
+global:
+  # -- Base URL for the environment
+  # @default -- Set by Argo CD
+  baseUrl: ""
+
+  # -- Host name for ingress
+  # @default -- Set by Argo CD
+  host: ""
+
+  # -- Base path for Vault secrets
+  # @default -- Set by Argo CD
+  vaultSecretsPath: ""

--- a/docs/applications/obsforgetap/index.rst
+++ b/docs/applications/obsforgetap/index.rst
@@ -1,0 +1,16 @@
+.. px-app:: obsforgetap
+
+##################################
+obsforgetap — ObsForge TAP service
+##################################
+
+.. jinja:: obsforgetap
+   :file: applications/_summary.rst.jinja
+
+Guides
+======
+
+.. toctree::
+   :maxdepth: 1
+
+   values

--- a/docs/applications/obsforgetap/values.md
+++ b/docs/applications/obsforgetap/values.md
@@ -1,0 +1,12 @@
+```{px-app-values} obsforgetap
+```
+
+# obsforgetap Helm values reference
+
+Helm values reference table for the {px-app}`obsforgetap` application.
+
+```{include} ../../../applications/obsforgetap/README.md
+---
+start-after: "## Values"
+---
+```

--- a/docs/applications/rsp.rst
+++ b/docs/applications/rsp.rst
@@ -21,6 +21,7 @@ Argo CD project: ``rsp``
    livetap/index
    noteburst/index
    nublado/index
+   obsforgetap/index
    portal/index
    ppdbtap/index
    qserv-kafka/index

--- a/environments/README.md
+++ b/environments/README.md
@@ -49,6 +49,7 @@
 | applications.noteburst | bool | `false` | Enable the noteburst application (required by times-square) |
 | applications.nublado | bool | `false` | Enable the nublado application (v3 of the Notebook Aspect) |
 | applications.nvr-control | bool | `false` | Enable the nvr-control application |
+| applications.obsforgetap | bool | `false` | Enable the obsforgetap application |
 | applications.obsloctap | bool | `false` | Enable the obsloctap application |
 | applications.obssys | bool | `false` | Enable the obssys control system application |
 | applications.onepassword-connect | bool | `false` | Enable the onepassword-connect application |

--- a/environments/templates/applications/rsp/obsforgetap.yaml
+++ b/environments/templates/applications/rsp/obsforgetap.yaml
@@ -1,0 +1,42 @@
+{{- if (index .Values "applications" "obsforgetap") -}}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "obsforgetap"
+  {{- if .Values.defaultComputeClass }}
+  labels:
+    cloud.google.com/default-compute-class: {{ .Values.defaultComputeClass | quote }}
+  {{- end}}
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: "obsforgetap"
+  namespace: "argocd"
+  finalizers:
+    - "resources-finalizer.argocd.argoproj.io"
+spec:
+  destination:
+    namespace: "obsforgetap"
+    server: "https://kubernetes.default.svc"
+  project: "rsp"
+  source:
+    path: "applications/obsforgetap"
+    repoURL: {{ .Values.repoUrl | quote }}
+    targetRevision: {{ or (index .Values "revisions" "obsforgetap") .Values.targetRevision | quote }}
+    helm:
+      parameters:
+        - name: "global.baseUrl"
+          value: "https://{{ .Values.fqdn }}"
+        - name: "global.environmentName"
+          value: {{ .Values.name | quote }}
+        - name: "global.host"
+          value: {{ .Values.fqdn | quote }}
+        - name: "global.repertoireUrl"
+          value: "https://{{ .Values.fqdn }}/repertoire"
+        - name: "global.vaultSecretsPath"
+          value: {{ .Values.vaultPathPrefix | quote }}
+      valueFiles:
+        - "values.yaml"
+        - "values-{{ .Values.name }}.yaml"
+{{- end -}}

--- a/environments/values-idfdev.yaml
+++ b/environments/values-idfdev.yaml
@@ -29,6 +29,7 @@ applications:
   muster: true
   noteburst: true
   nublado: true
+  obsforgetap: true
   portal: true
   ppdbtap: true
   qserv-kafka: true

--- a/environments/values.yaml
+++ b/environments/values.yaml
@@ -125,6 +125,9 @@ applications:
   # -- Enable the muster application
   muster: false
 
+  # -- Enable the obsforgetap application
+  obsforgetap: false
+
   # -- Enable the prompt-pub application
   prompt-pub: false
 


### PR DESCRIPTION
ObsForge requires at TAP server.
This PR adds `obsforgetap` and enables it on idfdev for now.
For TAP_SCHEMA and UWS schemas it uses uses the `obsforgetap` database on IDF dev CloudSQL and the data itself is on `obsforge-db-dev` a PostgreSQL database at USDF.