### PR TITLE
DM-55882: Add support to json_v2 data format in Sasquatch telegraf configuration

### DIFF
--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -859,6 +859,7 @@ Rubin Observatory's telemetry service
 | telegraf.kafkaConsumers.test.collection_jitter | string | "0s" | Data collection jitter. This is used to jitter the collection by a random amount. Each plugin will sleep for a random time within jitter before collecting. |
 | telegraf.kafkaConsumers.test.compression_codec | int | 3 | Compression codec. 0 : None, 1 : Gzip, 2 : Snappy, 3 : LZ4, 4 : ZSTD |
 | telegraf.kafkaConsumers.test.consumer_fetch_default | string | "1MB" | Maximum amount of data the server should return for a fetch request. |
+| telegraf.kafkaConsumers.test.data_format | string | `"avro"` | Input data format. Supported values are `avro` and `json_v2`. |
 | telegraf.kafkaConsumers.test.database | string | `""` | Name of the InfluxDB v1 database to write to (required) |
 | telegraf.kafkaConsumers.test.debug | bool | false | Run Telegraf in debug mode. |
 | telegraf.kafkaConsumers.test.enabled | bool | `false` | Enable the Telegraf Kafka consumer. |
@@ -872,8 +873,8 @@ Rubin Observatory's telemetry service
 | telegraf.kafkaConsumers.test.offset | string | `"oldest"` | Kafka consumer offset. Possible values are `oldest` and `newest`. |
 | telegraf.kafkaConsumers.test.precision | string | "1us" | Data precision. |
 | telegraf.kafkaConsumers.test.replicaCount | int | `1` | Number of Telegraf Kafka consumer replicas. Increase this value to increase the consumer throughput. |
