### PR TITLE
DM-55471: Deploy Ook 0.27.0 and wire OOK_OIDC_AUDIENCE

### DIFF
--- a/applications/ook/Chart.yaml
+++ b/applications/ook/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: ook
 version: 1.0.0
-appVersion: "0.26.0"
+appVersion: "0.27.0"
 description: >
   Ook is the librarian service for Rubin Observatory. Ook indexes
   documentation content into the Algolia search engine that powers the Rubin

--- a/applications/ook/templates/configmap.yaml
+++ b/applications/ook/templates/configmap.yaml
@@ -2,6 +2,16 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: "ook"
+  {{- if or .Values.config.updateSchema .Values.config.migrateCountryCodes }}
+  # The schema update and country code migration Jobs run as Helm pre-install
+  # and pre-upgrade hooks (Argo CD PreSync) and take their configuration from
+  # this ConfigMap, so it has to be created in the same phase at a lower hook
+  # weight. Otherwise those Jobs see the previous sync's configuration.
+  annotations:
+    helm.sh/hook: "pre-install,pre-upgrade"
+    helm.sh/hook-delete-policy: "before-hook-creation"
+    helm.sh/hook-weight: "0"
+  {{- end }}
   labels:
     {{- include "ook.labels" . | nindent 4 }}
 data:

--- a/applications/ook/templates/configmap.yaml
+++ b/applications/ook/templates/configmap.yaml
@@ -25,6 +25,7 @@ data:
   {{- with .Values.config.linkcheck.userAgent }}
   OOK_LINKCHECK_USER_AGENT: {{ . | quote }}
   {{- end }}
+  OOK_OIDC_AUDIENCE: {{ printf "%s%s" (required "global.baseUrl must be set" .Values.global.baseUrl) .Values.ingress.path | quote }}
   OOK_INTERSPHINX_TTL: {{ .Values.config.intersphinx.ttl | quote }}
   OOK_INTERSPHINX_NEGATIVE_TTL: {{ .Values.config.intersphinx.negativeTtl | quote }}
   OOK_INTERSPHINX_ACTIVE_WINDOW: {{ .Values.config.intersphinx.activeWindow | quote }}

--- a/applications/ook/templates/ingress.yaml
+++ b/applications/ook/templates/ingress.yaml
@@ -115,9 +115,12 @@ template:
 
 ---
 # The link-check submit-and-poll API requires the exec:linkcheck scope
-# (delegated to documentation CI via OOK_TOKEN). This covers POST
-# /ook/linkcheck/checks and GET /ook/linkcheck/checks/{id}; the submitting
-# client polls its own check with the same token. The other linkcheck read
+# (delegated to documentation CI via OOK_TOKEN). The Prefix path covers POST
+# /ook/linkcheck/checks, GET /ook/linkcheck/checks/{id}, and POST
+# /ook/linkcheck/checks/{id}/contributions; the submitting client polls its
+# own check and contributes results with the same token. The GitHub Actions
+# OIDC id-token a contribution carries attests provenance only — write
+# authorization is this scope. The other linkcheck read
 # endpoints (/ook/linkcheck/urls and /ook/linkcheck/projects/...) remain
 # anonymous via the catch-all ook ingress.
 apiVersion: gafaelfawr.lsst.io/v1alpha1

--- a/applications/ook/templates/job-country-code-migration.yaml
+++ b/applications/ook/templates/job-country-code-migration.yaml
@@ -5,7 +5,9 @@ metadata:
   name: "ook-country-code-migrate"
   annotations:
     helm.sh/hook: "pre-install,pre-upgrade"
-    helm.sh/hook-delete-policy: "hook-succeeded"
+    # before-hook-creation clears out a Job left behind by a previous failed
+    # sync, which would otherwise block the retry with a name collision.
+    helm.sh/hook-delete-policy: "hook-succeeded,before-hook-creation"
     helm.sh/hook-weight: "10" # Ensure this runs after schema update
   labels:
     {{- include "ook.labels" . | nindent 4 }}

--- a/applications/ook/templates/job-schema-update.yaml
+++ b/applications/ook/templates/job-schema-update.yaml
@@ -5,7 +5,9 @@ metadata:
   name: "ook-schema-update"
   annotations:
     helm.sh/hook: "pre-install,pre-upgrade"
