### PR TITLE
DM-56015: Add MetalLB annotations to pin Kafka broker IP addresses at USDF

### DIFF
--- a/applications/sasquatch/values-usdfdev.yaml
+++ b/applications/sasquatch/values-usdfdev.yaml
@@ -17,19 +17,27 @@ strimzi-kafka:
       tls:
         enabled: true
       bootstrap:
+        host: sasquatch-usdf-dev-kafka-bootstrap.lsst.cloud
         annotations:
           metallb.io/address-pool: sdf-rubin-ingest
+          metallb.io/loadBalancerIPs: 172.24.10.28
         allocateLoadBalancerNodePorts: false
       brokers:
         - broker: 0
+          host: sasquatch-usdf-dev-kafka-0.lsst.cloud
           annotations:
             metallb.io/address-pool: sdf-rubin-ingest
+            metallb.io/loadBalancerIPs: 172.24.10.29
         - broker: 1
+          host: sasquatch-usdf-dev-kafka-1.lsst.cloud
           annotations:
             metallb.io/address-pool: sdf-rubin-ingest
+            metallb.io/loadBalancerIPs: 172.24.10.30
         - broker: 2
+          host: sasquatch-usdf-dev-kafka-2.lsst.cloud
           annotations:
             metallb.io/address-pool: sdf-rubin-ingest
+            metallb.io/loadBalancerIPs: 172.24.10.31
   mirrormaker2:
     enabled: true
     source:

--- a/applications/sasquatch/values-usdfint.yaml
+++ b/applications/sasquatch/values-usdfint.yaml
@@ -14,19 +14,27 @@ strimzi-kafka:
       tls:
         enabled: true
       bootstrap:
+        host: sasquatch-usdf-int-kafka-bootstrap.lsst.cloud
         annotations:
           metallb.io/address-pool: sdf-rubin-ingest
+          metallb.io/loadBalancerIPs: 172.24.10.24
         allocateLoadBalancerNodePorts: false
       brokers:
         - broker: 0
+          host: sasquatch-usdf-int-kafka-0.lsst.cloud
           annotations:
             metallb.io/address-pool: sdf-rubin-ingest
+            metallb.io/loadBalancerIPs: 172.24.10.25
         - broker: 1
+          host: sasquatch-usdf-int-kafka-1.lsst.cloud
           annotations:
             metallb.io/address-pool: sdf-rubin-ingest
+            metallb.io/loadBalancerIPs: 172.24.10.26
         - broker: 2
+          host: sasquatch-usdf-int-kafka-2.lsst.cloud
           annotations:
             metallb.io/address-pool: sdf-rubin-ingest
+            metallb.io/loadBalancerIPs: 172.24.10.27
   mirrormaker2:
     enabled: true
     source:

--- a/applications/sasquatch/values-usdfprod.yaml
+++ b/applications/sasquatch/values-usdfprod.yaml
@@ -19,19 +19,27 @@ strimzi-kafka:
       tls:
         enabled: true
       bootstrap:
+        host: sasquatch-usdf-kafka-bootstrap.lsst.cloud
         annotations:
           metallb.io/address-pool: sdf-rubin-ingest
+          metallb.io/loadBalancerIPs: 172.24.10.13
         allocateLoadBalancerNodePorts: false
       brokers:
         - broker: 0
+          host: sasquatch-usdf-kafka-0.lsst.cloud
           annotations:
             metallb.io/address-pool: sdf-rubin-ingest
+            metallb.io/loadBalancerIPs: 172.24.10.15
         - broker: 1
+          host: sasquatch-usdf-kafka-1.lsst.cloud
           annotations:
             metallb.io/address-pool: sdf-rubin-ingest
+            metallb.io/loadBalancerIPs: 172.24.10.19
         - broker: 2
+          host: sasquatch-usdf-kafka-2.lsst.cloud
           annotations:
             metallb.io/address-pool: sdf-rubin-ingest
+            metallb.io/loadBalancerIPs: 172.24.10.20
   mirrormaker2:
     enabled: true
     source:


### PR DESCRIPTION
USDF dev, integration, and production Kafka brokers request addresses from `sdf-rubin-ingest` but do not specify `metallb.io/loadBalancerIPs`. 
Add annotations to pin the IPs.
Also configure DNS names for Kafka cluster external access.
