### PR TITLE
USDFSM-172: Update USDF Nublado Max Age Cull Time

### DIFF
--- a/applications/nublado/values-usdfdev.yaml
+++ b/applications/nublado/values-usdfdev.yaml
@@ -181,7 +181,7 @@ jupyterhub:
       upgrade: true
   cull:
     timeout: 432000  # 5 days
-    maxAge: 691200  # 8 days
+    maxAge: 648000  # 7 days 12 hours
 
 hub:
   internalDatabase: true

--- a/applications/nublado/values-usdfint.yaml
+++ b/applications/nublado/values-usdfint.yaml
@@ -178,7 +178,7 @@ jupyterhub:
       upgrade: true
   cull:
     timeout: 432000  # 5 days
-    maxAge: 691200  # 8 days
+    maxAge: 648000  # 7 days 12 hours
 
 hub:
   internalDatabase: true

--- a/applications/nublado/values-usdfprod.yaml
+++ b/applications/nublado/values-usdfprod.yaml
@@ -177,7 +177,7 @@ jupyterhub:
       upgrade: true
   cull:
     timeout: 432000  # 5 days
-    maxAge: 691200  # 8 days
+    maxAge: 648000  # 7 days 12 hours
 
 hub:
   internalDatabase: true


### PR DESCRIPTION
Set max age for cull time in USDF dev, int, and prod to 7 days and 12 hours.  The change to 12 hours instead of a whole day is to reduce users who are culled during working hours.