### PR TITLE
DM-55725: Update Templatebot to 0.5.6

### DIFF
--- a/applications/templatebot/Chart.yaml
+++ b/applications/templatebot/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "0.5.5"
+appVersion: "0.5.6"
 description: Create new projects
 name: templatebot
 sources:


### PR DESCRIPTION
## Summary

Deploys [Templatebot 0.5.6](https://github.com/lsst-sqre/templatebot/releases/tag/0.5.6),
which moves the Kafka/FastAPI integration off FastStream's deprecated built-in
plugin onto [`faststream_fastapi`](https://faststream-community.github.io/faststream_fastapi/)
(FastStream removes the old plugin in 1.0.0). Subscribers now hang off a plain
`KafkaBroker`, and `FastStreamAPI` wraps the FastAPI app to start and stop the
broker around its lifespan. This also lifts the `fastapi<0.140` cap that 0.5.5
shipped as a workaround for the old plugin.

Note this bump crosses two releases: the chart was still on `appVersion` 0.5.5,
so 0.5.6 also brings in whatever 0.5.5 carried.

- `applications/templatebot/Chart.yaml`: `appVersion` 0.5.5 to 0.5.6.

This PR previously pinned `image.tag` to the `tickets-DM-55725` branch build on
roundtable-dev; that override has been dropped now that the change is released.

## Validation

- Templatebot CI green on the merge; the release workflow published
  `ghcr.io/lsst-sqre/templatebot:0.5.6`.
- The branch image ran on roundtable-dev ahead of the release, handling
  template requests off squarebot's Kafka topic.

## References

- Service PR: https://github.com/lsst-sqre/templatebot/pull/106
- Release: https://github.com/lsst-sqre/templatebot/releases/tag/0.5.6
- Jira: https://rubinobs.atlassian.net/browse/DM-55725