### PR TITLE
DM-55894: Add biquery-kafka serviceAccountName to bigquery-kafka fast worker deployment

### DIFF
--- a/applications/bigquery-kafka/templates/fast-worker-deployment.yaml
+++ b/applications/bigquery-kafka/templates/fast-worker-deployment.yaml
@@ -28,7 +28,8 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      automountServiceAccountToken: false
+      automountServiceAccountToken: true
+      serviceAccountName: "bigquery-kafka"
       containers:
         - name: "{{ .Chart.Name }}-fast-worker"
           command:


### PR DESCRIPTION
Since `qserv-kafka` version **6.0** we introduced an additional worker deployment to `biguery-kafka` (fast worker) which needs a service account in order to make authenticated requests to the BigQuery API.

Change here adds the "bigquery-kafka" `serviceAccountName` to the fast worker deployment and sets `automountServiceAccountToken` = `true`.