### PR TITLE
USDFSM-114: Add TSOP Shared Chart with APDB Backup to GCP app

### DIFF
--- a/applications/apdb-backups-gcp/.helmignore
+++ b/applications/apdb-backups-gcp/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/applications/apdb-backups-gcp/Chart.yaml
+++ b/applications/apdb-backups-gcp/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+appVersion: 0.1.0
+description: Copies APDB Backups to Google Cloud.
+name: apdb-backups-gcp
+type: application
+version: 1.0.0
+dependencies:
+  - name: gcp-tsop
+    version: 1.0.0
+    repository: "file://../../charts/gcp-tsop"

--- a/applications/apdb-backups-gcp/README.md
+++ b/applications/apdb-backups-gcp/README.md
@@ -1,0 +1,19 @@
+# apdb-backups-gcp
+
+Copies APDB Backups to Google Cloud.
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| gcp-tsop.additionalVolumeMounts | list | `[]` | Kubernetes YAML configs for extra container volume(s). Any volumes required by other config options are automatically handled by the Helm chart. |
+| gcp-tsop.affinity | object | `{}` | Affinity rules for the gcp-tsop Pod |
+| gcp-tsop.gcp.projectId | string | `""` | GCP Project ID to run the agent |
+| gcp-tsop.image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev.  Set to `IfNotPresent` for scale testing in dev. | Pull policy for the gcp-tsop image |
+| gcp-tsop.image.repository | string | `"gcr.io/cloud-ingest/tsop-agent"` | Image to use in the gcp-tsop deployment |
+| gcp-tsop.image.tag | string | `"public-image-v1"` | Overrides the image tag whose default is the chart appVersion. |
+| gcp-tsop.nodeSelector | object | `{}` | Node selection rules for the gcp-tsop pod |
+| gcp-tsop.resources | object | See `values.yaml` | Kubernetes resource requests and limits |
+| gcp-tsop.s3.endpointURL | string | `"https://s3dfrgw.slac.stanford.edu"` | S3 Endpoint URL |
+| gcp-tsop.s3.metadataDisabled | string | `"true"` |  |
+| gcp-tsop.tolerations | list | `[]` | Tolerations for the gcp-tsop pod |

--- a/applications/apdb-backups-gcp/values-usdfdev-prompt-processing.yaml
+++ b/applications/apdb-backups-gcp/values-usdfdev-prompt-processing.yaml
@@ -1,0 +1,4 @@
+gcp-tsop:
+
+  gcp:
+    projectId: "usdf-backups-dev-2a6b"

--- a/applications/apdb-backups-gcp/values-usdfprod-prompt-processing.yaml
+++ b/applications/apdb-backups-gcp/values-usdfprod-prompt-processing.yaml
@@ -1,0 +1,4 @@
+gcp-tsop:
+
+  gcp:
+    projectId: "usdf-backups-prod-7e09"

--- a/applications/apdb-backups-gcp/values.yaml
+++ b/applications/apdb-backups-gcp/values.yaml
@@ -1,0 +1,47 @@
+# Default values for the gcp-tsop scaled job.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+gcp-tsop:
+  image:
+    # -- Image to use in the gcp-tsop deployment
+    repository: gcr.io/cloud-ingest/tsop-agent
+    # -- Pull policy for the gcp-tsop image
+    # @default -- `IfNotPresent` in prod, `Always` in dev.  Set to `IfNotPresent` for scale testing in dev.
+    pullPolicy: IfNotPresent
+    # -- Overrides the image tag whose default is the chart appVersion.
+    tag: public-image-v1
+
+  gcp:
+    # -- GCP Project ID to run the agent
+    projectId: ""
+
+  s3:
+    # -- S3 Endpoint URL
+    endpointURL: "https://s3dfrgw.slac.stanford.edu"
+
+    # S3 Metadata lookup.  Set to true for Ceph.
+    metadataDisabled: "true"
+
+  # -- Kubernetes resource requests and limits
+  # @default -- See `values.yaml`
+  resources:
+    requests:
+      cpu: 4
+      memory: 8Gi
+    limits:
+      cpu: 8
+      memory: 8Gi
+
+  # -- Kubernetes YAML configs for extra container volume(s).
+  # Any volumes required by other config options are automatically handled by the Helm chart.
+  additionalVolumeMounts: []
+
+  # -- Affinity rules for the gcp-tsop Pod
+  affinity: {}
+
+  # -- Node selection rules for the gcp-tsop pod
+  nodeSelector: {}
+
+  # -- Tolerations for the gcp-tsop pod
+  tolerations: []

