### PR TITLE
DM-55960: Allow kafka brokers and controllers to share the same kubernetes nodes in Sasquatch

### DIFF
--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -751,7 +751,7 @@ Rubin Observatory's telemetry service
 | scimma.cluster.name | string | `"sasquatch"` | Name of the Strimzi cluster. Synchronize this with the cluster name in the parent Sasquatch chart. |
 | square-events.cluster.name | string | `"sasquatch"` |  |
 | square-events.topics.slackViewSubmission.retentionMs | int | `1800000` | Retention period, in milliseconds, for the Slack `view_submission` interaction topic. These events drive project creation in templatebot, so retaining them well beyond the other Squarebot topics keeps the payload of a failed creation available for debugging and replay. |
-| strimzi-kafka.broker.affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchExpressions":[{"key":"app.kubernetes.io/name","operator":"In","values":["kafka"]}]},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for broker pod assignment |
+| strimzi-kafka.broker.affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchExpressions":[{"key":"strimzi.io/pool-name","operator":"In","values":["kafka"]}]},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for broker pod assignment |
 | strimzi-kafka.broker.backup | bool | `false` | Whether to label the broker PVCs for backup by k8up, enabled on the summit and base environments |
 | strimzi-kafka.broker.enabled | bool | `false` | Enable node pool for the kafka brokers |
 | strimzi-kafka.broker.name | string | `"kafka"` | Node pool name |
@@ -783,7 +783,7 @@ Rubin Observatory's telemetry service
 | strimzi-kafka.connect.image | string | `"ghcr.io/lsst-sqre/strimzi-0.47.0-kafka-4.0.0:tickets-DM-43491"` | Custom strimzi-kafka image with connector plugins used by sasquatch |
 | strimzi-kafka.connect.replicas | int | `3` | Number of Kafka Connect replicas to run |
 | strimzi-kafka.connect.resources | object | See `values.yaml` | Kubernetes requests and limits for Kafka Connect |
-| strimzi-kafka.controller.affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchExpressions":[{"key":"app.kubernetes.io/name","operator":"In","values":["kafka"]}]},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for controller pod assignment |
+| strimzi-kafka.controller.affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchExpressions":[{"key":"strimzi.io/pool-name","operator":"In","values":["controller"]}]},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for controller pod assignment |
 | strimzi-kafka.controller.backup | bool | `false` | Whether to label the controller PVCs for backup by k8up, enabled on the summit and base environments |
 | strimzi-kafka.controller.enabled | bool | `false` | Enable node pool for the kafka controllers |
 | strimzi-kafka.controller.nodeIds | string | `"[3,4,5]"` | IDs to assign to the controllers |

--- a/applications/sasquatch/charts/strimzi-kafka/README.md
+++ b/applications/sasquatch/charts/strimzi-kafka/README.md
@@ -6,7 +6,7 @@ A subchart to deploy Strimzi Kafka components for Sasquatch.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| broker.affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchExpressions":[{"key":"app.kubernetes.io/name","operator":"In","values":["kafka"]}]},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for broker pod assignment |
+| broker.affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchExpressions":[{"key":"strimzi.io/pool-name","operator":"In","values":["kafka"]}]},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for broker pod assignment |
 | broker.backup | bool | `false` | Whether to label the broker PVCs for backup by k8up, enabled on the summit and base environments |
 | broker.enabled | bool | `false` | Enable node pool for the kafka brokers |
 | broker.name | string | `"kafka"` | Node pool name |
@@ -38,7 +38,7 @@ A subchart to deploy Strimzi Kafka components for Sasquatch.
 | connect.image | string | `"ghcr.io/lsst-sqre/strimzi-0.47.0-kafka-4.0.0:tickets-DM-43491"` | Custom strimzi-kafka image with connector plugins used by sasquatch |
 | connect.replicas | int | `3` | Number of Kafka Connect replicas to run |
 | connect.resources | object | See `values.yaml` | Kubernetes requests and limits for Kafka Connect |
-| controller.affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchExpressions":[{"key":"app.kubernetes.io/name","operator":"In","values":["kafka"]}]},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for controller pod assignment |
+| controller.affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchExpressions":[{"key":"strimzi.io/pool-name","operator":"In","values":["controller"]}]},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for controller pod assignment |
 | controller.backup | bool | `false` | Whether to label the controller PVCs for backup by k8up, enabled on the summit and base environments |
 | controller.enabled | bool | `false` | Enable node pool for the kafka controllers |
 | controller.nodeIds | string | `"[3,4,5]"` | IDs to assign to the controllers |

--- a/applications/sasquatch/charts/strimzi-kafka/values.yaml
+++ b/applications/sasquatch/charts/strimzi-kafka/values.yaml
@@ -154,10 +154,10 @@ controller:
       requiredDuringSchedulingIgnoredDuringExecution:
         - labelSelector:
             matchExpressions:
-              - key: "app.kubernetes.io/name"
+              - key: "strimzi.io/pool-name"
                 operator: In
                 values:
-                  - kafka
+                  - controller
           topologyKey: "kubernetes.io/hostname"
 
   # -- Tolerations for controller pod assignment
@@ -205,7 +205,7 @@ broker:
       requiredDuringSchedulingIgnoredDuringExecution:
         - labelSelector:
             matchExpressions:
-              - key: "app.kubernetes.io/name"
+              - key: "strimzi.io/pool-name"
                 operator: In
                 values:
                   - kafka

--- a/applications/sasquatch/values-roundtable-dev.yaml
+++ b/applications/sasquatch/values-roundtable-dev.yaml
@@ -12,31 +12,11 @@ strimzi-kafka:
       enabled: true
   controller:
     enabled: true
-    affinity:
-      podAntiAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-                - key: "strimzi.io/pool-name"
-                  operator: "In"
-                  values:
-                    - "controller"
-            topologyKey: "kubernetes.io/hostname"
   broker:
     enabled: true
     storage:
       size: 100Gi
       storageClassName: "premium-rwo"
-    affinity:
-      podAntiAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-                - key: "strimzi.io/pool-name"
-                  operator: "In"
-                  values:
-                    - "kafka"
-            topologyKey: "kubernetes.io/hostname"
   connect:
     enabled: false
   mirrormaker2:

--- a/applications/sasquatch/values-roundtable-prod.yaml
+++ b/applications/sasquatch/values-roundtable-prod.yaml
@@ -12,31 +12,11 @@ strimzi-kafka:
       enabled: true
   controller:
     enabled: true
-    affinity:
-      podAntiAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-                - key: "strimzi.io/pool-name"
-                  operator: "In"
-                  values:
-                    - "controller"
-            topologyKey: "kubernetes.io/hostname"
   broker:
     enabled: true
     storage:
       size: 100Gi
       storageClassName: "premium-rwo"
-    affinity:
-      podAntiAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-                - key: "strimzi.io/pool-name"
-                  operator: "In"
-                  values:
-                    - "kafka"
-            topologyKey: "kubernetes.io/hostname"
   connect:
     enabled: false
   mirrormaker2:


### PR DESCRIPTION
Allow brokers and controllers to share the same Kubernetes node reducing the minimum number of nodes required to run Sasquatch from 6 to 3.

This is the configuration we had for the Roundtable environments and this PR makes it the default in Sasquatch.

Tested on idfdev and seems to be working fine.