### PR TITLE
ppdb - Enable Sentry error reporting

### DIFF
--- a/applications/ppdb-replication/README.md
+++ b/applications/ppdb-replication/README.md
@@ -31,8 +31,10 @@ Replicates data from the APDB to the PPDB
 | config.pathPrefix | string | `"/ppdb-replication"` | URL path prefix |
 | config.ppdbConfig | string | `nil` | PPDB config file resource |
 | config.s3EndpointUrl | string | `"https://s3dfrgw.slac.stanford.edu"` | S3 endpoint URL |
+| config.sentry.enabled | bool | `true` | Whether to enable Sentry error reporting |
 | config.uploadInterval | int | `0` | Time to wait between uploader file uploads |
 | config.waitInterval | int | `300` | Time to wait between uploader file scans |
+| global.environmentName | string | Set by Argo CD | Name of the Phalanx environment |
 | global.host | string | Set by Argo CD | Host name for ingress |
 | global.vaultSecretsPath | string | Set by Argo CD | Base path for Vault secrets |
 | image.pullPolicy | string | `"Always"` | Pull policy for the ppdb-replication image |

--- a/applications/ppdb-replication/templates/_helpers.tpl
+++ b/applications/ppdb-replication/templates/_helpers.tpl
@@ -42,3 +42,18 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{/*
+Sentry (https://sentry.io) error reporting config
+*/}}
+{{- define "ppdb-replication.sentryEnvVars" -}}
+{{- if .Values.config.sentry.enabled }}
+- name: "SENTRY_DSN"
+  valueFrom:
+    secretKeyRef:
+      name: "ppdb-replication"
+      key: "sentry-dsn"
+- name: "SENTRY_ENVIRONMENT"
+  value: {{ .Values.global.environmentName | quote }}
+{{- end }}
+{{- end }}

--- a/applications/ppdb-replication/templates/exporter-deployment.yaml
+++ b/applications/ppdb-replication/templates/exporter-deployment.yaml
@@ -91,6 +91,7 @@ spec:
               value: {{ .Values.config.cloudSql.user | quote }}
             - name: CLOUDSQL_DB_NAME
               value: {{ .Values.config.cloudSql.dbName | quote }}
+            {{- include "ppdb-replication.sentryEnvVars" . | nindent 12 }}
           volumeMounts:
             - name: "ppdb-replication-secrets"
               mountPath: "/app/secrets"

--- a/applications/ppdb-replication/templates/uploader-deployment.yaml
+++ b/applications/ppdb-replication/templates/uploader-deployment.yaml
@@ -85,6 +85,7 @@ spec:
               value: {{ .Values.config.cloudSql.user | quote }}
             - name: CLOUDSQL_DB_NAME
               value: {{ .Values.config.cloudSql.dbName | quote }}
+            {{- include "ppdb-replication.sentryEnvVars" . | nindent 12 }}
           volumeMounts:
             - name: "ppdb-replication-secrets"
               mountPath: "/app/secrets"

--- a/applications/ppdb-replication/values.yaml
+++ b/applications/ppdb-replication/values.yaml
@@ -48,6 +48,10 @@ tolerations: []
 # The following will be set by parameters injected by Argo CD and should not
 # be set in the individual environment values files.
 global:
+  # -- Name of the Phalanx environment
+  # @default -- Set by Argo CD
+  environmentName: null
+
   # -- Host name for ingress
   # @default -- Set by Argo CD
   host: null
@@ -67,6 +71,10 @@ config:
 
   # -- URL path prefix
   pathPrefix: "/ppdb-replication"
+
+  sentry:
+    # -- Whether to enable Sentry error reporting
+    enabled: true
 
   # -- APDB config file resource
   apdbConfig: null

--- a/environments/templates/applications/rubin/ppdb-replication.yaml
+++ b/environments/templates/applications/rubin/ppdb-replication.yaml
@@ -26,6 +26,8 @@ spec:
     targetRevision: {{ or (index .Values "revisions" "ppdb-replication") .Values.targetRevision | quote }}
     helm:
       parameters:
+        - name: "global.environmentName"
+          value: {{ .Values.name | quote }}
         - name: "global.host"
           value: {{ .Values.fqdn | quote }}
         - name: "global.baseUrl"


### PR DESCRIPTION
Inject [Sentry](https://sentry.io) error reporting config into `ppdb-replication` workloads. I've already added the secret `sentry-dsn` values in all USDF envs in Vault.

Goes with [this dax_ppdb PR](https://github.com/lsst/dax_ppdb/pull/58).