### PR TITLE
DM-55725: Update Unfurlbot to 0.5.3

### DIFF
--- a/applications/unfurlbot/Chart.yaml
+++ b/applications/unfurlbot/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "0.5.2"
+appVersion: "0.5.3"
 description: Squarebot backend that unfurls Jira issues.
 name: unfurlbot
 sources:


### PR DESCRIPTION
## Summary

Deploys [Unfurlbot 0.5.3](https://github.com/lsst-sqre/unfurlbot/releases/tag/0.5.3),
which moves the Kafka/FastAPI integration off FastStream's deprecated built-in
plugin onto [`faststream_fastapi`](https://faststream-community.github.io/faststream_fastapi/)
(FastStream removes the old plugin in 1.0.0). The subscriber now hangs off a plain
`KafkaBroker`, and `FastStreamAPI` wraps the FastAPI app to start and stop the
broker around its lifespan.

The release also carries the ruff 0.16 / `CPY001` config re-sync and the prek
adoption that had accumulated since 0.5.2.

- `applications/unfurlbot/Chart.yaml`: `appVersion` 0.5.2 to 0.5.3.

This PR previously pinned `image.tag` to the `tickets-DM-55725` branch build on
roundtable-dev; that override has been dropped now that the change is released.

## Validation

- Unfurlbot CI green on the merge; the release workflow published
  `ghcr.io/lsst-sqre/unfurlbot:0.5.3`.
- The branch image ran on roundtable-dev ahead of the release, unfurling Jira
  issue keys posted in Slack. Unfurlbot was the campaign pilot and the one
  service needing `faststream_fastapi.Context("message")` on a nested `Depends`
  annotation, so the live check mattered most here.

## References

- Service PR: https://github.com/lsst-sqre/unfurlbot/pull/43
- Release: https://github.com/lsst-sqre/unfurlbot/releases/tag/0.5.3
- Jira: https://rubinobs.atlassian.net/browse/DM-55725