### PR TITLE
DM-55762: Deploy docverse tickets-DM-55762 image on roundtable-dev

### DIFF
--- a/applications/docverse/values-roundtable-dev.yaml
+++ b/applications/docverse/values-roundtable-dev.yaml
@@ -1,6 +1,6 @@
 image:
   pullPolicy: "Always"
-  tag: "tickets-DM-55772"
+  tag: "tickets-DM-55762"
 
 config:
   logLevel: "DEBUG"


### PR DESCRIPTION
Point roundtable-dev at the `tickets-DM-55762` branch image so [lsst-sqre/docverse#574](https://github.com/lsst-sqre/docverse/pull/574) can be exercised before it merges.

## Summary

- `applications/docverse/values-roundtable-dev.yaml`: `image.tag` `tickets-DM-55772` → `tickets-DM-55762`. `pullPolicy` stays `Always`.

The previous pin is superseded rather than dropped: DM-55772's code is merged into docverse `main` (`bf28cd4`, `0d74bc9`) and `tickets/DM-55762` branches from `main`, so this image is a strict superset of what `tickets-DM-55772` was testing.

docverse#574 makes the server compute and own build content identity — the build-processing worker hashes each file during extraction and writes the manifest digest atomically with the transition to `completed`, sharing one implementation with the keeper-sync copier so the two producers cannot diverge. `BuildCreate.content_hash` becomes an optional, deprecated transport-provenance field.

**No schema migration.** The existing `content_hash` column is reused, and historical rows are deliberately not backfilled — dedup is forward-only for builds processed after deploy.

## Validation steps

- `ghcr.io/lsst-sqre/docverse:tickets-DM-55762` is built and pushed (CI run `33550265119` on `5a3fea8`, amd64 + arm64 manifest green).
- docverse#574 CI fully green: lint, typing, 2404 server tests, 214 client tests, worker and deploy-worker tests.
- `pre-commit run --files applications/docverse/values-roundtable-dev.yaml` passes (yamllint).

After merge, sync docverse on roundtable-dev with a **full app sync** — `config.updateSchema` is `true`, and a selective sync skips the schema-update PreSync hook. Then upload a build through the client and confirm the completed row's `content_hash` is the server-computed manifest digest rather than the client tarball digest.

## Teardown

Revert `image.tag` to a released version once docverse#574 merges and a release is cut.

## References

- App PR: lsst-sqre/docverse#574
- PRD: lsst-sqre/docverse#569
- Jira: [DM-55762](https://rubinobs.atlassian.net/browse/DM-55762)
- Supersedes the branch pin from lsst-sqre/phalanx#6855

[DM-55762]: https://rubinobs.atlassian.net/browse/DM-55762?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