### PR TITLE
DM-55929: Deploy squareone 0.39.0 with admin ingress scopes.any

### DIFF
--- a/applications/squareone/Chart.yaml
+++ b/applications/squareone/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
     url: https://github.com/jonathansick
 
 # The default version tag of the squareone docker image
-appVersion: "0.38.0"
+appVersion: "0.39.0"

--- a/applications/squareone/README.md
+++ b/applications/squareone/README.md
@@ -17,6 +17,7 @@ Squareone is the homepage UI for the Rubin Science Platform.
 | autoscaling.maxReplicas | int | `100` |  |
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
+| config.adminPageScopes | object | Squareone's built-in defaults, matching Gafaelfawr's admin scopes | Maps each admin page id (`notifications`, `serviceTokens`, `oidcClients`, `sentry`) to the Gafaelfawr scopes granting access to it. Holding any one of a page's scopes is sufficient; an empty list hides the page. Override only the pages that differ — the rest keep their defaults. Keep this consistent with `ingress.adminScopes`, which decides who gets past the /admin ingress at all. |
 | config.appLinks | list | `[{"href":"/argo-cd/","internal":false,"label":"Argo CD"}]` | App menu items |
 | config.coManageRegistryUrl | string | null disables the COmanage integration | URL to the COmanage registry, if the environment uses COmanage for identity. |
 | config.docsBaseUrl | string | `"https://rsp.lsst.io"` | Base URL for user documentation (excludes trailing slash) |

--- a/applications/squareone/README.md
+++ b/applications/squareone/README.md
@@ -51,7 +51,7 @@ Squareone is the homepage UI for the Rubin Science Platform.
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy (tip: use Always for development) |
 | image.repository | string | `"ghcr.io/lsst-sqre/squareone"` | Squareone Docker image repository |
 | image.tag | string | Chart's appVersion | Overrides the image tag. |
-| ingress.adminScope | string | `"exec:admin"` | Scope required for the /admin UI |
+| ingress.adminScopes | list | `["exec:admin","admin:notifications","admin:token","admin:oidc"]` | Scopes that grant access to the /admin UI. Holding any one of them is sufficient; which admin pages each scope reveals is decided by Squareone's own `adminPageScopes` configuration. |
 | ingress.annotations | object | `{}` | Additional annotations to add to the ingress |
 | ingress.enabled | bool | `true` | Enable ingress |
 | ingress.timesSquareScope | string | `"exec:notebook"` | Scope required for /times-square UI |

--- a/applications/squareone/README.md
+++ b/applications/squareone/README.md
@@ -17,7 +17,7 @@ Squareone is the homepage UI for the Rubin Science Platform.
 | autoscaling.maxReplicas | int | `100` |  |
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
-| config.adminPageScopes | object | Squareone's built-in defaults, matching Gafaelfawr's admin scopes | Maps each admin page id (`notifications`, `serviceTokens`, `oidcClients`, `sentry`) to the Gafaelfawr scopes granting access to it. Holding any one of a page's scopes is sufficient; an empty list hides the page. Override only the pages that differ — the rest keep their defaults. Keep this consistent with `ingress.adminScopes`, which decides who gets past the /admin ingress at all. |
+| config.adminPageScopes | object | `{"notifications":["admin:notifications"],"oidcClients":["admin:oidc"],"sentry":["exec:admin"],"serviceTokens":["admin:token"]}` | Maps each admin page id (`notifications`, `serviceTokens`, `oidcClients`, `sentry`) to the Gafaelfawr scopes granting access to it. Holding any one of a page's scopes is sufficient; an empty list hides the page. Override only the pages that differ — the rest keep their defaults. Keep this consistent with `ingress.adminScopes`, which decides who gets past the /admin ingress at all. |
 | config.appLinks | list | `[{"href":"/argo-cd/","internal":false,"label":"Argo CD"}]` | App menu items |
 | config.coManageRegistryUrl | string | null disables the COmanage integration | URL to the COmanage registry, if the environment uses COmanage for identity. |
 | config.docsBaseUrl | string | `"https://rsp.lsst.io"` | Base URL for user documentation (excludes trailing slash) |

--- a/applications/squareone/templates/configmap.yaml
+++ b/applications/squareone/templates/configmap.yaml
@@ -34,6 +34,10 @@ data:
     sentryReplaysSessionSampleRate: {{ .Values.config.sentryReplaysSessionSampleRate }}
     sentryReplaysOnErrorSampleRate: {{ .Values.config.sentryReplaysOnErrorSampleRate }}
     sentryDebug: {{ .Values.config.sentryDebug }}
