### PR TITLE
DM-55818: Update Ook to 0.26.0

### DIFF
--- a/applications/ook/Chart.yaml
+++ b/applications/ook/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: ook
 version: 1.0.0
-appVersion: "0.25.1"
+appVersion: "0.26.0"
 description: >
   Ook is the librarian service for Rubin Observatory. Ook indexes
   documentation content into the Algolia search engine that powers the Rubin


### PR DESCRIPTION
## Summary

Deploys **Ook 0.26.0** by bumping the chart's `appVersion`, and drops the roundtable-dev branch-image override this PR previously carried.

This PR started as a roundtable-dev deploy of the redirect-following branch image (`tickets-DM-55818`) built from lsst-sqre/ook#316, to test intersphinx inventory redirect handling ahead of a release. That fix has now shipped in [ook 0.26.0](https://github.com/lsst-sqre/ook/releases/tag/0.26.0), so the override is no longer needed: every Ook workload — the deployment and the `ingest-updated`, `ingest-texmf`, `audit`, `intersphinx-refresh`, and `linkcheck-recheck` cronjobs — templates its image as `.Values.image.tag | default .Chart.AppVersion` and so picks up 0.26.0 from the chart.

The net diff is one line. `values-roundtable-dev.yaml` returns to its state on `main`, and no other Ook values file carries a branch override.

What 0.26.0 delivers to production:

- **Intersphinx inventory redirects (DM-55818)** — the motivating fix. Redirecting `objects.inv` URLs previously failed as upstream errors and were negatively cached, making SQLAlchemy's, Pydantic's, and Sphinx's own inventories permanently uncacheable and 502-ing Documenteer builds. Chains are now followed with the SSRF guard applied per hop, a whole-fetch time budget, refresh backoff, and new `X-Ook-Inventory-*` response headers.
- **ORCID author lookup (DM-55866)** — `GET /ook/authors?orcid=` resolves an ORCID to its author, with the lsst-texmf ingest canonicalizing stored ORCIDs to match.
- **SQLAlchemy `pool_pre_ping` (DM-55688)** — idle connections dropped by the server are detected and replaced instead of failing the next request.

## Validation steps

- Confirm the Ook pods in roundtable-prod and roundtable-dev come up on `ghcr.io/lsst-sqre/ook:0.26.0` (the multi-arch manifest is published).
- Confirm `values-roundtable-dev.yaml` no longer pins `tickets-DM-55818` and that roundtable-dev moves off the branch image onto the release.
- Exercise `GET /ook/intersphinx/inventory?url=` against a known-redirecting inventory (SQLAlchemy's) and confirm a `200` with the inventory bytes rather than a `502`.
- Watch the `intersphinx-refresh` cronjob's next run for a clean exit and its refreshed/revalidated/failed counts.
- The pre-deployment `update-db-schema` job applies Alembic migrations, including the `date_refresh_failed` backoff column added in this release.

## References

- Release: https://github.com/lsst-sqre/ook/releases/tag/0.26.0
- Jira: https://rubinobs.atlassian.net/browse/DM-55818
- Ook PRs in this release: lsst-sqre/ook#316, lsst-sqre/ook#355, lsst-sqre/ook#356
