### PR TITLE
DM-55895: Enable ppdbtap in repertoire for idfint to enable move to CloudSQL tap_schema

### DIFF
--- a/applications/ppdbtap/README.md
+++ b/applications/ppdbtap/README.md
@@ -16,6 +16,10 @@ TAP service for the ppdb BigQuery backend
 | cadc-tap.config.voParquet | bool | `true` | Advertise VOParquet as a supported output format |
 | cadc-tap.ingress.path | string | `"ppdbtap"` | Ingress path that should be routed to this service |
 | cadc-tap.serviceAccount.name | string | `"ppdbtap"` | Name of the Kubernetes `ServiceAccount`, used for CloudSQL access |
+| cadc-tap.tapSchema.database | string | `"ppdbtap"` | Database name |
+| cadc-tap.tapSchema.type | string | `"cloudsql"` | Database backend type: "containerized", "cloudsql", or "external" |
+| cadc-tap.tapSchema.useVaultPassword | bool | `true` | Whether the TAP_SCHEMA database requires a password in Vault (true for cloudsql/external) |
+| cadc-tap.tapSchema.username | string | `"ppdbtap"` | Database username |
 | cadc-tap.uws.database | string | `"ppdbtap"` | Database name |
 | cadc-tap.uws.type | string | `"cloudsql"` | Database backend type: "containerized", "cloudsql", or "external" |
 | cadc-tap.uws.useVaultPassword | bool | `true` | Whether the UWS database requires a password in Vault (true for cloudsql/external) |

--- a/applications/ppdbtap/values-idfdev.yaml
+++ b/applications/ppdbtap/values-idfdev.yaml
@@ -1,10 +1,4 @@
 cadc-tap:
-  tapSchema:
-    type: "cloudsql"
-    database: "ppdbtap"
-    username: "ppdbtap"
-    useVaultPassword: true
-
   config:
     backend: "bigquery"
     kafka:

--- a/applications/ppdbtap/values-idfint.yaml
+++ b/applications/ppdbtap/values-idfint.yaml
@@ -1,10 +1,4 @@
 cadc-tap:
-  tapSchema:
-    image:
-      repository: "lsstsqre/tap-schema-idfint-ppdbtap"
-      tag: "main"
-      pullPolicy: "Always"
-
   config:
     backend: "bigquery"
     kafka:

--- a/applications/ppdbtap/values.yaml
+++ b/applications/ppdbtap/values.yaml
@@ -44,6 +44,19 @@ cadc-tap:
     # -- Whether the UWS database requires a password in Vault (true for cloudsql/external)
     useVaultPassword: true
 
+  tapSchema:
+    # -- Database backend type: "containerized", "cloudsql", or "external"
+    type: "cloudsql"
+
+    # -- Database name
+    database: "ppdbtap"
+
+    # -- Database username
+    username: "ppdbtap"
+
+    # -- Whether the TAP_SCHEMA database requires a password in Vault (true for cloudsql/external)
+    useVaultPassword: true
+
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:

--- a/applications/repertoire/values-idfdev.yaml
+++ b/applications/repertoire/values-idfdev.yaml
@@ -21,11 +21,11 @@ config:
   slackAlerts: true
   tap:
     servers:
-      tap:
+      ppdbtap:
         enabled: true
       ssotap:
         enabled: true
-      ppdbtap:
+      tap:
         enabled: true
   useSubdomains:
     - "nublado"

--- a/applications/repertoire/values-idfint.yaml
+++ b/applications/repertoire/values-idfint.yaml
@@ -13,9 +13,11 @@ config:
   slackAlerts: true
   tap:
     servers:
-      tap:
+      ppdbtap:
         enabled: true
       ssotap:
+        enabled: true
+      tap:
         enabled: true
   useSubdomains:
     - "nublado"

--- a/applications/repertoire/values-idfint.yaml
+++ b/applications/repertoire/values-idfint.yaml
@@ -15,6 +15,7 @@ config:
     servers:
       ppdbtap:
         enabled: true
+        schemaVersion: "releases/w.2026.33"
       ssotap:
         enabled: true
       tap:

--- a/charts/cadc-tap/templates/tap-deployment.yaml
+++ b/charts/cadc-tap/templates/tap-deployment.yaml
@@ -125,7 +125,6 @@ spec:
                 -Dtapschemauser.url=jdbc:postgresql://localhost:5432/{{ .Values.tapSchema.database }}
                 {{- end }}
                 -Dtapschemauser.maxActive={{ .Values.tapSchema.tapuser.maxActive }}
-                -Dtapuser.maxActive={{ .Values.tapSchema.tapuser.maxActive }}
                 -Dtapadm.maxActive={{ .Values.tapSchema.tapadm.maxActive }}
                 -Dtapuser.maxActive={{ .Values.tapSchema.tapuser.maxActive }}
                 -Duws.username={{ .Values.uws.username }}


### PR DESCRIPTION
Changes:
- Make `cloudsql` the default tap_schema type for `ppdbtap` and set the appropriate configuration for it
- Enable `ppdbtap` in repertoire for `idfint`
- Re-order tap.servers for idfint & idfdev
- Fix cadc-tap chart bug in deployment with duplicate `tapuser` `maxActive` setting