--- a/charts/gcp-tsop/Chart.yaml
+++ b/charts/gcp-tsop/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: gcp-tsop
+version: 1.0.0
+appVersion: "0.1.0"
+description: Google Cloud Transfer Agent On Prem
+type: application

--- a/charts/gcp-tsop/README.md
+++ b/charts/gcp-tsop/README.md
@@ -1,0 +1,19 @@
+# gcp-tsop
+
+Google Cloud Transfer Agent On Prem
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| additionalVolumeMounts | list | `[]` | Kubernetes YAML configs for extra container volume(s). Any volumes required by other config options are automatically handled by the Helm chart. |
+| affinity | object | `{}` | Affinity rules for the gcp-tsop Pod |
+| gcp.projectId | string | `""` | GCP Project ID to run the agent |
+| image.pullPolicy | string | `IfNotPresent` in prod, `Always` in dev.  Set to `IfNotPresent` for scale testing in dev. | Pull policy for the gcp-tsop image |
+| image.repository | string | `"gcr.io/cloud-ingest/tsop-agent"` | Image to use in the gcp-tsop deployment |
+| image.tag | string | `"latest"` | Overrides the image tag whose default is the chart appVersion. |
+| nodeSelector | object | `{}` | Node selection rules for the Prompt Porcessing pod |
+| resources | object | See `values.yaml` | Kubernetes resource requests and limits |
+| s3.endpointURL | string | `""` | S3 Endpoint URL |
+| s3.metadataDisabled | string | `"true"` |  |
+| tolerations | list | `[]` | Tolerations for the gcp-tsop pod |

--- a/charts/gcp-tsop/templates/_helpers.tpl
+++ b/charts/gcp-tsop/templates/_helpers.tpl
@@ -1,0 +1,41 @@
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "gcp-tsop.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "gcp-tsop.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "gcp-tsop.labels" -}}
+helm.sh/chart: {{ include "gcp-tsop.chart" . }}
+{{ include "gcp-tsop.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "gcp-tsop.selectorLabels" -}}
+app.kubernetes.io/name: "gcp-tsop"
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/gcp-tsop/templates/service.yaml
+++ b/charts/gcp-tsop/templates/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: gcp-tsop-headless
+spec:
+  clusterIP: None
+  selector:
+    {{- include "gcp-tsop.selectorLabels" . | nindent 4 }}
+  ports:
+    - port: 80
+      name: http

--- a/charts/gcp-tsop/templates/service.yaml
+++ b/charts/gcp-tsop/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: gcp-tsop-headless
+  name: {{ include "gcp-tsop.fullname" . | trimSuffix "-gcp-tsop" }}
 spec:
   clusterIP: None
   selector:

--- a/charts/gcp-tsop/templates/statefulset.yaml
+++ b/charts/gcp-tsop/templates/statefulset.yaml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: gcp-tsop
+  labels:
+    {{- include "gcp-tsop.labels" . | nindent 4 }}
+spec:
+  serviceName: gcp-tsop-headless
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "gcp-tsop.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "gcp-tsop.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          env:
+            - name: PYTHONUNBUFFERED
+              value: "1"
+            - name: KUBE_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /tmp/gcp-secret/gcp-key.json
+            - name: AWS_ENDPOINT_URL
+              value: {{ .Values.s3.endpointUrl }}
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "gcp-tsop.fullname" . }}-secret
+                  key: aws-access-key
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "gcp-tsop.fullname" . }}-secret
+                  key: aws-secret-key
+            - name: AWS_EC2_METADATA_DISABLED
+              value: {{ .Values.s3.metadataDisabled }}
+          args:
+            - --project-id={{ .Values.gcp.projectId }}
+            - --creds-file=/tmp/gcp-secret/gcp-key.json
+            - --hostname=$(KUBE_POD_NAME)
+          volumeMounts:
+            - name: gcp-credentials-file
+              mountPath: /tmp/gcp-secret/
+              readOnly: true
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+      - name: gcp-credentials-file
+        secret:
+          secretName: gcp-tsop
+          items:
+            - key: gcp-credentials-file
+              path: gcp-key.json
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/gcp-tsop/templates/statefulset.yaml
+++ b/charts/gcp-tsop/templates/statefulset.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: gcp-tsop
+  name: {{ include "gcp-tsop.fullname" . | trimSuffix "-gcp-tsop" }}
   labels:
     {{- include "gcp-tsop.labels" . | nindent 4 }}
 spec:

--- a/charts/gcp-tsop/templates/statefulset.yaml
+++ b/charts/gcp-tsop/templates/statefulset.yaml
@@ -16,7 +16,7 @@ spec:
         {{- include "gcp-tsop.selectorLabels" . | nindent 8 }}
     spec:
       containers:
