### PR TITLE
DM-55454: Upgrade s3proxy to 2.0.1 and scale USDF HiPS deployments.

### DIFF
--- a/applications/s3proxy/Chart.yaml
+++ b/applications/s3proxy/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 1.0.0
+appVersion: 2.0.1
 description: Simple application to gateway S3 URLs to HTTPS
 name: s3proxy
 sources:

--- a/applications/s3proxy/README.md
+++ b/applications/s3proxy/README.md
@@ -11,6 +11,7 @@ Simple application to gateway S3 URLs to HTTPS
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules for the s3proxy deployment pod |
+| config.cacheMaxAge | int | `0` | Cache-Control max-age in seconds for image MIME types (0 disables) |
 | config.logLevel | string | `"INFO"` | Logging level |
 | config.logProfile | string | `"production"` | Logging profile (`production` for JSON, `development` for human-friendly) |
 | config.pathPrefix | string | `"/s3proxy"` | URL path prefix |

--- a/applications/s3proxy/templates/configmap.yaml
+++ b/applications/s3proxy/templates/configmap.yaml
@@ -8,6 +8,7 @@ data:
   S3PROXY_LOG_LEVEL: {{ .Values.config.logLevel | quote }}
   S3PROXY_PATH_PREFIX: {{ .Values.config.pathPrefix | quote }}
   S3PROXY_PROFILE: {{ .Values.config.logProfile | quote }}
+  S3PROXY_CACHE_MAX_AGE: {{ .Values.config.cacheMaxAge | quote }}
   S3_ENDPOINT_URL: {{ .Values.config.s3EndpointUrl | quote }}
   {{- range .Values.config.profiles }}
   LSST_RESOURCES_S3_PROFILE_{{ .name }}: {{ .url | quote }}

--- a/applications/s3proxy/values-usdfdev.yaml
+++ b/applications/s3proxy/values-usdfdev.yaml
@@ -1,3 +1,5 @@
+replicaCount: 8
+
 config:
   profiles:
     - name: embargo
@@ -5,11 +7,16 @@ config:
     - name: hips
       url: "https://sdfdatas3.slac.stanford.edu/"
   s3EndpointUrl: "https://s3dfrgw.slac.stanford.edu/"
+  cacheMaxAge: 86400
+
+ingress:
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-buffering: "off"
 
 resources:
   limits:
-    cpu: 500m
+    cpu: 1000m
     memory: 1Gi
   requests:
-    cpu: 200m
-    memory: 100Mi
+    cpu: 500m
+    memory: 256Mi

--- a/applications/s3proxy/values-usdfprod.yaml
+++ b/applications/s3proxy/values-usdfprod.yaml
@@ -1,3 +1,5 @@
+replicaCount: 8
+
 config:
   profiles:
     - name: embargo
@@ -5,11 +7,16 @@ config:
     - name: hips
       url: "https://sdfdatas3.slac.stanford.edu/"
   s3EndpointUrl: "https://s3dfrgw.slac.stanford.edu/"
+  cacheMaxAge: 86400
+
+ingress:
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-buffering: "off"
 
 resources:
   limits:
-    cpu: 500m
+    cpu: 1000m
     memory: 1Gi
   requests:
-    cpu: 200m
-    memory: 100Mi
+    cpu: 500m
+    memory: 256Mi

--- a/applications/s3proxy/values.yaml
+++ b/applications/s3proxy/values.yaml
@@ -33,6 +33,9 @@ config:
   # -- Default S3 endpoint URL
   s3EndpointUrl: ""
 
+  # -- Cache-Control max-age in seconds for image MIME types (0 disables)
+  cacheMaxAge: 0
+
 ingress:
   # -- Additional annotations for the ingress rule
   annotations: {}


### PR DESCRIPTION
## Summary
- Bump s3proxy chart `appVersion` to `2.0.1` (image tag from chart defaults)
- Scale s3proxy replicas/CPU to match currently running USDF deployments
- Enable `S3PROXY_CACHE_MAX_AGE` (86400s) for image tiles on usdf-dev and usdf-prod
- Disable nginx ingress proxy buffering for streamed responses
- Add `config.cacheMaxAge` Helm value wired through the configmap
Related: [DM-55454](https://rubinobs.atlassian.net/browse/DM-55454)
[DM-55454]: https://rubinobs.atlassian.net/browse/DM-55454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