### PR TITLE
DM-55725: Update Ook to 0.25.1

### DIFF
--- a/applications/ook/Chart.yaml
+++ b/applications/ook/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: ook
 version: 1.0.0
-appVersion: "0.25.0"
+appVersion: "0.25.1"
 description: >
   Ook is the librarian service for Rubin Observatory. Ook indexes
   documentation content into the Algolia search engine that powers the Rubin


### PR DESCRIPTION
## Summary

Deploys [Ook 0.25.1](https://github.com/lsst-sqre/ook/releases/tag/0.25.1), which
moves the Kafka/FastAPI integration off FastStream's deprecated built-in plugin
onto [`faststream_fastapi`](https://faststream-community.github.io/faststream_fastapi/)
(FastStream removes the old plugin in 1.0.0). Subscribers now hang off a plain
`KafkaBroker`, and `FastStreamAPI` wraps the FastAPI app to start and stop the
broker around its lifespan.

The release also carries the ruff 0.16 / `CPY001` config re-sync and the prek
adoption that had accumulated since 0.25.0.

- `applications/ook/Chart.yaml`: `appVersion` 0.25.0 to 0.25.1.

This PR previously pinned `image.tag` to the `tickets-DM-55725` branch build on
roundtable-dev; that override has been dropped now that the change is released.

## Validation

- Ook CI green on the merge; the release workflow published
  `ghcr.io/lsst-sqre/ook:0.25.1`.
- The branch image ran on roundtable-dev ahead of the release: the broker started
  under the wrapped lifespan and Kafka handlers resolved their `ConsumerContext`
  injection normally.

## References

- Service PR: https://github.com/lsst-sqre/ook/pull/306
- Release: https://github.com/lsst-sqre/ook/releases/tag/0.25.1
- Jira: https://rubinobs.atlassian.net/browse/DM-55725