-        - name: {{ .Chart.Name }}
+        - name: {{ include "gcp-tsop.fullname" . | trimSuffix "-gcp-tsop" }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           env:
             - name: PYTHONUNBUFFERED
@@ -32,15 +32,15 @@ spec:
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "gcp-tsop.fullname" . }}-secret
+                  name: {{ .Release.Name }}
                   key: aws-access-key
             - name: AWS_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "gcp-tsop.fullname" . }}-secret
+                  name: {{ .Release.Name }}
                   key: aws-secret-key
             - name: AWS_EC2_METADATA_DISABLED
-              value: {{ .Values.s3.metadataDisabled }}
+              value: {{ .Values.s3.metadataDisabled | quote }}
           args:
             - --project-id={{ .Values.gcp.projectId }}
             - --creds-file=/tmp/gcp-secret/gcp-key.json
@@ -54,7 +54,7 @@ spec:
       volumes:
       - name: gcp-credentials-file
         secret:
-          secretName: gcp-tsop
+          secretName: {{ .Release.Name }}
           items:
             - key: gcp-credentials-file
               path: gcp-key.json

--- a/charts/gcp-tsop/templates/vault-secrets.yaml
+++ b/charts/gcp-tsop/templates/vault-secrets.yaml
@@ -1,0 +1,9 @@
+apiVersion: ricoberger.de/v1alpha1
+kind: VaultSecret
+metadata:
+  name: "gcp-tsop"
+  labels:
+    {{- include "gcp-tsop.labels" . | nindent 4 }}
+spec:
+  path: "{{ .Values.global.vaultSecretsPath }}/gcp-tsop"
+  type: Opaque

--- a/charts/gcp-tsop/templates/vault-secrets.yaml
+++ b/charts/gcp-tsop/templates/vault-secrets.yaml
@@ -1,9 +1,9 @@
 apiVersion: ricoberger.de/v1alpha1
 kind: VaultSecret
 metadata:
-  name: "gcp-tsop"
+  name: {{ .Release.Name }}
   labels:
     {{- include "gcp-tsop.labels" . | nindent 4 }}
 spec:
-  path: "{{ .Values.global.vaultSecretsPath }}/gcp-tsop"
+  path: "{{ .Values.global.vaultSecretsPath }}/{{ .Release.Name }}"
   type: Opaque

--- a/charts/gcp-tsop/values.yaml
+++ b/charts/gcp-tsop/values.yaml
@@ -1,0 +1,46 @@
+# Default values for the gcp-tsop scaled job.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  # -- Image to use in the gcp-tsop deployment
+  repository: gcr.io/cloud-ingest/tsop-agent
+  # -- Pull policy for the gcp-tsop image
+  # @default -- `IfNotPresent` in prod, `Always` in dev.  Set to `IfNotPresent` for scale testing in dev.
+  pullPolicy: IfNotPresent
+  # -- Overrides the image tag whose default is the chart appVersion.
+  tag: latest
+
+gcp:
+  # -- GCP Project ID to run the agent
+  projectId: ""
+
+s3:
+  # -- S3 Endpoint URL
+  endpointURL: ""
+
+  # S3 Metadata lookup.  Set to true for Ceph.
+  metadataDisabled: "true"
+
+# -- Kubernetes resource requests and limits
+# @default -- See `values.yaml`
+resources:
+  requests:
+    cpu: 4
+    memory: 8Gi
+  limits:
+    cpu: 8
+    memory: 8Gi
+
+# -- Kubernetes YAML configs for extra container volume(s).
+# Any volumes required by other config options are automatically handled by the Helm chart.
+additionalVolumeMounts: []
+
+# -- Affinity rules for the gcp-tsop Pod
+affinity: {}
+
+# -- Node selection rules for the Prompt Porcessing pod
+nodeSelector: {}
+
+# -- Tolerations for the gcp-tsop pod
+tolerations: []

--- a/docs/applications/apdb-backups-gcp/index.rst
+++ b/docs/applications/apdb-backups-gcp/index.rst
@@ -1,0 +1,16 @@
+.. px-app:: apdb-backups-gcp
+
+#######################################################
+apdb-backups-gcp — Copies APDB Backups to Google Cloud.
+#######################################################
+
+.. jinja:: apdb-backups-gcp
+   :file: applications/_summary.rst.jinja
+
+Guides
+======
+
+.. toctree::
+   :maxdepth: 1
+
+   values

