### PR TITLE
WIP: Ephemeris cache generation + computation apps, self-contained at USDF

### DIFF
--- a/applications/ephemcache/.helmignore
+++ b/applications/ephemcache/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/applications/ephemcache/Chart.yaml
+++ b/applications/ephemcache/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+description: Nightly ephemerides cache generator for mpsky
+name: ephemcache
+type: application
+version: 1.0.0

--- a/applications/ephemcache/README.md
+++ b/applications/ephemcache/README.md
@@ -1,0 +1,34 @@
+# ephemcache
+
+Nightly ephemerides cache generator for mpsky
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| activeDeadlineSeconds | int | `3600` | Deadline for a single run, in seconds, so a wedged job cannot run forever |
+| affinity | object | `{}` | Affinity rules for the pod |
+| backoffLimit | int | `0` | Number of retries before the Job is considered failed. Zero, because the next scheduled invocation retries anyway. |
+| command | string | `"selftest"` | Entrypoint subcommand. `selftest` checks the image and needs no database credential; `run` builds the cache for the current observing night. |
+| database.passwordSecretKey | string | `"usdf_mpc_postgres_password"` | Key in this application's Vault secret holding the database password, supplied to the pod as `PGPASSWORD` |
+| database.url | string | `""` | SQLAlchemy DSN for the MPC replica, supplied as `MPCDB`. Empty uses the value baked into the image. Must not contain a username or password: it is passed to `get-mpcorb.py` as a command-line argument. |
+| database.userSecretKey | string | `"usdf_mpc_postgres_user"` | Key in this application's Vault secret holding the database username, supplied to the pod as `PGUSER` |
+| failedJobsHistoryLimit | int | `3` | Number of failed Jobs to retain |
+| global.host | string | Set by Argo CD | Host name for ingress |
+| global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
+| image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the image. Use `Always` where the tag is mutable, such as a branch name. |
+| image.repository | string | `"ghcr.io/mjuric/lsst-gen-ephemcache"` | Image to run, built by the `lsst-gen-ephemcache` repository |
+| image.tag | string | `"u-mjuric-ephemcache"` | Tag of the image to run |
+| logToFile | bool | `false` | Whether to also write each run's log to a file under the output directory. Logs always go to stdout; this is a durable second copy that outlives the pod. |
+| ncores | string | `""` | Value of `NCORES`, which bounds sorcha's parallelism. Must match `resources.limits.cpu`: the scripts otherwise default it to `nproc`, which reports the node's core count rather than the pod's limit. |
+| nodeSelector | object | `{}` | Node selector rules for the pod |
+| outputDirMount.claimName | string | `"sdf-group-rubin"` | Name shared by the PVC, its storage class, and the pod volume |
+| outputDirMount.enabled | bool | `false` | Whether to mount the shared filesystem that output is published to. When disabled, output goes to an emptyDir and is discarded with the pod. |
+| outputDirMount.storageClassName | string | `"sdf-group-rubin"` | Storage class backing the claim |
+| outputDirMount.subPath | string | `"web_data/mpsky-data/test"` | Path within that filesystem to expose. Only this subtree is visible to the container, so widening it is a deliberate change. |
+| podSecurityContext | object | `{}` | Security context for the pod |
+| resources | object | `{"limits":{"cpu":"1","memory":"2Gi"},"requests":{"cpu":"1","memory":"2Gi"}}` | Resource requests and limits. Sized for `selftest`; a real `run` needs far more, and must be raised together with `ncores`. |
+| schedule | string | `"0 */3 * * *"` | Cron schedule for the cache build. Runs are idempotent and skip when the cache for the current observing night already exists, so this only has to be frequent enough to catch the night. |
+| successfulJobsHistoryLimit | int | `3` | Number of completed Jobs to retain |
+| suspend | bool | `true` | Whether to suspend the CronJob |
+| tolerations | list | `[]` | Tolerations for the pod |

--- a/applications/ephemcache/secrets.yaml
+++ b/applications/ephemcache/secrets.yaml
@@ -1,0 +1,6 @@
+usdf_mpc_postgres_user:
+  description: >-
+    Username for the Minor Planet Center database replica.
+usdf_mpc_postgres_password:
+  description: >-
+    Password for the Minor Planet Center database replica.

