### PR TITLE
DM-55868: Bump disk quota for /home on idfprod

### DIFF
--- a/applications/gafaelfawr/values-idfprod.yaml
+++ b/applications/gafaelfawr/values-idfprod.yaml
@@ -65,7 +65,7 @@ config:
         tap: 1000
         vo-cutouts: 35
       disk:
-        "/home": 41943040000
+        "/home": 52428800000
       notebook:
         cpu: 4.0
         memory: 32


### PR DESCRIPTION
Update Gafaelfawr configuration to reflect the quota change in Terraform to 50000MiB.