--- a/docs/applications/apdb-backups-gcp/values.md
+++ b/docs/applications/apdb-backups-gcp/values.md
@@ -1,0 +1,12 @@
+```{px-app-values} apdb-backups-gcp
+```
+
+# apdb-backups-gcp Helm values reference
+
+Helm values reference table for the {px-app}`apdb-backups-gcp` application.
+
+```{include} ../../../applications/apdb-backups-gcp/README.md
+---
+start-after: "## Values"
+---
+```

--- a/docs/applications/prompt.rst
+++ b/docs/applications/prompt.rst
@@ -9,6 +9,7 @@ Argo CD project: ``prompt``
 .. toctree::
    :maxdepth: 1
 
+   apdb-backups-gcp/index
    butler-writer-service/index
    next-visit-fan-out/index
    prompt-keda-hsc/index

--- a/environments/README.md
+++ b/environments/README.md
@@ -5,6 +5,7 @@
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | appOfAppsName | string | `"app-of-apps"` | Name of the parent Argo CD app-of-apps that manages all the applications enabled for this environment |
+| applications.apdb-backups-gcp | bool | `false` | Enable the apdb-backups-gcp application |
 | applications.argo-workflows | bool | `false` | Enable the argo-workflows application |
 | applications.argocd | bool | `true` | Enable the Argo CD application. This must be enabled for all environments and is present here only because it makes parsing easier |
 | applications.atlantis | bool | `false` | Enable the atlantis application |

--- a/environments/templates/applications/prompt/apdb-backups-gcp.yaml
+++ b/environments/templates/applications/prompt/apdb-backups-gcp.yaml
@@ -1,0 +1,42 @@
+{{- if (index .Values "applications" "apdb-backups-gcp") -}}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "apdb-backups-gcp"
+  {{- if .Values.defaultComputeClass }}
+  labels:
+    cloud.google.com/default-compute-class: {{ .Values.defaultComputeClass | quote }}
+  {{- end}}
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: "apdb-backups-gcp"
+  namespace: "argocd"
+  finalizers:
+    - "resources-finalizer.argocd.argoproj.io"
+spec:
+  destination:
+    namespace: "apdb-backups-gcp"
+    server: "https://kubernetes.default.svc"
+  project: "prompt"
+  source:
+    path: "applications/apdb-backups-gcp"
+    repoURL: {{ .Values.repoUrl | quote }}
+    targetRevision: {{ or (index .Values "revisions" "apdb-backups-gcp") .Values.targetRevision | quote }}
+    helm:
+      parameters:
+        - name: "global.baseUrl"
+          value: "https://{{ .Values.fqdn }}"
+        - name: "global.environmentName"
+          value: {{ .Values.name | quote }}
+        - name: "global.host"
+          value: {{ .Values.fqdn | quote }}
+        - name: "global.repertoireUrl"
+          value: "https://{{ .Values.fqdn }}/repertoire"
+        - name: "global.vaultSecretsPath"
+          value: {{ .Values.vaultPathPrefix | quote }}
+      valueFiles:
+        - "values.yaml"
+        - "values-{{ .Values.name }}.yaml"
+{{- end -}}

--- a/environments/values-usdfdev-prompt-processing.yaml
+++ b/environments/values-usdfdev-prompt-processing.yaml
@@ -5,6 +5,7 @@ vaultUrl: "https://vault.slac.stanford.edu"
 vaultPathPrefix: secret/rubin/usdf-prompt-processing-dev
 
 applications:
+  apdb-backups-gcp: true
   butler-writer-service: true
   cert-manager: false
   gafaelfawr: true

--- a/environments/values-usdfprod-prompt-processing.yaml
+++ b/environments/values-usdfprod-prompt-processing.yaml
@@ -5,6 +5,7 @@ vaultUrl: "https://vault.slac.stanford.edu"
 vaultPathPrefix: secret/rubin/usdf-prompt-processing
 
 applications:
+  apdb-backups-gcp: true
   butler-writer-service: true
   cert-manager: false
   gafaelfawr: true

--- a/environments/values.yaml
+++ b/environments/values.yaml
@@ -38,6 +38,9 @@ vaultPathPrefix: ""
 defaultComputeClass: null
 
 applications:
+  # -- Enable the apdb-backups-gcp application
+  apdb-backups-gcp: false
+
   # -- Enable the argo-workflows application
   argo-workflows: false
 


### PR DESCRIPTION
Add Google Cloud Transfer Service On Premise shared chart.  Add APDB Backup to GCP application that utilizes this shared chart to copy USDF on premise backups from S3 to GCS.  Deploys to Prompt Processing Dev and Prod.