### PR TITLE
DM-55868: Add disk quota information to idfint and idfprod

### DIFF
--- a/applications/gafaelfawr/values-idfint.yaml
+++ b/applications/gafaelfawr/values-idfint.yaml
@@ -46,6 +46,8 @@ config:
     default:
       api:
         hips: 1000
+      disk:
+        "/home": 41943040000
       notebook:
         cpu: 15.0
         memory: 120

--- a/applications/gafaelfawr/values-idfprod.yaml
+++ b/applications/gafaelfawr/values-idfprod.yaml
@@ -64,6 +64,8 @@ config:
         sia: 70
         tap: 1000
         vo-cutouts: 35
+      disk:
+        "/home": 41943040000
       notebook:
         cpu: 4.0
         memory: 32


### PR DESCRIPTION
Now that Gafaelfawr can track disk quota information, add the quota for `/home` for idfint and idfprod.