### PR TITLE
Point USDF qserv-kafkas around socat proxies

### DIFF
--- a/applications/qserv-kafka/values-usdfdev.yaml
+++ b/applications/qserv-kafka/values-usdfdev.yaml
@@ -4,9 +4,9 @@ config:
     enabled: true
   slack:
     enabled: true
-  qservDatabaseUrl: "mysql+asyncmy://qsmaster@qserv-int.slac.stanford.edu:4090/"
+  qservDatabaseUrl: "mysql+asyncmy://qsmaster@sdfqserv009.sdf.slac.stanford.edu:4090/"
   qservRestSendApiVersion: false
-  qservRestUrl: "https://qserv-int-https.slac.stanford.edu:4098"
+  qservRestUrl: "https://sdfqserv009.sdf.slac.stanford.edu:4098"
   qservRestUsername: "qsmaster"
 frontend:
   allowRootDebug: true

--- a/applications/qserv-kafka/values-usdfint.yaml
+++ b/applications/qserv-kafka/values-usdfint.yaml
@@ -1,8 +1,8 @@
 config:
   logLevel: "DEBUG"
-  qservDatabaseUrl: "mysql+asyncmy://qsmaster@qserv-int.slac.stanford.edu:4090/"
+  qservDatabaseUrl: "mysql+asyncmy://qsmaster@sdfqserv009.sdf.slac.stanford.edu:4090/"
   qservRestSendApiVersion: false
-  qservRestUrl: "https://qserv-int-https.slac.stanford.edu:4098/"
+  qservRestUrl: "https://sdfqserv009.sdf.slac.stanford.edu:4098/"
   qservRestUsername: "qsmaster"
 frontend:
   allowRootDebug: true

--- a/applications/qserv-kafka/values-usdfprod.yaml
+++ b/applications/qserv-kafka/values-usdfprod.yaml
@@ -1,7 +1,7 @@
 config:
-  qservDatabaseUrl: "mysql+asyncmy://qsmaster@qserv-prod.slac.stanford.edu:4040/"
+  qservDatabaseUrl: "mysql+asyncmy://qsmaster@sdfqserv001.sdf.slac.stanford.edu:4040/"
   qservRestSendApiVersion: false
-  qservRestUrl: "https://qserv-prod-https.slac.stanford.edu:4048/"
+  qservRestUrl: "https://sdfqserv001.sdf.slac.stanford.edu:4048/"
   qservRestUsername: "qsmaster"
 redis:
   resources:


### PR DESCRIPTION
Point the USDF `qserv-kafka` instances directly at their current target USDF Docker Qserv instances, instead of routing via the socat proxies.

This will allow us to decommission the socat proxies, which are no longer in use by the IDF RSP deployments.