-    helm.sh/hook-delete-policy: "hook-succeeded"
+    # before-hook-creation clears out a Job left behind by a previous failed
+    # sync, which would otherwise block the retry with a name collision.
+    helm.sh/hook-delete-policy: "hook-succeeded,before-hook-creation"
     helm.sh/hook-weight: "1"
   labels:
     {{- include "ook.labels" . | nindent 4 }}

--- a/applications/ook/templates/vaultsecret.yaml
+++ b/applications/ook/templates/vaultsecret.yaml
@@ -2,6 +2,14 @@ apiVersion: ricoberger.de/v1alpha1
 kind: VaultSecret
 metadata:
   name: "ook"
+  {{- if or .Values.config.updateSchema .Values.config.migrateCountryCodes }}
+  # See the comment in configmap.yaml: the pre-install and pre-upgrade Jobs
+  # also need this secret to exist before they run.
+  annotations:
+    helm.sh/hook: "pre-install,pre-upgrade"
+    helm.sh/hook-delete-policy: "before-hook-creation"
+    helm.sh/hook-weight: "0"
+  {{- end }}
   labels:
     {{- include "ook.labels" . | nindent 4 }}
 spec:

--- a/applications/ook/values-roundtable-dev.yaml
+++ b/applications/ook/values-roundtable-dev.yaml
@@ -1,3 +1,9 @@
+# TEMPORARY branch-image override for testing the link-check contributions
+# API (lsst-sqre/ook#366, DM-55471). Revert both keys before merging.
+image:
+  tag: "tickets-DM-55471"
+  pullPolicy: "Always"
+
 config:
   logLevel: "DEBUG"
   databaseUrl: "postgresql://ook@localhost/ook"

--- a/applications/ook/values-roundtable-dev.yaml
+++ b/applications/ook/values-roundtable-dev.yaml
@@ -1,9 +1,3 @@
-# TEMPORARY branch-image override for testing the link-check contributions
-# API (lsst-sqre/ook#366, DM-55471). Revert both keys before merging.
-image:
-  tag: "tickets-DM-55471"
-  pullPolicy: "Always"
-
 config:
   logLevel: "DEBUG"
   databaseUrl: "postgresql://ook@localhost/ook"


### PR DESCRIPTION
## Summary

