### PR TITLE
DM-55835: deploy templatebot 0.5.7 and extend view-submission retention

### DIFF
--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -750,6 +750,7 @@ Rubin Observatory's telemetry service
 | schema-registry-remote.topic.name | string | `"registry-schemas"` | Name of the Kafka topic used by the Schema Registry to store schemas. |
 | scimma.cluster.name | string | `"sasquatch"` | Name of the Strimzi cluster. Synchronize this with the cluster name in the parent Sasquatch chart. |
 | square-events.cluster.name | string | `"sasquatch"` |  |
+| square-events.topics.slackViewSubmission.retentionMs | int | `1800000` | Retention period, in milliseconds, for the Slack `view_submission` interaction topic. These events drive project creation in templatebot, so retaining them well beyond the other Squarebot topics keeps the payload of a failed creation available for debugging and replay. |
 | strimzi-kafka.broker.affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchExpressions":[{"key":"app.kubernetes.io/name","operator":"In","values":["kafka"]}]},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for broker pod assignment |
 | strimzi-kafka.broker.backup | bool | `false` | Whether to label the broker PVCs for backup by k8up, enabled on the summit and base environments |
 | strimzi-kafka.broker.enabled | bool | `false` | Enable node pool for the kafka brokers |

--- a/applications/sasquatch/charts/square-events/README.md
+++ b/applications/sasquatch/charts/square-events/README.md
@@ -7,3 +7,4 @@ Kafka topics and users for SQuaRE Events.
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | cluster.name | string | `"sasquatch"` |  |
+| topics.slackViewSubmission.retentionMs | int | `1800000` | Retention period, in milliseconds, for the Slack `view_submission` interaction topic. These events drive project creation in templatebot, so retaining them well beyond the other Squarebot topics keeps the payload of a failed creation available for debugging and replay. |

--- a/applications/sasquatch/charts/square-events/templates/squarebot-topics.yaml
+++ b/applications/sasquatch/charts/square-events/templates/squarebot-topics.yaml
@@ -23,7 +23,7 @@ spec:
   replicas: 3
   config:
     # http://kafka.apache.org/documentation/#topicconfigs
-    retention.ms: 1800000  # 30 minutes
+    retention.ms: {{ int64 .Values.topics.slackViewSubmission.retentionMs }}
 ---
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic

--- a/applications/sasquatch/charts/square-events/values.yaml
+++ b/applications/sasquatch/charts/square-events/values.yaml
@@ -2,3 +2,11 @@ cluster:
   # The name of the Strimzi cluster. Synchronize this with the cluster name in
   # the parent Sasquatch chart.
   name: sasquatch
+
+topics:
+  slackViewSubmission:
+    # -- Retention period, in milliseconds, for the Slack `view_submission`
+    # interaction topic. These events drive project creation in templatebot,
+    # so retaining them well beyond the other Squarebot topics keeps the
+    # payload of a failed creation available for debugging and replay.
+    retentionMs: 1800000

--- a/applications/sasquatch/values-roundtable-dev.yaml
+++ b/applications/sasquatch/values-roundtable-dev.yaml
@@ -96,3 +96,8 @@ app-metrics:
 
 squareEvents:
   enabled: true
+
+square-events:
+  topics:
+    slackViewSubmission:
+      retentionMs: 604800000  # 7 days

--- a/applications/sasquatch/values-roundtable-prod.yaml
+++ b/applications/sasquatch/values-roundtable-prod.yaml
@@ -95,3 +95,8 @@ app-metrics:
 
 squareEvents:
   enabled: true
+
+square-events:
+  topics:
+    slackViewSubmission:
+      retentionMs: 7776000000  # 90 days

--- a/applications/templatebot/Chart.yaml
+++ b/applications/templatebot/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "0.5.6"
+appVersion: "0.5.7"
 description: Create new projects
 name: templatebot
 sources:

--- a/applications/templatebot/README.md
+++ b/applications/templatebot/README.md
@@ -11,6 +11,7 @@ Create new projects
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules for the templatebot deployment pod |
+| config.httpTimeout | int | `30` | Timeout, in seconds, for outbound HTTP requests made with the shared HTTP client (Slack, GitHub, and LSST the Docs). Connecting is bounded separately by a fixed 10 second timeout in the application. |
 | config.logLevel | string | `"INFO"` | Logging level |
 | config.logProfile | string | `"production"` | Logging profile (`production` for JSON, `development` for human-friendly) |
 | config.pathPrefix | string | `"/templatebot"` | URL path prefix |

