### PR TITLE
DM-55874:   Load ivoa_obscore schema for the obsforgetap application

### DIFF
--- a/applications/repertoire/secrets.yaml
+++ b/applications/repertoire/secrets.yaml
@@ -22,7 +22,15 @@ livetap-database-password:
   copy:
     application: livetap
     key: tap-schema-password
-sentry-dsn:
+obsforgetap-database-password:
+  description: >-
+    Database password for the obsforgetap service, used by repertoire to manage
+    the obsforgetap TAP_SCHEMA. Copied from obsforgetap application's database-password.
+  if: config.tap.servers.obsforgetap.enabled
+  copy:
+    application: obsforgetap
+    key: tap-schema-password
+ssentry-dsn:
   description: >-
     DSN URL to which Sentry trace and error logging will be sent.
   if: config.sentry.enabled

--- a/applications/repertoire/secrets.yaml
+++ b/applications/repertoire/secrets.yaml
@@ -30,6 +30,14 @@ ppdbtap-database-password:
   copy:
     application: ppdbtap
     key: tap-schema-password
+obsforgetap-database-password:
+  description: >-
+    Database password for the obsforgetap service, used by repertoire to manage
+    the obsforgetap TAP_SCHEMA. Copied from obsforgetap application's database-password.
+  if: config.tap.servers.obsforgetap.enabled
+  copy:
+    application: obsforgetap
+    key: tap-schema-password
 sentry-dsn:
   description: >-
     DSN URL to which Sentry trace and error logging will be sent.

--- a/applications/repertoire/values-idfdev.yaml
+++ b/applications/repertoire/values-idfdev.yaml
@@ -25,6 +25,8 @@ config:
         enabled: true
       ssotap:
         enabled: true
+      obsforgetap:
+        enabled: true
   useSubdomains:
     - "nublado"
 

--- a/applications/repertoire/values-idfdev.yaml
+++ b/applications/repertoire/values-idfdev.yaml
@@ -28,6 +28,8 @@ config:
       ppdbtap:
         enabled: true
         schemaVersion: "tickets/DM-54475"
+      obsforgetap:
+        enabled: true
   useSubdomains:
     - "nublado"
 

--- a/applications/repertoire/values.yaml
+++ b/applications/repertoire/values.yaml
@@ -517,6 +517,13 @@ config:
         databaseUrl: "postgresql://ppdbtap@127.0.0.1:5432/ppdbtap"
         databasePasswordKey: "ppdbtap-database-password"
 
+      obsforgetap:
+        enabled: false
+        schemas:
+          - "ivoa_obscore"
+        databaseUrl: "postgresql://obsforgetap@127.0.0.1:5432/obsforgetap"
+        databasePasswordKey: "obsforgetap-database-password"
+
 cloudsql:
   # -- Enable the Cloud SQL Auth Proxy, used with Cloud SQL databases on
   # Google Cloud

--- a/applications/repertoire/values.yaml
+++ b/applications/repertoire/values.yaml
@@ -510,6 +510,13 @@ config:
         databaseUrl: "postgresql://livetap@127.0.0.1:5432/livetap"
         databasePasswordKey: "livetap-database-password"
 
+      obsforgetap:
+        enabled: false
+        schemas:
+          - "ivoa_obscore"
+        databaseUrl: "postgresql://obsforgetap@127.0.0.1:5432/obsforgetap"
+        databasePasswordKey: "obsforgetap-database-password"
+
 cloudsql:
   # -- Enable the Cloud SQL Auth Proxy, used with Cloud SQL databases on
   # Google Cloud


### PR DESCRIPTION
The `obsforgetap` application populates the `ivoa_obscore` schema. 
Use repertoire to load the `ivoa_obscore` schema from `sdm_schemas` to the `obsforgetap` database on CloudSQL.
Enable TAP_SCHEMA management for obsforgetap on idfdev for now.