### PR TITLE
DM-55835: deploy templatebot 0.6.0 with an operator alert webhook

### DIFF
--- a/applications/templatebot/Chart.yaml
+++ b/applications/templatebot/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "0.5.7"
+appVersion: "0.6.0"
 description: Create new projects
 name: templatebot
 sources:

--- a/applications/templatebot/secrets.yaml
+++ b/applications/templatebot/secrets.yaml
@@ -36,3 +36,10 @@ TEMPLATEBOT_LTD_USERNAME:
 TEMPLATEBOT_LTD_PASSWORD:
   description: >-
     The password for the LSST the Docs admin account.
+TEMPLATEBOT_SLACK_ALERT_WEBHOOK:
+  description: >-
+    Slack web hook to which Templatebot should post internal application
+    alerts, such as an abandoned project creation.
+  copy:
+    application: mobu
+    key: app-alert-webhook

--- a/applications/templatebot/templates/deployment.yaml
+++ b/applications/templatebot/templates/deployment.yaml
@@ -86,6 +86,11 @@ spec:
                 secretKeyRef:
                   name: "templatebot"
                   key: "TEMPLATEBOT_LTD_PASSWORD"
+            - name: "TEMPLATEBOT_SLACK_ALERT_WEBHOOK"
+              valueFrom:
+                secretKeyRef:
+                  name: "templatebot"
+                  key: "TEMPLATEBOT_SLACK_ALERT_WEBHOOK"
           volumeMounts:
             - name: "kafka"
               mountPath: "/etc/kafkacluster/ca.crt"


### PR DESCRIPTION
## Summary

Deploys [templatebot 0.6.0](https://github.com/lsst-sqre/templatebot/releases/tag/0.6.0),
which hardens the outbound HTTP path so a slow Slack call can no longer
silently discard a user's project-creation request.

Two changes:

- **Operator alert webhook.** Adds `TEMPLATEBOT_SLACK_ALERT_WEBHOOK`, copied
  from mobu's `app-alert-webhook` the same way Ook sources
  `OOK_SLACK_WEBHOOK`, and wires it into the deployment as an environment
  variable. Because it is a copied secret, no new static secret has to be
  entered in 1Password. Alerting is opt-in in the application and a no-op when
  the setting is unset.
- **Release deployment.** Bumps `appVersion` from 0.5.7 to 0.6.0.

The webhook is what makes 0.6.0's operator alert reach anyone, so the two land
together.

## What 0.6.0 changes

Slack Web API calls now retry transient failures with jittered backoff and
honour `Retry-After`; a Slack-side `{"ok": false}` raises `SlackApiError`
instead of being logged and ignored; cosmetic status updates can no longer
abort a project creation; and a genuinely failed creation reports the error to
the user in the channel, emits a `project_creation_abandoned` marker log, and
fires the operator alert this PR configures.

## Validation steps

- `helm template` of the templatebot chart with `values-roundtable-dev.yaml`
  renders `image: ghcr.io/lsst-sqre/templatebot:0.6.0` and the new
  `TEMPLATEBOT_SLACK_ALERT_WEBHOOK` env var backed by the `templatebot` secret.
- Pre-commit hooks (yamllint, jsonschema validation, helm-docs) pass on both
  commits. No `values.yaml` keys were added, so the chart README is unchanged.
- mobu is enabled on both roundtable-dev and roundtable-prod with
  `config.slackAlerts: true`, so the copied secret resolves in both.

**Requires a secrets sync before the new pods will start**, because the added
env var references a Vault key that does not exist yet — without it the
deployment fails with `CreateContainerConfigError`:

```
op run --env-file="op/roundtable-dev.env"  -- phalanx secrets sync roundtable-dev
op run --env-file="op/roundtable-prod.env" -- phalanx secrets sync roundtable-prod
```

Then confirm in Slack that a forced failure produces both the user-facing error
message and an operator alert.

## References

- Application PR: lsst-sqre/templatebot#120
- Release: [templatebot 0.6.0](https://github.com/lsst-sqre/templatebot/releases/tag/0.6.0)
- PRD: lsst-sqre/templatebot#112
- Jira: [DM-55835](https://rubinobs.atlassian.net/browse/DM-55835)
- Follows lsst-sqre/phalanx#6872, which deployed 0.5.7 and extended
  view-submission topic retention for the same incident.


[DM-55835]: https://rubinobs.atlassian.net/browse/DM-55835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