### PR TITLE
DM-55846: Update InfluxDB OSS and Enterprise versions to 1.12.4

### DIFF
--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -66,7 +66,7 @@ Rubin Observatory's telemetry service
 | influxdb.config.logging.format | string | `"json"` | Format to use for log messages |
 | influxdb.config.logging.level | string | `"debug"` | Logging level |
 | influxdb.enabled | bool | `true` | Whether InfluxDB is enabled |
-| influxdb.image.tag | string | `"1.12.3"` | InfluxDB image tag |
+| influxdb.image.tag | string | `"1.12.4"` | InfluxDB image tag |
 | influxdb.ingress.annotations | object | See `values.yaml` | Annotations to add to the ingress |
 | influxdb.ingress.className | string | `"nginx"` | Ingress class to use |
 | influxdb.ingress.enabled | bool | `false` | Whether to enable the InfluxDB ingress |

--- a/applications/sasquatch/charts/influxdb-enterprise/Chart.yaml
+++ b/applications/sasquatch/charts/influxdb-enterprise/Chart.yaml
@@ -4,4 +4,4 @@ version: 1.0.0
 description: Run InfluxDB Enterprise on Kubernetes
 sources:
   - https://github.com/influxdata/influxdb
-appVersion: 1.12.3
+appVersion: 1.12.4

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -44,7 +44,7 @@ schema-registry:
 
 influxdb:
   image:
-    tag: 1.12.3
+    tag: 1.12.4
   ingress:
     enabled: false
     hostname: data-dev.lsst.cloud
@@ -56,7 +56,7 @@ customInfluxDBIngress:
 influxdb-enterprise:
   enabled: true
   image:
-    tag: 1.12.3
+    tag: 1.12.4
   license:
     secret:
       name: sasquatch

--- a/applications/sasquatch/values.yaml
+++ b/applications/sasquatch/values.yaml
@@ -30,7 +30,7 @@ influxdb:
 
   image:
     # -- InfluxDB image tag
-    tag: "1.12.3"
+    tag: "1.12.4"
 
   livenessProbe:
     # -- Liveness probe initial delay in seconds


### PR DESCRIPTION
Try InfluxDB 1.12.4 on IDF dev and then update other environments.
1.12.4 fix a regression in 1.12.3. 
It doesn’t affect us directly because we don’t use TSI but is good to stay current.
[InfluxDB Enterprise v1 release notes](https://docs.influxdata.com/enterprise_influxdb/v1/about-the-project/release-notes/)