### PR TITLE
DM-55961: Avoid null for mobu sentryEnvironment

### DIFF
--- a/applications/mobu/README.md
+++ b/applications/mobu/README.md
@@ -25,7 +25,7 @@ Continuous integration testing
 | config.metrics.schemaManager.registryUrl | string | Sasquatch in the local cluster | URL of the Confluent-compatible schema registry server |
 | config.metrics.schemaManager.suffix | string | `""` | Suffix to add to all registered subjects. This is sometimes useful for experimentation during development. |
 | config.pathPrefix | string | `"/mobu"` | Prefix for mobu's API routes. |
-| config.sentryEnvironment | string | `nil` | The environment to report to Sentry |
+| config.sentryEnvironment | string | Phalanx environment | The environment to report to Sentry |
 | config.sentryTracesSampleConfig | float | `0` | Sentry tracing config: a float to specify a percentage, or "errors" to send all transactions with errors. |
 | config.slackAlerts | bool | `true` | Whether to send alerts and status to Slack. |
 | global.environmentName | string | Set by Argo CD | Name of the Phalanx environment |

--- a/applications/mobu/tests/github_ci_app_enabled_test.yaml
+++ b/applications/mobu/tests/github_ci_app_enabled_test.yaml
@@ -11,6 +11,7 @@ set:
       scopes:
         - "exec:notebook"
         - "read:tap"
+    sentryEnvironment: "minikube"
   global:
     host: "example.com"
 tests:
@@ -75,6 +76,6 @@ tests:
                 registryUrl: http://sasquatch-schema-registry.sasquatch.svc.cluster.local:8081
                 suffix: ""
             pathPrefix: /mobu
-            sentryEnvironment: null
+            sentryEnvironment: minikube
             sentryTracesSampleConfig: 0
             slackAlerts: true

--- a/applications/mobu/tests/github_disabled_test.yaml
+++ b/applications/mobu/tests/github_disabled_test.yaml
@@ -1,6 +1,8 @@
 suite: Github Integration Disabled
 set:
   # GitHub integrations are disabled by default
+  config:
+    sentryEnvironment: "minikube"
   global:
     host: "example.com"
 tests:
@@ -28,7 +30,7 @@ tests:
                 registryUrl: http://sasquatch-schema-registry.sasquatch.svc.cluster.local:8081
                 suffix: ""
             pathPrefix: /mobu
-            sentryEnvironment: null
+            sentryEnvironment: minikube
             sentryTracesSampleConfig: 0
             slackAlerts: true
   - it: "Should not inject GitHub CI app secrets into the StatefulSet env"

--- a/applications/mobu/tests/github_refresh_app_enabled_test.yaml
+++ b/applications/mobu/tests/github_refresh_app_enabled_test.yaml
@@ -5,6 +5,7 @@ set:
       acceptedGithubOrgs:
         - "org1"
         - "org2"
+    sentryEnvironment: "minikube"
   global:
     host: "example.com"
 tests:
@@ -53,6 +54,6 @@ tests:
                 registryUrl: http://sasquatch-schema-registry.sasquatch.svc.cluster.local:8081
                 suffix: ""
             pathPrefix: /mobu
-            sentryEnvironment: null
+            sentryEnvironment: minikube
             sentryTracesSampleConfig: 0
             slackAlerts: true

--- a/applications/mobu/values.yaml
+++ b/applications/mobu/values.yaml
@@ -52,7 +52,8 @@ config:
   pathPrefix: "/mobu"
 
   # -- The environment to report to Sentry
-  sentryEnvironment: null
+  # @default -- Phalanx environment
+  sentryEnvironment: ""
 
   # -- Sentry tracing config: a float to specify a percentage, or "errors" to
   # send all transactions with errors.


### PR DESCRIPTION
Helm v4 passes the null through to mobu and pydantic-settings has a bug where it attempts to validate the constructor parameters even if overridden by environment variables. Ensure that the default (always overridden) `sentryEnvironment` is valid.