### PR TITLE
DM-56026: Fix IVOID format in default SIA chart values

### DIFF
--- a/applications/sia/README.md
+++ b/applications/sia/README.md
@@ -12,7 +12,7 @@ Simple Image Access (SIA) IVOA Service using Butler
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules for the sia deployment pod |
 | config.datasets | list | `["dp02","dp1"]` | List of datasets enabled in this environment. |
-| config.ivoidFormat | string | `"ivo://org.rubinobs/{dataset}/sia"` | Format string for the IVOID used for self-identification. This must contain a `dataset` variable that will be replaced with the label of the dataset. |
+| config.ivoidFormat | string | `"ivo://org.rubinobs/lsst-{dataset}/sia"` | Format string for the IVOID used for self-identification. This must contain a `dataset` variable that will be replaced with the label of the dataset. |
 | config.logLevel | string | `"INFO"` | Logging level |
 | config.logProfile | string | `"production"` | Logging profile (`production` for JSON, `development` for human-friendly) |
 | config.metrics.application | string | `"sia"` | Name under which to log metrics. Generally there is no reason to change this. |

--- a/applications/sia/values.yaml
+++ b/applications/sia/values.yaml
@@ -25,7 +25,7 @@ config:
   # -- Format string for the IVOID used for self-identification. This must
   # contain a `dataset` variable that will be replaced with the label of the
   # dataset.
-  ivoidFormat: "ivo://org.rubinobs/{dataset}/sia"
+  ivoidFormat: "ivo://org.rubinobs/lsst-{dataset}/sia"
 
   metrics:
     # -- Whether to enable sending metrics


### PR DESCRIPTION
New agreed on IVOID format has `/lsst-dp1` not `/dp1`