### PR TITLE
DM-55118: Move USDF RSP Prod to CNPG Database

### DIFF
--- a/applications/gafaelfawr/values-usdfprod.yaml
+++ b/applications/gafaelfawr/values-usdfprod.yaml
@@ -16,8 +16,8 @@ config:
   sentry:
     enabled: true
 
-  internalDatabase: true
   updateSchema: true
+  databaseUrl: postgresql://gafaelfawr@rsp-db-rw.postgres-db:5432/gafaelfawr
 
   oidcServer:
     enabled: true

--- a/applications/nublado/values-usdfprod.yaml
+++ b/applications/nublado/values-usdfprod.yaml
@@ -173,7 +173,7 @@ proxy:
 jupyterhub:
   hub:
     db:
-      url: "postgresql://nublado3@postgres.postgres/nublado3"
+      url: "postgresql://nublado@rsp-db-rw.postgres-db/nublado"
       upgrade: true
   cull:
     timeout: 432000  # 5 days

--- a/applications/times-square/values-usdfprod.yaml
+++ b/applications/times-square/values-usdfprod.yaml
@@ -2,7 +2,7 @@ replicaCount:
   api: 2
   worker: 2
 config:
-  databaseUrl: "postgresql://timessquare@postgres.postgres/timessquare"
+  databaseUrl: "postgresql://timessquare@rsp-db-rw.postgres-db/timessquare"
   githubAppId: "1112177"
   enableGitHubApp: "True"
   sentryTracesSampleRate: 1


### PR DESCRIPTION
Update database connection strings for nublado, gafaelfawr, and timesquare to the CNPG instance.  The database name is changed from `nublado3` to `nublado` as part of the change to be consistent with other environments.