+    {{- if .Values.config.adminPageScopes }}
+    adminPageScopes:
+      {{- toYaml .Values.config.adminPageScopes | nindent 6 }}
+    {{- end }}
     enableAppsMenu: {{ .Values.config.enableAppsMenu }}
     appLinks:
       {{- toYaml .Values.config.appLinks | nindent 6 }}

--- a/applications/squareone/templates/ingress-admin.yaml
+++ b/applications/squareone/templates/ingress-admin.yaml
@@ -7,8 +7,8 @@ metadata:
 config:
   loginRedirect: true
   scopes:
-    all:
-      - {{ .Values.ingress.adminScope | quote }}
+    any:
+      {{- toYaml (required "ingress.adminScopes must be a non-empty list" .Values.ingress.adminScopes) | nindent 6 }}
   service: "squareone"
 template:
   metadata:

--- a/applications/squareone/values-idfdev.yaml
+++ b/applications/squareone/values-idfdev.yaml
@@ -1,4 +1,8 @@
 image:
+  # Branch build of squareone for DM-55929 (lsst-sqre/squareone#678):
+  # the /admin/oidc-clients pages and configurable adminPageScopes.
+  # Revert to the chart appVersion once that PR is merged and released.
+  tag: "tickets-DM-55929"
   pullPolicy: Always
 
 ingress:

--- a/applications/squareone/values-idfdev.yaml
+++ b/applications/squareone/values-idfdev.yaml
@@ -1,8 +1,4 @@
 image:
-  # Branch build of squareone for DM-55929 (lsst-sqre/squareone#678):
-  # the /admin/oidc-clients pages and configurable adminPageScopes.
-  # Revert to the chart appVersion once that PR is merged and released.
-  tag: "tickets-DM-55929"
   pullPolicy: Always
 
 ingress:

--- a/applications/squareone/values.yaml
+++ b/applications/squareone/values.yaml
@@ -141,8 +141,11 @@ config:
   # page. Override only the pages that differ — the rest keep their defaults.
   # Keep this consistent with `ingress.adminScopes`, which decides who gets
   # past the /admin ingress at all.
-  # @default -- Squareone's built-in defaults, matching Gafaelfawr's admin scopes
-  adminPageScopes: {}
+  adminPageScopes:
+    notifications: ["admin:notifications"]
+    serviceTokens: ["admin:token"]
+    oidcClients: ["admin:oidc"]
+    sentry: ["exec:admin"]
 
   # -- Enable the App menu
   enableAppsMenu: false

--- a/applications/squareone/values.yaml
+++ b/applications/squareone/values.yaml
@@ -33,8 +33,14 @@ ingress:
   # -- Scope required for /times-square UI
   timesSquareScope: "exec:notebook"
 
-  # -- Scope required for the /admin UI
-  adminScope: "exec:admin"
+  # -- Scopes that grant access to the /admin UI. Holding any one of them is
+  # sufficient; which admin pages each scope reveals is decided by Squareone's
+  # own `adminPageScopes` configuration.
+  adminScopes:
+    - "exec:admin"
+    - "admin:notifications"
+    - "admin:token"
+    - "admin:oidc"
 
 # -- Resource requests and limits for Squareone pods
 # @default -- see `values.yaml`

--- a/applications/squareone/values.yaml
+++ b/applications/squareone/values.yaml
@@ -135,6 +135,15 @@ config:
   # -- Sentry debug mode
   sentryDebug: false
 
+  # -- Maps each admin page id (`notifications`, `serviceTokens`,
+  # `oidcClients`, `sentry`) to the Gafaelfawr scopes granting access to it.
+  # Holding any one of a page's scopes is sufficient; an empty list hides the
+  # page. Override only the pages that differ — the rest keep their defaults.
+  # Keep this consistent with `ingress.adminScopes`, which decides who gets
+  # past the /admin ingress at all.
+  # @default -- Squareone's built-in defaults, matching Gafaelfawr's admin scopes
+  adminPageScopes: {}
+
   # -- Enable the App menu
   enableAppsMenu: false
 


### PR DESCRIPTION
## Summary

Deploy squareone 0.39.0 to every environment and rework the admin ingress so it follows the set of admin scopes rather than a single one.