--- a/applications/ephemcache/templates/_helpers.tpl
+++ b/applications/ephemcache/templates/_helpers.tpl
@@ -1,0 +1,23 @@
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "ephemcache.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "ephemcache.labels" -}}
+helm.sh/chart: {{ include "ephemcache.chart" . }}
+{{ include "ephemcache.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "ephemcache.selectorLabels" -}}
+app.kubernetes.io/name: "ephemcache"
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/applications/ephemcache/templates/cronjob.yaml
+++ b/applications/ephemcache/templates/cronjob.yaml
@@ -1,0 +1,98 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: "ephemcache"
+  labels:
+    {{- include "ephemcache.labels" . | nindent 4 }}
+spec:
+  schedule: {{ .Values.schedule | quote }}
+  suspend: {{ .Values.suspend }}
+  concurrencyPolicy: "Forbid"
+  successfulJobsHistoryLimit: {{ .Values.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.failedJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      backoffLimit: {{ .Values.backoffLimit }}
+      activeDeadlineSeconds: {{ .Values.activeDeadlineSeconds }}
+      template:
+        metadata:
+          labels:
+            {{- include "ephemcache.selectorLabels" . | nindent 12 }}
+        spec:
+          restartPolicy: "Never"
+          automountServiceAccountToken: false
+          {{- with .Values.podSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          containers:
+            - name: "ephemcache"
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+              imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+              args:
+                - {{ .Values.command | quote }}
+              env:
+                {{- with .Values.ncores }}
+                - name: "NCORES"
+                  value: {{ . | quote }}
+                {{- end }}
+                {{- if .Values.logToFile }}
+                - name: "EPHEMCACHE_LOG_TO_FILE"
+                  value: "true"
+                {{- end }}
+                {{- with .Values.database.url }}
+                - name: "MPCDB"
+                  value: {{ . | quote }}
+                {{- end }}
+                {{- with .Values.database.userSecretKey }}
+                - name: "PGUSER"
+                  valueFrom:
+                    secretKeyRef:
+                      name: "ephemcache"
+                      key: {{ . | quote }}
+                      optional: true
+                {{- end }}
+                {{- with .Values.database.passwordSecretKey }}
+                - name: "PGPASSWORD"
+                  valueFrom:
+                    secretKeyRef:
+                      name: "ephemcache"
+                      key: {{ . | quote }}
+                      optional: true
+                {{- end }}
+              resources:
+                {{- toYaml .Values.resources | nindent 16 }}
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - "all"
+                readOnlyRootFilesystem: false
+              volumeMounts:
+                - name: "outputs"
+                  mountPath: "/app/outputs"
+                  {{- if .Values.outputDirMount.enabled }}
+                  subPath: {{ .Values.outputDirMount.subPath | quote }}
+                  {{- end }}
+          volumes:
+            {{- if .Values.outputDirMount.enabled }}
+            - name: "outputs"
+              persistentVolumeClaim:
+                claimName: {{ .Values.outputDirMount.claimName | quote }}
+            {{- else }}
+            - name: "outputs"
+              emptyDir:
+                sizeLimit: "1Gi"
+            {{- end }}

--- a/applications/ephemcache/templates/pvc.yaml
+++ b/applications/ephemcache/templates/pvc.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.outputDirMount.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Values.outputDirMount.claimName | quote }}
+  labels:
+    {{- include "ephemcache.labels" . | nindent 4 }}
+  annotations:
+    # This storage class provisions PVs whose source path is the whole shared
+    # filesystem, with reclaimPolicy Delete. Do not let anything delete this
+    # claim automatically.
+    argocd.argoproj.io/sync-options: Prune=false
+    helm.sh/resource-policy: keep
+spec:
+  storageClassName: {{ .Values.outputDirMount.storageClassName | quote }}
+  accessModes:
+    - "ReadWriteMany"
+  resources:
+    requests:
+      storage: "1Gi"
+{{- end }}

--- a/applications/ephemcache/templates/vault-secret.yaml
+++ b/applications/ephemcache/templates/vault-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: ricoberger.de/v1alpha1
+kind: VaultSecret
+metadata:
+  name: "ephemcache"
+  labels:
+    {{- include "ephemcache.labels" . | nindent 4 }}
+spec:
+  path: "{{ .Values.global.vaultSecretsPath }}/ephemcache"
+  type: Opaque

--- a/applications/ephemcache/values-usdfdev.yaml
+++ b/applications/ephemcache/values-usdfdev.yaml
@@ -1,0 +1,41 @@
+image:
+  pullPolicy: "Always"
+
+suspend: false
+
+command: "run"
+
+# uid 18728 has write access to the output directory through an explicit ACL, so
+# changing it silently breaks writes.
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 18728
+  runAsGroup: 4085
+  fsGroup: 4085
+
+logToFile: true
+
+outputDirMount:
+  enabled: true
+  subPath: "web_data/mpsky-data"
+
+resources:
+  requests:
+    cpu: "48"
+    memory: "64Gi"
+  limits:
+    cpu: "48"
+    memory: "64Gi"
+
+ncores: "48"
+
+activeDeadlineSeconds: 5400
+
+nodeSelector:
+  edu.stanford.slac.sdf.project/rsp: "true"
+
+tolerations:
+  - key: "edu.stanford.slac.sdf.project/rsp"
+    operator: "Equal"
+    value: "true"
+    effect: "NoSchedule"

--- a/applications/ephemcache/values.yaml
+++ b/applications/ephemcache/values.yaml
@@ -1,0 +1,110 @@
+# Default values for ephemcache.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  # -- Image to run, built by the `lsst-gen-ephemcache` repository
+  repository: "ghcr.io/mjuric/lsst-gen-ephemcache"
+
+  # -- Tag of the image to run
+  tag: "u-mjuric-ephemcache"
+
+  # -- Pull policy for the image. Use `Always` where the tag is mutable, such as
+  # a branch name.
+  pullPolicy: "IfNotPresent"
+
+# -- Cron schedule for the cache build. Runs are idempotent and skip when the
+# cache for the current observing night already exists, so this only has to be
+# frequent enough to catch the night.
+schedule: "0 */3 * * *"
+
+# -- Whether to suspend the CronJob
+suspend: true
+
+# -- Entrypoint subcommand. `selftest` checks the image and needs no database
+# credential; `run` builds the cache for the current observing night.
+command: "selftest"
+
+# -- Value of `NCORES`, which bounds sorcha's parallelism. Must match
+# `resources.limits.cpu`: the scripts otherwise default it to `nproc`, which
+# reports the node's core count rather than the pod's limit.
+ncores: ""
+
+# -- Resource requests and limits. Sized for `selftest`; a real `run` needs far
+# more, and must be raised together with `ncores`.
+resources:
+  requests:
+    cpu: "1"
+    memory: "2Gi"
+  limits:
+    cpu: "1"
+    memory: "2Gi"
+
+# -- Deadline for a single run, in seconds, so a wedged job cannot run forever
+activeDeadlineSeconds: 3600
+
+# -- Number of retries before the Job is considered failed. Zero, because the
+# next scheduled invocation retries anyway.
+backoffLimit: 0
+
+# -- Number of completed Jobs to retain
+successfulJobsHistoryLimit: 3
+
+# -- Number of failed Jobs to retain
+failedJobsHistoryLimit: 3
+
+# -- Whether to also write each run's log to a file under the output directory.
+# Logs always go to stdout; this is a durable second copy that outlives the pod.
+logToFile: false
+
+outputDirMount:
+  # -- Whether to mount the shared filesystem that output is published to. When
+  # disabled, output goes to an emptyDir and is discarded with the pod.
+  enabled: false
+
+  # -- Name shared by the PVC, its storage class, and the pod volume
+  claimName: "sdf-group-rubin"
+
+  # -- Storage class backing the claim
+  storageClassName: "sdf-group-rubin"
+
+  # -- Path within that filesystem to expose. Only this subtree is visible to
+  # the container, so widening it is a deliberate change.
+  subPath: "web_data/mpsky-data/test"
+
+database:
+  # -- SQLAlchemy DSN for the MPC replica, supplied as `MPCDB`. Empty uses the
+  # value baked into the image. Must not contain a username or password: it is
+  # passed to `get-mpcorb.py` as a command-line argument.
+  url: ""
+
+  # -- Key in this application's Vault secret holding the database username,
+  # supplied to the pod as `PGUSER`
+  userSecretKey: "usdf_mpc_postgres_user"
+
+  # -- Key in this application's Vault secret holding the database password,
+  # supplied to the pod as `PGPASSWORD`
+  passwordSecretKey: "usdf_mpc_postgres_password"
+
+# -- Security context for the pod
+podSecurityContext: {}
+
+# -- Node selector rules for the pod
+nodeSelector: {}
+
+# -- Tolerations for the pod
+tolerations: []
+
+# -- Affinity rules for the pod
+affinity: {}
+
+# The following will be set by parameters injected by Argo CD and should not
+# be set in the individual environment values files.
+global:
+  # -- Host name for ingress
+  # @default -- Set by Argo CD
+  host: null
+
+  # -- Base path for Vault secrets
+  # @default -- Set by Argo CD
+  vaultSecretsPath: null

--- a/applications/mpsky/README.md
+++ b/applications/mpsky/README.md
@@ -11,6 +11,7 @@ Solar System Ephemerides
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules for the mpsky deployment pod |
+| datastoreUrl | string | `"https://epyc.astro.washington.edu/~mjuric/mpsky-data"` | Base URL of the datastore holding the nightly caches. Must follow the layout produced by the cache builder: `caches/` and `catalogs/` beneath it. |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | image.pullPolicy | string | `"Always"` |  |

--- a/applications/mpsky/templates/deployment.yaml
+++ b/applications/mpsky/templates/deployment.yaml
@@ -36,8 +36,7 @@ spec:
             - "8080"
             - --verbose
             - --datastore
-            - "https://epyc.astro.washington.edu/~mjuric/mpsky-data"
-#            - "https://data.mpsky.org/mpsky-data/"
+            - {{ .Values.datastoreUrl | quote }}
             - --max-loaded-nights
             - "7"
             - --max-ondisk-nights

--- a/applications/mpsky/values-usdfdev.yaml
+++ b/applications/mpsky/values-usdfdev.yaml
@@ -1,3 +1,5 @@
+datastoreUrl: "https://s3df.slac.stanford.edu/data/rubin/mpsky-data"
+
 serviceAnnotations:
   metallb.io/address-pool: sdf-rubin-ingest
   metallb.io/loadBalancerIPs: 172.24.10.34

--- a/applications/mpsky/values.yaml
+++ b/applications/mpsky/values.yaml
@@ -19,6 +19,10 @@ image:
   #tag: null
   tag: auto-load
 
+# -- Base URL of the datastore holding the nightly caches. Must follow the
+# layout produced by the cache builder: `caches/` and `catalogs/` beneath it.
+datastoreUrl: "https://epyc.astro.washington.edu/~mjuric/mpsky-data"
+
 ingress:
   # -- Additional annotations for the ingress rule
   annotations: {}

--- a/docs/applications/ephemcache/index.rst
+++ b/docs/applications/ephemcache/index.rst
@@ -1,0 +1,16 @@
+.. px-app:: ephemcache
+
+##########################################################
+ephemcache — Nightly ephemerides cache generator for mpsky
+##########################################################
+
+.. jinja:: ephemcache
+   :file: applications/_summary.rst.jinja
+
+Guides
+======
+
+.. toctree::
+   :maxdepth: 1
+
+   values

--- a/docs/applications/ephemcache/values.md
+++ b/docs/applications/ephemcache/values.md
@@ -1,0 +1,12 @@
+```{px-app-values} ephemcache
+```
+
+# ephemcache Helm values reference
+
+Helm values reference table for the {px-app}`ephemcache` application.
+
+```{include} ../../../applications/ephemcache/README.md
+---
+start-after: "## Values"
+---
+```

--- a/docs/applications/rubin.rst
+++ b/docs/applications/rubin.rst
@@ -11,6 +11,7 @@ Argo CD project: ``rubin``
 
    cm-service/index
    consdb/index
+   ephemcache/index
    exposurelog/index
    exposure-checker/index
    fastapi-bootcamp/index

--- a/environments/README.md
+++ b/environments/README.md
@@ -21,6 +21,7 @@
 | applications.datalinker | bool | `false` | Eanble the datalinker application |
 | applications.docverse | bool | `false` | Enable the docverse application |
 | applications.envsys | bool | `false` | Enable the envsys control system application |
+| applications.ephemcache | bool | `false` | Enable the ephemcache application |
 | applications.eups-distributor | bool | `false` | Enable the eups-distributor application |
 | applications.exposure-checker | bool | `false` | Enable the exposure-checker application |
 | applications.exposurelog | bool | `false` | Enable the exposurelog application |

--- a/environments/templates/applications/rubin/ephemcache.yaml
+++ b/environments/templates/applications/rubin/ephemcache.yaml
@@ -1,0 +1,42 @@
+{{- if (index .Values "applications" "ephemcache") -}}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "ephemcache"
+  {{- if .Values.defaultComputeClass }}
+  labels:
+    cloud.google.com/default-compute-class: {{ .Values.defaultComputeClass | quote }}
+  {{- end}}
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: "ephemcache"
+  namespace: "argocd"
+  finalizers:
+    - "resources-finalizer.argocd.argoproj.io"
+spec:
+  destination:
+    namespace: "ephemcache"
+    server: "https://kubernetes.default.svc"
+  project: "rubin"
+  source:
+    path: "applications/ephemcache"
+    repoURL: {{ .Values.repoUrl | quote }}
+    targetRevision: {{ or (index .Values "revisions" "ephemcache") .Values.targetRevision | quote }}
+    helm:
+      parameters:
+        - name: "global.baseUrl"
+          value: "https://{{ .Values.fqdn }}"
+        - name: "global.environmentName"
+          value: {{ .Values.name | quote }}
+        - name: "global.host"
+          value: {{ .Values.fqdn | quote }}
+        - name: "global.repertoireUrl"
+          value: "https://{{ .Values.fqdn }}/repertoire"
+        - name: "global.vaultSecretsPath"
+          value: {{ .Values.vaultPathPrefix | quote }}
+      valueFiles:
+        - "values.yaml"
+        - "values-{{ .Values.name }}.yaml"
+{{- end -}}

--- a/environments/values-usdfdev.yaml
+++ b/environments/values-usdfdev.yaml
@@ -15,6 +15,7 @@ applications:
   consdbtap: true
   consdb: true
   datalinker: true
+  ephemcache: true
   exposure-checker: true
   exposurelog: true
   fov-quicklook: true

--- a/environments/values.yaml
+++ b/environments/values.yaml
@@ -88,6 +88,9 @@ applications:
   # -- Enable the envsys control system application
   envsys: false
 
+  # -- Enable the ephemcache application
+  ephemcache: false
+
   # -- Enable the eups-distributor application
   eups-distributor: false
 


### PR DESCRIPTION
Adds `ephemcache`, a new application that moves the nightly mpsky ephemerides-cache build from a hand-managed crontab into a CronJob at usdfdev. It runs 3-hourly and skips when the current night's cache already exists, so over-scheduling is cheap and gives free retries.

It requests 48 CPU / 64 Gi on the RSP node pool, using both a nodeSelector and a toleration; smaller requests will not schedule on the general pool. Measured runtime is ~17 min per night at ~21 GiB peak.

Output is written directly into `/sdf/group/rubin/web_data/mpsky-data` through a subPath-scoped sdf-group-rubin claim, so nothing else on that shared, served filesystem is visible to the container. 

This PR also repoints the mpsky app to https://s3df.slac.stanford.edu/data/rubin/mpsky-data as the data store URL. Once `mpsky` learns how to read directories directly, we'll be able to skip that step.