### PR TITLE
DM-55928: Wire up NOTEBURST_WORKER_NBEXEC_JOB_TIMEOUT for noteburst

### DIFF
--- a/applications/noteburst/Chart.yaml
+++ b/applications/noteburst/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: noteburst
 version: 1.0.0
-appVersion: "0.27.0"
+appVersion: "0.27.1"
 description: Noteburst is a notebook execution service for the Rubin Science Platform.
 type: application
 home: https://noteburst.lsst.io/

--- a/applications/noteburst/README.md
+++ b/applications/noteburst/README.md
@@ -28,9 +28,10 @@ Noteburst is a notebook execution service for the Rubin Science Platform.
 | config.worker.identities | list | `[]` | Science Platform user identities that workers can acquire. Each item is an object with username and uuid keys |
 | config.worker.imageReference | string | `""` | Nublado image reference, applicable when imageSelector is "reference" |
 | config.worker.imageSelector | string | `"recommended"` | Nublado image stream to select: "recommended", "weekly" or "reference" |
-| config.worker.jobTimeout | int | `300` | The maximum allowed notebook execution time, in seconds. |
+| config.worker.jobTimeout | int | `300` | The backstop timeout, in seconds, for the short worker tasks (`ping`, `run_python`, and the `keep_alive` cron). Notebook execution is bounded by `nbexecJobTimeout` instead. |
 | config.worker.keepAlive | string | `"hourly"` | Worker keep alive mode: "normal", "fast", "hourly", "daily", "disabled" |
 | config.worker.maxConcurrentJobs | int | `1` | Max number of concurrent notebook executions per worker |
+| config.worker.nbexecJobTimeout | int | `3660` | The absolute arq timeout, in seconds, for notebook execution (`nbexec`) jobs. The per-request notebook timeout is what normally ends an over-running notebook; the frontend rejects request timeouts that are not at least 60 seconds shorter than this backstop. |
 | config.worker.tokenLifetime | string | `"2419200"` | Worker token lifetime, in seconds. |
 | config.worker.tokenScopes | string | `"exec:notebook,read:image,read:tap,read:sasquatch"` | Nublado2 worker account's token scopes as a comma-separated list. |
 | config.worker.workerCount | int | `1` | Number of workers to run |

--- a/applications/noteburst/templates/configmap.yaml
+++ b/applications/noteburst/templates/configmap.yaml
@@ -9,6 +9,9 @@ data:
   NOTEBURST_PATH_PREFIX: {{ .Values.ingress.path | quote }}
   NOTEBURST_ENVIRONMENT_URL: {{ .Values.global.baseUrl | quote }}
   NOTEBURST_REDIS_URL: "redis://{{ include "noteburst.fullname" . }}-redis.{{ .Release.Namespace }}:6379/0"
+  # The frontend validates per-request notebook timeouts against the nbexec
+  # backstop, so it must see the same value as the worker.
+  NOTEBURST_WORKER_NBEXEC_JOB_TIMEOUT: {{ .Values.config.worker.nbexecJobTimeout | quote }}
   METRICS_ENABLED: {{ .Values.config.metrics.enabled | quote }}
   METRICS_APPLICATION: {{ .Values.config.metrics.application | quote }}
   REPERTOIRE_BASE_URL: {{ .Values.global.repertoireUrl | quote }}

--- a/applications/noteburst/templates/worker-configmap.yaml
+++ b/applications/noteburst/templates/worker-configmap.yaml
@@ -10,6 +10,7 @@ data:
   NOTEBURST_REDIS_URL: "redis://{{ include "noteburst.fullname" . }}-redis.{{ .Release.Namespace }}:6379/0"
   NOTEBURST_WORKER_LOCK_REDIS_URL: "redis://{{ include "noteburst.fullname" . }}-redis.{{ .Release.Namespace }}:6379/1"
   NOTEBURST_WORKER_JOB_TIMEOUT: {{ .Values.config.worker.jobTimeout | quote }}
