### PR TITLE
OSW-2819: Update nginx image for nightlydigest and love due to CVE-2026-42533.

### DIFF
--- a/applications/love/values-base.yaml
+++ b/applications/love/values-base.yaml
@@ -198,7 +198,7 @@ love-manager:
 love-nginx:
   image:
     repository: nginx
-    tag: 1.25.1
+    tag: 1.31.3
     pullPolicy: Always
   ingress:
     hostname: base-lsp.lsst.codes

--- a/applications/love/values-base.yaml
+++ b/applications/love/values-base.yaml
@@ -223,7 +223,6 @@ love-nginx:
     storageClass: rook-ceph-block
     accessMode: ReadWriteOnce
     claimSize: 2Gi
-  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 50m

--- a/applications/love/values-summit.yaml
+++ b/applications/love/values-summit.yaml
@@ -239,7 +239,7 @@ love-manager:
 love-nginx:
   image:
     repository: nginx
-    tag: 1.25.1
+    tag: 1.31.3
     pullPolicy: Always
   ingress:
     hostname: summit-lsp.lsst.codes

--- a/applications/love/values-summit.yaml
+++ b/applications/love/values-summit.yaml
@@ -266,7 +266,6 @@ love-nginx:
     storageClass: rook-ceph-block
     accessMode: ReadWriteOnce
     claimSize: 2Gi
-  <<: *pod-antiaffinity
   resources:
     requests:
       cpu: 120m

--- a/applications/love/values-tucson-teststand.yaml
+++ b/applications/love/values-tucson-teststand.yaml
@@ -184,7 +184,7 @@ love-manager:
 love-nginx:
   image:
     repository: nginx
-    tag: 1.25.1
+    tag: 1.31.3
     pullPolicy: Always
   ingress:
     hostname: tucson-teststand.lsst.codes

--- a/applications/nightlydigest/values-base.yaml
+++ b/applications/nightlydigest/values-base.yaml
@@ -1,7 +1,7 @@
 nightlydigest-nginx:
   image:
     repository: nginx
-    tag: 1.25.1
+    tag: 1.31.3
     pullPolicy: Always
   ingress:
     httpPath: /nightlydigest

--- a/applications/nightlydigest/values-summit.yaml
+++ b/applications/nightlydigest/values-summit.yaml
@@ -1,7 +1,7 @@
 nightlydigest-nginx:
   image:
     repository: nginx
-    tag: 1.25.1
+    tag: 1.31.3
     pullPolicy: Always
   ingress:
     httpPath: /nightlydigest

--- a/applications/nightlydigest/values-usdfdev.yaml
+++ b/applications/nightlydigest/values-usdfdev.yaml
@@ -1,7 +1,7 @@
 nightlydigest-nginx:
   image:
     repository: nginx
-    tag: 1.25.1
+    tag: 1.31.3
     pullPolicy: Always
   ingress:
     httpPath: /nightlydigest

--- a/applications/nightlydigest/values-usdfprod.yaml
+++ b/applications/nightlydigest/values-usdfprod.yaml
@@ -1,7 +1,7 @@
 nightlydigest-nginx:
   image:
     repository: nginx
-    tag: 1.25.1
+    tag: 1.31.3
     pullPolicy: Always
   ingress:
     httpPath: /nightlydigest


### PR DESCRIPTION
This PR also removes pod-antiaffinity from the love nginx deployment configurations as it was preventing the pod from being synced up.