--- a/applications/templatebot/templates/configmap.yaml
+++ b/applications/templatebot/templates/configmap.yaml
@@ -10,6 +10,7 @@ data:
   TEMPLATEBOT_PATH_PREFIX: {{ .Values.config.pathPrefix | quote }}
   TEMPLATEBOT_PROFILE: {{ .Values.config.logProfile | quote }}
   TEMPLATEBOT_TEMPLATE_REPO_URL: {{ .Values.config.templateRepoUrl | quote }}
+  TEMPLATEBOT_HTTP_TIMEOUT: {{ .Values.config.httpTimeout | quote }}
   TEMPLATEBOT_APP_MENTION_TOPIC: {{ .Values.config.topics.slackAppMention | quote }}
   TEMPLATEBOT_MESSAGE_IM_TOPIC: {{ .Values.config.topics.slackMessageIm | quote }}
   TEMPLATEBOT_BLOCK_ACTIONS_TOPIC: {{ .Values.config.topics.slackBlockActions | quote }}

--- a/applications/templatebot/values.yaml
+++ b/applications/templatebot/values.yaml
@@ -17,6 +17,11 @@ image:
   tag: null
 
 config:
+  # -- Timeout, in seconds, for outbound HTTP requests made with the shared
+  # HTTP client (Slack, GitHub, and LSST the Docs). Connecting is bounded
+  # separately by a fixed 10 second timeout in the application.
+  httpTimeout: 30
+
   # -- Logging level
   logLevel: "INFO"
 


### PR DESCRIPTION
## Summary

- Bump `templatebot` to [0.5.7](https://github.com/lsst-sqre/templatebot/releases/tag/0.5.7), which makes the shared `httpx.AsyncClient` timeout explicit and configurable. The client had no timeout set, so httpx's 5 s default governed every outbound Slack, GitHub, and LSST the Docs call — a slow Slack `chat.update` was enough to abort a technote request mid-flight with no repo and no error to the user.
- Add `config.httpTimeout` (default `30`), passed to the application as `TEMPLATEBOT_HTTP_TIMEOUT` in the config map. The default matches the application's own default, so this deploy is a no-op for behavior unless an environment overrides it. The connect phase is bounded separately by a fixed 10 s timeout inside the application and is deliberately not exposed here, so `httpTimeout` stays the single operator-facing knob.
- Make the retention of `lsst.square-events.squarebot.slack.interaction.view-submission` configurable per environment via `square-events.topics.slackViewSubmission.retentionMs`, and raise it from 30 minutes to **7 days on roundtable-dev** and **90 days on roundtable-prod**. That topic carries the modal payload that drives project creation, so retaining it well past the point of failure is what makes a lost request recoverable after the fact.

Notes for review:

- The templatebot bump jumps two versions: roundtable was on 0.5.6, and 0.5.7 is the first release since.
- The other Squarebot topics keep their 30 minute retention, and the `square-events` chart default is unchanged at 30 minutes, so no environment other than the two roundtables is affected.
- The topic template converts the value with `int64` so the 90 day figure renders as `7776000000` rather than in scientific notation.

## Validation steps

- `phalanx application lint templatebot` passes for `roundtable-dev` and `roundtable-prod`; `phalanx application lint sasquatch` passes for all 14 environments.
- `phalanx application template templatebot roundtable-prod` renders `TEMPLATEBOT_HTTP_TIMEOUT: "30"` in the config map and `image: "ghcr.io/lsst-sqre/templatebot:0.5.7"` in the deployment.
- `phalanx application template sasquatch <env>` renders `retention.ms: 604800000` on roundtable-dev and `retention.ms: 7776000000` on roundtable-prod for the view-submission topic, with every other Squarebot topic still at `1800000`.
- `ghcr.io/lsst-sqre/templatebot:0.5.7` is published as a multi-arch manifest (amd64 + arm64).
- After sync, confirm the templatebot pod comes up healthy on roundtable-dev with `TEMPLATEBOT_HTTP_TIMEOUT=30` in its environment, then exercise a template creation from Slack end to end.
- After sync, confirm the Strimzi topic operator has applied the new `retention.ms` to the existing view-submission topic (`kubectl describe kafkatopic` in the sasquatch namespace).

## References

- Release: https://github.com/lsst-sqre/templatebot/releases/tag/0.5.7
- Jira: https://rubinobs.atlassian.net/browse/DM-55835