+  NOTEBURST_WORKER_NBEXEC_JOB_TIMEOUT: {{ .Values.config.worker.nbexecJobTimeout | quote }}
   NOTEBURST_WORKER_TOKEN_LIFETIME: {{ .Values.config.worker.tokenLifetime | quote }}
   NOTEBURST_WORKER_IMAGE_SELECTOR: {{ .Values.config.worker.imageSelector | quote  }}
   NOTEBURST_WORKER_IMAGE_REFERENCE: {{ .Values.config.worker.imageReference | quote  }}

--- a/applications/noteburst/values-idfdev.yaml
+++ b/applications/noteburst/values-idfdev.yaml
@@ -1,8 +1,5 @@
 image:
   pullPolicy: Always
-  # Temporary branch deployment for DM-55928; replace with the 0.27.1
-  # release image (and drop this override) once it is published.
-  tag: "tickets-DM-55928-timeout-reporting"
 
 config:
   logLevel: "DEBUG"

--- a/applications/noteburst/values-idfdev.yaml
+++ b/applications/noteburst/values-idfdev.yaml
@@ -1,5 +1,8 @@
 image:
   pullPolicy: Always
+  # Temporary branch deployment for DM-55928; replace with the 0.27.1
+  # release image (and drop this override) once it is published.
+  tag: "tickets-DM-55928-timeout-reporting"
 
 config:
   logLevel: "DEBUG"

--- a/applications/noteburst/values.yaml
+++ b/applications/noteburst/values.yaml
@@ -170,8 +170,16 @@ config:
     # -- Number of workers to run
     workerCount: 1
 
-    # -- The maximum allowed notebook execution time, in seconds.
+    # -- The backstop timeout, in seconds, for the short worker tasks
+    # (`ping`, `run_python`, and the `keep_alive` cron). Notebook execution
+    # is bounded by `nbexecJobTimeout` instead.
     jobTimeout: 300
+
+    # -- The absolute arq timeout, in seconds, for notebook execution
+    # (`nbexec`) jobs. The per-request notebook timeout is what normally
+    # ends an over-running notebook; the frontend rejects request timeouts
+    # that are not at least 60 seconds shorter than this backstop.
+    nbexecJobTimeout: 3660
 
     # -- Max number of concurrent notebook executions per worker
     maxConcurrentJobs: 1


### PR DESCRIPTION
## Summary

Noteburst 0.27.1 ([lsst-sqre/noteburst#186](https://github.com/lsst-sqre/noteburst/pull/186), [release notes](https://github.com/lsst-sqre/noteburst/releases/tag/0.27.1)) gives notebook execution (`nbexec`) jobs their own arq timeout, `NOTEBURST_WORKER_NBEXEC_JOB_TIMEOUT` (default 3660 seconds); `NOTEBURST_WORKER_JOB_TIMEOUT` now bounds only the short worker tasks (`ping`, `run_python`, and the `keep_alive` cron).

- Bump the chart `appVersion` to 0.27.1.
- Add `config.worker.nbexecJobTimeout` (default 3660) and emit `NOTEBURST_WORKER_NBEXEC_JOB_TIMEOUT` in **both** config maps. The worker registers it as the arq timeout for `nbexec`, and the frontend validates per-request notebook timeouts against it (rejecting requests within 60 seconds of the backstop with a 422), so both deployments must see the same value.
- Correct the `config.worker.jobTimeout` documentation, which described it as "the maximum allowed notebook execution time"; it no longer governs notebooks.

Note for operators: with noteburst 0.27.1 the absolute cap on notebook execution rises from the previous worker-wide 300 seconds to 3660 seconds unless `nbexecJobTimeout` is overridden.

## Validation

- `phalanx application lint noteburst` passes for all five environments.
- `phalanx application template noteburst idfdev` shows `NOTEBURST_WORKER_NBEXEC_JOB_TIMEOUT: "3660"` in both config maps and the `0.27.1` image on all noteburst containers.

## References

- Jira: [DM-55928](https://rubinobs.atlassian.net/browse/DM-55928)
- Application PR: lsst-sqre/noteburst#186

[DM-55928]: https://rubinobs.atlassian.net/browse/DM-55928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