### PR TITLE
Set up g_oidc_managers in idfprod

### DIFF
--- a/applications/gafaelfawr/values-idfprod.yaml
+++ b/applications/gafaelfawr/values-idfprod.yaml
@@ -80,6 +80,7 @@ config:
       - "g_admins"
     "admin:oidc":
       - "g_admins"
+      - "g_oidc_managers"
     "admin:token":
       - "g_admins"
     "admin:userinfo":


### PR DESCRIPTION
Give the group `g_oidc_managers` the `admin:oidc` scope in idfprod.