### PR TITLE
DM-55024: Add Sasquatch GafaelfawrServiceToken

### DIFF
--- a/applications/sasquatch/README.md
+++ b/applications/sasquatch/README.md
@@ -45,6 +45,7 @@ Rubin Observatory's telemetry service
 | customInfluxDBIngress.hostname | string | None, must be set if the ingress is enabled | Hostname of the ingress |
 | customInfluxDBIngress.path | string | `"/influxdb(/\|$)(.*)"` | Path for the ingress |
 | data-transfer-monitoring.enabled | bool | `false` | Whether to enable the data-transfer-monitoring subchart |
+| gafaelfawrServiceToken.enabled | bool | `false` | Whether to create a Gafaelfawr service token for Sasquatch |
 | grafana.enabled | bool | `false` | Whether to enable the grafana subchart |
 | influxdb-enterprise-active.enabled | bool | `false` | Whether to enable influxdb-enterprise-active |
 | influxdb-enterprise-standby.enabled | bool | `false` | Whether to enable influxdb-enterprise-standby |

--- a/applications/sasquatch/templates/gafaelfawr-token.yaml
+++ b/applications/sasquatch/templates/gafaelfawr-token.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.gafaelfawrServiceToken.enabled }}
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrServiceToken
+metadata:
+  name: "sasquatch-gafaelfawr-token"
+  labels:
+    app.kubernetes.io/name: "sasquatch"
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  service: "bot-sasquatch"
+  scopes:
+    - "write:sasquatch"
+{{- end }}

--- a/applications/sasquatch/values-usdfdev.yaml
+++ b/applications/sasquatch/values-usdfdev.yaml
@@ -1,3 +1,6 @@
+gafaelfawrServiceToken:
+  enabled: true
+
 strimzi-kafka:
   kafka:
     config:

--- a/applications/sasquatch/values-usdfint.yaml
+++ b/applications/sasquatch/values-usdfint.yaml
@@ -1,3 +1,6 @@
+gafaelfawrServiceToken:
+  enabled: true
+
 strimzi-kafka:
   kafka:
     listeners:

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -1,3 +1,6 @@
+gafaelfawrServiceToken:
+  enabled: true
+
 strimzi-kafka:
   kafka:
     config:

--- a/applications/sasquatch/values.yaml
+++ b/applications/sasquatch/values.yaml
@@ -3,6 +3,10 @@
 # Override strimzi-kafka subchart configuration.
 strimzi-kafka: {}
 
+gafaelfawrServiceToken:
+  # -- Whether to create a Gafaelfawr service token for Sasquatch
+  enabled: false
+
 alert-brokers:
   # -- Whether to enable the alert-brokers subchart
   enabled: false


### PR DESCRIPTION
ObsForge needs to connect to the Sasquatch Schema Registry at USDF RSP clusters. 
The Sasquatch Schema Registry is protected by a Gafaelfawr ingress and requires a Gafaelfawr token with `write:sasquatch` scope.
Deploy a `GafaelfawrServiceToken` resource in Sasquatch to request a service token with the right scope.
