### PR TITLE
DM-55714: Update times-square to 0.26.0

### DIFF
--- a/applications/times-square/Chart.yaml
+++ b/applications/times-square/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 type: application
 
 # The default version tag of the times-square docker image
-appVersion: "0.25.0"
+appVersion: "0.26.0"
 
 dependencies:
   - name: redis


### PR DESCRIPTION
## Summary

Bump the times-square chart `appVersion` from 0.25.0 to **0.26.0**, deploying the new release to every environment that follows the chart default (idfdev, idfint, idfprod, usdfdev, usdfprod).

Release notes: https://github.com/lsst-sqre/times-square/releases/tag/0.26.0

Highlights of 0.26.0 — all on the `GET /v1/pages/{page}/html/events` SSE stream:

- The stream no longer restates unchanged state once a second: subscribers get one initial state event, then an event only when state changes. Terminal execution failures are reported once, and the stream still never closes.
- The stream renders and caches a page instance's HTML when it observes a successful execution, so subscribers get `html_hash`/`html_url` as soon as the notebook finishes, without any client hitting the HTML endpoint.
- Idle subscriptions back off their Redis polling (1→2→4→8→10 s, resetting on activity), cutting the cost of long-lived dashboard streams on settled pages.

This branch also retires the temporary idfdev branch-deploy pin (`image.tag: tickets-DM-55714`) that was used to test this work — idfdev returns to the chart default and picks up 0.26.0 with this deploy.

Note: `idfdemo` pins `image.tag: tickets-DM-52819` in `values-idfdemo.yaml`, so it deliberately stays on that branch build and is not affected by this bump.

## References

- Jira: [DM-55714](https://rubinobs.atlassian.net/browse/DM-55714)

[DM-55714]: https://rubinobs.atlassian.net/browse/DM-55714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