-| telegraf.kafkaConsumers.test.tags | list | `[]` | List of Avro fields to be recorded as InfluxDB tags.  The Avro fields specified as tags will be converted to strings before ingestion into InfluxDB. |
-| telegraf.kafkaConsumers.test.timestamp_field | string | `"private_efdStamp"` | Avro field to be used as the InfluxDB timestamp (optional).  If unspecified or set to the empty string, Telegraf will use the time it received the measurement. |
+| telegraf.kafkaConsumers.test.tags | list | `[]` | List of input fields to be recorded as InfluxDB tags.  The input fields specified as tags will be converted to strings before ingestion into InfluxDB. |
+| telegraf.kafkaConsumers.test.timestamp_field | string | `"private_efdStamp"` | Input field to be used as the InfluxDB timestamp (optional).  If unspecified or set to the empty string, Telegraf will use the time it received the measurement. |
 | telegraf.kafkaConsumers.test.timestamp_format | string | `"unix"` | Timestamp format. Possible values are `unix` (the default if unset) a timestamp in seconds since the Unix epoch, `unix_ms` (milliseconds), `unix_us` (microsseconds), or `unix_ns` (nanoseconds). |
 | telegraf.kafkaConsumers.test.topicRegexps | list | `[".*Test"]` | List of regular expressions to specify the Kafka topics consumed by this agent. |
 | telegraf.kafkaConsumers.test.union_field_separator | string | `""` | Union field separator: if a single Avro field is flattened into more than one InfluxDB field (e.g. an array `a`, with four members, would yield `a0`, `a1`, `a2`, `a3`; if the field separator were `_`, these would be `a_0`...`a_3`. |
@@ -898,6 +899,7 @@ Rubin Observatory's telemetry service
 | telegraf-standby.kafkaConsumers.test.collection_jitter | string | "0s" | Data collection jitter. This is used to jitter the collection by a random amount. Each plugin will sleep for a random time within jitter before collecting. |
 | telegraf-standby.kafkaConsumers.test.compression_codec | int | 3 | Compression codec. 0 : None, 1 : Gzip, 2 : Snappy, 3 : LZ4, 4 : ZSTD |
 | telegraf-standby.kafkaConsumers.test.consumer_fetch_default | string | "1MB" | Maximum amount of data the server should return for a fetch request. |
+| telegraf-standby.kafkaConsumers.test.data_format | string | `"avro"` | Input data format. Supported values are `avro` and `json_v2`. |
 | telegraf-standby.kafkaConsumers.test.database | string | `""` | Name of the InfluxDB v1 database to write to (required) |
 | telegraf-standby.kafkaConsumers.test.debug | bool | false | Run Telegraf in debug mode. |
 | telegraf-standby.kafkaConsumers.test.enabled | bool | `false` | Enable the Telegraf Kafka consumer. |
@@ -911,8 +913,8 @@ Rubin Observatory's telemetry service
 | telegraf-standby.kafkaConsumers.test.offset | string | `"oldest"` | Kafka consumer offset. Possible values are `oldest` and `newest`. |
 | telegraf-standby.kafkaConsumers.test.precision | string | "1us" | Data precision. |
 | telegraf-standby.kafkaConsumers.test.replicaCount | int | `1` | Number of Telegraf Kafka consumer replicas. Increase this value to increase the consumer throughput. |
-| telegraf-standby.kafkaConsumers.test.tags | list | `[]` | List of Avro fields to be recorded as InfluxDB tags.  The Avro fields specified as tags will be converted to strings before ingestion into InfluxDB. |
-| telegraf-standby.kafkaConsumers.test.timestamp_field | string | `"private_efdStamp"` | Avro field to be used as the InfluxDB timestamp (optional).  If unspecified or set to the empty string, Telegraf will use the time it received the measurement. |
+| telegraf-standby.kafkaConsumers.test.tags | list | `[]` | List of input fields to be recorded as InfluxDB tags.  The input fields specified as tags will be converted to strings before ingestion into InfluxDB. |
+| telegraf-standby.kafkaConsumers.test.timestamp_field | string | `"private_efdStamp"` | Input field to be used as the InfluxDB timestamp (optional).  If unspecified or set to the empty string, Telegraf will use the time it received the measurement. |
 | telegraf-standby.kafkaConsumers.test.timestamp_format | string | `"unix"` | Timestamp format. Possible values are `unix` (the default if unset) a timestamp in seconds since the Unix epoch, `unix_ms` (milliseconds), `unix_us` (microsseconds), or `unix_ns` (nanoseconds). |
 | telegraf-standby.kafkaConsumers.test.topicRegexps | list | `[".*Test"]` | List of regular expressions to specify the Kafka topics consumed by this agent. |
 | telegraf-standby.kafkaConsumers.test.union_field_separator | string | `""` | Union field separator: if a single Avro field is flattened into more than one InfluxDB field (e.g. an array `a`, with four members, would yield `a0`, `a1`, `a2`, `a3`; if the field separator were `_`, these would be `a_0`...`a_3`. |

--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -879,6 +879,16 @@ Rubin Observatory's telemetry service
 | telegraf.kafkaConsumers.test.topicRegexps | list | `[".*Test"]` | List of regular expressions to specify the Kafka topics consumed by this agent. |
 | telegraf.kafkaConsumers.test.union_field_separator | string | `""` | Union field separator: if a single Avro field is flattened into more than one InfluxDB field (e.g. an array `a`, with four members, would yield `a0`, `a1`, `a2`, `a3`; if the field separator were `_`, these would be `a_0`...`a_3`. |
 | telegraf.kafkaConsumers.test.union_mode | string | `"nullable"` | Union mode: this can be one of `flatten`, `nullable`, or `any`. See `values.yaml` for extensive discussion. |
+| telegraf.kafkaConsumers.test_json_v2.compression_codec | int | `3` |  |
+| telegraf.kafkaConsumers.test_json_v2.data_format | string | `"json_v2"` |  |
+| telegraf.kafkaConsumers.test_json_v2.database | string | `""` |  |
+| telegraf.kafkaConsumers.test_json_v2.enabled | bool | `false` |  |
+| telegraf.kafkaConsumers.test_json_v2.offset | string | `"oldest"` |  |
+| telegraf.kafkaConsumers.test_json_v2.replicaCount | int | `1` |  |
+| telegraf.kafkaConsumers.test_json_v2.tags[0] | string | `"tag"` |  |
+| telegraf.kafkaConsumers.test_json_v2.timestamp_field | string | `"timestamp"` |  |
+| telegraf.kafkaConsumers.test_json_v2.timestamp_format | string | `"unix"` |  |
+| telegraf.kafkaConsumers.test_json_v2.topicRegexps[0] | string | `".*JsonV2Test"` |  |
 | telegraf.kafkaVersion | string | `"4.0.0"` |  |
 | telegraf.nodeSelector | object | `{}` | Node labels for pod assignment |
 | telegraf.podAnnotations | object | `{}` | Annotations for the Telegraf pods |
@@ -919,6 +929,16 @@ Rubin Observatory's telemetry service
 | telegraf-standby.kafkaConsumers.test.topicRegexps | list | `[".*Test"]` | List of regular expressions to specify the Kafka topics consumed by this agent. |
 | telegraf-standby.kafkaConsumers.test.union_field_separator | string | `""` | Union field separator: if a single Avro field is flattened into more than one InfluxDB field (e.g. an array `a`, with four members, would yield `a0`, `a1`, `a2`, `a3`; if the field separator were `_`, these would be `a_0`...`a_3`. |
 | telegraf-standby.kafkaConsumers.test.union_mode | string | `"nullable"` | Union mode: this can be one of `flatten`, `nullable`, or `any`. See `values.yaml` for extensive discussion. |
+| telegraf-standby.kafkaConsumers.test_json_v2.compression_codec | int | `3` |  |
+| telegraf-standby.kafkaConsumers.test_json_v2.data_format | string | `"json_v2"` |  |
+| telegraf-standby.kafkaConsumers.test_json_v2.database | string | `""` |  |
+| telegraf-standby.kafkaConsumers.test_json_v2.enabled | bool | `false` |  |
+| telegraf-standby.kafkaConsumers.test_json_v2.offset | string | `"oldest"` |  |
+| telegraf-standby.kafkaConsumers.test_json_v2.replicaCount | int | `1` |  |
+| telegraf-standby.kafkaConsumers.test_json_v2.tags[0] | string | `"tag"` |  |
+| telegraf-standby.kafkaConsumers.test_json_v2.timestamp_field | string | `"timestamp"` |  |
+| telegraf-standby.kafkaConsumers.test_json_v2.timestamp_format | string | `"unix"` |  |
+| telegraf-standby.kafkaConsumers.test_json_v2.topicRegexps[0] | string | `".*JsonV2Test"` |  |
 | telegraf-standby.kafkaVersion | string | `"4.0.0"` |  |
 | telegraf-standby.nodeSelector | object | `{}` | Node labels for pod assignment |
 | telegraf-standby.podAnnotations | object | `{}` | Annotations for the Telegraf pods |

--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -875,7 +875,7 @@ Rubin Observatory's telemetry service
 | telegraf.kafkaConsumers.test.tags | list | `[]` | List of Avro fields to be recorded as InfluxDB tags.  The Avro fields specified as tags will be converted to strings before ingestion into InfluxDB. |
 | telegraf.kafkaConsumers.test.timestamp_field | string | `"private_efdStamp"` | Avro field to be used as the InfluxDB timestamp (optional).  If unspecified or set to the empty string, Telegraf will use the time it received the measurement. |
 | telegraf.kafkaConsumers.test.timestamp_format | string | `"unix"` | Timestamp format. Possible values are `unix` (the default if unset) a timestamp in seconds since the Unix epoch, `unix_ms` (milliseconds), `unix_us` (microsseconds), or `unix_ns` (nanoseconds). |
-| telegraf.kafkaConsumers.test.topicRegexps | string | `"[ \".*Test\" ]\n"` | List of regular expressions to specify the Kafka topics consumed by this agent. |
+| telegraf.kafkaConsumers.test.topicRegexps | list | `[".*Test"]` | List of regular expressions to specify the Kafka topics consumed by this agent. |
 | telegraf.kafkaConsumers.test.union_field_separator | string | `""` | Union field separator: if a single Avro field is flattened into more than one InfluxDB field (e.g. an array `a`, with four members, would yield `a0`, `a1`, `a2`, `a3`; if the field separator were `_`, these would be `a_0`...`a_3`. |
 | telegraf.kafkaConsumers.test.union_mode | string | `"nullable"` | Union mode: this can be one of `flatten`, `nullable`, or `any`. See `values.yaml` for extensive discussion. |
 | telegraf.kafkaVersion | string | `"4.0.0"` |  |
@@ -914,7 +914,7 @@ Rubin Observatory's telemetry service
 | telegraf-standby.kafkaConsumers.test.tags | list | `[]` | List of Avro fields to be recorded as InfluxDB tags.  The Avro fields specified as tags will be converted to strings before ingestion into InfluxDB. |
 | telegraf-standby.kafkaConsumers.test.timestamp_field | string | `"private_efdStamp"` | Avro field to be used as the InfluxDB timestamp (optional).  If unspecified or set to the empty string, Telegraf will use the time it received the measurement. |
 | telegraf-standby.kafkaConsumers.test.timestamp_format | string | `"unix"` | Timestamp format. Possible values are `unix` (the default if unset) a timestamp in seconds since the Unix epoch, `unix_ms` (milliseconds), `unix_us` (microsseconds), or `unix_ns` (nanoseconds). |
-| telegraf-standby.kafkaConsumers.test.topicRegexps | string | `"[ \".*Test\" ]\n"` | List of regular expressions to specify the Kafka topics consumed by this agent. |
+| telegraf-standby.kafkaConsumers.test.topicRegexps | list | `[".*Test"]` | List of regular expressions to specify the Kafka topics consumed by this agent. |
 | telegraf-standby.kafkaConsumers.test.union_field_separator | string | `""` | Union field separator: if a single Avro field is flattened into more than one InfluxDB field (e.g. an array `a`, with four members, would yield `a0`, `a1`, `a2`, `a3`; if the field separator were `_`, these would be `a_0`...`a_3`. |
 | telegraf-standby.kafkaConsumers.test.union_mode | string | `"nullable"` | Union mode: this can be one of `flatten`, `nullable`, or `any`. See `values.yaml` for extensive discussion. |
 | telegraf-standby.kafkaVersion | string | `"4.0.0"` |  |

--- a/applications/sasquatch/charts/telegraf/README.md
+++ b/applications/sasquatch/charts/telegraf/README.md
@@ -19,6 +19,7 @@ Telegraf is an agent for collecting, processing, aggregating, and writing metric
 | kafkaConsumers.test.collection_jitter | string | "0s" | Data collection jitter. This is used to jitter the collection by a random amount. Each plugin will sleep for a random time within jitter before collecting. |
 | kafkaConsumers.test.compression_codec | int | 3 | Compression codec. 0 : None, 1 : Gzip, 2 : Snappy, 3 : LZ4, 4 : ZSTD |
 | kafkaConsumers.test.consumer_fetch_default | string | "1MB" | Maximum amount of data the server should return for a fetch request. |
+| kafkaConsumers.test.data_format | string | `"avro"` | Input data format. Supported values are `avro` and `json_v2`. |
 | kafkaConsumers.test.database | string | `""` | Name of the InfluxDB v1 database to write to (required) |
 | kafkaConsumers.test.debug | bool | false | Run Telegraf in debug mode. |
 | kafkaConsumers.test.enabled | bool | `false` | Enable the Telegraf Kafka consumer. |
@@ -32,8 +33,8 @@ Telegraf is an agent for collecting, processing, aggregating, and writing metric
 | kafkaConsumers.test.offset | string | `"oldest"` | Kafka consumer offset. Possible values are `oldest` and `newest`. |
 | kafkaConsumers.test.precision | string | "1us" | Data precision. |
 | kafkaConsumers.test.replicaCount | int | `1` | Number of Telegraf Kafka consumer replicas. Increase this value to increase the consumer throughput. |
-| kafkaConsumers.test.tags | list | `[]` | List of Avro fields to be recorded as InfluxDB tags.  The Avro fields specified as tags will be converted to strings before ingestion into InfluxDB. |
-| kafkaConsumers.test.timestamp_field | string | `"private_efdStamp"` | Avro field to be used as the InfluxDB timestamp (optional).  If unspecified or set to the empty string, Telegraf will use the time it received the measurement. |
+| kafkaConsumers.test.tags | list | `[]` | List of input fields to be recorded as InfluxDB tags.  The input fields specified as tags will be converted to strings before ingestion into InfluxDB. |
+| kafkaConsumers.test.timestamp_field | string | `"private_efdStamp"` | Input field to be used as the InfluxDB timestamp (optional).  If unspecified or set to the empty string, Telegraf will use the time it received the measurement. |
 | kafkaConsumers.test.timestamp_format | string | `"unix"` | Timestamp format. Possible values are `unix` (the default if unset) a timestamp in seconds since the Unix epoch, `unix_ms` (milliseconds), `unix_us` (microsseconds), or `unix_ns` (nanoseconds). |
 | kafkaConsumers.test.topicRegexps | list | `[".*Test"]` | List of regular expressions to specify the Kafka topics consumed by this agent. |
 | kafkaConsumers.test.union_field_separator | string | `""` | Union field separator: if a single Avro field is flattened into more than one InfluxDB field (e.g. an array `a`, with four members, would yield `a0`, `a1`, `a2`, `a3`; if the field separator were `_`, these would be `a_0`...`a_3`. |

--- a/applications/sasquatch/charts/telegraf/README.md
+++ b/applications/sasquatch/charts/telegraf/README.md
@@ -39,6 +39,16 @@ Telegraf is an agent for collecting, processing, aggregating, and writing metric
 | kafkaConsumers.test.topicRegexps | list | `[".*Test"]` | List of regular expressions to specify the Kafka topics consumed by this agent. |
 | kafkaConsumers.test.union_field_separator | string | `""` | Union field separator: if a single Avro field is flattened into more than one InfluxDB field (e.g. an array `a`, with four members, would yield `a0`, `a1`, `a2`, `a3`; if the field separator were `_`, these would be `a_0`...`a_3`. |
 | kafkaConsumers.test.union_mode | string | `"nullable"` | Union mode: this can be one of `flatten`, `nullable`, or `any`. See `values.yaml` for extensive discussion. |
+| kafkaConsumers.test_json_v2.compression_codec | int | `3` |  |
+| kafkaConsumers.test_json_v2.data_format | string | `"json_v2"` |  |
+| kafkaConsumers.test_json_v2.database | string | `""` |  |
+| kafkaConsumers.test_json_v2.enabled | bool | `false` |  |
+| kafkaConsumers.test_json_v2.offset | string | `"oldest"` |  |
+| kafkaConsumers.test_json_v2.replicaCount | int | `1` |  |
+| kafkaConsumers.test_json_v2.tags[0] | string | `"tag"` |  |
+| kafkaConsumers.test_json_v2.timestamp_field | string | `"timestamp"` |  |
+| kafkaConsumers.test_json_v2.timestamp_format | string | `"unix"` |  |
+| kafkaConsumers.test_json_v2.topicRegexps[0] | string | `".*JsonV2Test"` |  |
 | kafkaVersion | string | `"4.0.0"` |  |
 | nodeSelector | object | `{}` | Node labels for pod assignment |
 | podAnnotations | object | `{}` | Annotations for the Telegraf pods |

--- a/applications/sasquatch/charts/telegraf/README.md
+++ b/applications/sasquatch/charts/telegraf/README.md
@@ -35,7 +35,7 @@ Telegraf is an agent for collecting, processing, aggregating, and writing metric
 | kafkaConsumers.test.tags | list | `[]` | List of Avro fields to be recorded as InfluxDB tags.  The Avro fields specified as tags will be converted to strings before ingestion into InfluxDB. |
 | kafkaConsumers.test.timestamp_field | string | `"private_efdStamp"` | Avro field to be used as the InfluxDB timestamp (optional).  If unspecified or set to the empty string, Telegraf will use the time it received the measurement. |
 | kafkaConsumers.test.timestamp_format | string | `"unix"` | Timestamp format. Possible values are `unix` (the default if unset) a timestamp in seconds since the Unix epoch, `unix_ms` (milliseconds), `unix_us` (microsseconds), or `unix_ns` (nanoseconds). |
-| kafkaConsumers.test.topicRegexps | string | `"[ \".*Test\" ]\n"` | List of regular expressions to specify the Kafka topics consumed by this agent. |
+| kafkaConsumers.test.topicRegexps | list | `[".*Test"]` | List of regular expressions to specify the Kafka topics consumed by this agent. |
 | kafkaConsumers.test.union_field_separator | string | `""` | Union field separator: if a single Avro field is flattened into more than one InfluxDB field (e.g. an array `a`, with four members, would yield `a0`, `a1`, `a2`, `a3`; if the field separator were `_`, these would be `a_0`...`a_3`. |
 | kafkaConsumers.test.union_mode | string | `"nullable"` | Union mode: this can be one of `flatten`, `nullable`, or `any`. See `values.yaml` for extensive discussion. |
 | kafkaVersion | string | `"4.0.0"` |  |

--- a/applications/sasquatch/charts/telegraf/templates/_helpers.tpl
+++ b/applications/sasquatch/charts/telegraf/templates/_helpers.tpl
@@ -1,3 +1,12 @@
+{{/* Convert a list to a TOML array of quoted string values. */}}
+{{- define "telegraf.toTomlArray" -}}
+{{- $items := list -}}
+{{- range . -}}
+{{- $items = (quote .) | append $items -}}
+{{- end -}}
+[ {{ join ", " $items }} ]
+{{- end }}
+
 {{- define "configmap" -}}
 {{- if .value.enabled }}
 ---
@@ -59,10 +68,10 @@ data:
       avro_union_mode = {{ default "nullable" .value.union_mode | quote }}
       avro_field_separator = {{ default "" .value.union_field_separator | quote }}
       {{- if .value.fields }}
-      avro_fields = {{ .value.fields }}
+      avro_fields = {{ include "telegraf.toTomlArray" .value.fields }}
       {{- end }}
       {{- if .value.tags }}
-      avro_tags = {{ .value.tags }}
+      avro_tags = {{ include "telegraf.toTomlArray" .value.tags }}
       {{- end }}
       topic_regexps = {{ .value.topicRegexps }}
       offset = {{ default "oldest" .value.offset | quote }}
@@ -89,10 +98,10 @@ data:
       avro_union_mode = {{ default "nullable" .value.union_mode | quote }}
       avro_field_separator = {{ default "" .value.union_field_separator | quote }}
       {{- if .value.fields }}
-      avro_fields = {{ .value.fields }}
+      avro_fields = {{ include "telegraf.toTomlArray" .value.fields }}
       {{- end }}
       {{- if .value.tags }}
-      avro_tags = {{ .value.tags }}
+      avro_tags = {{ include "telegraf.toTomlArray" .value.tags }}
       {{- end }}
       topic_regexps = {{ .value.topicRegexps }}
       offset = "oldest"

--- a/applications/sasquatch/charts/telegraf/templates/_helpers.tpl
+++ b/applications/sasquatch/charts/telegraf/templates/_helpers.tpl
@@ -73,7 +73,7 @@ data:
       {{- if .value.tags }}
       avro_tags = {{ include "telegraf.toTomlArray" .value.tags }}
       {{- end }}
-      topic_regexps = {{ .value.topicRegexps }}
+      topic_regexps = {{ include "telegraf.toTomlArray" .value.topicRegexps }}
       offset = {{ default "oldest" .value.offset | quote }}
       precision = {{ default "1us" .value.precision | quote }}
       max_processing_time = {{ default "1s" .value.max_processing_time | quote }}
@@ -103,7 +103,7 @@ data:
       {{- if .value.tags }}
       avro_tags = {{ include "telegraf.toTomlArray" .value.tags }}
       {{- end }}
-      topic_regexps = {{ .value.topicRegexps }}
+      topic_regexps = {{ include "telegraf.toTomlArray" .value.topicRegexps }}
       offset = "oldest"
       precision = {{ default "1us" .value.precision | quote }}
       max_processing_time = {{ default "1s" .value.max_processing_time | quote }}

--- a/applications/sasquatch/charts/telegraf/templates/_helpers.tpl
+++ b/applications/sasquatch/charts/telegraf/templates/_helpers.tpl
@@ -9,6 +9,10 @@
 
 {{/* Render a Telegraf Kafka consumer input. */}}
 {{- define "telegraf.kafkaConsumer" }}
+{{- $dataFormat := default "avro" .value.data_format }}
+{{- if and (ne $dataFormat "avro") (ne $dataFormat "json_v2") }}
+{{- fail (printf "unsupported data_format %q for %s; expected avro or json_v2" $dataFormat .consumerGroup) }}
+{{- end }}
     [[inputs.kafka_consumer]]
       brokers = [
         "sasquatch-kafka-brokers.sasquatch:9092"
@@ -17,7 +21,16 @@
       sasl_mechanism = "SCRAM-SHA-512"
       sasl_password = "$TELEGRAF_PASSWORD"
       sasl_username = "telegraf"
-      data_format = "avro"
+      data_format = {{ $dataFormat | quote }}
+      topic_regexps = {{ include "telegraf.toTomlArray" .value.topicRegexps }}
+      offset = {{ .offset | quote }}
+      precision = {{ default "1us" .value.precision | quote }}
+      max_processing_time = {{ default "1s" .value.max_processing_time | quote }}
+      consumer_fetch_default = {{ default "1MB" .value.consumer_fetch_default | quote }}
+      max_undelivered_messages = {{ default 10000 .value.max_undelivered_messages }}
+      compression_codec = {{ .compressionCodec }}
+      kafka_version = {{ .kafkaVersion | quote }}
+      {{- if eq $dataFormat "avro" }}
       avro_schema_registry = {{ default "http://sasquatch-schema-registry.sasquatch:8081" .registryUrl | quote }}
       {{- if .timestampField }}
       avro_timestamp = {{ .timestampField | quote }}
@@ -31,14 +44,15 @@
       {{- if .value.tags }}
       avro_tags = {{ include "telegraf.toTomlArray" .value.tags }}
       {{- end }}
-      topic_regexps = {{ include "telegraf.toTomlArray" .value.topicRegexps }}
-      offset = {{ .offset | quote }}
-      precision = {{ default "1us" .value.precision | quote }}
-      max_processing_time = {{ default "1s" .value.max_processing_time | quote }}
-      consumer_fetch_default = {{ default "1MB" .value.consumer_fetch_default | quote }}
-      max_undelivered_messages = {{ default 10000 .value.max_undelivered_messages }}
-      compression_codec = {{ .compressionCodec }}
-      kafka_version = {{ .kafkaVersion | quote }}
+      {{- else }}
+    [[inputs.kafka_consumer.json_v2]]
+      [[inputs.kafka_consumer.json_v2.object]]
+
+        path = "@this"
+        timestamp_key = {{ .timestampField | quote }}
+        timestamp_format = {{ default "unix" .value.timestamp_format | quote }}
+        tags = {{ include "telegraf.toTomlArray" .value.tags }}
+      {{- end }}
 {{ end -}}
 
 {{- define "configmap" -}}

--- a/applications/sasquatch/charts/telegraf/templates/_helpers.tpl
+++ b/applications/sasquatch/charts/telegraf/templates/_helpers.tpl
@@ -46,12 +46,14 @@
       {{- end }}
       {{- else }}
     [[inputs.kafka_consumer.json_v2]]
+      measurement_name_path = "measurement"
       [[inputs.kafka_consumer.json_v2.object]]
 
         path = "@this"
         timestamp_key = {{ .timestampField | quote }}
         timestamp_format = {{ default "unix" .value.timestamp_format | quote }}
         tags = {{ include "telegraf.toTomlArray" .value.tags }}
+        excluded_keys = ["measurement"]
       {{- end }}
 {{ end -}}
 

--- a/applications/sasquatch/charts/telegraf/templates/_helpers.tpl
+++ b/applications/sasquatch/charts/telegraf/templates/_helpers.tpl
@@ -33,6 +33,10 @@ data:
 
 
     {{- $database := .value.database }}
+    {{- $timestampField := "private_efdStamp" }}
+    {{- if hasKey .value "timestamp_field" }}
+    {{- $timestampField = .value.timestamp_field }}
+    {{- end }}
     {{- range .influxdbUrls }}
     [[outputs.influxdb]]
       namedrop = ["telegraf_*"]
@@ -63,8 +67,10 @@ data:
       sasl_username = "telegraf"
       data_format = "avro"
       avro_schema_registry = {{ default "http://sasquatch-schema-registry.sasquatch:8081" .registryUrl | quote }}
-      avro_timestamp = {{ default "private_efdStamp" .value.timestamp_field | quote }}
+      {{- if $timestampField }}
+      avro_timestamp = {{ $timestampField | quote }}
       avro_timestamp_format = {{ default "unix" .value.timestamp_format | quote }}
+      {{- end }}
       avro_union_mode = {{ default "nullable" .value.union_mode | quote }}
       avro_field_separator = {{ default "" .value.union_field_separator | quote }}
       {{- if .value.fields }}
@@ -93,8 +99,10 @@ data:
       sasl_username = "telegraf"
       data_format = "avro"
       avro_schema_registry = {{ default "http://sasquatch-schema-registry.sasquatch:8081" .registryUrl | quote }}
-      avro_timestamp = {{ default "private_efdStamp" .value.timestamp_field | quote }}
+      {{- if $timestampField }}
+      avro_timestamp = {{ $timestampField | quote }}
       avro_timestamp_format = {{ default "unix" .value.timestamp_format | quote }}
+      {{- end }}
       avro_union_mode = {{ default "nullable" .value.union_mode | quote }}
       avro_field_separator = {{ default "" .value.union_field_separator | quote }}
       {{- if .value.fields }}

--- a/applications/sasquatch/charts/telegraf/templates/_helpers.tpl
+++ b/applications/sasquatch/charts/telegraf/templates/_helpers.tpl
@@ -37,6 +37,10 @@ data:
     {{- if hasKey .value "timestamp_field" }}
     {{- $timestampField = .value.timestamp_field }}
     {{- end }}
+    {{- $compressionCodec := 3 }}
+    {{- if hasKey .value "compression_codec" }}
+    {{- $compressionCodec = .value.compression_codec }}
+    {{- end }}
     {{- range .influxdbUrls }}
     [[outputs.influxdb]]
       namedrop = ["telegraf_*"]
@@ -85,7 +89,7 @@ data:
       max_processing_time = {{ default "1s" .value.max_processing_time | quote }}
       consumer_fetch_default = {{ default "1MB" .value.consumer_fetch_default | quote }}
       max_undelivered_messages = {{ default 10000 .value.max_undelivered_messages }}
-      compression_codec = {{ default 3 .value.compression_codec }}
+      compression_codec = {{ $compressionCodec }}
       kafka_version = {{ .kafkaVersion | quote }}
 
     {{- if .value.repair }}
@@ -117,7 +121,7 @@ data:
       max_processing_time = {{ default "1s" .value.max_processing_time | quote }}
       consumer_fetch_default = {{ default "1MB" .value.consumer_fetch_default | quote }}
       max_undelivered_messages = {{ default 10000 .value.max_undelivered_messages }}
-      compression_codec = {{ default 3 .value.compression_codec }}
+      compression_codec = {{ $compressionCodec }}
       kafka_version = {{ .kafkaVersion | quote }}
     {{- end }}
 

--- a/applications/sasquatch/charts/telegraf/templates/_helpers.tpl
+++ b/applications/sasquatch/charts/telegraf/templates/_helpers.tpl
@@ -7,6 +7,40 @@
 [ {{ join ", " $items }} ]
 {{- end }}
 
+{{/* Render a Telegraf Kafka consumer input. */}}
+{{- define "telegraf.kafkaConsumer" }}
+    [[inputs.kafka_consumer]]
+      brokers = [
+        "sasquatch-kafka-brokers.sasquatch:9092"
+      ]
+      consumer_group = {{ .consumerGroup | quote }}
+      sasl_mechanism = "SCRAM-SHA-512"
+      sasl_password = "$TELEGRAF_PASSWORD"
+      sasl_username = "telegraf"
+      data_format = "avro"
+      avro_schema_registry = {{ default "http://sasquatch-schema-registry.sasquatch:8081" .registryUrl | quote }}
+      {{- if .timestampField }}
+      avro_timestamp = {{ .timestampField | quote }}
+      avro_timestamp_format = {{ default "unix" .value.timestamp_format | quote }}
+      {{- end }}
+      avro_union_mode = {{ default "nullable" .value.union_mode | quote }}
+      avro_field_separator = {{ default "" .value.union_field_separator | quote }}
+      {{- if .value.fields }}
+      avro_fields = {{ include "telegraf.toTomlArray" .value.fields }}
+      {{- end }}
+      {{- if .value.tags }}
+      avro_tags = {{ include "telegraf.toTomlArray" .value.tags }}
+      {{- end }}
+      topic_regexps = {{ include "telegraf.toTomlArray" .value.topicRegexps }}
+      offset = {{ .offset | quote }}
+      precision = {{ default "1us" .value.precision | quote }}
+      max_processing_time = {{ default "1s" .value.max_processing_time | quote }}
+      consumer_fetch_default = {{ default "1MB" .value.consumer_fetch_default | quote }}
+      max_undelivered_messages = {{ default 10000 .value.max_undelivered_messages }}
+      compression_codec = {{ .compressionCodec }}
+      kafka_version = {{ .kafkaVersion | quote }}
+{{ end -}}
+
 {{- define "configmap" -}}
 {{- if .value.enabled }}
 ---
@@ -61,68 +95,27 @@ data:
       password = "${INFLUXDB_PASSWORD}"
     {{ end }}
 
-    [[inputs.kafka_consumer]]
-      brokers = [
-        "sasquatch-kafka-brokers.sasquatch:9092"
-      ]
-      consumer_group = "telegraf-kafka-consumer-{{ .key }}"
-      sasl_mechanism = "SCRAM-SHA-512"
-      sasl_password = "$TELEGRAF_PASSWORD"
-      sasl_username = "telegraf"
-      data_format = "avro"
-      avro_schema_registry = {{ default "http://sasquatch-schema-registry.sasquatch:8081" .registryUrl | quote }}
-      {{- if $timestampField }}
-      avro_timestamp = {{ $timestampField | quote }}
-      avro_timestamp_format = {{ default "unix" .value.timestamp_format | quote }}
-      {{- end }}
-      avro_union_mode = {{ default "nullable" .value.union_mode | quote }}
-      avro_field_separator = {{ default "" .value.union_field_separator | quote }}
-      {{- if .value.fields }}
-      avro_fields = {{ include "telegraf.toTomlArray" .value.fields }}
-      {{- end }}
-      {{- if .value.tags }}
-      avro_tags = {{ include "telegraf.toTomlArray" .value.tags }}
-      {{- end }}
-      topic_regexps = {{ include "telegraf.toTomlArray" .value.topicRegexps }}
-      offset = {{ default "oldest" .value.offset | quote }}
-      precision = {{ default "1us" .value.precision | quote }}
-      max_processing_time = {{ default "1s" .value.max_processing_time | quote }}
-      consumer_fetch_default = {{ default "1MB" .value.consumer_fetch_default | quote }}
-      max_undelivered_messages = {{ default 10000 .value.max_undelivered_messages }}
-      compression_codec = {{ $compressionCodec }}
-      kafka_version = {{ .kafkaVersion | quote }}
-
+    {{- $config := . }}
+    {{- $consumers := list (dict
+      "consumerGroup" (printf "telegraf-kafka-consumer-%s" .key)
+      "offset" (default "oldest" .value.offset)
+    ) }}
     {{- if .value.repair }}
-    [[inputs.kafka_consumer]]
-      brokers = [
-        "sasquatch-kafka-brokers.sasquatch:9092"
-      ]
-      consumer_group = "telegraf-kafka-consumer-{{ .key }}-repairer"
-      sasl_mechanism = "SCRAM-SHA-512"
-      sasl_password = "$TELEGRAF_PASSWORD"
-      sasl_username = "telegraf"
-      data_format = "avro"
-      avro_schema_registry = {{ default "http://sasquatch-schema-registry.sasquatch:8081" .registryUrl | quote }}
-      {{- if $timestampField }}
-      avro_timestamp = {{ $timestampField | quote }}
-      avro_timestamp_format = {{ default "unix" .value.timestamp_format | quote }}
-      {{- end }}
-      avro_union_mode = {{ default "nullable" .value.union_mode | quote }}
-      avro_field_separator = {{ default "" .value.union_field_separator | quote }}
-      {{- if .value.fields }}
-      avro_fields = {{ include "telegraf.toTomlArray" .value.fields }}
-      {{- end }}
-      {{- if .value.tags }}
-      avro_tags = {{ include "telegraf.toTomlArray" .value.tags }}
-      {{- end }}
-      topic_regexps = {{ include "telegraf.toTomlArray" .value.topicRegexps }}
-      offset = "oldest"
-      precision = {{ default "1us" .value.precision | quote }}
-      max_processing_time = {{ default "1s" .value.max_processing_time | quote }}
-      consumer_fetch_default = {{ default "1MB" .value.consumer_fetch_default | quote }}
-      max_undelivered_messages = {{ default 10000 .value.max_undelivered_messages }}
-      compression_codec = {{ $compressionCodec }}
-      kafka_version = {{ .kafkaVersion | quote }}
+    {{- $consumers = append $consumers (dict
+      "consumerGroup" (printf "telegraf-kafka-consumer-%s-repairer" .key)
+      "offset" "oldest"
+    ) }}
+    {{- end }}
+    {{- range $consumer := $consumers }}
+{{ include "telegraf.kafkaConsumer" (dict
+  "value" $config.value
+  "registryUrl" $config.registryUrl
+  "kafkaVersion" $config.kafkaVersion
+  "timestampField" $timestampField
+  "compressionCodec" $compressionCodec
+  "consumerGroup" $consumer.consumerGroup
+  "offset" $consumer.offset
+) }}
     {{- end }}
 
     [[inputs.internal]]

--- a/applications/sasquatch/charts/telegraf/templates/deployment.yaml
+++ b/applications/sasquatch/charts/telegraf/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: sasquatch-telegraf
         app.kubernetes.io/instance: sasquatch-telegraf-{{ $key }}
       annotations:
-        checksum/config: {{ include "configmap" (dict "key" $key "value" $value "influxdbUrl" $.Values.influxdb.url ) | sha256sum }}
+        checksum/config: {{ include "configmap" (dict "key" $key "value" $value "influxdbUrls" $.Values.influxdb.urls "registryUrl" $.Values.registry.url "kafkaVersion" $.Values.kafkaVersion) | sha256sum }}
         {{- if $.Values.podAnnotations }}
         {{- toYaml $.Values.podAnnotations | nindent 8 }}
         {{- end }}

--- a/applications/sasquatch/charts/telegraf/templates/deployment.yaml
+++ b/applications/sasquatch/charts/telegraf/templates/deployment.yaml
@@ -17,6 +17,9 @@ spec:
   template:
     metadata:
       labels:
+        {{- with $.Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         app.kubernetes.io/name: sasquatch-telegraf
         app.kubernetes.io/instance: sasquatch-telegraf-{{ $key }}
       annotations:

--- a/applications/sasquatch/charts/telegraf/values.yaml
+++ b/applications/sasquatch/charts/telegraf/values.yaml
@@ -97,12 +97,15 @@ kafkaConsumers:
     # @default -- false
     debug: false
 
+    # -- Input data format. Supported values are `avro` and `json_v2`.
+    data_format: "avro"
+
     # -- Timestamp format. Possible values are `unix` (the default if unset) a
     # timestamp in seconds since the Unix epoch, `unix_ms` (milliseconds),
     # `unix_us` (microsseconds), or `unix_ns` (nanoseconds).
     timestamp_format: "unix"
 
-    # -- Avro field to be used as the InfluxDB timestamp (optional).  If
+    # -- Input field to be used as the InfluxDB timestamp (optional).  If
     # unspecified or set to the empty string, Telegraf will use the time it
     # received the measurement.
     timestamp_field: "private_efdStamp"
@@ -150,7 +153,7 @@ kafkaConsumers:
     # InfluxDB field.
     fields: []
 
-    # -- List of Avro fields to be recorded as InfluxDB tags.  The Avro fields
+    # -- List of input fields to be recorded as InfluxDB tags.  The input fields
     # specified as tags will be converted to strings before ingestion into
     # InfluxDB.
     tags: []

--- a/applications/sasquatch/charts/telegraf/values.yaml
+++ b/applications/sasquatch/charts/telegraf/values.yaml
@@ -157,8 +157,7 @@ kafkaConsumers:
 
     # -- List of regular expressions to specify the Kafka topics consumed by
     # this agent.
-    topicRegexps: |
-      [ ".*Test" ]
+    topicRegexps: [".*Test"]
 
     # -- Kafka consumer offset. Possible values are `oldest` and `newest`.
     offset: "oldest"

--- a/applications/sasquatch/charts/telegraf/values.yaml
+++ b/applications/sasquatch/charts/telegraf/values.yaml
@@ -157,7 +157,8 @@ kafkaConsumers:
 
     # -- List of regular expressions to specify the Kafka topics consumed by
     # this agent.
-    topicRegexps: [".*Test"]
+    topicRegexps:
+      - ".*Test"
 
     # -- Kafka consumer offset. Possible values are `oldest` and `newest`.
     offset: "oldest"

--- a/applications/sasquatch/charts/telegraf/values.yaml
+++ b/applications/sasquatch/charts/telegraf/values.yaml
@@ -188,6 +188,21 @@ kafkaConsumers:
     # @default -- 3
     compression_codec: 3
 
+  # Example JSON v2 Kafka consumer. This consumer is disabled by default.
+  test_json_v2:
+    enabled: false
+    replicaCount: 1
+    database: ""
+    data_format: "json_v2"
+    timestamp_format: "unix"
+    timestamp_field: "timestamp"
+    tags:
+      - "tag"
+    topicRegexps:
+      - ".*JsonV2Test"
+    offset: "oldest"
+    compression_codec: 3
+
 
 # Must match the Kafka broker version used in Sasquatch.
 # @default -- the default Kafka version in Sasquatch (see strimzi-kafka subchart values.yaml)

--- a/applications/sasquatch/values-base.yaml
+++ b/applications/sasquatch/values-base.yaml
@@ -138,50 +138,96 @@ telegraf:
       database: "lsst.obsenv"
       timestamp_format: "unix_ms"
       timestamp_field: "timestamp"
-      topicRegexps: ["lsst.obsenv"]
+      topicRegexps:
+        - "lsst.obsenv"
     scimma:
       enabled: true
       database: "lsst.scimma"
       timestamp_format: "unix_ms"
       timestamp_field: "timestamp"
-      topicRegexps: ["lsst.scimma"]
+      topicRegexps:
+        - "lsst.scimma"
       offset: oldest
     cp:
       enabled: true
       database: "lsst.cp"
       timestamp_format: "unix"
       timestamp_field: "timestamp"
-      topicRegexps: ["lsst.cp"]
-      tags: ["dataset_tag", "band", "instrument", "skymap", "detector", "physical_filter", "tract", "patch", "pipeline"]
+      topicRegexps:
+        - "lsst.cp"
+      tags:
+        - "dataset_tag"
+        - "band"
+        - "instrument"
+        - "skymap"
+        - "detector"
+        - "physical_filter"
+        - "tract"
+        - "patch"
+        - "pipeline"
     # CSC connectors
     auxtel:
       enabled: true
       database: "efd"
-      topicRegexps: ["lsst.sal.ATAOS", "lsst.sal.ATBuilding", "lsst.sal.ATDome", "lsst.sal.ATDomeTrajectory", "lsst.sal.ATHexapod", "lsst.sal.ATPneumatics", "lsst.sal.ATPtg", "lsst.sal.ATMCS"]
+      topicRegexps:
+        - "lsst.sal.ATAOS"
+        - "lsst.sal.ATBuilding"
+        - "lsst.sal.ATDome"
+        - "lsst.sal.ATDomeTrajectory"
+        - "lsst.sal.ATHexapod"
+        - "lsst.sal.ATPneumatics"
+        - "lsst.sal.ATPtg"
+        - "lsst.sal.ATMCS"
     maintel:
       enabled: true
       database: "efd"
-      topicRegexps: ["lsst.sal.MTAOS", "lsst.sal.MTDome", "lsst.sal.MTDomeTrajectory", "lsst.sal.MTPtg"]
+      topicRegexps:
+        - "lsst.sal.MTAOS"
+        - "lsst.sal.MTDome"
+        - "lsst.sal.MTDomeTrajectory"
+        - "lsst.sal.MTPtg"
     mtmount:
       enabled: true
       database: "efd"
-      topicRegexps: ["lsst.sal.MTMount"]
+      topicRegexps:
+        - "lsst.sal.MTMount"
     envsys:
       enabled: true
       database: "efd"
-      topicRegexps: ["lsst.sal.DIMM", "lsst.sal.DREAM", "lsst.sal.DSM", "lsst.sal.EAS", "lsst.sal.EPM", "lsst.sal.ESS", "lsst.sal.HVAC", "lsst.sal.WeatherForecast"]
+      topicRegexps:
+        - "lsst.sal.DIMM"
+        - "lsst.sal.DREAM"
+        - "lsst.sal.DSM"
+        - "lsst.sal.EAS"
+        - "lsst.sal.EPM"
+        - "lsst.sal.ESS"
+        - "lsst.sal.HVAC"
+        - "lsst.sal.WeatherForecast"
     latiss:
       enabled: true
       database: "efd"
-      topicRegexps: ["lsst.sal.ATHeaderService", "lsst.sal.ATOODS", "lsst.sal.ATSpectrograph", "lsst.sal.ATCamera"]
+      topicRegexps:
+        - "lsst.sal.ATHeaderService"
+        - "lsst.sal.ATOODS"
+        - "lsst.sal.ATSpectrograph"
+        - "lsst.sal.ATCamera"
     m1m3:
       enabled: true
       database: "efd"
-      topicRegexps: ["lsst.sal.MTM1M3.ackcmd", "lsst.sal.MTM1M3.logevent*", "lsst.sal.MTM1M3.command*"]
+      topicRegexps:
+        - "lsst.sal.MTM1M3.ackcmd"
+        - "lsst.sal.MTM1M3.logevent*"
+        - "lsst.sal.MTM1M3.command*"
     m1m3-tel1:
       enabled: true
       database: "efd"
-      topicRegexps: ["lsst.sal.MTM1M3.accelerometerData", "lsst.sal.MTM1M3.appliedCylinderForces", "lsst.sal.MTM1M3.appliedForces", "lsst.sal.MTM1M3.gyroData", "lsst.sal.MTM1M3.hardpointActuatorData", "lsst.sal.MTM1M3.hardpointMonitorData"]
+      topicRegexps:
+        - "lsst.sal.MTM1M3.accelerometerData"
+        - "lsst.sal.MTM1M3.appliedCylinderForces"
+        - "lsst.sal.MTM1M3.appliedForces"
+        - "lsst.sal.MTM1M3.gyroData"
+        - "lsst.sal.MTM1M3.hardpointActuatorData"
+        - "lsst.sal.MTM1M3.hardpointMonitorData"
       resources:
         limits:
           cpu: "6"
@@ -193,7 +239,12 @@ telegraf:
       enabled: true
       database: "efd"
       metric_batch_size: 750
-      topicRegexps: ["lsst.sal.MTM1M3.forceActuatorData", "lsst.sal.MTM1M3.outerLoopData", "lsst.sal.MTM1M3.imsData", "lsst.sal.MTM1M3.inclinometerData", "lsst.sal.MTM1M3.powerSupplyData"]
+      topicRegexps:
+        - "lsst.sal.MTM1M3.forceActuatorData"
+        - "lsst.sal.MTM1M3.outerLoopData"
+        - "lsst.sal.MTM1M3.imsData"
+        - "lsst.sal.MTM1M3.inclinometerData"
+        - "lsst.sal.MTM1M3.powerSupplyData"
       resources:
         limits:
           cpu: "6"
@@ -204,7 +255,15 @@ telegraf:
     m1m3-tel3:
       enabled: true
       database: "efd"
-      topicRegexps: ["lsst.sal.MTM1M3.appliedAccelerationForces", "lsst.sal.MTM1M3.appliedAzimuthForces", "lsst.sal.MTM1M3.appliedBalanceForces", "lsst.sal.MTM1M3.appliedElevationForces", "lsst.sal.MTM1M3.appliedThermalForces", "lsst.sal.MTM1M3.appliedVelocityForces", "lsst.sal.MTM1M3.forceActuatorPressure", "lsst.sal.MTM1M3.pidData"]
+      topicRegexps:
+        - "lsst.sal.MTM1M3.appliedAccelerationForces"
+        - "lsst.sal.MTM1M3.appliedAzimuthForces"
+        - "lsst.sal.MTM1M3.appliedBalanceForces"
+        - "lsst.sal.MTM1M3.appliedElevationForces"
+        - "lsst.sal.MTM1M3.appliedThermalForces"
+        - "lsst.sal.MTM1M3.appliedVelocityForces"
+        - "lsst.sal.MTM1M3.forceActuatorPressure"
+        - "lsst.sal.MTM1M3.pidData"
       resources:
         limits:
           cpu: "5"
@@ -217,63 +276,126 @@ telegraf:
       metric_batch_size: 1500
       max_undelivered_messages: 4000
       database: "efd"
-      topicRegexps: ["lsst.sal.MTM1M3TS"]
+      topicRegexps:
+        - "lsst.sal.MTM1M3TS"
     m2:
       enabled: true
       database: "efd"
-      topicRegexps: ["lsst.sal.MTHexapod", "lsst.sal.MTM2", "lsst.sal.MTRotator"]
+      topicRegexps:
+        - "lsst.sal.MTHexapod"
+        - "lsst.sal.MTM2"
+        - "lsst.sal.MTRotator"
     obssys:
       enabled: true
       database: "efd"
-      topicRegexps: ["lsst.sal.Scheduler", "lsst.sal.Script", "lsst.sal.ScriptQueue", "lsst.sal.Watcher"]
+      topicRegexps:
+        - "lsst.sal.Scheduler"
+        - "lsst.sal.Script"
+        - "lsst.sal.ScriptQueue"
+        - "lsst.sal.Watcher"
     ocps:
       enabled: true
       database: "efd"
-      topicRegexps: ["lsst.sal.OCPS"]
+      topicRegexps:
+        - "lsst.sal.OCPS"
     test:
       enabled: true
       database: "efd"
-      topicRegexps: ["lsst.sal.Test"]
+      topicRegexps:
+        - "lsst.sal.Test"
     mtaircompressor:
       enabled: true
       database: "efd"
-      topicRegexps: ["lsst.sal.MTAirCompressor"]
+      topicRegexps:
+        - "lsst.sal.MTAirCompressor"
     lasertracker:
       enabled: true
       database: "efd"
-      topicRegexps: ["lsst.sal.LaserTracker"]
+      topicRegexps:
+        - "lsst.sal.LaserTracker"
     genericcamera:
       enabled: true
       database: "efd"
-      topicRegexps: ["lsst.sal.GCHeaderService", "lsst.sal.GenericCamera"]
+      topicRegexps:
+        - "lsst.sal.GCHeaderService"
+        - "lsst.sal.GenericCamera"
     lsstcam:
       enabled: true
       database: "efd"
-      topicRegexps: ["lsst.sal.MTHeaderService", "lsst.sal.MTOODS", "lsst.sal.WFOODS", "lsst.sal.MTCamera"]
+      topicRegexps:
+        - "lsst.sal.MTHeaderService"
+        - "lsst.sal.MTOODS"
+        - "lsst.sal.WFOODS"
+        - "lsst.sal.MTCamera"
     calsys:
       enabled: true
       database: "efd"
-      topicRegexps: ["lsst.sal.CBP", "lsst.sal.Electrometer", "lsst.sal.FiberSpectrograph", "lsst.sal.LEDProjector", "lsst.sal.LinearStage", "lsst.sal.MTReflector", "lsst.sal.TunableLaser"]
+      topicRegexps:
+        - "lsst.sal.CBP"
+        - "lsst.sal.Electrometer"
+        - "lsst.sal.FiberSpectrograph"
+        - "lsst.sal.LEDProjector"
+        - "lsst.sal.LinearStage"
+        - "lsst.sal.MTReflector"
+        - "lsst.sal.TunableLaser"
     mtvms:
       enabled: true
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: ["lsst.sal.MTVMS"]
+      topicRegexps:
+        - "lsst.sal.MTVMS"
     # CCS connectors (experimental) data is being written on separate databases for now
     atcamera:
       enabled: true
       database: "lsst.ATCamera"
       timestamp_format: "unix_ms"
       timestamp_field: "timestamp"
-      tags: ["Agent", "Aspic", "Location", "Raft", "Reb", "Sensor", "Source", "VersionType"]
-      topicRegexps: ["lsst.ATCamera"]
+      tags:
+        - "Agent"
+        - "Aspic"
+        - "Location"
+        - "Raft"
+        - "Reb"
+        - "Sensor"
+        - "Source"
+        - "VersionType"
+      topicRegexps:
+        - "lsst.ATCamera"
     mtcamera:
       enabled: true
       database: "lsst.MTCamera"
       timestamp_format: "unix_ms"
       timestamp_field: "timestamp"
-      tags: ["Agent", "Aspic", "Axis", "Bay", "Buffer", "Canbus", "Cip", "Clamp", "Cold", "Controller", "Cryo", "Gateway", "Hardware", "Hip", "Hook", "Latch", "Location", "Ps", "RTD", "Raft", "Reb", "Segment", "Sensor", "Socket", "Source", "Truck", "VersionType"]
-      topicRegexps: ["lsst.MTCamera"]
+      tags:
+        - "Agent"
+        - "Aspic"
+        - "Axis"
+        - "Bay"
+        - "Buffer"
+        - "Canbus"
+        - "Cip"
+        - "Clamp"
+        - "Cold"
+        - "Controller"
+        - "Cryo"
+        - "Gateway"
+        - "Hardware"
+        - "Hip"
+        - "Hook"
+        - "Latch"
+        - "Location"
+        - "Ps"
+        - "RTD"
+        - "Raft"
+        - "Reb"
+        - "Segment"
+        - "Sensor"
+        - "Socket"
+        - "Source"
+        - "Truck"
+        - "VersionType"
+      topicRegexps:
+        - "lsst.MTCamera"
   resources:
     limits:
       cpu: "2"

--- a/applications/sasquatch/values-base.yaml
+++ b/applications/sasquatch/values-base.yaml
@@ -155,8 +155,7 @@ telegraf:
       timestamp_field: "timestamp"
       topicRegexps: |
         [ "lsst.cp" ]
-      tags: |
-        [ "dataset_tag", "band", "instrument", "skymap", "detector", "physical_filter", "tract", "patch", "pipeline" ]
+      tags: ["dataset_tag", "band", "instrument", "skymap", "detector", "physical_filter", "tract", "patch", "pipeline"]
     # CSC connectors
     auxtel:
       enabled: true
@@ -289,8 +288,7 @@ telegraf:
       database: "lsst.ATCamera"
       timestamp_format: "unix_ms"
       timestamp_field: "timestamp"
-      tags: |
-        [ "Agent", "Aspic", "Location", "Raft", "Reb", "Sensor", "Source", "VersionType" ]
+      tags: ["Agent", "Aspic", "Location", "Raft", "Reb", "Sensor", "Source", "VersionType"]
       topicRegexps: |
         [ "lsst.ATCamera" ]
     mtcamera:
@@ -298,8 +296,7 @@ telegraf:
       database: "lsst.MTCamera"
       timestamp_format: "unix_ms"
       timestamp_field: "timestamp"
-      tags: |
-        [ "Agent", "Aspic", "Axis", "Bay", "Buffer", "Canbus", "Cip", "Clamp", "Cold", "Controller", "Cryo", "Gateway" , "Hardware", "Hip", "Hook", "Latch", "Location", "Ps", "RTD", "Raft", "Reb", "Segment", "Sensor", "Socket", "Source", "Truck", "VersionType" ]
+      tags: ["Agent", "Aspic", "Axis", "Bay", "Buffer", "Canbus", "Cip", "Clamp", "Cold", "Controller", "Cryo", "Gateway", "Hardware", "Hip", "Hook", "Latch", "Location", "Ps", "RTD", "Raft", "Reb", "Segment", "Sensor", "Socket", "Source", "Truck", "VersionType"]
       topicRegexps: |
         [ "lsst.MTCamera" ]
   resources:

--- a/applications/sasquatch/values-base.yaml
+++ b/applications/sasquatch/values-base.yaml
@@ -138,60 +138,50 @@ telegraf:
       database: "lsst.obsenv"
       timestamp_format: "unix_ms"
       timestamp_field: "timestamp"
-      topicRegexps: |
-        [ "lsst.obsenv" ]
+      topicRegexps: ["lsst.obsenv"]
     scimma:
       enabled: true
       database: "lsst.scimma"
       timestamp_format: "unix_ms"
       timestamp_field: "timestamp"
-      topicRegexps: |
-        [ "lsst.scimma" ]
+      topicRegexps: ["lsst.scimma"]
       offset: oldest
     cp:
       enabled: true
       database: "lsst.cp"
       timestamp_format: "unix"
       timestamp_field: "timestamp"
-      topicRegexps: |
-        [ "lsst.cp" ]
+      topicRegexps: ["lsst.cp"]
       tags: ["dataset_tag", "band", "instrument", "skymap", "detector", "physical_filter", "tract", "patch", "pipeline"]
     # CSC connectors
     auxtel:
       enabled: true
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.ATAOS", "lsst.sal.ATBuilding", "lsst.sal.ATDome", "lsst.sal.ATDomeTrajectory", "lsst.sal.ATHexapod", "lsst.sal.ATPneumatics", "lsst.sal.ATPtg", "lsst.sal.ATMCS" ]
+      topicRegexps: ["lsst.sal.ATAOS", "lsst.sal.ATBuilding", "lsst.sal.ATDome", "lsst.sal.ATDomeTrajectory", "lsst.sal.ATHexapod", "lsst.sal.ATPneumatics", "lsst.sal.ATPtg", "lsst.sal.ATMCS"]
     maintel:
       enabled: true
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.MTAOS", "lsst.sal.MTDome", "lsst.sal.MTDomeTrajectory", "lsst.sal.MTPtg" ]
+      topicRegexps: ["lsst.sal.MTAOS", "lsst.sal.MTDome", "lsst.sal.MTDomeTrajectory", "lsst.sal.MTPtg"]
     mtmount:
       enabled: true
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.MTMount" ]
+      topicRegexps: ["lsst.sal.MTMount"]
     envsys:
       enabled: true
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.DIMM", "lsst.sal.DREAM", "lsst.sal.DSM", "lsst.sal.EAS", "lsst.sal.EPM", "lsst.sal.ESS", "lsst.sal.HVAC", "lsst.sal.WeatherForecast" ]
+      topicRegexps: ["lsst.sal.DIMM", "lsst.sal.DREAM", "lsst.sal.DSM", "lsst.sal.EAS", "lsst.sal.EPM", "lsst.sal.ESS", "lsst.sal.HVAC", "lsst.sal.WeatherForecast"]
     latiss:
       enabled: true
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.ATHeaderService", "lsst.sal.ATOODS", "lsst.sal.ATSpectrograph", "lsst.sal.ATCamera" ]
+      topicRegexps: ["lsst.sal.ATHeaderService", "lsst.sal.ATOODS", "lsst.sal.ATSpectrograph", "lsst.sal.ATCamera"]
     m1m3:
       enabled: true
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.MTM1M3.ackcmd", "lsst.sal.MTM1M3.logevent*", "lsst.sal.MTM1M3.command*" ]
+      topicRegexps: ["lsst.sal.MTM1M3.ackcmd", "lsst.sal.MTM1M3.logevent*", "lsst.sal.MTM1M3.command*"]
     m1m3-tel1:
       enabled: true
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.MTM1M3.accelerometerData", "lsst.sal.MTM1M3.appliedCylinderForces", "lsst.sal.MTM1M3.appliedForces", "lsst.sal.MTM1M3.gyroData", "lsst.sal.MTM1M3.hardpointActuatorData", "lsst.sal.MTM1M3.hardpointMonitorData" ]
+      topicRegexps: ["lsst.sal.MTM1M3.accelerometerData", "lsst.sal.MTM1M3.appliedCylinderForces", "lsst.sal.MTM1M3.appliedForces", "lsst.sal.MTM1M3.gyroData", "lsst.sal.MTM1M3.hardpointActuatorData", "lsst.sal.MTM1M3.hardpointMonitorData"]
       resources:
         limits:
           cpu: "6"
@@ -203,8 +193,7 @@ telegraf:
       enabled: true
       database: "efd"
       metric_batch_size: 750
-      topicRegexps: |
-        [ "lsst.sal.MTM1M3.forceActuatorData", "lsst.sal.MTM1M3.outerLoopData", "lsst.sal.MTM1M3.imsData", "lsst.sal.MTM1M3.inclinometerData", "lsst.sal.MTM1M3.powerSupplyData" ]
+      topicRegexps: ["lsst.sal.MTM1M3.forceActuatorData", "lsst.sal.MTM1M3.outerLoopData", "lsst.sal.MTM1M3.imsData", "lsst.sal.MTM1M3.inclinometerData", "lsst.sal.MTM1M3.powerSupplyData"]
       resources:
         limits:
           cpu: "6"
@@ -215,8 +204,7 @@ telegraf:
     m1m3-tel3:
       enabled: true
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.MTM1M3.appliedAccelerationForces", "lsst.sal.MTM1M3.appliedAzimuthForces", "lsst.sal.MTM1M3.appliedBalanceForces", "lsst.sal.MTM1M3.appliedElevationForces", "lsst.sal.MTM1M3.appliedThermalForces", "lsst.sal.MTM1M3.appliedVelocityForces", "lsst.sal.MTM1M3.forceActuatorPressure", "lsst.sal.MTM1M3.pidData" ]
+      topicRegexps: ["lsst.sal.MTM1M3.appliedAccelerationForces", "lsst.sal.MTM1M3.appliedAzimuthForces", "lsst.sal.MTM1M3.appliedBalanceForces", "lsst.sal.MTM1M3.appliedElevationForces", "lsst.sal.MTM1M3.appliedThermalForces", "lsst.sal.MTM1M3.appliedVelocityForces", "lsst.sal.MTM1M3.forceActuatorPressure", "lsst.sal.MTM1M3.pidData"]
       resources:
         limits:
           cpu: "5"
@@ -229,59 +217,48 @@ telegraf:
       metric_batch_size: 1500
       max_undelivered_messages: 4000
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.MTM1M3TS" ]
+      topicRegexps: ["lsst.sal.MTM1M3TS"]
     m2:
       enabled: true
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.MTHexapod", "lsst.sal.MTM2", "lsst.sal.MTRotator" ]
+      topicRegexps: ["lsst.sal.MTHexapod", "lsst.sal.MTM2", "lsst.sal.MTRotator"]
     obssys:
       enabled: true
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.Scheduler", "lsst.sal.Script", "lsst.sal.ScriptQueue", "lsst.sal.Watcher" ]
+      topicRegexps: ["lsst.sal.Scheduler", "lsst.sal.Script", "lsst.sal.ScriptQueue", "lsst.sal.Watcher"]
     ocps:
       enabled: true
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.OCPS" ]
+      topicRegexps: ["lsst.sal.OCPS"]
     test:
       enabled: true
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.Test" ]
+      topicRegexps: ["lsst.sal.Test"]
     mtaircompressor:
       enabled: true
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.MTAirCompressor" ]
+      topicRegexps: ["lsst.sal.MTAirCompressor"]
     lasertracker:
       enabled: true
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.LaserTracker" ]
+      topicRegexps: ["lsst.sal.LaserTracker"]
     genericcamera:
       enabled: true
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.GCHeaderService", "lsst.sal.GenericCamera" ]
+      topicRegexps: ["lsst.sal.GCHeaderService", "lsst.sal.GenericCamera"]
     lsstcam:
       enabled: true
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.MTHeaderService", "lsst.sal.MTOODS", "lsst.sal.WFOODS", "lsst.sal.MTCamera" ]
+      topicRegexps: ["lsst.sal.MTHeaderService", "lsst.sal.MTOODS", "lsst.sal.WFOODS", "lsst.sal.MTCamera"]
     calsys:
       enabled: true
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.CBP", "lsst.sal.Electrometer", "lsst.sal.FiberSpectrograph", "lsst.sal.LEDProjector", "lsst.sal.LinearStage", "lsst.sal.MTReflector", "lsst.sal.TunableLaser" ]
+      topicRegexps: ["lsst.sal.CBP", "lsst.sal.Electrometer", "lsst.sal.FiberSpectrograph", "lsst.sal.LEDProjector", "lsst.sal.LinearStage", "lsst.sal.MTReflector", "lsst.sal.TunableLaser"]
     mtvms:
       enabled: true
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: |
-        [ "lsst.sal.MTVMS" ]
+      topicRegexps: ["lsst.sal.MTVMS"]
     # CCS connectors (experimental) data is being written on separate databases for now
     atcamera:
       enabled: true
@@ -289,16 +266,14 @@ telegraf:
       timestamp_format: "unix_ms"
       timestamp_field: "timestamp"
       tags: ["Agent", "Aspic", "Location", "Raft", "Reb", "Sensor", "Source", "VersionType"]
-      topicRegexps: |
-        [ "lsst.ATCamera" ]
+      topicRegexps: ["lsst.ATCamera"]
     mtcamera:
       enabled: true
       database: "lsst.MTCamera"
       timestamp_format: "unix_ms"
       timestamp_field: "timestamp"
       tags: ["Agent", "Aspic", "Axis", "Bay", "Buffer", "Canbus", "Cip", "Clamp", "Cold", "Controller", "Cryo", "Gateway", "Hardware", "Hip", "Hook", "Latch", "Location", "Ps", "RTD", "Raft", "Reb", "Segment", "Sensor", "Socket", "Source", "Truck", "VersionType"]
-      topicRegexps: |
-        [ "lsst.MTCamera" ]
+      topicRegexps: ["lsst.MTCamera"]
   resources:
     limits:
       cpu: "2"

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -97,8 +97,7 @@ telegraf:
       enabled: true
       replicaCount: 1
       database: "lsst.example"
-      tags: |
-        [ "band", "instrument" ]
+      tags: ["band", "instrument"]
       timestamp_format: "unix_ms"
       timestamp_field: "timestamp"
       topicRegexps: |

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -100,16 +100,14 @@ telegraf:
       tags: ["band", "instrument"]
       timestamp_format: "unix_ms"
       timestamp_field: "timestamp"
-      topicRegexps: |
-        [ "lsst.example" ]
+      topicRegexps: ["lsst.example"]
     backpack:
       enabled: true
       replicaCount: 1
       database: "lsst.backpack"
       timestamp_format: "unix"
       timestamp_field: "timestamp"
-      topicRegexps: |
-        [ "lsst.backpack" ]
+      topicRegexps: ["lsst.backpack"]
 
 kafdrop:
   cmdArgs: "--message.format=AVRO --message.keyFormat=DEFAULT --topic.deleteEnabled=true --topic.createEnabled=true"

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -97,17 +97,21 @@ telegraf:
       enabled: true
       replicaCount: 1
       database: "lsst.example"
-      tags: ["band", "instrument"]
+      tags:
+        - "band"
+        - "instrument"
       timestamp_format: "unix_ms"
       timestamp_field: "timestamp"
-      topicRegexps: ["lsst.example"]
+      topicRegexps:
+        - "lsst.example"
     backpack:
       enabled: true
       replicaCount: 1
       database: "lsst.backpack"
       timestamp_format: "unix"
       timestamp_field: "timestamp"
-      topicRegexps: ["lsst.backpack"]
+      topicRegexps:
+        - "lsst.backpack"
 
 kafdrop:
   cmdArgs: "--message.format=AVRO --message.keyFormat=DEFAULT --topic.deleteEnabled=true --topic.createEnabled=true"

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -104,6 +104,18 @@ telegraf:
       timestamp_field: "timestamp"
       topicRegexps:
         - "lsst.example"
+    examplejson:
+      enabled: true
+      replicaCount: 1
+      data_format: "json_v2"
+      database: "lsst.examplejson"
+      tags:
+        - "band"
+        - "instrument"
+      timestamp_format: "unix_ms"
+      timestamp_field: "timestamp"
+      topicRegexps:
+        - "lsst.examplejson"
     backpack:
       enabled: true
       replicaCount: 1

--- a/applications/sasquatch/values-idfint.yaml
+++ b/applications/sasquatch/values-idfint.yaml
@@ -54,8 +54,7 @@ telegraf:
       enabled: true
       replicaCount: 1
       database: "lsst.example"
-      tags: |
-        [ "band", "instrument" ]
+      tags: ["band", "instrument"]
       timestamp_format: "unix_ms"
       timestamp_field: "timestamp"
       topicRegexps: |

--- a/applications/sasquatch/values-idfint.yaml
+++ b/applications/sasquatch/values-idfint.yaml
@@ -57,16 +57,14 @@ telegraf:
       tags: ["band", "instrument"]
       timestamp_format: "unix_ms"
       timestamp_field: "timestamp"
-      topicRegexps: |
-        [ "lsst.example" ]
+      topicRegexps: ["lsst.example"]
     backpack:
       enabled: true
       replicaCount: 1
       database: "lsst.backpack"
       timestamp_format: "unix"
       timestamp_field: "timestamp"
-      topicRegexps: |
-        [ "lsst.backpack" ]
+      topicRegexps: ["lsst.backpack"]
 
 kafdrop:
   ingress:

--- a/applications/sasquatch/values-idfint.yaml
+++ b/applications/sasquatch/values-idfint.yaml
@@ -54,17 +54,21 @@ telegraf:
       enabled: true
       replicaCount: 1
       database: "lsst.example"
-      tags: ["band", "instrument"]
+      tags:
+        - "band"
+        - "instrument"
       timestamp_format: "unix_ms"
       timestamp_field: "timestamp"
-      topicRegexps: ["lsst.example"]
+      topicRegexps:
+        - "lsst.example"
     backpack:
       enabled: true
       replicaCount: 1
       database: "lsst.backpack"
       timestamp_format: "unix"
       timestamp_field: "timestamp"
-      topicRegexps: ["lsst.backpack"]
+      topicRegexps:
+        - "lsst.backpack"
 
 kafdrop:
   ingress:

--- a/applications/sasquatch/values-summit.yaml
+++ b/applications/sasquatch/values-summit.yaml
@@ -231,23 +231,20 @@ telegraf:
       database: "lsst.obsenv"
       timestamp_format: "unix_ms"
       timestamp_field: "timestamp"
-      topicRegexps: |
-        [ "lsst.obsenv" ]
+      topicRegexps: ["lsst.obsenv"]
     scimma:
       enabled: true
       database: "lsst.scimma"
       timestamp_format: "unix_ms"
       timestamp_field: "timestamp"
-      topicRegexps: |
-        [ "lsst.scimma" ]
+      topicRegexps: ["lsst.scimma"]
       offset: oldest
     cp:
       enabled: true
       database: "lsst.cp"
       timestamp_format: "unix"
       timestamp_field: "timestamp"
-      topicRegexps: |
-        [ "lsst.cp" ]
+      topicRegexps: ["lsst.cp"]
       tags: ["dataset_tag", "band", "instrument", "skymap", "detector", "physical_filter", "tract", "exposure", "patch", "visit", "run", "pipeline"]
     backpack:
       enabled: true
@@ -255,36 +252,30 @@ telegraf:
       database: "lsst.backpack"
       timestamp_format: "unix"
       timestamp_field: "timestamp"
-      topicRegexps: |
-        [ "lsst.backpack" ]
+      topicRegexps: ["lsst.backpack"]
     # CSC connectors
     maintel:
       enabled: true
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.MTAOS", "lsst.sal.MTDome", "lsst.sal.MTDomeTrajectory", "lsst.sal.MTPtg" ]
+      topicRegexps: ["lsst.sal.MTAOS", "lsst.sal.MTDome", "lsst.sal.MTDomeTrajectory", "lsst.sal.MTPtg"]
     mtmount:
       enabled: true
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.MTMount" ]
+      topicRegexps: ["lsst.sal.MTMount"]
     comcam:
       enabled: true
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.CCCamera", "lsst.sal.CCHeaderService", "lsst.sal.CCOODS" ]
+      topicRegexps: ["lsst.sal.CCCamera", "lsst.sal.CCHeaderService", "lsst.sal.CCOODS"]
     envsys:
       enabled: true
       database: "efd"
-      topicRegexps: |
-         [ "lsst.sal.DIMM", "lsst.sal.DREAM", "lsst.sal.DSM", "lsst.sal.EAS", "lsst.sal.EPM", "lsst.sal.ESS", "lsst.sal.HVAC", "lsst.sal.WeatherForecast" ]
+      topicRegexps: ["lsst.sal.DIMM", "lsst.sal.DREAM", "lsst.sal.DSM", "lsst.sal.EAS", "lsst.sal.EPM", "lsst.sal.ESS", "lsst.sal.HVAC", "lsst.sal.WeatherForecast"]
     m1m3:
       enabled: true
       metric_batch_size: 1500
       max_undelivered_messages: 4000
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.MTM1M3([^T].*)" ]
+      topicRegexps: ["lsst.sal.MTM1M3([^T].*)"]
       resources:
         limits:
           cpu: "5"
@@ -297,13 +288,11 @@ telegraf:
       metric_batch_size: 1000
       max_undelivered_messages: 4000
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.MTM1M3TS" ]
+      topicRegexps: ["lsst.sal.MTM1M3TS"]
     m2:
       enabled: true
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.MTHexapod", "lsst.sal.MTM2", "lsst.sal.MTRotator" ]
+      topicRegexps: ["lsst.sal.MTHexapod", "lsst.sal.MTM2", "lsst.sal.MTRotator"]
       resources:
         limits:
           cpu: "5"
@@ -314,70 +303,57 @@ telegraf:
     obssys:
       enabled: true
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.Scheduler", "lsst.sal.Script", "lsst.sal.ScriptQueue", "lsst.sal.Watcher" ]
+      topicRegexps: ["lsst.sal.Scheduler", "lsst.sal.Script", "lsst.sal.ScriptQueue", "lsst.sal.Watcher"]
     ocps:
       enabled: true
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.OCPS" ]
+      topicRegexps: ["lsst.sal.OCPS"]
     pmd:
       enabled: true
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.PMD" ]
+      topicRegexps: ["lsst.sal.PMD"]
     calsys:
       enabled: true
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.ATMonochromator", "lsst.sal.ATWhiteLight", "lsst.sal.CBP", "lsst.sal.Electrometer", "lsst.sal.FiberSpectrograph", "lsst.sal.LEDProjector", "lsst.sal.LinearStage", "lsst.sal.MTReflector", "lsst.sal.TunableLaser" ]
+      topicRegexps: ["lsst.sal.ATMonochromator", "lsst.sal.ATWhiteLight", "lsst.sal.CBP", "lsst.sal.Electrometer", "lsst.sal.FiberSpectrograph", "lsst.sal.LEDProjector", "lsst.sal.LinearStage", "lsst.sal.MTReflector", "lsst.sal.TunableLaser"]
     mtaircompressor:
       enabled: true
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.MTAirCompressor" ]
+      topicRegexps: ["lsst.sal.MTAirCompressor"]
     genericcamera:
       enabled: true
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.GCHeaderService", "lsst.sal.GenericCamera" ]
+      topicRegexps: ["lsst.sal.GCHeaderService", "lsst.sal.GenericCamera"]
     gis:
       enabled: true
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.GIS" ]
+      topicRegexps: ["lsst.sal.GIS"]
     mtvms:
       enabled: true
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.MTVMS" ]
+      topicRegexps: ["lsst.sal.MTVMS"]
     lsstcam:
       enabled: true
       metric_batch_size: 250
       max_undelivered_messages: 5000
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.MTCamera", "lsst.sal.MTHeaderService", "lsst.sal.MTOODS", "lsst.sal.WFOODS" ]
+      topicRegexps: ["lsst.sal.MTCamera", "lsst.sal.MTHeaderService", "lsst.sal.MTOODS", "lsst.sal.WFOODS"]
     auxtel:
       enabled: true
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.ATAOS", "lsst.sal.ATBuilding", "lsst.sal.ATDome", "lsst.sal.ATDomeTrajectory", "lsst.sal.ATHexapod", "lsst.sal.ATPneumatics", "lsst.sal.ATPtg", "lsst.sal.ATMCS" ]
+      topicRegexps: ["lsst.sal.ATAOS", "lsst.sal.ATBuilding", "lsst.sal.ATDome", "lsst.sal.ATDomeTrajectory", "lsst.sal.ATHexapod", "lsst.sal.ATPneumatics", "lsst.sal.ATPtg", "lsst.sal.ATMCS"]
     latiss:
       enabled: true
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.ATCamera", "lsst.sal.ATHeaderService", "lsst.sal.ATOODS", "lsst.sal.ATSpectrograph" ]
+      topicRegexps: ["lsst.sal.ATCamera", "lsst.sal.ATHeaderService", "lsst.sal.ATOODS", "lsst.sal.ATSpectrograph"]
     test:
       enabled: true
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.Test" ]
+      topicRegexps: ["lsst.sal.Test"]
     lasertracker:
       enabled: true
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.LaserTracker" ]
+      topicRegexps: ["lsst.sal.LaserTracker"]
     # CCS connectors (experimental) data is being written on separate databases for now
     atcamera:
       enabled: true
@@ -385,24 +361,21 @@ telegraf:
       timestamp_format: "unix_ms"
       timestamp_field: "timestamp"
       tags: ["Agent", "Aspic", "Location", "Raft", "Reb", "Sensor", "Source", "VersionType"]
-      topicRegexps: |
-        [ "lsst.ATCamera" ]
+      topicRegexps: ["lsst.ATCamera"]
     cccamera:
       enabled: true
       database: "lsst.CCCamera"
       timestamp_format: "unix_ms"
       timestamp_field: "timestamp"
       tags: ["Agent", "Aspic", "Cold", "Cryo", "Hardware", "Location", "Ps", "RTD", "Raft", "Reb", "Segment", "Sensor", "Source", "VersionType"]
-      topicRegexps: |
-        [ "lsst.CCCamera" ]
+      topicRegexps: ["lsst.CCCamera"]
     mtcamera:
       enabled: true
       database: "lsst.MTCamera"
       timestamp_format: "unix_ms"
       timestamp_field: "timestamp"
       tags: ["Agent", "Aspic", "Axis", "Bay", "Canbus", "Cip", "Clamp", "Cold", "Controller", "Cryo", "Gateway", "Hardware", "Hip", "Hook", "Latch", "Location", "Ps", "RTD", "Raft", "Reb", "Segment", "Sensor", "Socket", "Source", "Truck", "VersionType"]
-      topicRegexps: |
-        [ "lsst.MTCamera" ]
+      topicRegexps: ["lsst.MTCamera"]
 
 kafdrop:
   ingress:

--- a/applications/sasquatch/values-summit.yaml
+++ b/applications/sasquatch/values-summit.yaml
@@ -248,8 +248,7 @@ telegraf:
       timestamp_field: "timestamp"
       topicRegexps: |
         [ "lsst.cp" ]
-      tags: |
-        [ "dataset_tag", "band", "instrument", "skymap", "detector", "physical_filter", "tract", "exposure", "patch", "visit", "run", "pipeline" ]
+      tags: ["dataset_tag", "band", "instrument", "skymap", "detector", "physical_filter", "tract", "exposure", "patch", "visit", "run", "pipeline"]
     backpack:
       enabled: true
       replicaCount: 1
@@ -385,8 +384,7 @@ telegraf:
       database: "lsst.ATCamera"
       timestamp_format: "unix_ms"
       timestamp_field: "timestamp"
-      tags: |
-        [ "Agent", "Aspic", "Location", "Raft", "Reb", "Sensor", "Source", "VersionType" ]
+      tags: ["Agent", "Aspic", "Location", "Raft", "Reb", "Sensor", "Source", "VersionType"]
       topicRegexps: |
         [ "lsst.ATCamera" ]
     cccamera:
@@ -394,8 +392,7 @@ telegraf:
       database: "lsst.CCCamera"
       timestamp_format: "unix_ms"
       timestamp_field: "timestamp"
-      tags: |
-        [ "Agent", "Aspic", "Cold", "Cryo", "Hardware", "Location", "Ps", "RTD", "Raft", "Reb", "Segment", "Sensor", "Source", "VersionType" ]
+      tags: ["Agent", "Aspic", "Cold", "Cryo", "Hardware", "Location", "Ps", "RTD", "Raft", "Reb", "Segment", "Sensor", "Source", "VersionType"]
       topicRegexps: |
         [ "lsst.CCCamera" ]
     mtcamera:
@@ -403,8 +400,7 @@ telegraf:
       database: "lsst.MTCamera"
       timestamp_format: "unix_ms"
       timestamp_field: "timestamp"
-      tags: |
-        [ "Agent", "Aspic", "Axis", "Bay", "Canbus", "Cip", "Clamp", "Cold", "Controller", "Cryo", "Gateway", "Hardware", "Hip", "Hook", "Latch", "Location", "Ps", "RTD", "Raft", "Reb", "Segment", "Sensor", "Socket", "Source", "Truck", "VersionType" ]
+      tags: ["Agent", "Aspic", "Axis", "Bay", "Canbus", "Cip", "Clamp", "Cold", "Controller", "Cryo", "Gateway", "Hardware", "Hip", "Hook", "Latch", "Location", "Ps", "RTD", "Raft", "Reb", "Segment", "Sensor", "Socket", "Source", "Truck", "VersionType"]
       topicRegexps: |
         [ "lsst.MTCamera" ]
 

--- a/applications/sasquatch/values-summit.yaml
+++ b/applications/sasquatch/values-summit.yaml
@@ -231,51 +231,84 @@ telegraf:
       database: "lsst.obsenv"
       timestamp_format: "unix_ms"
       timestamp_field: "timestamp"
-      topicRegexps: ["lsst.obsenv"]
+      topicRegexps:
+        - "lsst.obsenv"
     scimma:
       enabled: true
       database: "lsst.scimma"
       timestamp_format: "unix_ms"
       timestamp_field: "timestamp"
-      topicRegexps: ["lsst.scimma"]
+      topicRegexps:
+        - "lsst.scimma"
       offset: oldest
     cp:
       enabled: true
       database: "lsst.cp"
       timestamp_format: "unix"
       timestamp_field: "timestamp"
-      topicRegexps: ["lsst.cp"]
-      tags: ["dataset_tag", "band", "instrument", "skymap", "detector", "physical_filter", "tract", "exposure", "patch", "visit", "run", "pipeline"]
+      topicRegexps:
+        - "lsst.cp"
+      tags:
+        - "dataset_tag"
+        - "band"
+        - "instrument"
+        - "skymap"
+        - "detector"
+        - "physical_filter"
+        - "tract"
+        - "exposure"
+        - "patch"
+        - "visit"
+        - "run"
+        - "pipeline"
     backpack:
       enabled: true
       replicaCount: 1
       database: "lsst.backpack"
       timestamp_format: "unix"
       timestamp_field: "timestamp"
-      topicRegexps: ["lsst.backpack"]
+      topicRegexps:
+        - "lsst.backpack"
     # CSC connectors
     maintel:
       enabled: true
       database: "efd"
-      topicRegexps: ["lsst.sal.MTAOS", "lsst.sal.MTDome", "lsst.sal.MTDomeTrajectory", "lsst.sal.MTPtg"]
+      topicRegexps:
+        - "lsst.sal.MTAOS"
+        - "lsst.sal.MTDome"
+        - "lsst.sal.MTDomeTrajectory"
+        - "lsst.sal.MTPtg"
     mtmount:
       enabled: true
       database: "efd"
-      topicRegexps: ["lsst.sal.MTMount"]
+      topicRegexps:
+        - "lsst.sal.MTMount"
     comcam:
       enabled: true
       database: "efd"
-      topicRegexps: ["lsst.sal.CCCamera", "lsst.sal.CCHeaderService", "lsst.sal.CCOODS"]
+      topicRegexps:
+        - "lsst.sal.CCCamera"
+        - "lsst.sal.CCHeaderService"
+        - "lsst.sal.CCOODS"
     envsys:
       enabled: true
       database: "efd"
-      topicRegexps: ["lsst.sal.DIMM", "lsst.sal.DREAM", "lsst.sal.DSM", "lsst.sal.EAS", "lsst.sal.EPM", "lsst.sal.ESS", "lsst.sal.HVAC", "lsst.sal.WeatherForecast"]
+      topicRegexps:
+        - "lsst.sal.DIMM"
+        - "lsst.sal.DREAM"
+        - "lsst.sal.DSM"
+        - "lsst.sal.EAS"
+        - "lsst.sal.EPM"
+        - "lsst.sal.ESS"
+        - "lsst.sal.HVAC"
+        - "lsst.sal.WeatherForecast"
     m1m3:
       enabled: true
       metric_batch_size: 1500
       max_undelivered_messages: 4000
       database: "efd"
-      topicRegexps: ["lsst.sal.MTM1M3([^T].*)"]
+      topicRegexps:
+        - "lsst.sal.MTM1M3([^T].*)"
       resources:
         limits:
           cpu: "5"
@@ -288,11 +321,15 @@ telegraf:
       metric_batch_size: 1000
       max_undelivered_messages: 4000
       database: "efd"
-      topicRegexps: ["lsst.sal.MTM1M3TS"]
+      topicRegexps:
+        - "lsst.sal.MTM1M3TS"
     m2:
       enabled: true
       database: "efd"
-      topicRegexps: ["lsst.sal.MTHexapod", "lsst.sal.MTM2", "lsst.sal.MTRotator"]
+      topicRegexps:
+        - "lsst.sal.MTHexapod"
+        - "lsst.sal.MTM2"
+        - "lsst.sal.MTRotator"
       resources:
         limits:
           cpu: "5"
@@ -303,79 +340,168 @@ telegraf:
     obssys:
       enabled: true
       database: "efd"
-      topicRegexps: ["lsst.sal.Scheduler", "lsst.sal.Script", "lsst.sal.ScriptQueue", "lsst.sal.Watcher"]
+      topicRegexps:
+        - "lsst.sal.Scheduler"
+        - "lsst.sal.Script"
+        - "lsst.sal.ScriptQueue"
+        - "lsst.sal.Watcher"
     ocps:
       enabled: true
       database: "efd"
-      topicRegexps: ["lsst.sal.OCPS"]
+      topicRegexps:
+        - "lsst.sal.OCPS"
     pmd:
       enabled: true
       database: "efd"
-      topicRegexps: ["lsst.sal.PMD"]
+      topicRegexps:
+        - "lsst.sal.PMD"
     calsys:
       enabled: true
       database: "efd"
-      topicRegexps: ["lsst.sal.ATMonochromator", "lsst.sal.ATWhiteLight", "lsst.sal.CBP", "lsst.sal.Electrometer", "lsst.sal.FiberSpectrograph", "lsst.sal.LEDProjector", "lsst.sal.LinearStage", "lsst.sal.MTReflector", "lsst.sal.TunableLaser"]
+      topicRegexps:
+        - "lsst.sal.ATMonochromator"
+        - "lsst.sal.ATWhiteLight"
+        - "lsst.sal.CBP"
+        - "lsst.sal.Electrometer"
+        - "lsst.sal.FiberSpectrograph"
+        - "lsst.sal.LEDProjector"
+        - "lsst.sal.LinearStage"
+        - "lsst.sal.MTReflector"
+        - "lsst.sal.TunableLaser"
     mtaircompressor:
       enabled: true
       database: "efd"
-      topicRegexps: ["lsst.sal.MTAirCompressor"]
+      topicRegexps:
+        - "lsst.sal.MTAirCompressor"
     genericcamera:
       enabled: true
       database: "efd"
-      topicRegexps: ["lsst.sal.GCHeaderService", "lsst.sal.GenericCamera"]
+      topicRegexps:
+        - "lsst.sal.GCHeaderService"
+        - "lsst.sal.GenericCamera"
     gis:
       enabled: true
       database: "efd"
-      topicRegexps: ["lsst.sal.GIS"]
+      topicRegexps:
+        - "lsst.sal.GIS"
     mtvms:
       enabled: true
       database: "efd"
-      topicRegexps: ["lsst.sal.MTVMS"]
+      topicRegexps:
+        - "lsst.sal.MTVMS"
     lsstcam:
       enabled: true
       metric_batch_size: 250
       max_undelivered_messages: 5000
       database: "efd"
-      topicRegexps: ["lsst.sal.MTCamera", "lsst.sal.MTHeaderService", "lsst.sal.MTOODS", "lsst.sal.WFOODS"]
+      topicRegexps:
+        - "lsst.sal.MTCamera"
+        - "lsst.sal.MTHeaderService"
+        - "lsst.sal.MTOODS"
+        - "lsst.sal.WFOODS"
     auxtel:
       enabled: true
       database: "efd"
-      topicRegexps: ["lsst.sal.ATAOS", "lsst.sal.ATBuilding", "lsst.sal.ATDome", "lsst.sal.ATDomeTrajectory", "lsst.sal.ATHexapod", "lsst.sal.ATPneumatics", "lsst.sal.ATPtg", "lsst.sal.ATMCS"]
+      topicRegexps:
+        - "lsst.sal.ATAOS"
+        - "lsst.sal.ATBuilding"
+        - "lsst.sal.ATDome"
+        - "lsst.sal.ATDomeTrajectory"
+        - "lsst.sal.ATHexapod"
+        - "lsst.sal.ATPneumatics"
+        - "lsst.sal.ATPtg"
+        - "lsst.sal.ATMCS"
     latiss:
       enabled: true
       database: "efd"
-      topicRegexps: ["lsst.sal.ATCamera", "lsst.sal.ATHeaderService", "lsst.sal.ATOODS", "lsst.sal.ATSpectrograph"]
+      topicRegexps:
+        - "lsst.sal.ATCamera"
+        - "lsst.sal.ATHeaderService"
+        - "lsst.sal.ATOODS"
+        - "lsst.sal.ATSpectrograph"
     test:
       enabled: true
       database: "efd"
-      topicRegexps: ["lsst.sal.Test"]
+      topicRegexps:
+        - "lsst.sal.Test"
     lasertracker:
       enabled: true
       database: "efd"
-      topicRegexps: ["lsst.sal.LaserTracker"]
+      topicRegexps:
+        - "lsst.sal.LaserTracker"
     # CCS connectors (experimental) data is being written on separate databases for now
     atcamera:
       enabled: true
       database: "lsst.ATCamera"
       timestamp_format: "unix_ms"
       timestamp_field: "timestamp"
-      tags: ["Agent", "Aspic", "Location", "Raft", "Reb", "Sensor", "Source", "VersionType"]
-      topicRegexps: ["lsst.ATCamera"]
+      tags:
+        - "Agent"
+        - "Aspic"
+        - "Location"
+        - "Raft"
+        - "Reb"
+        - "Sensor"
+        - "Source"
+        - "VersionType"
+      topicRegexps:
+        - "lsst.ATCamera"
     cccamera:
       enabled: true
       database: "lsst.CCCamera"
       timestamp_format: "unix_ms"
       timestamp_field: "timestamp"
-      tags: ["Agent", "Aspic", "Cold", "Cryo", "Hardware", "Location", "Ps", "RTD", "Raft", "Reb", "Segment", "Sensor", "Source", "VersionType"]
-      topicRegexps: ["lsst.CCCamera"]
+      tags:
+        - "Agent"
+        - "Aspic"
+        - "Cold"
+        - "Cryo"
+        - "Hardware"
+        - "Location"
+        - "Ps"
+        - "RTD"
+        - "Raft"
+        - "Reb"
+        - "Segment"
+        - "Sensor"
+        - "Source"
+        - "VersionType"
+      topicRegexps:
+        - "lsst.CCCamera"
     mtcamera:
       enabled: true
       database: "lsst.MTCamera"
       timestamp_format: "unix_ms"
       timestamp_field: "timestamp"
-      tags: ["Agent", "Aspic", "Axis", "Bay", "Canbus", "Cip", "Clamp", "Cold", "Controller", "Cryo", "Gateway", "Hardware", "Hip", "Hook", "Latch", "Location", "Ps", "RTD", "Raft", "Reb", "Segment", "Sensor", "Socket", "Source", "Truck", "VersionType"]
-      topicRegexps: ["lsst.MTCamera"]
+      tags:
+        - "Agent"
+        - "Aspic"
+        - "Axis"
+        - "Bay"
+        - "Canbus"
+        - "Cip"
+        - "Clamp"
+        - "Cold"
+        - "Controller"
+        - "Cryo"
+        - "Gateway"
+        - "Hardware"
+        - "Hip"
+        - "Hook"
+        - "Latch"
+        - "Location"
+        - "Ps"
+        - "RTD"
+        - "Raft"
+        - "Reb"
+        - "Segment"
+        - "Sensor"
+        - "Socket"
+        - "Source"
+        - "Truck"
+        - "VersionType"
+      topicRegexps:
+        - "lsst.MTCamera"
 
 kafdrop:
   ingress:

--- a/applications/sasquatch/values-tucson-teststand.yaml
+++ b/applications/sasquatch/values-tucson-teststand.yaml
@@ -113,46 +113,39 @@ telegraf:
     auxtel:
       enabled: true
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.ATAOS", "lsst.sal.ATBuilding", "lsst.sal.ATDome", "lsst.sal.ATDomeTrajectory", "lsst.sal.ATHexapod", "lsst.sal.ATPneumatics", "lsst.sal.ATPtg", "lsst.sal.ATMCS" ]
+      topicRegexps: ["lsst.sal.ATAOS", "lsst.sal.ATBuilding", "lsst.sal.ATDome", "lsst.sal.ATDomeTrajectory", "lsst.sal.ATHexapod", "lsst.sal.ATPneumatics", "lsst.sal.ATPtg", "lsst.sal.ATMCS"]
       debug: true
     maintel:
       enabled: true
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.MTAOS", "lsst.sal.MTDome", "lsst.sal.MTDomeTrajectory", "lsst.sal.MTPtg", "lsst.sal.WFOODS" ]
+      topicRegexps: ["lsst.sal.MTAOS", "lsst.sal.MTDome", "lsst.sal.MTDomeTrajectory", "lsst.sal.MTPtg", "lsst.sal.WFOODS"]
       debug: true
     mtmount:
       enabled: true
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.MTMount" ]
+      topicRegexps: ["lsst.sal.MTMount"]
       debug: true
     envsys:
       enabled: true
       database: "efd"
       metric_batch_size: 100
       flush_interval: 20s
-      topicRegexps: |
-        [ "lsst.sal.DIMM", "lsst.sal.DREAM", "lsst.sal.DSM", "lsst.sal.EAS", "lsst.sal.EPM", "lsst.sal.ESS", "lsst.sal.HVAC", "lsst.sal.WeatherForecast" ]
+      topicRegexps: ["lsst.sal.DIMM", "lsst.sal.DREAM", "lsst.sal.DSM", "lsst.sal.EAS", "lsst.sal.EPM", "lsst.sal.ESS", "lsst.sal.HVAC", "lsst.sal.WeatherForecast"]
       debug: true
     latiss:
       enabled: true
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.ATCamera", "lsst.sal.ATHeaderService", "lsst.sal.ATOODS", "lsst.sal.ATSpectrograph" ]
+      topicRegexps: ["lsst.sal.ATCamera", "lsst.sal.ATHeaderService", "lsst.sal.ATOODS", "lsst.sal.ATSpectrograph"]
       debug: true
     m1m3:
       enabled: true
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.MTM1M3.ackcmd", "lsst.sal.MTM1M3.logevent*", "lsst.sal.MTM1M3.command*" ]
+      topicRegexps: ["lsst.sal.MTM1M3.ackcmd", "lsst.sal.MTM1M3.logevent*", "lsst.sal.MTM1M3.command*"]
       debug: true
     m1m3-tel1:
       enabled: true
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.MTM1M3.accelerometerData", "lsst.sal.MTM1M3.appliedCylinderForces", "lsst.sal.MTM1M3.appliedForces", "lsst.sal.MTM1M3.gyroData", "lsst.sal.MTM1M3.hardpointActuatorData", "lsst.sal.MTM1M3.hardpointMonitorData" ]
+      topicRegexps: ["lsst.sal.MTM1M3.accelerometerData", "lsst.sal.MTM1M3.appliedCylinderForces", "lsst.sal.MTM1M3.appliedForces", "lsst.sal.MTM1M3.gyroData", "lsst.sal.MTM1M3.hardpointActuatorData", "lsst.sal.MTM1M3.hardpointMonitorData"]
       debug: true
       resources:
         limits:
@@ -165,8 +158,7 @@ telegraf:
       enabled: true
       database: "efd"
       metric_batch_size: 750
-      topicRegexps: |
-        [ "lsst.sal.MTM1M3.forceActuatorData", "lsst.sal.MTM1M3.outerLoopData", "lsst.sal.MTM1M3.imsData", "lsst.sal.MTM1M3.inclinometerData", "lsst.sal.MTM1M3.powerSupplyData" ]
+      topicRegexps: ["lsst.sal.MTM1M3.forceActuatorData", "lsst.sal.MTM1M3.outerLoopData", "lsst.sal.MTM1M3.imsData", "lsst.sal.MTM1M3.inclinometerData", "lsst.sal.MTM1M3.powerSupplyData"]
       debug: true
       resources:
         limits:
@@ -178,8 +170,7 @@ telegraf:
     m1m3-tel3:
       enabled: true
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.MTM1M3.appliedAccelerationForces", "lsst.sal.MTM1M3.appliedAzimuthForces", "lsst.sal.MTM1M3.appliedBalanceForces", "lsst.sal.MTM1M3.appliedElevationForces", "lsst.sal.MTM1M3.appliedThermalForces", "lsst.sal.MTM1M3.appliedVelocityForces", "lsst.sal.MTM1M3.forceActuatorPressure", "lsst.sal.MTM1M3.pidData" ]
+      topicRegexps: ["lsst.sal.MTM1M3.appliedAccelerationForces", "lsst.sal.MTM1M3.appliedAzimuthForces", "lsst.sal.MTM1M3.appliedBalanceForces", "lsst.sal.MTM1M3.appliedElevationForces", "lsst.sal.MTM1M3.appliedThermalForces", "lsst.sal.MTM1M3.appliedVelocityForces", "lsst.sal.MTM1M3.forceActuatorPressure", "lsst.sal.MTM1M3.pidData"]
       debug: true
       resources:
         limits:
@@ -193,77 +184,65 @@ telegraf:
       metric_batch_size: 1500
       max_undelivered_messages: 4000
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.MTM1M3TS" ]
+      topicRegexps: ["lsst.sal.MTM1M3TS"]
       debug: true
     m2:
       enabled: true
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.MTHexapod", "lsst.sal.MTM2", "lsst.sal.MTRotator" ]
+      topicRegexps: ["lsst.sal.MTHexapod", "lsst.sal.MTM2", "lsst.sal.MTRotator"]
       debug: true
     obssys:
       enabled: true
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.Scheduler", "lsst.sal.Script", "lsst.sal.ScriptQueue", "lsst.sal.Watcher" ]
+      topicRegexps: ["lsst.sal.Scheduler", "lsst.sal.Script", "lsst.sal.ScriptQueue", "lsst.sal.Watcher"]
       debug: true
     ocps:
       enabled: true
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.OCPS" ]
+      topicRegexps: ["lsst.sal.OCPS"]
       debug: true
     calsys:
       enabled: true
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.CBP", "lsst.sal.Electrometer", "lsst.sal.FiberSpectrograph", "lsst.sal.LEDProjector", "lsst.sal.LinearStage", "lsst.sal.MTReflector", "lsst.sal.TunableLaser" ]
+      topicRegexps: ["lsst.sal.CBP", "lsst.sal.Electrometer", "lsst.sal.FiberSpectrograph", "lsst.sal.LEDProjector", "lsst.sal.LinearStage", "lsst.sal.MTReflector", "lsst.sal.TunableLaser"]
       debug: true
     comcam:
       enabled: true
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.CCCamera", "lsst.sal.CCHeaderService", "lsst.sal.CCOODS" ]
+      topicRegexps: ["lsst.sal.CCCamera", "lsst.sal.CCHeaderService", "lsst.sal.CCOODS"]
       debug: true
     test:
       enabled: true
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.Test" ]
+      topicRegexps: ["lsst.sal.Test"]
       debug: true
     mtaircompressor:
       enabled: true
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.MTAirCompressor" ]
+      topicRegexps: ["lsst.sal.MTAirCompressor"]
       debug: true
     lasertracker:
       enabled: true
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.LaserTracker" ]
+      topicRegexps: ["lsst.sal.LaserTracker"]
       debug: true
     genericcamera:
       enabled: true
       database: "efd"
-      topicRegexps: |
-        [ "lsst.sal.GCHeaderService", "lsst.sal.GenericCamera" ]
+      topicRegexps: ["lsst.sal.GCHeaderService", "lsst.sal.GenericCamera"]
       debug: true
     mtvms:
       enabled: true
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: |
-        [ "lsst.sal.MTVMS" ]
+      topicRegexps: ["lsst.sal.MTVMS"]
       debug: true
     obsenv:
       enabled: true
       database: "lsst.obsenv"
       timestamp_format: "unix_ms"
       timestamp_field: "timestamp"
-      topicRegexps: |
-        [ "lsst.obsenv" ]
+      topicRegexps: ["lsst.obsenv"]
       debug: true
   resources:
     limits:

--- a/applications/sasquatch/values-tucson-teststand.yaml
+++ b/applications/sasquatch/values-tucson-teststand.yaml
@@ -113,39 +113,74 @@ telegraf:
     auxtel:
       enabled: true
       database: "efd"
-      topicRegexps: ["lsst.sal.ATAOS", "lsst.sal.ATBuilding", "lsst.sal.ATDome", "lsst.sal.ATDomeTrajectory", "lsst.sal.ATHexapod", "lsst.sal.ATPneumatics", "lsst.sal.ATPtg", "lsst.sal.ATMCS"]
+      topicRegexps:
+        - "lsst.sal.ATAOS"
+        - "lsst.sal.ATBuilding"
+        - "lsst.sal.ATDome"
+        - "lsst.sal.ATDomeTrajectory"
+        - "lsst.sal.ATHexapod"
+        - "lsst.sal.ATPneumatics"
+        - "lsst.sal.ATPtg"
+        - "lsst.sal.ATMCS"
       debug: true
     maintel:
       enabled: true
       database: "efd"
-      topicRegexps: ["lsst.sal.MTAOS", "lsst.sal.MTDome", "lsst.sal.MTDomeTrajectory", "lsst.sal.MTPtg", "lsst.sal.WFOODS"]
+      topicRegexps:
+        - "lsst.sal.MTAOS"
+        - "lsst.sal.MTDome"
+        - "lsst.sal.MTDomeTrajectory"
+        - "lsst.sal.MTPtg"
+        - "lsst.sal.WFOODS"
       debug: true
     mtmount:
       enabled: true
       database: "efd"
-      topicRegexps: ["lsst.sal.MTMount"]
+      topicRegexps:
+        - "lsst.sal.MTMount"
       debug: true
     envsys:
       enabled: true
       database: "efd"
       metric_batch_size: 100
       flush_interval: 20s
-      topicRegexps: ["lsst.sal.DIMM", "lsst.sal.DREAM", "lsst.sal.DSM", "lsst.sal.EAS", "lsst.sal.EPM", "lsst.sal.ESS", "lsst.sal.HVAC", "lsst.sal.WeatherForecast"]
+      topicRegexps:
+        - "lsst.sal.DIMM"
+        - "lsst.sal.DREAM"
+        - "lsst.sal.DSM"
+        - "lsst.sal.EAS"
+        - "lsst.sal.EPM"
+        - "lsst.sal.ESS"
+        - "lsst.sal.HVAC"
+        - "lsst.sal.WeatherForecast"
       debug: true
     latiss:
       enabled: true
       database: "efd"
-      topicRegexps: ["lsst.sal.ATCamera", "lsst.sal.ATHeaderService", "lsst.sal.ATOODS", "lsst.sal.ATSpectrograph"]
+      topicRegexps:
+        - "lsst.sal.ATCamera"
+        - "lsst.sal.ATHeaderService"
+        - "lsst.sal.ATOODS"
+        - "lsst.sal.ATSpectrograph"
       debug: true
     m1m3:
       enabled: true
       database: "efd"
-      topicRegexps: ["lsst.sal.MTM1M3.ackcmd", "lsst.sal.MTM1M3.logevent*", "lsst.sal.MTM1M3.command*"]
+      topicRegexps:
+        - "lsst.sal.MTM1M3.ackcmd"
+        - "lsst.sal.MTM1M3.logevent*"
+        - "lsst.sal.MTM1M3.command*"
       debug: true
     m1m3-tel1:
       enabled: true
       database: "efd"
-      topicRegexps: ["lsst.sal.MTM1M3.accelerometerData", "lsst.sal.MTM1M3.appliedCylinderForces", "lsst.sal.MTM1M3.appliedForces", "lsst.sal.MTM1M3.gyroData", "lsst.sal.MTM1M3.hardpointActuatorData", "lsst.sal.MTM1M3.hardpointMonitorData"]
+      topicRegexps:
+        - "lsst.sal.MTM1M3.accelerometerData"
+        - "lsst.sal.MTM1M3.appliedCylinderForces"
+        - "lsst.sal.MTM1M3.appliedForces"
+        - "lsst.sal.MTM1M3.gyroData"
+        - "lsst.sal.MTM1M3.hardpointActuatorData"
+        - "lsst.sal.MTM1M3.hardpointMonitorData"
       debug: true
       resources:
         limits:
@@ -158,7 +193,12 @@ telegraf:
       enabled: true
       database: "efd"
       metric_batch_size: 750
-      topicRegexps: ["lsst.sal.MTM1M3.forceActuatorData", "lsst.sal.MTM1M3.outerLoopData", "lsst.sal.MTM1M3.imsData", "lsst.sal.MTM1M3.inclinometerData", "lsst.sal.MTM1M3.powerSupplyData"]
+      topicRegexps:
+        - "lsst.sal.MTM1M3.forceActuatorData"
+        - "lsst.sal.MTM1M3.outerLoopData"
+        - "lsst.sal.MTM1M3.imsData"
+        - "lsst.sal.MTM1M3.inclinometerData"
+        - "lsst.sal.MTM1M3.powerSupplyData"
       debug: true
       resources:
         limits:
@@ -170,7 +210,15 @@ telegraf:
     m1m3-tel3:
       enabled: true
       database: "efd"
-      topicRegexps: ["lsst.sal.MTM1M3.appliedAccelerationForces", "lsst.sal.MTM1M3.appliedAzimuthForces", "lsst.sal.MTM1M3.appliedBalanceForces", "lsst.sal.MTM1M3.appliedElevationForces", "lsst.sal.MTM1M3.appliedThermalForces", "lsst.sal.MTM1M3.appliedVelocityForces", "lsst.sal.MTM1M3.forceActuatorPressure", "lsst.sal.MTM1M3.pidData"]
+      topicRegexps:
+        - "lsst.sal.MTM1M3.appliedAccelerationForces"
+        - "lsst.sal.MTM1M3.appliedAzimuthForces"
+        - "lsst.sal.MTM1M3.appliedBalanceForces"
+        - "lsst.sal.MTM1M3.appliedElevationForces"
+        - "lsst.sal.MTM1M3.appliedThermalForces"
+        - "lsst.sal.MTM1M3.appliedVelocityForces"
+        - "lsst.sal.MTM1M3.forceActuatorPressure"
+        - "lsst.sal.MTM1M3.pidData"
       debug: true
       resources:
         limits:
@@ -184,65 +232,91 @@ telegraf:
       metric_batch_size: 1500
       max_undelivered_messages: 4000
       database: "efd"
-      topicRegexps: ["lsst.sal.MTM1M3TS"]
+      topicRegexps:
+        - "lsst.sal.MTM1M3TS"
       debug: true
     m2:
       enabled: true
       database: "efd"
-      topicRegexps: ["lsst.sal.MTHexapod", "lsst.sal.MTM2", "lsst.sal.MTRotator"]
+      topicRegexps:
+        - "lsst.sal.MTHexapod"
+        - "lsst.sal.MTM2"
+        - "lsst.sal.MTRotator"
       debug: true
     obssys:
       enabled: true
       database: "efd"
-      topicRegexps: ["lsst.sal.Scheduler", "lsst.sal.Script", "lsst.sal.ScriptQueue", "lsst.sal.Watcher"]
+      topicRegexps:
+        - "lsst.sal.Scheduler"
+        - "lsst.sal.Script"
+        - "lsst.sal.ScriptQueue"
+        - "lsst.sal.Watcher"
       debug: true
     ocps:
       enabled: true
       database: "efd"
-      topicRegexps: ["lsst.sal.OCPS"]
+      topicRegexps:
+        - "lsst.sal.OCPS"
       debug: true
     calsys:
       enabled: true
       database: "efd"
-      topicRegexps: ["lsst.sal.CBP", "lsst.sal.Electrometer", "lsst.sal.FiberSpectrograph", "lsst.sal.LEDProjector", "lsst.sal.LinearStage", "lsst.sal.MTReflector", "lsst.sal.TunableLaser"]
+      topicRegexps:
+        - "lsst.sal.CBP"
+        - "lsst.sal.Electrometer"
+        - "lsst.sal.FiberSpectrograph"
+        - "lsst.sal.LEDProjector"
+        - "lsst.sal.LinearStage"
+        - "lsst.sal.MTReflector"
+        - "lsst.sal.TunableLaser"
       debug: true
     comcam:
       enabled: true
       database: "efd"
-      topicRegexps: ["lsst.sal.CCCamera", "lsst.sal.CCHeaderService", "lsst.sal.CCOODS"]
+      topicRegexps:
+        - "lsst.sal.CCCamera"
+        - "lsst.sal.CCHeaderService"
+        - "lsst.sal.CCOODS"
       debug: true
     test:
       enabled: true
       database: "efd"
-      topicRegexps: ["lsst.sal.Test"]
+      topicRegexps:
+        - "lsst.sal.Test"
       debug: true
     mtaircompressor:
       enabled: true
       database: "efd"
-      topicRegexps: ["lsst.sal.MTAirCompressor"]
+      topicRegexps:
+        - "lsst.sal.MTAirCompressor"
       debug: true
     lasertracker:
       enabled: true
       database: "efd"
-      topicRegexps: ["lsst.sal.LaserTracker"]
+      topicRegexps:
+        - "lsst.sal.LaserTracker"
       debug: true
     genericcamera:
       enabled: true
       database: "efd"
-      topicRegexps: ["lsst.sal.GCHeaderService", "lsst.sal.GenericCamera"]
+      topicRegexps:
+        - "lsst.sal.GCHeaderService"
+        - "lsst.sal.GenericCamera"
       debug: true
     mtvms:
       enabled: true
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: ["lsst.sal.MTVMS"]
+      topicRegexps:
+        - "lsst.sal.MTVMS"
       debug: true
     obsenv:
       enabled: true
       database: "lsst.obsenv"
       timestamp_format: "unix_ms"
       timestamp_field: "timestamp"
-      topicRegexps: ["lsst.obsenv"]
+      topicRegexps:
+        - "lsst.obsenv"
       debug: true
   resources:
     limits:

--- a/applications/sasquatch/values-usdfdev.yaml
+++ b/applications/sasquatch/values-usdfdev.yaml
@@ -123,8 +123,7 @@ telegraf:
       topicRegexps: |
         [ "lsst.verify" ]
       timestamp_field: "timestamp"
-      tags: |
-        [ "dataset_tag", "band", "instrument", "skymap", "detector", "physical_filter", "tract", "patch", "pipeline"]
+      tags: ["dataset_tag", "band", "instrument", "skymap", "detector", "physical_filter", "tract", "patch", "pipeline"]
     prompt:
       enabled: true
       debug: true
@@ -132,8 +131,7 @@ telegraf:
       topicRegexps: |
         [ "lsst.prompt" ]
       timestamp_field: "timestamp"
-      tags: |
-        [ "dataset_tag", "band", "instrument", "skymap", "detector", "physical_filter", "tract", "patch"]
+      tags: ["dataset_tag", "band", "instrument", "skymap", "detector", "physical_filter", "tract", "patch"]
     dm:
       enabled: true
       debug: true
@@ -141,8 +139,7 @@ telegraf:
       topicRegexps: |
         [ "lsst.dm" ]
       timestamp_field: "timestamp"
-      tags: |
-        [ "dataset_tag", "band", "instrument", "skymap", "detector", "physical_filter", "tract", "patch"]
+      tags: ["dataset_tag", "band", "instrument", "skymap", "detector", "physical_filter", "tract", "patch"]
   resources:
     limits:
       cpu: "1"

--- a/applications/sasquatch/values-usdfdev.yaml
+++ b/applications/sasquatch/values-usdfdev.yaml
@@ -120,23 +120,51 @@ telegraf:
       enabled: true
       debug: true
       database: "lsst.verify"
-      topicRegexps: ["lsst.verify"]
+      topicRegexps:
+        - "lsst.verify"
       timestamp_field: "timestamp"
-      tags: ["dataset_tag", "band", "instrument", "skymap", "detector", "physical_filter", "tract", "patch", "pipeline"]
+      tags:
+        - "dataset_tag"
+        - "band"
+        - "instrument"
+        - "skymap"
+        - "detector"
+        - "physical_filter"
+        - "tract"
+        - "patch"
+        - "pipeline"
     prompt:
       enabled: true
       debug: true
       database: "lsst.prompt"
-      topicRegexps: ["lsst.prompt"]
+      topicRegexps:
+        - "lsst.prompt"
       timestamp_field: "timestamp"
-      tags: ["dataset_tag", "band", "instrument", "skymap", "detector", "physical_filter", "tract", "patch"]
+      tags:
+        - "dataset_tag"
+        - "band"
+        - "instrument"
+        - "skymap"
+        - "detector"
+        - "physical_filter"
+        - "tract"
+        - "patch"
     dm:
       enabled: true
       debug: true
       database: "lsst.dm"
-      topicRegexps: ["lsst.dm"]
+      topicRegexps:
+        - "lsst.dm"
       timestamp_field: "timestamp"
-      tags: ["dataset_tag", "band", "instrument", "skymap", "detector", "physical_filter", "tract", "patch"]
+      tags:
+        - "dataset_tag"
+        - "band"
+        - "instrument"
+        - "skymap"
+        - "detector"
+        - "physical_filter"
+        - "tract"
+        - "patch"
   resources:
     limits:
       cpu: "1"

--- a/applications/sasquatch/values-usdfdev.yaml
+++ b/applications/sasquatch/values-usdfdev.yaml
@@ -120,24 +120,21 @@ telegraf:
       enabled: true
       debug: true
       database: "lsst.verify"
-      topicRegexps: |
-        [ "lsst.verify" ]
+      topicRegexps: ["lsst.verify"]
       timestamp_field: "timestamp"
       tags: ["dataset_tag", "band", "instrument", "skymap", "detector", "physical_filter", "tract", "patch", "pipeline"]
     prompt:
       enabled: true
       debug: true
       database: "lsst.prompt"
-      topicRegexps: |
-        [ "lsst.prompt" ]
+      topicRegexps: ["lsst.prompt"]
       timestamp_field: "timestamp"
       tags: ["dataset_tag", "band", "instrument", "skymap", "detector", "physical_filter", "tract", "patch"]
     dm:
       enabled: true
       debug: true
       database: "lsst.dm"
-      topicRegexps: |
-        [ "lsst.dm" ]
+      topicRegexps: ["lsst.dm"]
       timestamp_field: "timestamp"
       tags: ["dataset_tag", "band", "instrument", "skymap", "detector", "physical_filter", "tract", "patch"]
   resources:

--- a/applications/sasquatch/values-usdfint.yaml
+++ b/applications/sasquatch/values-usdfint.yaml
@@ -101,8 +101,7 @@ telegraf:
     test:
       enabled: true
       database: "efd"
-      topicRegexps: |
-        [ "summit.lsst.sal.Test" ]
+      topicRegexps: ["summit.lsst.sal.Test"]
       debug: true
 
 kafdrop:

--- a/applications/sasquatch/values-usdfint.yaml
+++ b/applications/sasquatch/values-usdfint.yaml
@@ -101,7 +101,8 @@ telegraf:
     test:
       enabled: true
       database: "efd"
-      topicRegexps: ["summit.lsst.sal.Test"]
+      topicRegexps:
+        - "summit.lsst.sal.Test"
       debug: true
 
 kafdrop:

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -248,114 +248,98 @@ telegraf:
       enabled: true
       database: "lsst.backpack"
       timestamp_field: "timestamp"
-      topicRegexps: |
-        [ "summit.lsst.backpack" ]
+      topicRegexps: ["summit.lsst.backpack"]
     # CSC connectors
     maintel:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: |
-        [ "summit.lsst.sal.MTAOS", "summit.lsst.sal.MTDome", "summit.lsst.sal.MTDomeTrajectory", "summit.lsst.sal.MTPtg" ]
+      topicRegexps: ["summit.lsst.sal.MTAOS", "summit.lsst.sal.MTDome", "summit.lsst.sal.MTDomeTrajectory", "summit.lsst.sal.MTPtg"]
     mtmount:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: |
-        [ "summit.lsst.sal.MTMount" ]
+      topicRegexps: ["summit.lsst.sal.MTMount"]
     comcam:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: |
-        [ "summit.lsst.sal.CCCamera", "summit.lsst.sal.CCHeaderService", "summit.lsst.sal.CCOODS" ]
+      topicRegexps: ["summit.lsst.sal.CCCamera", "summit.lsst.sal.CCHeaderService", "summit.lsst.sal.CCOODS"]
     envsys:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: |
-        [ "summit.lsst.sal.DIMM", "summit.lsst.sal.DREAM", "summit.lsst.sal.EAS", "summit.lsst.sal.ESS", "summit.lsst.sal.DSM", "summit.lsst.sal.EPM", "summit.lsst.sal.HVAC", "summit.lsst.sal.WeatherForecast" ]
+      topicRegexps: ["summit.lsst.sal.DIMM", "summit.lsst.sal.DREAM", "summit.lsst.sal.EAS", "summit.lsst.sal.ESS", "summit.lsst.sal.DSM", "summit.lsst.sal.EPM", "summit.lsst.sal.HVAC", "summit.lsst.sal.WeatherForecast"]
     m1m3:
       enabled: true
       metric_batch_size: 1500
       max_undelivered_messages: 4000
       database: "efd"
-      topicRegexps: |
-        [ "summit.lsst.sal.MTM1M3([^T].*)" ]
+      topicRegexps: ["summit.lsst.sal.MTM1M3([^T].*)"]
     m1m3ts:
       enabled: true
       metric_batch_size: 1500
       max_undelivered_messages: 4000
       database: "efd"
-      topicRegexps: |
-        [ "summit.lsst.sal.MTM1M3TS" ]
+      topicRegexps: ["summit.lsst.sal.MTM1M3TS"]
     m2:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: |
-        [ "summit.lsst.sal.MTHexapod", "summit.lsst.sal.MTM2", "summit.lsst.sal.MTRotator" ]
+      topicRegexps: ["summit.lsst.sal.MTHexapod", "summit.lsst.sal.MTM2", "summit.lsst.sal.MTRotator"]
     obssys:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: |
-        [ "summit.lsst.sal.Scheduler", "summit.lsst.sal.Script", "summit.lsst.sal.ScriptQueue", "summit.lsst.sal.Watcher" ]
+      topicRegexps: ["summit.lsst.sal.Scheduler", "summit.lsst.sal.Script", "summit.lsst.sal.ScriptQueue", "summit.lsst.sal.Watcher"]
     ocps:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: |
-        [ "summit.lsst.sal.OCPS" ]
+      topicRegexps: ["summit.lsst.sal.OCPS"]
     pmd:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: |
-        [ "summit.lsst.sal.PMD" ]
+      topicRegexps: ["summit.lsst.sal.PMD"]
     calsys:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: |
-        [ "summit.lsst.sal.ATMonochromator", "summit.lsst.sal.ATWhiteLight", "summit.lsst.sal.CBP", "summit.lsst.sal.Electrometer", "summit.lsst.sal.FiberSpectrograph", "summit.lsst.sal.LEDProjector", "summit.lsst.sal.LinearStage", "summit.lsst.sal.MTReflector", "summit.lsst.sal.TunableLaser" ]
+      topicRegexps: ["summit.lsst.sal.ATMonochromator", "summit.lsst.sal.ATWhiteLight", "summit.lsst.sal.CBP", "summit.lsst.sal.Electrometer", "summit.lsst.sal.FiberSpectrograph", "summit.lsst.sal.LEDProjector", "summit.lsst.sal.LinearStage", "summit.lsst.sal.MTReflector", "summit.lsst.sal.TunableLaser"]
     mtaircompressor:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: |
-        [ "summit.lsst.sal.MTAirCompressor" ]
+      topicRegexps: ["summit.lsst.sal.MTAirCompressor"]
     genericcamera:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: |
-        [ "summit.lsst.sal.GCHeaderService", "summit.lsst.sal.GenericCamera" ]
+      topicRegexps: ["summit.lsst.sal.GCHeaderService", "summit.lsst.sal.GenericCamera"]
     gis:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: |
-        [ "summit.lsst.sal.GIS" ]
+      topicRegexps: ["summit.lsst.sal.GIS"]
     mtvms:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: |
-        [ "summit.lsst.sal.MTVMS" ]
+      topicRegexps: ["summit.lsst.sal.MTVMS"]
     lsstcam:
       enabled: true
       repair: false
@@ -363,36 +347,31 @@ telegraf:
       max_undelivered_messages: 5000
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: |
-        [ "summit.lsst.sal.MTCamera", "summit.lsst.sal.MTHeaderService", "summit.lsst.sal.MTOODS" ]
+      topicRegexps: ["summit.lsst.sal.MTCamera", "summit.lsst.sal.MTHeaderService", "summit.lsst.sal.MTOODS"]
     auxtel:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: |
-        [ "summit.lsst.sal.ATAOS", "summit.lsst.sal.ATBuilding", "summit.lsst.sal.ATDome", "summit.lsst.sal.ATDomeTrajectory", "summit.lsst.sal.ATHexapod", "summit.lsst.sal.ATPneumatics", "summit.lsst.sal.ATPtg", "summit.lsst.sal.ATMCS" ]
+      topicRegexps: ["summit.lsst.sal.ATAOS", "summit.lsst.sal.ATBuilding", "summit.lsst.sal.ATDome", "summit.lsst.sal.ATDomeTrajectory", "summit.lsst.sal.ATHexapod", "summit.lsst.sal.ATPneumatics", "summit.lsst.sal.ATPtg", "summit.lsst.sal.ATMCS"]
     latiss:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: |
-        [ "summit.lsst.sal.ATCamera", "summit.lsst.sal.ATHeaderService", "summit.lsst.sal.ATOODS", "summit.lsst.sal.ATSpectrograph" ]
+      topicRegexps: ["summit.lsst.sal.ATCamera", "summit.lsst.sal.ATHeaderService", "summit.lsst.sal.ATOODS", "summit.lsst.sal.ATSpectrograph"]
     test:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: |
-        [ "summit.lsst.sal.Test" ]
+      topicRegexps: ["summit.lsst.sal.Test"]
     lasertracker:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: |
-        [ "summit.lsst.sal.LaserTracker" ]
+      topicRegexps: ["summit.lsst.sal.LaserTracker"]
     # CCS connectors (experimental) data is being written on separate databases for now
     atcamera:
       enabled: true
@@ -400,38 +379,33 @@ telegraf:
       timestamp_format: "unix_ms"
       timestamp_field: "timestamp"
       tags: ["Agent", "Aspic", "Location", "Raft", "Reb", "Sensor", "Source", "VersionType"]
-      topicRegexps: |
-        [ "summit.lsst.ATCamera" ]
+      topicRegexps: ["summit.lsst.ATCamera"]
     cccamera:
       enabled: true
       database: "lsst.CCCamera"
       timestamp_format: "unix_ms"
       timestamp_field: "timestamp"
       tags: ["Agent", "Aspic", "Cold", "Cryo", "Hardware", "Location", "Ps", "RTD", "Raft", "Reb", "Segment", "Sensor", "Source", "VersionType"]
-      topicRegexps: |
-        [ "summit.lsst.CCCamera" ]
+      topicRegexps: ["summit.lsst.CCCamera"]
     mtcamera:
       enabled: true
       database: "lsst.MTCamera"
       timestamp_format: "unix_ms"
       timestamp_field: "timestamp"
       tags: ["Agent", "Aspic", "Axis", "Bay", "Canbus", "Cip", "Clamp", "Cold", "Controller", "Cryo", "Gateway", "Hardware", "Hip", "Hook", "Latch", "Location", "Ps", "RTD", "Raft", "Reb", "Segment", "Sensor", "Socket", "Source", "Truck", "VersionType"]
-      topicRegexps: |
-        [ "summit.lsst.MTCamera" ]
+      topicRegexps: ["summit.lsst.MTCamera"]
     obsenv:
       enabled: true
       database: "lsst.obsenv"
       timestamp_format: "unix_ms"
       timestamp_field: "timestamp"
-      topicRegexps: |
-        [ "summit.lsst.obsenv" ]
+      topicRegexps: ["summit.lsst.obsenv"]
     cp:
       enabled: true
       database: "lsst.cp"
       timestamp_format: "unix"
       timestamp_field: "timestamp"
-      topicRegexps: |
-        [ "summit.lsst.cp" ]
+      topicRegexps: ["summit.lsst.cp"]
       tags: ["dataset_tag", "band", "instrument", "skymap", "detector", "physical_filter", "tract", "exposure", "patch", "visit", "run", "pipeline"]
 
 telegraf-standby:
@@ -447,114 +421,98 @@ telegraf-standby:
       enabled: true
       database: "lsst.backpack"
       timestamp_field: "timestamp"
-      topicRegexps: |
-        [ "summit.lsst.backpack" ]
+      topicRegexps: ["summit.lsst.backpack"]
     # CSC connectors
     standby-maintel:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: |
-        [ "summit.lsst.sal.MTAOS", "summit.lsst.sal.MTDome", "summit.lsst.sal.MTDomeTrajectory", "summit.lsst.sal.MTPtg" ]
+      topicRegexps: ["summit.lsst.sal.MTAOS", "summit.lsst.sal.MTDome", "summit.lsst.sal.MTDomeTrajectory", "summit.lsst.sal.MTPtg"]
     standby-mtmount:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: |
-        [ "summit.lsst.sal.MTMount" ]
+      topicRegexps: ["summit.lsst.sal.MTMount"]
     standby-comcam:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: |
-        [ "summit.lsst.sal.CCCamera", "summit.lsst.sal.CCHeaderService", "summit.lsst.sal.CCOODS" ]
+      topicRegexps: ["summit.lsst.sal.CCCamera", "summit.lsst.sal.CCHeaderService", "summit.lsst.sal.CCOODS"]
     standby-envsys:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: |
-        [ "summit.lsst.sal.DIMM", "summit.lsst.sal.DREAM", "summit.lsst.sal.EAS", "summit.lsst.sal.ESS", "summit.lsst.sal.DSM", "summit.lsst.sal.EPM", "summit.lsst.sal.HVAC", "summit.lsst.sal.WeatherForecast" ]
+      topicRegexps: ["summit.lsst.sal.DIMM", "summit.lsst.sal.DREAM", "summit.lsst.sal.EAS", "summit.lsst.sal.ESS", "summit.lsst.sal.DSM", "summit.lsst.sal.EPM", "summit.lsst.sal.HVAC", "summit.lsst.sal.WeatherForecast"]
     standby-m1m3:
       enabled: true
       metric_batch_size: 1500
       max_undelivered_messages: 4000
       database: "efd"
-      topicRegexps: |
-        [ "summit.lsst.sal.MTM1M3([^T].*)" ]
+      topicRegexps: ["summit.lsst.sal.MTM1M3([^T].*)"]
     standby-m1m3ts:
       enabled: true
       metric_batch_size: 1500
       max_undelivered_messages: 4000
       database: "efd"
-      topicRegexps: |
-        [ "summit.lsst.sal.MTM1M3TS" ]
+      topicRegexps: ["summit.lsst.sal.MTM1M3TS"]
     standby-m2:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: |
-        [ "summit.lsst.sal.MTHexapod", "summit.lsst.sal.MTM2", "summit.lsst.sal.MTRotator" ]
+      topicRegexps: ["summit.lsst.sal.MTHexapod", "summit.lsst.sal.MTM2", "summit.lsst.sal.MTRotator"]
     standby-obssys:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: |
-        [ "summit.lsst.sal.Scheduler", "summit.lsst.sal.Script", "summit.lsst.sal.ScriptQueue", "summit.lsst.sal.Watcher" ]
+      topicRegexps: ["summit.lsst.sal.Scheduler", "summit.lsst.sal.Script", "summit.lsst.sal.ScriptQueue", "summit.lsst.sal.Watcher"]
     standby-ocps:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: |
-        [ "summit.lsst.sal.OCPS" ]
+      topicRegexps: ["summit.lsst.sal.OCPS"]
     standby-pmd:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: |
-        [ "summit.lsst.sal.PMD" ]
+      topicRegexps: ["summit.lsst.sal.PMD"]
     standby-calsys:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: |
-        [ "summit.lsst.sal.ATMonochromator", "summit.lsst.sal.ATWhiteLight", "summit.lsst.sal.CBP", "summit.lsst.sal.Electrometer", "summit.lsst.sal.FiberSpectrograph", "summit.lsst.sal.LEDProjector", "summit.lsst.sal.LinearStage", "summit.lsst.sal.MTReflector", "summit.lsst.sal.TunableLaser" ]
+      topicRegexps: ["summit.lsst.sal.ATMonochromator", "summit.lsst.sal.ATWhiteLight", "summit.lsst.sal.CBP", "summit.lsst.sal.Electrometer", "summit.lsst.sal.FiberSpectrograph", "summit.lsst.sal.LEDProjector", "summit.lsst.sal.LinearStage", "summit.lsst.sal.MTReflector", "summit.lsst.sal.TunableLaser"]
     standby-mtaircompressor:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: |
-        [ "summit.lsst.sal.MTAirCompressor" ]
+      topicRegexps: ["summit.lsst.sal.MTAirCompressor"]
     standby-genericcamera:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: |
-        [ "summit.lsst.sal.GCHeaderService", "summit.lsst.sal.GenericCamera" ]
+      topicRegexps: ["summit.lsst.sal.GCHeaderService", "summit.lsst.sal.GenericCamera"]
     standby-gis:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: |
-        [ "summit.lsst.sal.GIS" ]
+      topicRegexps: ["summit.lsst.sal.GIS"]
     standby-mtvms:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: |
-        [ "summit.lsst.sal.MTVMS" ]
+      topicRegexps: ["summit.lsst.sal.MTVMS"]
     standby-lsstcam:
       enabled: true
       repair: false
@@ -562,36 +520,31 @@ telegraf-standby:
       max_undelivered_messages: 5000
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: |
-        [ "summit.lsst.sal.MTCamera", "summit.lsst.sal.MTHeaderService", "summit.lsst.sal.MTOODS" ]
+      topicRegexps: ["summit.lsst.sal.MTCamera", "summit.lsst.sal.MTHeaderService", "summit.lsst.sal.MTOODS"]
     standby-auxtel:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: |
-        [ "summit.lsst.sal.ATAOS", "summit.lsst.sal.ATBuilding", "summit.lsst.sal.ATDome", "summit.lsst.sal.ATDomeTrajectory", "summit.lsst.sal.ATHexapod", "summit.lsst.sal.ATPneumatics", "summit.lsst.sal.ATPtg", "summit.lsst.sal.ATMCS" ]
+      topicRegexps: ["summit.lsst.sal.ATAOS", "summit.lsst.sal.ATBuilding", "summit.lsst.sal.ATDome", "summit.lsst.sal.ATDomeTrajectory", "summit.lsst.sal.ATHexapod", "summit.lsst.sal.ATPneumatics", "summit.lsst.sal.ATPtg", "summit.lsst.sal.ATMCS"]
     standby-latiss:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: |
-        [ "summit.lsst.sal.ATCamera", "summit.lsst.sal.ATHeaderService", "summit.lsst.sal.ATOODS", "summit.lsst.sal.ATSpectrograph" ]
+      topicRegexps: ["summit.lsst.sal.ATCamera", "summit.lsst.sal.ATHeaderService", "summit.lsst.sal.ATOODS", "summit.lsst.sal.ATSpectrograph"]
     standby-test:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: |
-        [ "summit.lsst.sal.Test" ]
+      topicRegexps: ["summit.lsst.sal.Test"]
     standby-lasertracker:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: |
-        [ "summit.lsst.sal.LaserTracker" ]
+      topicRegexps: ["summit.lsst.sal.LaserTracker"]
     # CCS connectors (experimental) data is being written on separate databases for now
     standby-atcamera:
       enabled: true
@@ -599,38 +552,33 @@ telegraf-standby:
       timestamp_format: "unix_ms"
       timestamp_field: "timestamp"
       tags: ["Agent", "Aspic", "Location", "Raft", "Reb", "Sensor", "Source"]
-      topicRegexps: |
-        [ "summit.lsst.ATCamera" ]
+      topicRegexps: ["summit.lsst.ATCamera"]
     standby-cccamera:
       enabled: true
       database: "lsst.CCCamera"
       timestamp_format: "unix_ms"
       timestamp_field: "timestamp"
       tags: ["Agent", "Aspic", "Cold", "Cryo", "Hardware", "Location", "Ps", "RTD", "Raft", "Reb", "Segment", "Sensor", "Source"]
-      topicRegexps: |
-        [ "summit.lsst.CCCamera" ]
+      topicRegexps: ["summit.lsst.CCCamera"]
     standby-mtcamera:
       enabled: true
       database: "lsst.MTCamera"
       timestamp_format: "unix_ms"
       timestamp_field: "timestamp"
       tags: ["Agent", "Aspic", "Axis", "Bay", "Canbus", "Cip", "Clamp", "Cold", "Controller", "Cryo", "Gateway", "Hardware", "Hip", "Hook", "Latch", "Location", "Ps", "RTD", "Raft", "Reb", "Segment", "Sensor", "Socket", "Source", "Truck"]
-      topicRegexps: |
-        [ "summit.lsst.MTCamera" ]
+      topicRegexps: ["summit.lsst.MTCamera"]
     standby-obsenv:
       enabled: true
       database: "lsst.obsenv"
       timestamp_format: "unix_ms"
       timestamp_field: "timestamp"
-      topicRegexps: |
-        [ "summit.lsst.obsenv" ]
+      topicRegexps: ["summit.lsst.obsenv"]
     standby-cp:
       enabled: true
       database: "lsst.cp"
       timestamp_format: "unix"
       timestamp_field: "timestamp"
-      topicRegexps: |
-        [ "summit.lsst.cp" ]
+      topicRegexps: ["summit.lsst.cp"]
       tags: ["dataset_tag", "band", "instrument", "skymap", "detector", "physical_filter", "tract", "exposure", "patch", "visit", "run", "pipeline"]
 
 kafdrop:

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -248,98 +248,140 @@ telegraf:
       enabled: true
       database: "lsst.backpack"
       timestamp_field: "timestamp"
-      topicRegexps: ["summit.lsst.backpack"]
+      topicRegexps:
+        - "summit.lsst.backpack"
     # CSC connectors
     maintel:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: ["summit.lsst.sal.MTAOS", "summit.lsst.sal.MTDome", "summit.lsst.sal.MTDomeTrajectory", "summit.lsst.sal.MTPtg"]
+      topicRegexps:
+        - "summit.lsst.sal.MTAOS"
+        - "summit.lsst.sal.MTDome"
+        - "summit.lsst.sal.MTDomeTrajectory"
+        - "summit.lsst.sal.MTPtg"
     mtmount:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: ["summit.lsst.sal.MTMount"]
+      topicRegexps:
+        - "summit.lsst.sal.MTMount"
     comcam:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: ["summit.lsst.sal.CCCamera", "summit.lsst.sal.CCHeaderService", "summit.lsst.sal.CCOODS"]
+      topicRegexps:
+        - "summit.lsst.sal.CCCamera"
+        - "summit.lsst.sal.CCHeaderService"
+        - "summit.lsst.sal.CCOODS"
     envsys:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: ["summit.lsst.sal.DIMM", "summit.lsst.sal.DREAM", "summit.lsst.sal.EAS", "summit.lsst.sal.ESS", "summit.lsst.sal.DSM", "summit.lsst.sal.EPM", "summit.lsst.sal.HVAC", "summit.lsst.sal.WeatherForecast"]
+      topicRegexps:
+        - "summit.lsst.sal.DIMM"
+        - "summit.lsst.sal.DREAM"
+        - "summit.lsst.sal.EAS"
+        - "summit.lsst.sal.ESS"
+        - "summit.lsst.sal.DSM"
+        - "summit.lsst.sal.EPM"
+        - "summit.lsst.sal.HVAC"
+        - "summit.lsst.sal.WeatherForecast"
     m1m3:
       enabled: true
       metric_batch_size: 1500
       max_undelivered_messages: 4000
       database: "efd"
-      topicRegexps: ["summit.lsst.sal.MTM1M3([^T].*)"]
+      topicRegexps:
+        - "summit.lsst.sal.MTM1M3([^T].*)"
     m1m3ts:
       enabled: true
       metric_batch_size: 1500
       max_undelivered_messages: 4000
       database: "efd"
-      topicRegexps: ["summit.lsst.sal.MTM1M3TS"]
+      topicRegexps:
+        - "summit.lsst.sal.MTM1M3TS"
     m2:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: ["summit.lsst.sal.MTHexapod", "summit.lsst.sal.MTM2", "summit.lsst.sal.MTRotator"]
+      topicRegexps:
+        - "summit.lsst.sal.MTHexapod"
+        - "summit.lsst.sal.MTM2"
+        - "summit.lsst.sal.MTRotator"
     obssys:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: ["summit.lsst.sal.Scheduler", "summit.lsst.sal.Script", "summit.lsst.sal.ScriptQueue", "summit.lsst.sal.Watcher"]
+      topicRegexps:
+        - "summit.lsst.sal.Scheduler"
+        - "summit.lsst.sal.Script"
+        - "summit.lsst.sal.ScriptQueue"
+        - "summit.lsst.sal.Watcher"
     ocps:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: ["summit.lsst.sal.OCPS"]
+      topicRegexps:
+        - "summit.lsst.sal.OCPS"
     pmd:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: ["summit.lsst.sal.PMD"]
+      topicRegexps:
+        - "summit.lsst.sal.PMD"
     calsys:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: ["summit.lsst.sal.ATMonochromator", "summit.lsst.sal.ATWhiteLight", "summit.lsst.sal.CBP", "summit.lsst.sal.Electrometer", "summit.lsst.sal.FiberSpectrograph", "summit.lsst.sal.LEDProjector", "summit.lsst.sal.LinearStage", "summit.lsst.sal.MTReflector", "summit.lsst.sal.TunableLaser"]
+      topicRegexps:
+        - "summit.lsst.sal.ATMonochromator"
+        - "summit.lsst.sal.ATWhiteLight"
+        - "summit.lsst.sal.CBP"
+        - "summit.lsst.sal.Electrometer"
+        - "summit.lsst.sal.FiberSpectrograph"
+        - "summit.lsst.sal.LEDProjector"
+        - "summit.lsst.sal.LinearStage"
+        - "summit.lsst.sal.MTReflector"
+        - "summit.lsst.sal.TunableLaser"
     mtaircompressor:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: ["summit.lsst.sal.MTAirCompressor"]
+      topicRegexps:
+        - "summit.lsst.sal.MTAirCompressor"
     genericcamera:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: ["summit.lsst.sal.GCHeaderService", "summit.lsst.sal.GenericCamera"]
+      topicRegexps:
+        - "summit.lsst.sal.GCHeaderService"
+        - "summit.lsst.sal.GenericCamera"
     gis:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: ["summit.lsst.sal.GIS"]
+      topicRegexps:
+        - "summit.lsst.sal.GIS"
     mtvms:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: ["summit.lsst.sal.MTVMS"]
+      topicRegexps:
+        - "summit.lsst.sal.MTVMS"
     lsstcam:
       enabled: true
       repair: false
@@ -347,66 +389,148 @@ telegraf:
       max_undelivered_messages: 5000
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: ["summit.lsst.sal.MTCamera", "summit.lsst.sal.MTHeaderService", "summit.lsst.sal.MTOODS"]
+      topicRegexps:
+        - "summit.lsst.sal.MTCamera"
+        - "summit.lsst.sal.MTHeaderService"
+        - "summit.lsst.sal.MTOODS"
     auxtel:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: ["summit.lsst.sal.ATAOS", "summit.lsst.sal.ATBuilding", "summit.lsst.sal.ATDome", "summit.lsst.sal.ATDomeTrajectory", "summit.lsst.sal.ATHexapod", "summit.lsst.sal.ATPneumatics", "summit.lsst.sal.ATPtg", "summit.lsst.sal.ATMCS"]
+      topicRegexps:
+        - "summit.lsst.sal.ATAOS"
+        - "summit.lsst.sal.ATBuilding"
+        - "summit.lsst.sal.ATDome"
+        - "summit.lsst.sal.ATDomeTrajectory"
+        - "summit.lsst.sal.ATHexapod"
+        - "summit.lsst.sal.ATPneumatics"
+        - "summit.lsst.sal.ATPtg"
+        - "summit.lsst.sal.ATMCS"
     latiss:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: ["summit.lsst.sal.ATCamera", "summit.lsst.sal.ATHeaderService", "summit.lsst.sal.ATOODS", "summit.lsst.sal.ATSpectrograph"]
+      topicRegexps:
+        - "summit.lsst.sal.ATCamera"
+        - "summit.lsst.sal.ATHeaderService"
+        - "summit.lsst.sal.ATOODS"
+        - "summit.lsst.sal.ATSpectrograph"
     test:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: ["summit.lsst.sal.Test"]
+      topicRegexps:
+        - "summit.lsst.sal.Test"
     lasertracker:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: ["summit.lsst.sal.LaserTracker"]
+      topicRegexps:
+        - "summit.lsst.sal.LaserTracker"
     # CCS connectors (experimental) data is being written on separate databases for now
     atcamera:
       enabled: true
       database: "lsst.ATCamera"
       timestamp_format: "unix_ms"
       timestamp_field: "timestamp"
-      tags: ["Agent", "Aspic", "Location", "Raft", "Reb", "Sensor", "Source", "VersionType"]
-      topicRegexps: ["summit.lsst.ATCamera"]
+      tags:
+        - "Agent"
+        - "Aspic"
+        - "Location"
+        - "Raft"
+        - "Reb"
+        - "Sensor"
+        - "Source"
+        - "VersionType"
+      topicRegexps:
+        - "summit.lsst.ATCamera"
     cccamera:
       enabled: true
       database: "lsst.CCCamera"
       timestamp_format: "unix_ms"
       timestamp_field: "timestamp"
-      tags: ["Agent", "Aspic", "Cold", "Cryo", "Hardware", "Location", "Ps", "RTD", "Raft", "Reb", "Segment", "Sensor", "Source", "VersionType"]
-      topicRegexps: ["summit.lsst.CCCamera"]
+      tags:
+        - "Agent"
+        - "Aspic"
+        - "Cold"
+        - "Cryo"
+        - "Hardware"
+        - "Location"
+        - "Ps"
+        - "RTD"
+        - "Raft"
+        - "Reb"
+        - "Segment"
+        - "Sensor"
+        - "Source"
+        - "VersionType"
+      topicRegexps:
+        - "summit.lsst.CCCamera"
     mtcamera:
       enabled: true
       database: "lsst.MTCamera"
       timestamp_format: "unix_ms"
       timestamp_field: "timestamp"
-      tags: ["Agent", "Aspic", "Axis", "Bay", "Canbus", "Cip", "Clamp", "Cold", "Controller", "Cryo", "Gateway", "Hardware", "Hip", "Hook", "Latch", "Location", "Ps", "RTD", "Raft", "Reb", "Segment", "Sensor", "Socket", "Source", "Truck", "VersionType"]
-      topicRegexps: ["summit.lsst.MTCamera"]
+      tags:
+        - "Agent"
+        - "Aspic"
+        - "Axis"
+        - "Bay"
+        - "Canbus"
+        - "Cip"
+        - "Clamp"
+        - "Cold"
+        - "Controller"
+        - "Cryo"
+        - "Gateway"
+        - "Hardware"
+        - "Hip"
+        - "Hook"
+        - "Latch"
+        - "Location"
+        - "Ps"
+        - "RTD"
+        - "Raft"
+        - "Reb"
+        - "Segment"
+        - "Sensor"
+        - "Socket"
+        - "Source"
+        - "Truck"
+        - "VersionType"
+      topicRegexps:
+        - "summit.lsst.MTCamera"
     obsenv:
       enabled: true
       database: "lsst.obsenv"
       timestamp_format: "unix_ms"
       timestamp_field: "timestamp"
-      topicRegexps: ["summit.lsst.obsenv"]
+      topicRegexps:
+        - "summit.lsst.obsenv"
     cp:
       enabled: true
       database: "lsst.cp"
       timestamp_format: "unix"
       timestamp_field: "timestamp"
-      topicRegexps: ["summit.lsst.cp"]
-      tags: ["dataset_tag", "band", "instrument", "skymap", "detector", "physical_filter", "tract", "exposure", "patch", "visit", "run", "pipeline"]
+      topicRegexps:
+        - "summit.lsst.cp"
+      tags:
+        - "dataset_tag"
+        - "band"
+        - "instrument"
+        - "skymap"
+        - "detector"
+        - "physical_filter"
+        - "tract"
+        - "exposure"
+        - "patch"
+        - "visit"
+        - "run"
+        - "pipeline"
 
 telegraf-standby:
   enabled: false
@@ -421,98 +545,140 @@ telegraf-standby:
       enabled: true
       database: "lsst.backpack"
       timestamp_field: "timestamp"
-      topicRegexps: ["summit.lsst.backpack"]
+      topicRegexps:
+        - "summit.lsst.backpack"
     # CSC connectors
     standby-maintel:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: ["summit.lsst.sal.MTAOS", "summit.lsst.sal.MTDome", "summit.lsst.sal.MTDomeTrajectory", "summit.lsst.sal.MTPtg"]
+      topicRegexps:
+        - "summit.lsst.sal.MTAOS"
+        - "summit.lsst.sal.MTDome"
+        - "summit.lsst.sal.MTDomeTrajectory"
+        - "summit.lsst.sal.MTPtg"
     standby-mtmount:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: ["summit.lsst.sal.MTMount"]
+      topicRegexps:
+        - "summit.lsst.sal.MTMount"
     standby-comcam:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: ["summit.lsst.sal.CCCamera", "summit.lsst.sal.CCHeaderService", "summit.lsst.sal.CCOODS"]
+      topicRegexps:
+        - "summit.lsst.sal.CCCamera"
+        - "summit.lsst.sal.CCHeaderService"
+        - "summit.lsst.sal.CCOODS"
     standby-envsys:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: ["summit.lsst.sal.DIMM", "summit.lsst.sal.DREAM", "summit.lsst.sal.EAS", "summit.lsst.sal.ESS", "summit.lsst.sal.DSM", "summit.lsst.sal.EPM", "summit.lsst.sal.HVAC", "summit.lsst.sal.WeatherForecast"]
+      topicRegexps:
+        - "summit.lsst.sal.DIMM"
+        - "summit.lsst.sal.DREAM"
+        - "summit.lsst.sal.EAS"
+        - "summit.lsst.sal.ESS"
+        - "summit.lsst.sal.DSM"
+        - "summit.lsst.sal.EPM"
+        - "summit.lsst.sal.HVAC"
+        - "summit.lsst.sal.WeatherForecast"
     standby-m1m3:
       enabled: true
       metric_batch_size: 1500
       max_undelivered_messages: 4000
       database: "efd"
-      topicRegexps: ["summit.lsst.sal.MTM1M3([^T].*)"]
+      topicRegexps:
+        - "summit.lsst.sal.MTM1M3([^T].*)"
     standby-m1m3ts:
       enabled: true
       metric_batch_size: 1500
       max_undelivered_messages: 4000
       database: "efd"
-      topicRegexps: ["summit.lsst.sal.MTM1M3TS"]
+      topicRegexps:
+        - "summit.lsst.sal.MTM1M3TS"
     standby-m2:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: ["summit.lsst.sal.MTHexapod", "summit.lsst.sal.MTM2", "summit.lsst.sal.MTRotator"]
+      topicRegexps:
+        - "summit.lsst.sal.MTHexapod"
+        - "summit.lsst.sal.MTM2"
+        - "summit.lsst.sal.MTRotator"
     standby-obssys:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: ["summit.lsst.sal.Scheduler", "summit.lsst.sal.Script", "summit.lsst.sal.ScriptQueue", "summit.lsst.sal.Watcher"]
+      topicRegexps:
+        - "summit.lsst.sal.Scheduler"
+        - "summit.lsst.sal.Script"
+        - "summit.lsst.sal.ScriptQueue"
+        - "summit.lsst.sal.Watcher"
     standby-ocps:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: ["summit.lsst.sal.OCPS"]
+      topicRegexps:
+        - "summit.lsst.sal.OCPS"
     standby-pmd:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: ["summit.lsst.sal.PMD"]
+      topicRegexps:
+        - "summit.lsst.sal.PMD"
     standby-calsys:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: ["summit.lsst.sal.ATMonochromator", "summit.lsst.sal.ATWhiteLight", "summit.lsst.sal.CBP", "summit.lsst.sal.Electrometer", "summit.lsst.sal.FiberSpectrograph", "summit.lsst.sal.LEDProjector", "summit.lsst.sal.LinearStage", "summit.lsst.sal.MTReflector", "summit.lsst.sal.TunableLaser"]
+      topicRegexps:
+        - "summit.lsst.sal.ATMonochromator"
+        - "summit.lsst.sal.ATWhiteLight"
+        - "summit.lsst.sal.CBP"
+        - "summit.lsst.sal.Electrometer"
+        - "summit.lsst.sal.FiberSpectrograph"
+        - "summit.lsst.sal.LEDProjector"
+        - "summit.lsst.sal.LinearStage"
+        - "summit.lsst.sal.MTReflector"
+        - "summit.lsst.sal.TunableLaser"
     standby-mtaircompressor:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: ["summit.lsst.sal.MTAirCompressor"]
+      topicRegexps:
+        - "summit.lsst.sal.MTAirCompressor"
     standby-genericcamera:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: ["summit.lsst.sal.GCHeaderService", "summit.lsst.sal.GenericCamera"]
+      topicRegexps:
+        - "summit.lsst.sal.GCHeaderService"
+        - "summit.lsst.sal.GenericCamera"
     standby-gis:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: ["summit.lsst.sal.GIS"]
+      topicRegexps:
+        - "summit.lsst.sal.GIS"
     standby-mtvms:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: ["summit.lsst.sal.MTVMS"]
+      topicRegexps:
+        - "summit.lsst.sal.MTVMS"
     standby-lsstcam:
       enabled: true
       repair: false
@@ -520,66 +686,145 @@ telegraf-standby:
       max_undelivered_messages: 5000
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: ["summit.lsst.sal.MTCamera", "summit.lsst.sal.MTHeaderService", "summit.lsst.sal.MTOODS"]
+      topicRegexps:
+        - "summit.lsst.sal.MTCamera"
+        - "summit.lsst.sal.MTHeaderService"
+        - "summit.lsst.sal.MTOODS"
     standby-auxtel:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: ["summit.lsst.sal.ATAOS", "summit.lsst.sal.ATBuilding", "summit.lsst.sal.ATDome", "summit.lsst.sal.ATDomeTrajectory", "summit.lsst.sal.ATHexapod", "summit.lsst.sal.ATPneumatics", "summit.lsst.sal.ATPtg", "summit.lsst.sal.ATMCS"]
+      topicRegexps:
+        - "summit.lsst.sal.ATAOS"
+        - "summit.lsst.sal.ATBuilding"
+        - "summit.lsst.sal.ATDome"
+        - "summit.lsst.sal.ATDomeTrajectory"
+        - "summit.lsst.sal.ATHexapod"
+        - "summit.lsst.sal.ATPneumatics"
+        - "summit.lsst.sal.ATPtg"
+        - "summit.lsst.sal.ATMCS"
     standby-latiss:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: ["summit.lsst.sal.ATCamera", "summit.lsst.sal.ATHeaderService", "summit.lsst.sal.ATOODS", "summit.lsst.sal.ATSpectrograph"]
+      topicRegexps:
+        - "summit.lsst.sal.ATCamera"
+        - "summit.lsst.sal.ATHeaderService"
+        - "summit.lsst.sal.ATOODS"
+        - "summit.lsst.sal.ATSpectrograph"
     standby-test:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: ["summit.lsst.sal.Test"]
+      topicRegexps:
+        - "summit.lsst.sal.Test"
     standby-lasertracker:
       enabled: true
       repair: false
       database: "efd"
       timestamp_field: "private_efdStamp"
-      topicRegexps: ["summit.lsst.sal.LaserTracker"]
+      topicRegexps:
+        - "summit.lsst.sal.LaserTracker"
     # CCS connectors (experimental) data is being written on separate databases for now
     standby-atcamera:
       enabled: true
       database: "lsst.ATCamera"
       timestamp_format: "unix_ms"
       timestamp_field: "timestamp"
-      tags: ["Agent", "Aspic", "Location", "Raft", "Reb", "Sensor", "Source"]
-      topicRegexps: ["summit.lsst.ATCamera"]
+      tags:
+        - "Agent"
+        - "Aspic"
+        - "Location"
+        - "Raft"
+        - "Reb"
+        - "Sensor"
+        - "Source"
+      topicRegexps:
+        - "summit.lsst.ATCamera"
     standby-cccamera:
       enabled: true
       database: "lsst.CCCamera"
       timestamp_format: "unix_ms"
       timestamp_field: "timestamp"
-      tags: ["Agent", "Aspic", "Cold", "Cryo", "Hardware", "Location", "Ps", "RTD", "Raft", "Reb", "Segment", "Sensor", "Source"]
-      topicRegexps: ["summit.lsst.CCCamera"]
+      tags:
+        - "Agent"
+        - "Aspic"
+        - "Cold"
+        - "Cryo"
+        - "Hardware"
+        - "Location"
+        - "Ps"
+        - "RTD"
+        - "Raft"
+        - "Reb"
+        - "Segment"
+        - "Sensor"
+        - "Source"
+      topicRegexps:
+        - "summit.lsst.CCCamera"
     standby-mtcamera:
       enabled: true
       database: "lsst.MTCamera"
       timestamp_format: "unix_ms"
       timestamp_field: "timestamp"
-      tags: ["Agent", "Aspic", "Axis", "Bay", "Canbus", "Cip", "Clamp", "Cold", "Controller", "Cryo", "Gateway", "Hardware", "Hip", "Hook", "Latch", "Location", "Ps", "RTD", "Raft", "Reb", "Segment", "Sensor", "Socket", "Source", "Truck"]
-      topicRegexps: ["summit.lsst.MTCamera"]
+      tags:
+        - "Agent"
+        - "Aspic"
+        - "Axis"
+        - "Bay"
+        - "Canbus"
+        - "Cip"
+        - "Clamp"
+        - "Cold"
+        - "Controller"
+        - "Cryo"
+        - "Gateway"
+        - "Hardware"
+        - "Hip"
+        - "Hook"
+        - "Latch"
+        - "Location"
+        - "Ps"
+        - "RTD"
+        - "Raft"
+        - "Reb"
+        - "Segment"
+        - "Sensor"
+        - "Socket"
+        - "Source"
+        - "Truck"
+      topicRegexps:
+        - "summit.lsst.MTCamera"
     standby-obsenv:
       enabled: true
       database: "lsst.obsenv"
       timestamp_format: "unix_ms"
       timestamp_field: "timestamp"
-      topicRegexps: ["summit.lsst.obsenv"]
+      topicRegexps:
+        - "summit.lsst.obsenv"
     standby-cp:
       enabled: true
       database: "lsst.cp"
       timestamp_format: "unix"
       timestamp_field: "timestamp"
-      topicRegexps: ["summit.lsst.cp"]
-      tags: ["dataset_tag", "band", "instrument", "skymap", "detector", "physical_filter", "tract", "exposure", "patch", "visit", "run", "pipeline"]
+      topicRegexps:
+        - "summit.lsst.cp"
+      tags:
+        - "dataset_tag"
+        - "band"
+        - "instrument"
+        - "skymap"
+        - "detector"
+        - "physical_filter"
+        - "tract"
+        - "exposure"
+        - "patch"
+        - "visit"
+        - "run"
+        - "pipeline"
 
 kafdrop:
   ingress:

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -399,8 +399,7 @@ telegraf:
       database: "lsst.ATCamera"
       timestamp_format: "unix_ms"
       timestamp_field: "timestamp"
-      tags: |
-        [ "Agent", "Aspic", "Location", "Raft", "Reb", "Sensor", "Source", "VersionType" ]
+      tags: ["Agent", "Aspic", "Location", "Raft", "Reb", "Sensor", "Source", "VersionType"]
       topicRegexps: |
         [ "summit.lsst.ATCamera" ]
     cccamera:
@@ -408,8 +407,7 @@ telegraf:
       database: "lsst.CCCamera"
       timestamp_format: "unix_ms"
       timestamp_field: "timestamp"
-      tags: |
-        [ "Agent", "Aspic", "Cold", "Cryo", "Hardware", "Location", "Ps", "RTD", "Raft", "Reb", "Segment", "Sensor", "Source", "VersionType" ]
+      tags: ["Agent", "Aspic", "Cold", "Cryo", "Hardware", "Location", "Ps", "RTD", "Raft", "Reb", "Segment", "Sensor", "Source", "VersionType"]
       topicRegexps: |
         [ "summit.lsst.CCCamera" ]
     mtcamera:
@@ -417,8 +415,7 @@ telegraf:
       database: "lsst.MTCamera"
       timestamp_format: "unix_ms"
       timestamp_field: "timestamp"
-      tags: |
-        [ "Agent", "Aspic", "Axis", "Bay", "Canbus", "Cip", "Clamp", "Cold", "Controller", "Cryo", "Gateway", "Hardware", "Hip", "Hook", "Latch", "Location", "Ps", "RTD", "Raft", "Reb", "Segment", "Sensor", "Socket", "Source", "Truck", "VersionType" ]
+      tags: ["Agent", "Aspic", "Axis", "Bay", "Canbus", "Cip", "Clamp", "Cold", "Controller", "Cryo", "Gateway", "Hardware", "Hip", "Hook", "Latch", "Location", "Ps", "RTD", "Raft", "Reb", "Segment", "Sensor", "Socket", "Source", "Truck", "VersionType"]
       topicRegexps: |
         [ "summit.lsst.MTCamera" ]
     obsenv:
@@ -435,8 +432,7 @@ telegraf:
       timestamp_field: "timestamp"
       topicRegexps: |
         [ "summit.lsst.cp" ]
-      tags: |
-        [ "dataset_tag", "band", "instrument", "skymap", "detector", "physical_filter", "tract", "exposure", "patch", "visit", "run", "pipeline" ]
+      tags: ["dataset_tag", "band", "instrument", "skymap", "detector", "physical_filter", "tract", "exposure", "patch", "visit", "run", "pipeline"]
 
 telegraf-standby:
   enabled: false
@@ -602,8 +598,7 @@ telegraf-standby:
       database: "lsst.ATCamera"
       timestamp_format: "unix_ms"
       timestamp_field: "timestamp"
-      tags: |
-        [ "Agent", "Aspic", "Location", "Raft", "Reb", "Sensor", "Source" ]
+      tags: ["Agent", "Aspic", "Location", "Raft", "Reb", "Sensor", "Source"]
       topicRegexps: |
         [ "summit.lsst.ATCamera" ]
     standby-cccamera:
@@ -611,8 +606,7 @@ telegraf-standby:
       database: "lsst.CCCamera"
       timestamp_format: "unix_ms"
       timestamp_field: "timestamp"
-      tags: |
-        [ "Agent", "Aspic", "Cold", "Cryo", "Hardware", "Location", "Ps", "RTD", "Raft", "Reb", "Segment", "Sensor", "Source" ]
+      tags: ["Agent", "Aspic", "Cold", "Cryo", "Hardware", "Location", "Ps", "RTD", "Raft", "Reb", "Segment", "Sensor", "Source"]
       topicRegexps: |
         [ "summit.lsst.CCCamera" ]
     standby-mtcamera:
@@ -620,8 +614,7 @@ telegraf-standby:
       database: "lsst.MTCamera"
       timestamp_format: "unix_ms"
       timestamp_field: "timestamp"
-      tags: |
-        [ "Agent", "Aspic", "Axis", "Bay", "Canbus", "Cip", "Clamp", "Cold", "Controller", "Cryo", "Gateway", "Hardware", "Hip", "Hook", "Latch", "Location", "Ps", "RTD", "Raft", "Reb", "Segment", "Sensor", "Socket", "Source", "Truck" ]
+      tags: ["Agent", "Aspic", "Axis", "Bay", "Canbus", "Cip", "Clamp", "Cold", "Controller", "Cryo", "Gateway", "Hardware", "Hip", "Hook", "Latch", "Location", "Ps", "RTD", "Raft", "Reb", "Segment", "Sensor", "Socket", "Source", "Truck"]
       topicRegexps: |
         [ "summit.lsst.MTCamera" ]
     standby-obsenv:
@@ -638,8 +631,7 @@ telegraf-standby:
       timestamp_field: "timestamp"
       topicRegexps: |
         [ "summit.lsst.cp" ]
-      tags: |
-        [ "dataset_tag", "band", "instrument", "skymap", "detector", "physical_filter", "tract", "exposure", "patch", "visit", "run", "pipeline" ]
+      tags: ["dataset_tag", "band", "instrument", "skymap", "detector", "physical_filter", "tract", "exposure", "patch", "visit", "run", "pipeline"]
 
 kafdrop:
   ingress:


### PR DESCRIPTION
Refactor the Sasquatch `telegraf` subchart and support sending data in JSON format using Telegraf `json_v2` parser. 

The Telegraf connector configuration for the `SkyFlux` example metric in Sasquatch looks like:

```
telegraf:
  enabled: true
  kafkaConsumers:
    examplejson:
      enabled: true
      data_format: "json_v2"
      timestamp_format: "unix_ms"
      timestamp_field: "timestamp"
      tags:
        - "band"
        - "instrument"
      topicRegexps:
        - "lsst.examplejson"
      database: "lsst.examplejson"
```

Example of JSON payload for this configuration:

```
payload = {
    "records": [
        {
            "value": {
                "measurement": "SkyFlux",
                "band": "y",
                "instrument": "LSSTCam",
                "meanSky": -213.75839364883444,
                "stdevSky": 2328.906118708811,
            }
        },
   ],
}
```

The `measurement` field corresponds to the measurement name in InfluxDB which will hold the data. 
A `timestamp` is optional, if not provided it will use the system time when the data is recorded in InfluxDB. 
In the example `band` and `instrument` are configured as tags in Sasquatch.



