### PR TITLE
DM-55965: Define ObsForge Kubernetes resources

### DIFF
--- a/applications/obsforge/values.yaml
+++ b/applications/obsforge/values.yaml
@@ -75,7 +75,13 @@ podAnnotations: {}
 
 # -- Resource limits and requests for the obsforge deployment pod
 # @default -- See `values.yaml`
-resources: {}
+resources:
+  limits:
+    cpu: "1"
+    memory: "512Mi"
+  requests:
+    cpu: "100m"
+    memory: "128Mi"
 
 # -- Tolerations for the obsforge deployment pod
 tolerations: []
@@ -108,7 +114,13 @@ worker:
 
   # -- Resource limits and requests for the obsforge worker pods
   # @default -- See `values.yaml`
-  resources: {}
+  resources:
+    limits:
+      cpu: "1"
+      memory: "1Gi"
+    requests:
+      cpu: "100m"
+      memory: "256Mi"
 
   # -- Tolerations for the obsforge worker pods
   tolerations: []
@@ -125,7 +137,13 @@ schemaUpdate:
 
   # -- Resource limits and requests for the schema update job
   # @default -- See `values.yaml`
-  resources: {}
+  resources:
+    limits:
+      cpu: "1"
+      memory: "512Mi"
+    requests:
+      cpu: "100m"
+      memory: "128Mi"
 
   # -- Tolerations for the schema update job
   tolerations: []
@@ -158,7 +176,13 @@ redis:
 
   # -- Resource limits and requests for the Redis pod
   # @default -- See `values.yaml`
-  resources: {}
+  resources:
+    limits:
+      cpu: "1"
+      memory: "100Mi"
+    requests:
+      cpu: "100m"
+      memory: "20Mi"
 
   # -- Tolerations for the Redis pod
   tolerations: []


### PR DESCRIPTION
These are the observed resource utilization for idle ObsForge Pods
 
```
kubectl top pods -n obsforge
NAME                              CPU(cores)   MEMORY(bytes)
obsforge-577cc568df-5trg5         2m           85Mi
obsforge-redis-0                  3m           10Mi
obsforge-worker-8fd8d5cbd-hxx5t   2m           148Mi
```

Set 100m cpu requests 1 cpu limit for all workloads. 
The workers idle utilization is approximately 2% of the requests. 
With the existing 75% HPA target, scaling begins around 75m average CPU rather than being triggered by idle usage. 
This will be revisited with real load to better adjust autoscaling.
For memory request and limits setting 128Mi / 512Mi  for the API, 256Mi / 1Gi for the workers, 128Mi / 512Mi for schema update and 20Mi / 100Mi  for Redis seems reasonable.