### PR TITLE
DM-55470: Deploy squareone 0.38.0

### DIFF
--- a/applications/squareone/Chart.yaml
+++ b/applications/squareone/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
     url: https://github.com/jonathansick
 
 # The default version tag of the squareone docker image
-appVersion: "0.37.3"
+appVersion: "0.38.0"

--- a/applications/squareone/values-idfdev.yaml
+++ b/applications/squareone/values-idfdev.yaml
@@ -1,6 +1,5 @@
 image:
   pullPolicy: Always
-  tag: "tickets-DM-55470"
 
 ingress:
   timesSquareScope: "exec:admin"

--- a/applications/squareone/values-idfdev.yaml
+++ b/applications/squareone/values-idfdev.yaml
@@ -1,5 +1,6 @@
 image:
   pullPolicy: Always
+  tag: "tickets-DM-55470"
 
 ingress:
   timesSquareScope: "exec:admin"


### PR DESCRIPTION
## Summary

- Bump the squareone chart `appVersion` from 0.37.3 to 0.38.0, deploying the Times Square notebook execution-error and re-run UI (lsst-sqre/squareone#631).
- Drop the temporary idfdev pin to the `tickets-DM-55470` branch image now that the feature has shipped in a release; idfdev returns to tracking the chart's appVersion.

## Validation steps

- Sync squareone on idfdev in Argo CD and confirm the pod runs `ghcr.io/lsst-sqre/squareone:0.38.0` (not the `tickets-DM-55470` branch image).
- On data-dev, load a Times Square notebook page that fails execution and confirm the execution-error display and re-run controls work as they did with the branch deployment.

## References

- Release: https://github.com/lsst-sqre/squareone/releases/tag/squareone%400.38.0
- Jira: https://rubinobs.atlassian.net/browse/DM-55470