### PR TITLE
DM-55913: Upgrade version of mobu

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -168,7 +168,7 @@ jobs:
       - uses: medyagh/setup-minikube@latest
         with:
           cpus: max
-          memory: 5500m  # Linux virtual machines have 7GB of RAM
+          memory: 13500m  # Linux virtual machines have 7GB of RAM
 
       - name: Test interaction with the cluster
         run: kubectl get nodes

--- a/applications/mobu/Chart.yaml
+++ b/applications/mobu/Chart.yaml
@@ -5,4 +5,4 @@ description: "Continuous integration testing"
 home: https://mobu.lsst.io/
 sources:
   - "https://github.com/lsst-sqre/mobu"
-appVersion: 19.1.1
+appVersion: 19.1.2


### PR DESCRIPTION
Updates to a version of mobu to `19.1.2` which includes a fix for gracefully handling Github auth failures in the mobu github CI workers