### PR TITLE
Increase vo-cutouts Redis memory limit

### DIFF
--- a/applications/vo-cutouts/values.yaml
+++ b/applications/vo-cutouts/values.yaml
@@ -200,7 +200,7 @@ redis:
   resources:
     limits:
       cpu: "0.5"
-      memory: "20Mi"
+      memory: "30Mi"
     requests:
       cpu: "0.1"
       memory: "8Mi"


### PR DESCRIPTION
A flood of cutout requests with numerous erroneous requests caused Redis to grow beyond 20MiB. Increase the memory limit to 30MiB. The steady-state still appears to match the request.