### PR TITLE
Switch nublado back to the original nodepools

### DIFF
--- a/applications/nublado/values-idfint.yaml
+++ b/applications/nublado/values-idfint.yaml
@@ -20,10 +20,7 @@ controller:
     fileserver:
       enabled: true
       nodeSelector:
-        # Google Cloud has no more capacity in us-central1-b for n2-highmem-16s
-        # on 2026-08-04. Use an AMD nodepool with the same size and tier of
-        # instance; these seem to be available
-        node_pool: "user-lab-pool-amd"
+        node_pool: "user-lab-pool"
       tolerations:
         - key: "nublado.lsst.io/permitted"
           operator: "Exists"
@@ -59,10 +56,7 @@ controller:
         TUTORIAL_NOTEBOOKS_CACHE_DIR: "/rubin/cst_repos/tutorial-notebooks"
       initContainers:
       nodeSelector:
-        # Google Cloud has no more capacity in us-central1-b for n2-highmem-16s
-        # on 2026-08-04. Use an AMD nodepool with the same size and tier of
-        # instance; these seem to be available
-        node_pool: "user-lab-pool-amd"
+        node_pool: "user-lab-pool"
       secrets:
         - secretName: "nublado-lab-secret"
           secretKey: "rubin-epo-cit-sci-pipeline.json"

--- a/applications/nublado/values-idfprod.yaml
+++ b/applications/nublado/values-idfprod.yaml
@@ -20,10 +20,7 @@ controller:
     fileserver:
       enabled: true
       nodeSelector:
-        # Google Cloud has no more capacity in us-central1-b for n2-highmem-16s
-        # on 2026-08-04. Use an AMD nodepool with the same size and tier of
-        # instance; these seem to be available
-        node_pool: "user-lab-pool-amd"
+        node_pool: "user-lab-pool"
       tolerations:
         - key: "nublado.lsst.io/permitted"
           operator: "Exists"
@@ -49,10 +46,7 @@ controller:
         TUTORIAL_DATA: "/rubin/cst_repos/tutorial-notebooks/data"
         TUTORIAL_NOTEBOOKS_CACHE_DIR: "/rubin/cst_repos/tutorial-notebooks"
       nodeSelector:
-        # Google Cloud has no more capacity in us-central1-b for n2-highmem-16s
-        # on 2026-08-04. Use an AMD nodepool with the same size and tier of
-        # instance; these seem to be available
-        node_pool: "user-lab-pool-amd"
+        node_pool: "user-lab-pool"
       secrets:
         - secretName: "nublado-lab-secret"
           secretKey: "rubin-epo-cit-sci-pipeline.json"


### PR DESCRIPTION
We can now provision `n2-highmem-16` instances in `us-central1-b` again.