### PR TITLE
DM-55968: Pin redis version for RA deployments

### DIFF
--- a/applications/rapid-analysis/values-base.yaml
+++ b/applications/rapid-analysis/values-base.yaml
@@ -327,6 +327,8 @@ resources:
     memory: 2.5G
 redis:
   enabled: true
+  image:
+    tag: "8.10.1"
   port: 6379
   env:
     MASTER: true

--- a/applications/rapid-analysis/values-summit.yaml
+++ b/applications/rapid-analysis/values-summit.yaml
@@ -411,6 +411,8 @@ resources:
     memory: 2.5G
 redis:
   enabled: true
+  image:
+    tag: "8.10.1"
   port: 6379
   env:
     MASTER: true


### PR DESCRIPTION
The chart default is redis:latest with pullPolicy IfNotPresent, so each node runs whatever "latest" it first cached. Rescheduling redis-0 on BTS onto a node with an older cached image (8.8.0) downgraded Redis, which then refused to load the RDB (format v15) written by the newer 8.10.x on the PVC. Pin 8.10.1 explicitly so version changes are deliberate.

USDF is intentionally left as-is for now.