### PR TITLE
DM-55118: Migrate USDF RSP Int to CNPG instance

### DIFF
--- a/applications/gafaelfawr/values-usdfint.yaml
+++ b/applications/gafaelfawr/values-usdfint.yaml
@@ -9,7 +9,7 @@ config:
   sentry:
     enabled: true
 
-  internalDatabase: true
+  databaseUrl: postgresql://gafaelfawr@rsp-db-rw.postgres-db:5432/gafaelfawr
 
   oidcServer:
     enabled: true

--- a/applications/nublado/values-usdfint.yaml
+++ b/applications/nublado/values-usdfint.yaml
@@ -174,7 +174,7 @@ jupyterhub:
   hub:
     baseUrl: "/nb"
     db:
-      url: "postgresql://nublado3@postgres.postgres/nublado3"
+      url: "postgresql://nublado@rsp-db-rw.postgres-db/nublado"
       upgrade: true
   cull:
     timeout: 432000  # 5 days


### PR DESCRIPTION
Migrate the USDF RSP Int instances to the RSP Cloud Native Postgres instance by changing the connection strings.