### PR TITLE
DM-56012: Deploy docverse tickets-DM-56012 image on roundtable-dev

### DIFF
--- a/applications/docverse/values-roundtable-dev.yaml
+++ b/applications/docverse/values-roundtable-dev.yaml
@@ -1,6 +1,6 @@
 image:
   pullPolicy: "Always"
-  tag: "tickets-DM-55762"
+  tag: "tickets-DM-56012"
 
 config:
   logLevel: "DEBUG"


### PR DESCRIPTION
Point roundtable-dev at the `tickets-DM-56012` branch image so [lsst-sqre/docverse#583](https://github.com/lsst-sqre/docverse/pull/583) can be exercised before it merges.

## Summary

- `applications/docverse/values-roundtable-dev.yaml`: `image.tag` `tickets-DM-55762` → `tickets-DM-56012`. `pullPolicy` stays `Always`.

The previous pin is superseded rather than dropped: DM-55762's code is merged into docverse `main` (docverse#574, `2026-09-02`) and `tickets/DM-56012` branches from `main` after it, so this image is a strict superset of what `tickets-DM-55762` was testing.

docverse#583 fixes bug docverse#575 (stale-skipped and deleted builds stranded in `processing`, PRD docverse#577): two new terminal build statuses `superseded` and `cancelled`, `DELETE /builds/{build}` cancels an unfinished build in the same transaction as the soft-delete, every status decision is made under the row lock that writes it, the worker closes out a build retired mid-upload instead of raising, and `build_processing_reaper` gains a stranded-build sweep that fails `processing` rows with no live queue job past the 8 h threshold.

**Schema migration.** Alembic revision `b3c4d5e6f7a8` widens the `builds_status_check` constraint for the two new statuses and backfills pre-existing soft-deleted `pending`/`processing` rows to `cancelled`. `config.updateSchema` is already `true` on roundtable-dev, so the PreSync schema-update hook applies it.

## Validation steps

- `ghcr.io/lsst-sqre/docverse:tickets-DM-56012` is built and pushed (CI run `34241722958` on `ac3bc74`, amd64 + arm64 manifest green).
- docverse#583 CI fully green on `ac3bc74`: lint, typing, 2487 server tests, 223 client tests, worker and deploy-worker tests, client packaging.
- `pre-commit run --files applications/docverse/values-roundtable-dev.yaml` passes.

After merge, sync docverse on roundtable-dev with a **full app sync** — a selective sync skips the schema-update PreSync hook, and this deploy needs the migration. Then confirm the sync's hook phase shows `docverse-schema-update` succeeded, that the stranded build `1x7r-9fd4-hw1b-51` is moved to `failed` by the reaper's next tick, and that deleting a `processing` build leaves it `cancelled` with `date_deleted` set.

## Teardown

Revert `image.tag` to a released version once docverse#583 merges and a release is cut.

## References

- App PR: lsst-sqre/docverse#583
- PRD: lsst-sqre/docverse#577
- Bug: lsst-sqre/docverse#575
- Jira: [DM-56012](https://rubinobs.atlassian.net/browse/DM-56012)
- Supersedes the branch pin from lsst-sqre/phalanx#6949


[DM-56012]: https://rubinobs.atlassian.net/browse/DM-56012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