### PR TITLE
DM-54907: Enable conesearch metrics in sasquatch for idfdev and idfint

### DIFF
--- a/applications/sasquatch/charts/app-metrics/values.yaml
+++ b/applications/sasquatch/charts/app-metrics/values.yaml
@@ -11,6 +11,12 @@ globalAppConfig:
     influxTags:
       - "username"
       - "queue"
+  conesearch:
+    influxTags:
+      - "username"
+  datalinker:
+    influxTags:
+      - "username"
   docverse:
     influxTags:
       - "organization"
@@ -23,9 +29,6 @@ globalAppConfig:
       - "ci_platform"
       - "success"
       - "github_repository"
-  datalinker:
-    influxTags:
-      - "username"
   gafaelfawr:
     influxTags:
       - "service"

--- a/applications/sasquatch/values-idfdev.yaml
+++ b/applications/sasquatch/values-idfdev.yaml
@@ -160,6 +160,7 @@ app-metrics:
   enabled: true
   apps:
     - bigquerykafka
+    - conesearch
     - datalinker
     - gafaelfawr
     - herald

--- a/applications/sasquatch/values-idfint.yaml
+++ b/applications/sasquatch/values-idfint.yaml
@@ -104,6 +104,7 @@ app-metrics:
   enabled: true
   apps:
     - bigquerykafka
+    - conesearch
     - datalinker
     - gafaelfawr
     - herald


### PR DESCRIPTION
Add conesearch configuration to sasquatch for idfdev and idfint where it is currently enabled.