### PR TITLE
DM-56000: Update Butler server

### DIFF
--- a/applications/butler/Chart.yaml
+++ b/applications/butler/Chart.yaml
@@ -4,4 +4,4 @@ version: 1.0.0
 description: Server for Butler data abstraction service
 sources:
   - https://github.com/lsst/daf_butler
-appVersion: server-4.2.3
+appVersion: server-4.2.4


### PR DESCRIPTION
Update Butler server to version 4.2.4, which includes fixes for DM-55631 and DM-53347, and rolls all libraries up to the latest versions.