### PR TITLE
DM-55828: Exposure Checker USDF Dev scale down

### DIFF
--- a/applications/exposure-checker/README.md
+++ b/applications/exposure-checker/README.md
@@ -27,4 +27,5 @@ An interface for visually identifying artifacts in Rubin images.
 | image.repository | string | `"ghcr.io/lsst-sitcom/rubin_exp_checker"` | rubin_exp_checker image to use |
 | image.tag | string | The appVersion of the chart | Tag of rubin_exp_checker image to use |
 | ingress.annotations | object | `{}` | Additional annotations to add to the ingress |
+| replicaCount | int | `1` | Number of pods to start |
 | resources | object | see `values.yaml` | Resource limits and requests for the nodejs pod |

--- a/applications/exposure-checker/templates/deployment.yaml
+++ b/applications/exposure-checker/templates/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "application.labels" . | nindent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
       {{- include "application.selectorLabels" . | nindent 6 }}

--- a/applications/exposure-checker/values-usdfdev.yaml
+++ b/applications/exposure-checker/values-usdfdev.yaml
@@ -1,6 +1,8 @@
 image:
   tag: v1.0
 
+replicaCount: 0
+
 environment:
   AWS_SHARED_CREDENTIALS_FILE: "/opt/lsst/butler/secrets/aws-credentials.ini"
   S3_ENDPOINT_URL: "https://s3dfrgw.slac.stanford.edu"

--- a/applications/exposure-checker/values.yaml
+++ b/applications/exposure-checker/values.yaml
@@ -6,6 +6,9 @@ image:
   # @default -- The appVersion of the chart
   tag: ""
 
+# -- Number of pods to start
+replicaCount: 1
+
 # -- Environment variables
 environment: {}
 


### PR DESCRIPTION
Scale down exposure checker to 0 replicas.   Exposure Checker is not currently being used.  The GitHub Repository moved so there is an image pull backoff error.  Work needs to be done to create a new image.