### PR TITLE
DM-55927: Update times-square to 0.27.1

### DIFF
--- a/applications/times-square/Chart.yaml
+++ b/applications/times-square/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 type: application
 
 # The default version tag of the times-square docker image
-appVersion: "0.27.0"
+appVersion: "0.27.1"
 
 dependencies:
   - name: redis


### PR DESCRIPTION
## Summary

Updates the times-square app version from 0.27.0 to 0.27.1. This patch release bounds the length of values serialized into Sentry events (`max_value_length=1024`) in both the API and the arq worker, so uncaught errors raised while a large (>100 KB) notebook is in flight are reported to Sentry instead of being dropped server-side as `too_large:event`. It also enables SQLAlchemy pessimistic connection checking (`pool_pre_ping=True`) on the database session dependency.

No new configuration, migrations, or GitHub App changes are required.

## Validation steps

- Confirm the `0.27.1` image exists on ghcr.io (the times-square release CI run was in progress when this PR was opened).
- After sync, confirm `sentry_sdk.get_client().options["max_value_length"] == 1024` in an API and a worker pod.
- Watch the times-square Sentry project's stats outcomes for the absence of new `too_large:event` rejections.

## References

- Release: https://github.com/lsst-sqre/times-square/releases/tag/0.27.1
- Changes: https://github.com/lsst-sqre/times-square/pull/210
- Jira: https://rubinobs.atlassian.net/browse/DM-55927