### PR TITLE
DM-55841: Update vo-cutouts to 5.1.1

### DIFF
--- a/applications/vo-cutouts/Chart.yaml
+++ b/applications/vo-cutouts/Chart.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 description: "Image cutout service complying with IVOA SODA"
 sources:
   - "https://github.com/lsst-sqre/vo-cutouts"
-appVersion: 5.1.0
+appVersion: 5.1.1
 
 dependencies:
   - name: redis


### PR DESCRIPTION
This version treats `ValueError` from the backend as a usage error rather than a backend error, which will get rid of some alert spam.