### PR TITLE
DM-55940: Update S3 File Notifications Kafka to 4.2.0

### DIFF
--- a/applications/s3-file-notifications/values-usdfdev-prompt-processing.yaml
+++ b/applications/s3-file-notifications/values-usdfdev-prompt-processing.yaml
@@ -4,7 +4,7 @@ strimzi-kafka:
   kafkaController:
     enabled: true
   kafka:
-    version: "4.0.0"
+    version: "4.2.0"
     config:
       log.retention.minutes: 10080
       offsets.retention.minutes: 10080

--- a/applications/s3-file-notifications/values-usdfprod-prompt-processing.yaml
+++ b/applications/s3-file-notifications/values-usdfprod-prompt-processing.yaml
@@ -4,7 +4,7 @@ strimzi-kafka:
   kafkaController:
     enabled: true
   kafka:
-    version: "4.0.0"
+    version: "4.2.0"
     config:
       log.retention.minutes: 10080
       offsets.retention.minutes: 10080


### PR DESCRIPTION
Update Kafka version to 4.2.0 on S3 File Notifications Kafka.  This is the latest release supported by the running Strimzi 0.51 version.