### PR TITLE
DM-56006: Bump tap-postgres version to 1.26.1

### DIFF
--- a/charts/cadc-tap/README.md
+++ b/charts/cadc-tap/README.md
@@ -52,7 +52,7 @@ IVOA TAP service
 | config.pg.host | string | None, must be set if backend is `pg` | Host to connect to |
 | config.pg.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the TAP image |
 | config.pg.image.repository | string | `"ghcr.io/lsst-sqre/tap-postgres-service"` | TAP image to use |
-| config.pg.image.tag | string | `"1.26.0"` | Tag of TAP image to use |
+| config.pg.image.tag | string | `"1.26.1"` | Tag of TAP image to use |
 | config.pg.username | string | None, must be set if backend is `pg` | Username to connect with |
 | config.qserv.host | string | `"mock-db:3306"` (the mock QServ) | QServ hostname:port to connect to |
 | config.qserv.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the TAP image |

--- a/charts/cadc-tap/values.yaml
+++ b/charts/cadc-tap/values.yaml
@@ -76,7 +76,7 @@ config:
       pullPolicy: "IfNotPresent"
 
       # -- Tag of TAP image to use
-      tag: "1.26.0"
+      tag: "1.26.1"
 
   qserv:
     # -- QServ hostname:port to connect to


### PR DESCRIPTION
New version of tap-postgres includes a fix to initialize UWS correctly if the UWS schema does exist but is empty.