### PR TITLE
DM-55222: Deploy Times Square 0.27.0

### DIFF
--- a/applications/times-square/Chart.yaml
+++ b/applications/times-square/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 type: application
 
 # The default version tag of the times-square docker image
-appVersion: "0.26.0"
+appVersion: "0.27.0"
 
 dependencies:
   - name: redis

--- a/applications/times-square/values-idfdev.yaml
+++ b/applications/times-square/values-idfdev.yaml
@@ -1,9 +1,14 @@
 image:
+  # Trial the DM-55222 branch build ahead of the next Times Square release.
+  tag: "tickets-DM-55222"
   pullPolicy: Always
 ingress:
   defaultScope: "exec:admin"
 config:
   logLevel: "DEBUG"
+  # DM-55222 adds the GitHub numeric ID columns. Drop this again once the
+  # migration has been applied.
+  updateSchema: true
   databaseUrl: "postgresql://times-square@localhost/times-square"
   githubAppId: "196798"
   enableGitHubApp: "True"

--- a/applications/times-square/values-idfdev.yaml
+++ b/applications/times-square/values-idfdev.yaml
@@ -1,14 +1,9 @@
 image:
-  # Trial the DM-55222 branch build ahead of the next Times Square release.
-  tag: "tickets-DM-55222"
   pullPolicy: Always
 ingress:
   defaultScope: "exec:admin"
 config:
   logLevel: "DEBUG"
-  # DM-55222 adds the GitHub numeric ID columns. Drop this again once the
-  # migration has been applied.
-  updateSchema: true
   databaseUrl: "postgresql://times-square@localhost/times-square"
   githubAppId: "196798"
   enableGitHubApp: "True"

--- a/applications/times-square/values.yaml
+++ b/applications/times-square/values.yaml
@@ -126,7 +126,7 @@ config:
 
   # -- Whether to run the database migration job
   # @default -- false to disable schema upgrades
-  updateSchema: false
+  updateSchema: true
 
   # -- URL for Redis html / noteburst job cache database
   # @default -- Points to embedded Redis


### PR DESCRIPTION
## Summary

Deploys the [Times Square 0.27.0 release](https://github.com/lsst-sqre/times-square/releases/tag/0.27.0) to all environments. This release carries the [DM-55222 work](https://github.com/lsst-sqre/times-square/pull/197): Times Square records GitHub's stable numeric IDs (repository, owner, and app installation) on every GitHub-backed page, follows repository renames/transfers and owner renames via webhooks keyed on those IDs, reconciles stored names against GitHub daily, and adds a `times-square backfill-github-ids` CLI command for pages that predate ID capture.

Changes:

- `applications/times-square/Chart.yaml`: `appVersion` 0.26.0 → 0.27.0.
- `applications/times-square/values-idfdev.yaml`: drop the temporary `image.tag: "tickets-DM-55222"` override used to trial the branch build on data-dev (that image is now superseded by the release, which data-dev verified — see the [verification comment](https://github.com/lsst-sqre/times-square/pull/197#issuecomment-5272497875)).
- `applications/times-square/values.yaml`: enable `config.updateSchema` globally (moved from the idfdev override). 0.27.0 ships an Alembic migration (`d30084ab26c8`, the new GitHub numeric ID columns) and Times Square refuses to start against a stale schema, so every environment needs the schema-update job when it syncs this release, per the usual Times Square schema-update dance (as for 0.19). **A follow-up PR will disable `updateSchema` once all environments have synced.**

## Validation steps

- `phalanx application lint times-square --environment <env>` passes for all six environments (idfdev, idfdemo, idfint, idfprod, usdfdev, usdfprod).
- `phalanx application template` renders `image: "ghcr.io/lsst-sqre/times-square:0.27.0"` and the `times-square-schema-update` pre-upgrade hook Job (spot-checked idfdev and usdfprod).
- The DM-55222 branch build (functionally identical to 0.27.0) has been running on data-dev since 2026-08-12: the schema migration applied, and `times-square backfill-github-ids` filled the numeric IDs on all 441 pre-existing pages.

After each environment syncs:

- Confirm the schema-update job succeeded.
- Run `times-square backfill-github-ids` (with `--dry-run` first) as a one-off job to fill the IDs on pre-existing pages, per the [backfill guide](https://times-square.lsst.io/user-guide/github-id-backfill.html).
- Ensure that environment's Times Square GitHub App is subscribed to the **Installation target** webhook event so owner-rename webhooks arrive. That is a GitHub App setting, not a Phalanx one, and it needs no additional permission.

## References

- Times Square release: https://github.com/lsst-sqre/times-square/releases/tag/0.27.0
- Times Square PR: https://github.com/lsst-sqre/times-square/pull/197
- Jira: https://rubinobs.atlassian.net/browse/DM-55222