**Release bump.** `Chart.yaml` `appVersion` moves from 0.38.0 to 0.39.0. That release ships the `/admin/oidc-clients` pages (list, create with one-time secret reveal, detail with edit and delete) and the `adminPageScopes` configuration key that the ingress change below relies on. See the [squareone 0.39.0 changelog](https://github.com/lsst-sqre/squareone/blob/main/apps/squareone/CHANGELOG.md).

**Chart change.** `ingress.adminScope` (string, `exec:admin`) becomes `ingress.adminScopes` (list, defaulting to `exec:admin`, `admin:notifications`, `admin:token`, `admin:oidc`), and `templates/ingress-admin.yaml` switches from `scopes.all` to `scopes.any` over it.

This is deliberately a *widening*: the ingress now admits anyone holding **any** admin scope, and which pages they actually see is decided inside Squareone by its `adminPageScopes` configuration. Someone holding only `admin:oidc` reaches `/admin` and is redirected to `/admin/oidc-clients` instead of being refused at the ingress; someone holding none of the four is still refused there. No environment set `ingress.adminScope`, so no per-environment values needed updating and every environment picks up the new default.

**Config passthrough.** The configmap template enumerates every `squareone.config.yaml` key explicitly, so the new `adminPageScopes` mapping would have been unreachable from Phalanx. `config.adminPageScopes` is now passed through and declared in `values.yaml` with its four page ids spelled out, so the policy is visible in the chart and in the README. The values match Squareone's built-in defaults exactly, so behaviour is unchanged, but the rendered ConfigMap now carries the mapping explicitly in every environment, which shows as a ConfigMap diff and rolls pods on first sync.

These two are halves of one policy: `ingress.adminScopes` decides who gets past the `/admin` ingress, `config.adminPageScopes` decides which pages they see once inside. Overriding one without the other is how an environment gets an inconsistent admin UI, hence the cross-reference in both values docs.

**idfdev.** The earlier `tickets-DM-55929` branch image override that this PR carried during development has been dropped; idfdev now renders the released image like every other environment.

**Gafaelfawr.** `admin:oidc` is already present in `applications/gafaelfawr/values.yaml` `knownScopes` on main, so the scope can be granted through the token UI everywhere. No Gafaelfawr change is needed here.

This supersedes #6884 (the DM-55604 branch deploy): squareone#609 merged to main and is included in 0.39.0.

## Validation steps

- `phalanx application lint squareone` passes for all 17 environments.
- `phalanx application template squareone` renders `ghcr.io/lsst-sqre/squareone:0.39.0` for idfdev, idfprod and usdfprod; idfdev keeps `imagePullPolicy: Always`, the others `IfNotPresent`.
- All environments render the admin `GafaelfawrIngress` with `scopes.any` over the four scopes; the Times Square ingress is unchanged.
- The `0.39.0` image exists in GHCR, pushed by the squareone CI run for the release merge.
- `values-idfdev.yaml` is byte-identical to main again.
- No remaining references to the singular `ingress.adminScope` anywhere in the repo.
- The chart's spelled-out `adminPageScopes` defaults match Squareone's exactly, checked against both `squareone.config.schema.json` per-page defaults and `DEFAULT_ADMIN_PAGE_SCOPES` in `adminPageScopes.ts`.
- Helm merge semantics verified for a partial environment override (`oidcClients` widened, `serviceTokens: []`): untouched pages keep their defaults, the overridden list replaces rather than appends, and the empty list survives coalescing so a page can still be hidden per environment.
- README regenerated by helm-docs 1.14.2 (matching the pre-commit pin); only squareone's README changed.
- Branch rebased onto current main with no conflicts.

After sync, on data-dev:

- Visit `/admin` with `exec:admin` and confirm the nav lists only the pages your scopes allow, and that `/admin` redirects to the first visible one.
- With an `admin:oidc`-only token, confirm `/admin` redirects to `/admin/oidc-clients`, that creating a client reveals `client_id` and `client_secret` exactly once, and that the detail page edits and deletes.
- Confirm a token holding none of the four admin scopes is refused at the ingress rather than reaching the app.

## References

- squareone release: https://github.com/lsst-sqre/squareone/releases/tag/squareone%400.39.0
- squareone PR: lsst-sqre/squareone#678
- Task: lsst-sqre/squareone#677
- PRD: lsst-sqre/squareone#670
- Jira: https://rubinobs.atlassian.net/browse/DM-55929
