### PR TITLE
DM-55388: Deploy ook 0.28.0 (intersphinx links)

### DIFF
--- a/applications/ook/Chart.yaml
+++ b/applications/ook/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: ook
 version: 1.0.0
-appVersion: "0.27.0"
+appVersion: "0.28.0"
 description: >
   Ook is the librarian service for Rubin Observatory. Ook indexes
   documentation content into the Algolia search engine that powers the Rubin

--- a/applications/ook/README.md
+++ b/applications/ook/README.md
@@ -78,6 +78,14 @@ Ook is the librarian service for Rubin Observatory. Ook indexes documentation co
 | ingestUpdated.window | string | `"2d"` | Time window to look for updated documents (e.g. 1h, 2d, 3w). This must be set to a value greater than the cron schedule for the ingest-updated job. |
 | ingress.annotations | object | `{}` | Additional annotations to add to the ingress |
 | ingress.path | string | `"/ook"` | Path prefix where Squarebot is hosted |
+| intersphinxIngest.affinity | object | `{}` | Affinity rules for Ook intersphinx-ingest pods |
+| intersphinxIngest.enabled | bool | `false` | Enable the intersphinx-ingest job, which pulls every enabled documentation source registered at /ook/intersphinx/sources through the inventory cache and rebuilds the Python link domain from their inventories. Independent of the intersphinx-refresh job: ingest revalidates the inventories it parses itself |
+| intersphinxIngest.nodeSelector | object | `{}` | Node selection rules for Ook intersphinx-ingest pods |
+| intersphinxIngest.podAnnotations | object | `{}` | Annotations for Ook intersphinx-ingest pods |
+| intersphinxIngest.resources | object | `{}` | Resource limits and requests for Ook intersphinx-ingest pods |
+| intersphinxIngest.schedule | string | `"30 5 * * *"` | Cron schedule string for the ook intersphinx-ingest job (UTC) |
+| intersphinxIngest.tolerations | list | `[]` | Tolerations for Ook intersphinx-ingest pods |
+| intersphinxIngest.ttlSecondsAfterFinished | int | `86400` | Time (second) to keep a finished job before cleaning up |
 | intersphinxRefresh.affinity | object | `{}` | Affinity rules for Ook intersphinx-refresh pods |
 | intersphinxRefresh.enabled | bool | `false` | Enable the intersphinx-refresh job |
 | intersphinxRefresh.nodeSelector | object | `{}` | Node selection rules for Ook intersphinx-refresh pods |

