### PR TITLE
Double the memory of the qserv-kafka slow workers on idfprod

### DIFF
--- a/applications/qserv-kafka/values-idfprod.yaml
+++ b/applications/qserv-kafka/values-idfprod.yaml
@@ -13,6 +13,13 @@ slowWorker:
   autoscaling:
     minReplicas: 4
     maxReplicas: 50
+  resources:
+    limits:
+      cpu: "1"
+      memory: "1000Mi"
+    requests:
+      cpu: "1"
+      memory: "290Mi"
 redis:
   resources:
     limits:


### PR DESCRIPTION
Doubling the memory of the slow workers on idfprod (qserv-kafka) to see if this addresses the out of memory issues