### PR TITLE
DM-55734: Increase Qserv upload timeout to 30m

### DIFF
--- a/applications/qserv-kafka/README.md
+++ b/applications/qserv-kafka/README.md
@@ -36,7 +36,7 @@ Qserv Kafka bridge
 | config.qservRestUsername | string | `nil` | Username for HTTP Basic Authentication for the Qserv REST API. If not null, the password will be assumed to be the same as the database password. |
 | config.qservRetryCount | int | `3` | How many times to retry after a Qserv API network failure |
 | config.qservRetryDelay | string | `"1s"` | How long to wait between retries after a Qserv API network failure in Safir `parse_timedelta` format |
-| config.qservUploadTimeout | string | `"5m"` | How long to allow for user table upload before timing out in Safir `parse_timedelta` format. |
+| config.qservUploadTimeout | string | `"30m"` | How long to allow for user table upload before timing out in Safir `parse_timedelta` format. |
 | config.redisMaxConnections | int | `15` | Size of the Redis connection pool. This should be set to `jobRunBatchSize` plus some extra connections for the monitor, cancel jobs. |
 | config.resultTimeout | int | 3600 (1 hour) | How long to wait for result processing (retrieval and upload) before timing out, in seconds. This doubles as the timeout forcibly terminating result worker pods. |
 | config.sentry.enabled | bool | `false` | Set to true to enable the Sentry integration. |

--- a/applications/qserv-kafka/values.yaml
+++ b/applications/qserv-kafka/values.yaml
@@ -3,6 +3,11 @@
 # Declare variables to be passed into your templates.
 
 config:
+  # -- Timeout for REST API calls in Safir `parse_timedelta` format. This
+  # includes time spent waiting for a connection if the maximum number of
+  # connections has been reached.
+  backendApiTimeout: "60s"
+
   # -- Kafka consumer group ID
   consumerGroupId: "qserv"
 
@@ -99,11 +104,6 @@ config:
   # -- Whether to send the expected API version in REST API calls to Qserv
   qservRestSendApiVersion: true
 
-  # -- Timeout for REST API calls in Safir `parse_timedelta` format. This
-  # includes time spent waiting for a connection if the maximum number of
-  # connections has been reached.
-  backendApiTimeout: "60s"
-
   # -- URL to the Qserv REST API
   # @default -- None, must be set
   qservRestUrl: null
@@ -115,7 +115,7 @@ config:
 
   # -- How long to allow for user table upload before timing out in Safir
   # `parse_timedelta` format.
-  qservUploadTimeout: "5m"
+  qservUploadTimeout: "30m"
 
   # -- How many times to retry after a Qserv API network failure
   qservRetryCount: 3


### PR DESCRIPTION
Increase the upload timeout for user tables in the Qserv Kafka bridge to 30 minutes.