--- a/applications/ook/templates/cronjob-intersphinx-ingest.yaml
+++ b/applications/ook/templates/cronjob-intersphinx-ingest.yaml
@@ -1,0 +1,83 @@
+{{- if .Values.intersphinxIngest.enabled -}}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: "ook-intersphinx-ingest"
+  labels:
+    {{- include "ook.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "intersphinx-ingest"
+    app.kubernetes.io/part-of: "ook"
+spec:
+  schedule: {{ .Values.intersphinxIngest.schedule | quote }}
+  concurrencyPolicy: "Forbid"
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      ttlSecondsAfterFinished: {{ .Values.intersphinxIngest.ttlSecondsAfterFinished }}
+      template:
+        metadata:
+          {{- with .Values.intersphinxIngest.podAnnotations }}
+          annotations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          labels:
+            {{- include "ook.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: "intersphinx-ingest"
+            app.kubernetes.io/part-of: "ook"
+        spec:
+          restartPolicy: "Never"
+          {{- if or .Values.cloudsql.enabled }}
+          serviceAccountName: "ook"
+          {{- else }}
+          automountServiceAccountToken: false
+          {{- end }}
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+          containers:
+            - name: {{ .Chart.Name }}
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              command:
+                - "ook"
+                - "ingest-intersphinx"
+              resources:
+                {{- toYaml .Values.resources | nindent 16 }}
+              envFrom:
+                - configMapRef:
+                    name: "ook"
+              env:
+                {{- include "ook.envVars" (dict "Chart" .Chart "Release" .Release "Values" .Values) | nindent 16 }}
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - "all"
+                readOnlyRootFilesystem: true
+              volumeMounts:
+                {{- include "ook.volumeMounts" (dict "Chart" .Chart "Release" .Release "Values" .Values) | nindent 16 }}
+          {{- if .Values.cloudsql.enabled }}
+          initContainers:
+            {{- include "ook.cloudsqlSidecar" . | nindent 12 }}
+          {{- end }}
+          {{with .Values.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumes:
+            {{- include "ook.volumes" (dict "Chart" .Chart "Release" .Release "Values" .Values) | nindent 12 }}
+{{- end }}

--- a/applications/ook/templates/ingress.yaml
+++ b/applications/ook/templates/ingress.yaml
@@ -191,3 +191,56 @@ template:
                   name: "ook"
                   port:
                     number: {{ .Values.service.port }}
+
+---
+# The intersphinx source registry and the manual intersphinx ingest trigger
+# require the exec:admin scope. Registering a site commits Ook to serving
+# links from it, so this is deliberately not the write:intersphinx scope that
+# only warms the inventory cache. Gafaelfawr gates by path, not by method, so
+# the registry's reads (GET /ook/intersphinx/sources and
+# GET /ook/intersphinx/sources/{id}) are admin-only along with its writes;
+# the links the registry produces are served anonymously from
+# /ook/links/domains/python via the catch-all ook ingress. The
+# /ook/ingest/intersphinx path is listed here so it wins the longest-prefix
+# match over the exec:internal-tools /ook/ingest rule in ook-admin above.
+apiVersion: gafaelfawr.lsst.io/v1alpha1
+kind: GafaelfawrIngress
+metadata:
+  name: "ook-intersphinx-admin"
+  labels:
+    {{- include "ook.labels" . | nindent 4 }}
+config:
+  loginRedirect: false
+  scopes:
+    all:
+      - "exec:admin"
+  service: "ook"
+template:
+  metadata:
+    name: "ook-intersphinx-admin"
+    {{- with .Values.ingress.annotations }}
+    annotations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  spec:
+    rules:
+      - host: {{ required "global.host must be set" .Values.global.host | quote }}
+        http:
+          paths:
+            - path: "{{ .Values.ingress.path }}/intersphinx/sources"
+              pathType: "Prefix"
+              backend:
+                service:
+                  name: "ook"
+                  port:
+                    number: {{ .Values.service.port }}
+      - host: {{ required "global.host must be set" .Values.global.host | quote }}
+        http:
+          paths:
+            - path: "{{ .Values.ingress.path }}/ingest/intersphinx"
+              pathType: "Prefix"
+              backend:
+                service:
+                  name: "ook"
+                  port:
+                    number: {{ .Values.service.port }}

--- a/applications/ook/values-roundtable-dev.yaml
+++ b/applications/ook/values-roundtable-dev.yaml
@@ -1,3 +1,9 @@
+# Branch build of ook PR #392 (tickets/DM-55388) for testing on
+# roundtable-dev. Revert to the chart's appVersion once ook releases.
+image:
+  tag: "tickets-DM-55388"
+  pullPolicy: "Always"
+
 config:
   logLevel: "DEBUG"
   databaseUrl: "postgresql://ook@localhost/ook"
@@ -21,6 +27,10 @@ linkcheckRecheck:
 intersphinxRefresh:
   enabled: true
   schedule: "15 * * * *"
+
+intersphinxIngest:
+  enabled: true
+  schedule: "30 5 * * *"
 
 ingestLsstTexmf:
   enabled: true

--- a/applications/ook/values-roundtable-dev.yaml
+++ b/applications/ook/values-roundtable-dev.yaml
@@ -1,9 +1,3 @@
-# Branch build of ook PR #392 (tickets/DM-55388) for testing on
-# roundtable-dev. Revert to the chart's appVersion once ook releases.
-image:
-  tag: "tickets-DM-55388"
-  pullPolicy: "Always"
-
 config:
   logLevel: "DEBUG"
   databaseUrl: "postgresql://ook@localhost/ook"

--- a/applications/ook/values-roundtable-prod.yaml
+++ b/applications/ook/values-roundtable-prod.yaml
@@ -18,6 +18,9 @@ linkcheckRecheck:
 intersphinxRefresh:
   enabled: true
   schedule: "15 * * * *"
+intersphinxIngest:
+  enabled: true
+  schedule: "30 5 * * *"
 ingestLsstTexmf:
   enabled: true
 

--- a/applications/ook/values.yaml
+++ b/applications/ook/values.yaml
@@ -272,6 +272,35 @@ intersphinxRefresh:
   # -- Affinity rules for Ook intersphinx-refresh pods
   affinity: {}
 
+intersphinxIngest:
+  # -- Enable the intersphinx-ingest job, which pulls every enabled
+  # documentation source registered at /ook/intersphinx/sources through the
+  # inventory cache and rebuilds the Python link domain from their
+  # inventories. Independent of the intersphinx-refresh job: ingest
+  # revalidates the inventories it parses itself
+  enabled: false
+
+  # -- Cron schedule string for the ook intersphinx-ingest job (UTC)
+  schedule: "30 5 * * *"
+
+  # -- Time (second) to keep a finished job before cleaning up
+  ttlSecondsAfterFinished: 86400
+
+  # -- Resource limits and requests for Ook intersphinx-ingest pods
+  resources: {}
+
+  # -- Annotations for Ook intersphinx-ingest pods
+  podAnnotations: {}
+
+  # -- Node selection rules for Ook intersphinx-ingest pods
+  nodeSelector: {}
+
+  # -- Tolerations for Ook intersphinx-ingest pods
+  tolerations: []
+
+  # -- Affinity rules for Ook intersphinx-ingest pods
+  affinity: {}
+
 ingestLsstTexmf:
   # -- Enable the ingest-lsst-texmf job
   enabled: false


### PR DESCRIPTION
## Summary

Deploys [Ook 0.28.0](https://github.com/lsst-sqre/ook/releases/tag/0.28.0) (lsst-sqre/ook#392, intersphinx source registry + Python link domain) to roundtable-dev and roundtable-prod, and adds the Helm resources that release needs.

- **Chart `appVersion` bumped to 0.28.0.** The roundtable-dev branch-image override (`tickets-DM-55388`) used while testing PR #392 is dropped, so dev follows the chart's `appVersion` again.
- **New `ook-intersphinx-admin` GafaelfawrIngress** (`exec:admin`) covering `/ook/intersphinx/sources` and `/ook/ingest/intersphinx`. The ook API publishes `exec:admin` as the gate for the source registry and the manual ingest trigger (deliberately not the `write:intersphinx` cache-warming scope). Without this, the registry would fall through to the anonymous catch-all `ook` ingress, and the ingest trigger would sit under the `exec:internal-tools` `/ook/ingest` rule. Listing `/ook/ingest/intersphinx` separately lets it win the longest-prefix match over `/ook/ingest`.
  - Gafaelfawr gates by path, not method, so registry reads (`GET /ook/intersphinx/sources[/{id}]`) become admin-only along with the writes. The public output, `/ook/links/domains/python`, stays anonymous via the catch-all ingress.
  - `exec:admin` already exists and maps to `lsst-sqre/square` on both roundtable-dev and roundtable-prod, so no Gafaelfawr change is needed.
- **New `ook-intersphinx-ingest` CronJob** running `ook ingest-intersphinx`, with an `intersphinxIngest` values block mirroring `intersphinxRefresh` (default off, `30 5 * * *` UTC). Enabled on both roundtable-dev and roundtable-prod. There is no ordering dependency on the hourly `intersphinx-refresh` job: ingest revalidates the inventories it parses itself. With no sources registered the job is a no-op, so enabling it on prod ahead of registering sources is safe.

No ConfigMap or secret changes: the release adds no new settings. The new Alembic migration (`ec0c04ddd611`, adding the `intersphinx_source`, `intersphinx_entity`, and `links_intersphinx` tables) runs through the existing `updateSchema` PreSync job.

## Validation steps

- `helm template` against `values-roundtable-dev.yaml` and `values-roundtable-prod.yaml` renders every ook container on `ghcr.io/lsst-sqre/ook:0.28.0`, the new ingress with both paths, and the new CronJob in both environments.
- `ghcr.io/lsst-sqre/ook:0.28.0` is published.
- `pre-commit` (yamllint, helm-docs) passes; README regenerated.
- The branch build was exercised on roundtable-dev before the release: register a source with `POST /ook/intersphinx/sources` (needs an `exec:admin` token), trigger `POST /ook/ingest/intersphinx`, and read back `GET /ook/links/domains/python/objects/<name>` anonymously.

## Post-merge

- Sync `ook` on roundtable-dev and roundtable-prod. The PreSync migration runs before the new pods roll.
- Register the production documentation sources at `POST /ook/intersphinx/sources` with an `exec:admin` token; the `ook-intersphinx-ingest` CronJob (or `POST /ook/ingest/intersphinx`) then populates the Python link domain.

## References

- Ook release: https://github.com/lsst-sqre/ook/releases/tag/0.28.0
- Ook PR: https://github.com/lsst-sqre/ook/pull/392
- PRD: https://github.com/lsst-sqre/ook/issues/237
- Jira: https://rubinobs.atlassian.net/browse/DM-55388
