### PR TITLE
DM-55725: Update Squarebot to 0.10.4

### DIFF
--- a/applications/squarebot/Chart.yaml
+++ b/applications/squarebot/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: squarebot
 version: 1.0.0
-appVersion: "0.10.3"
+appVersion: "0.10.4"
 description: Squarebot feeds events from services like Slack and GitHub into the SQuaRE Events Kafka message bus running on Roundtable. Backend apps like Templatebot and Unfurlbot can subscribe to these events and take domain-specific action.
 type: application
 home: https://squarebot.lsst.io/


### PR DESCRIPTION
## Summary

Deploys [Squarebot 0.10.4](https://github.com/lsst-sqre/squarebot/releases/tag/0.10.4),
which moves the Kafka/FastAPI integration off FastStream's deprecated built-in
plugin onto [`faststream_fastapi`](https://faststream-community.github.io/faststream_fastapi/)
(FastStream removes the old plugin in 1.0.0). Subscribers now hang off a plain
`KafkaBroker`, and `FastStreamAPI` wraps the FastAPI app to start and stop the
broker around its lifespan.

The release also carries the ruff 0.16 / `CPY001` config re-sync, the prek
adoption, and a dependency refresh accumulated since 0.10.3. The published
`rubin-squarebot` client package is unchanged by this work.

- `applications/squarebot/Chart.yaml`: `appVersion` 0.10.3 to 0.10.4.

This PR previously pinned `image.tag` to the `tickets-DM-55725` branch build on
roundtable-dev; that override has been dropped now that the change is released.

## Validation

- Squarebot CI green on the merge; the release workflow published
  `ghcr.io/lsst-sqre/squarebot:0.10.4` and `rubin-squarebot` 0.10.4 to PyPI.
- The branch image ran on roundtable-dev ahead of the release, with Slack events
  flowing through to the downstream bots.

## References

- Service PR: https://github.com/lsst-sqre/squarebot/pull/61
- Release: https://github.com/lsst-sqre/squarebot/releases/tag/0.10.4
- Jira: https://rubinobs.atlassian.net/browse/DM-55725