### PR TITLE
Update datalink URLs to EDP2-deploy-v3b

### DIFF
--- a/applications/datalinker/values-idfint.yaml
+++ b/applications/datalinker/values-idfint.yaml
@@ -4,4 +4,4 @@ config:
   slackAlerts: true
 
   # -- TAP configuration
-  tapMetadataUrl: "https://github.com/lsst/sdm_schemas/releases/download/EDP2-deploy-v2/datalink-columns.zip"
+  tapMetadataUrl: "https://github.com/lsst/sdm_schemas/releases/download/EDP2-deploy-v3b/datalink-columns.zip"

--- a/applications/datalinker/values-idfprod.yaml
+++ b/applications/datalinker/values-idfprod.yaml
@@ -4,4 +4,4 @@ config:
   slackAlerts: true
 
   # -- TAP configuration
-  tapMetadataUrl: "https://github.com/lsst/sdm_schemas/releases/download/EDP2-deploy-v2/datalink-columns.zip"
+  tapMetadataUrl: "https://github.com/lsst/sdm_schemas/releases/download/EDP2-deploy-v3b/datalink-columns.zip"

--- a/applications/tap/values-idfint.yaml
+++ b/applications/tap/values-idfint.yaml
@@ -14,7 +14,7 @@ cadc-tap:
         - "dp02_dc2_catalogs.ObsCore:access_url"
         - "dp1.ObsCore:access_url"
 
-    datalinkPayloadUrl: "https://github.com/lsst/sdm_schemas/releases/download/EDP2-deploy-v2/datalink-snippets.zip"
+    datalinkPayloadUrl: "https://github.com/lsst/sdm_schemas/releases/download/EDP2-deploy-v3b/datalink-snippets.zip"
 
   cloudsql:
     enabled: true

--- a/applications/tap/values-idfprod.yaml
+++ b/applications/tap/values-idfprod.yaml
@@ -12,7 +12,7 @@ cadc-tap:
         - "dp02_dc2_catalogs.ObsCore:access_url"
         - "dp1.ObsCore:access_url"
 
-    datalinkPayloadUrl: "https://github.com/lsst/sdm_schemas/releases/download/EDP2-deploy-v2/datalink-snippets.zip"
+    datalinkPayloadUrl: "https://github.com/lsst/sdm_schemas/releases/download/EDP2-deploy-v3b/datalink-snippets.zip"
 
   cloudsql:
     enabled: true


### PR DESCRIPTION
Restores consistency after #6866 but should have no effect (DataLink config was not changed between -v2 and -v3b).