Deploys [Ook 0.27.0](https://github.com/lsst-sqre/ook/releases/tag/0.27.0), which adds the link-check contributions API ([lsst-sqre/ook#366](https://github.com/lsst-sqre/ook/pull/366)), and supplies the required `OOK_OIDC_AUDIENCE` setting that release introduces.

A contributing client posts results it observed from its own vantage point — the case Ook's GKE egress is bot-blocked from — and attests provenance with a GitHub Actions OIDC id-token. Verifying that token needs an audience, so Ook makes `OOK_OIDC_AUDIENCE` required with no default: it will not start without it.

Three things land together:

1. **`OOK_OIDC_AUDIENCE` wired from the environment's base URL** (below).
2. **The ConfigMap and VaultSecret run as PreSync hooks** — a prerequisite for this upgrade, not a cleanup (below).
3. **`appVersion` 0.26.0 → 0.27.0**, and the temporary `tickets-DM-55471` branch-image override on roundtable-dev reverted, so both environments run the released image.

## The audience is derived, not configured per environment

The ConfigMap builds it from the Argo CD-injected `global.baseUrl` plus the application's own `ingress.path`:

```yaml
OOK_OIDC_AUDIENCE: {{ printf "%s%s" (required "global.baseUrl must be set" .Values.global.baseUrl) .Values.ingress.path | quote }}
```

which renders as:

| Environment | Rendered audience |
|---|---|
| roundtable-dev | `https://roundtable-dev.lsst.cloud/ook` |
| roundtable-prod | `https://roundtable.lsst.cloud/ook` |

This follows the established Phalanx pattern for an application referring to its own public URL (`butler` builds its repository URLs as `global.baseUrl` + `config.pathPrefix`; `grafana` builds `root_url` the same way; `atlantis` and `nublado` likewise). Deriving it means the audience cannot drift away from the ingress the service is actually served at, and no environment needs to restate its own hostname.

The audience must be per-environment: it is precisely what stops a token minted for the dev deployment being replayed against production, which is why Ook makes the setting required.

Repertoire was considered and is not the right mechanism. It is runtime service *discovery* — it answers "what is the URL of service X" for clients, from `config.rules`. It is not a Helm-time source of an application's own URL, `ook` is not among its registered rules, and it is not deployed on roundtable-dev at all.

## The ConfigMap must reach the pre-upgrade Jobs

`ook-schema-update` and `ook-country-code-migrate` run as Helm `pre-install,pre-upgrade` hooks (Argo CD PreSync) and take their configuration with `envFrom: configMapRef: {name: ook}`. The ConfigMap itself was an ordinary resource, so it was applied in the main sync phase — *after* those Jobs had already run against the previous sync's copy.

That is a latent bug in any config-changing deploy, and this release trips it: the pre-upgrade `ook update-db-schema` Job would start from a ConfigMap with no `OOK_OIDC_AUDIENCE`, and 0.27.0 refuses to start without it, so the Job would fail before running a single migration and the sync would never reach the Deployment.

The ConfigMap and VaultSecret therefore carry the same hook annotations at `hook-weight: 0`, ahead of the schema update (weight 1) and the country-code migration (weight 10). They are annotated only when one of those Jobs is enabled, so an environment that runs neither keeps them as plain resources. Both Jobs also gain `before-hook-creation` alongside `hook-succeeded` in their delete policy, so a Job left behind by a failed sync no longer blocks the retry with a name collision.

## Migrations

0.27.0 carries two Alembic migrations, applied by the pre-upgrade `ook update-db-schema` Job:

- `0bfe17a5f990` — adds the `linkcheck_contribution` table and the `result_source` / `contributed_by` columns on `checked_url` (existing rows backfill to the `server` source).
- `f43554a10acb` — renames link-check's datetime columns to the `date_` convention, in place, preserving stored history.

roundtable-dev already sits at `0bfe17a5f990` from the branch deployment, so only `f43554a10acb` applies there. roundtable-prod is at 0.26.0 (`6f68334c9c9b`) and applies both.

## Ingress

No ingress change is needed: the `exec:linkcheck` `GafaelfawrIngress` is a `Prefix` match on `{{ .Values.ingress.path }}/linkcheck/checks`, so it already covers `POST /ook/linkcheck/checks/{id}/contributions`. Its comment is updated to say so, and to record that the OIDC id-token attests provenance while `exec:linkcheck` remains the write authorization.

## Validation steps

- `helm template` for roundtable-prod renders `OOK_OIDC_AUDIENCE: "https://roundtable.lsst.cloud/ook"` and `ghcr.io/lsst-sqre/ook:0.27.0` across the Deployment and all four CronJobs.
- `helm template` for roundtable-dev renders `OOK_OIDC_AUDIENCE: "https://roundtable-dev.lsst.cloud/ook"` and the same `0.27.0` image — the branch-image override and its `pullPolicy: Always` are gone.
- Rendering without `global.baseUrl` fails loudly with `global.baseUrl must be set` rather than emitting a truncated audience.
- `helm lint` passes; pre-commit (yamllint, helm-docs, merge-conflict, trailing whitespace) passes. No new Helm values, so no `helm-docs` regeneration is needed.
- The `0.27.0` image is in GHCR from the tagged release build.

After sync, confirm that the PreSync `ook-schema-update` Job succeeds (it is the first thing to consume the new ConfigMap), that the ook pod starts — a missing or wrong audience surfaces at startup, since the field is required — and that a contribution carrying a token minted for that environment's audience verifies while one minted for the other environment's audience is rejected.

## References

- Ook release: [0.27.0](https://github.com/lsst-sqre/ook/releases/tag/0.27.0)
- Ook PR: lsst-sqre/ook#366
- Ook PRD: lsst-sqre/ook#293
- Jira: [DM-55471](https://rubinobs.atlassian.net/browse/DM-55471)

[DM-55471]: https://rubinobs.atlassian.net/browse/DM-55471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
