### PR TITLE
DM-55604: Deploy squareone branch image to idfdev

### DIFF
--- a/applications/squareone/values-idfdev.yaml
+++ b/applications/squareone/values-idfdev.yaml
@@ -1,4 +1,8 @@
 image:
+  # Branch build of squareone for DM-55604 (lsst-sqre/squareone#609):
+  # handled-error Sentry capture and the pino->Sentry Logs bridge.
+  # Revert to the chart appVersion once that PR is merged and released.
+  tag: "tickets-DM-55604-pino-logs"
   pullPolicy: Always
 
 ingress:


### PR DESCRIPTION
## Summary

Point idfdev (data-dev) at the `tickets-DM-55604-pino-logs` branch build of squareone so the DM-55604 work can be exercised on a real deployment before release.

That branch (lsst-sqre/squareone#609) adds:

- Handled-but-critical error capture: `reportError` with a dedupe window, applied across the client packages, the app data layer, and four UI components.
- A pino → Sentry Logs bridge for server-side warn/error/fatal records.
- An `/admin/sentry` smoke-test button that emits a marked server log on demand, so the bridge can be verified end-to-end from the browser.

Only `image.tag` is overridden, and only for idfdev — `pullPolicy: Always` is already set there on main, and `Chart.yaml` `appVersion` stays at 0.38.0, so every other environment keeps the released image (verified by rendering idfint/idfprod/usdfprod/summit).

## Validation steps

- `phalanx application lint squareone` passes for all 15 environments.
- `phalanx application template squareone idfdev` renders `ghcr.io/lsst-sqre/squareone:tickets-DM-55604-pino-logs` with `imagePullPolicy: Always`; idfint/idfprod/usdfprod/summit still render `0.38.0`.
- The image tag exists in GHCR as a multi-arch manifest, pushed by the CI run for squareone commit `9ff180ca`.

After sync, on data-dev:

- Visit `/admin/sentry` (requires `exec:admin`) and click **Emit server log**; confirm the readout reports delivery and names the `sentry-logs-smoke-test` marker, then find that record in Sentry Logs for the squareone project.
- Confirm the readout distinguishes a real failure: it only shows the "Search Sentry Logs" hint when the flush actually succeeded.
- Sanity-check the broadcast banner and app menu still render (the semaphore/repertoire clients were migrated to the new reporting query wrapper, with unchanged empty-fallback UX).

Note one deployment-visible change: `POST /admin/sentry/emit-log` now returns 403 `not_behind_ingress` unless the request carries Gafaelfawr's `X-Auth-Request-User` header, so in-cluster curl or a port-forward straight to the pod will be refused. Browser traffic through the `/admin` GafaelfawrIngress is unaffected.

## References

- squareone PR: lsst-sqre/squareone#609
- PRD: lsst-sqre/squareone#598
- Jira: https://rubinobs.atlassian.net/browse/DM-55604

**Revert before/after merge of the squareone release:** drop the `image.tag` override from `values-idfdev.yaml` once squareone is released and `appVersion` is bumped.