### PR TITLE
DM-55758: Return to a 75% CPU utilization for qserv-kafka

### DIFF
--- a/applications/qserv-kafka/README.md
+++ b/applications/qserv-kafka/README.md
@@ -90,7 +90,7 @@ Qserv Kafka bridge
 | slowWorker.autoscaling.enabled | bool | `true` | Enable autoscaling of qserv-kafka slow workers |
 | slowWorker.autoscaling.maxReplicas | int | `10` | Maximum number of qserv-kafka slow worker pods. Each replica will open database connections up to the configured pool size and overflow limits, so make sure the combined connections are under the connection limit. |
 | slowWorker.autoscaling.minReplicas | int | `1` | Minimum number of qserv-kafka slow worker pods |
-| slowWorker.autoscaling.targetCPUUtilizationPercentage | int | `30` | Target CPU utilization of qserv-kafka slow worker pods. |
+| slowWorker.autoscaling.targetCPUUtilizationPercentage | int | `75` | Target CPU utilization of qserv-kafka slow worker pods. |
 | slowWorker.nodeSelector | object | `{}` | Node selection rules for the qserv-kafka worker pods |
 | slowWorker.podAnnotations | object | `{}` | Annotations for the qserv-kafka worker pods |
 | slowWorker.replicaCount | int | `1` | Number of slow worker pods to start if autoscaling is disabled |

--- a/applications/qserv-kafka/values.yaml
+++ b/applications/qserv-kafka/values.yaml
@@ -272,7 +272,7 @@ slowWorker:
     maxReplicas: 10
 
     # -- Target CPU utilization of qserv-kafka slow worker pods.
-    targetCPUUtilizationPercentage: 30
+    targetCPUUtilizationPercentage: 75
 
   # -- Node selection rules for the qserv-kafka worker pods
   nodeSelector: {}


### PR DESCRIPTION
Increase the threshold for worker scaling to 75% again. The new release seems to once again be able to saturate a CPU.