### PR TITLE
DM-54691: Enable the docverse purgatory cleanup sweep

### DIFF
--- a/applications/docverse/README.md
+++ b/applications/docverse/README.md
@@ -28,7 +28,11 @@ Publish versioned docs
 | config.logProfile | string | `"production"` | Logging profile (`production` for JSON, `development` for human-friendly) |
 | config.maintenance.enabled | bool | `false` | Enable the maintenance worker that consumes the `docverse:maintenance-queue` arq queue. Requires the docverse image to provide `docverse.worker.main.MaintenanceWorkerSettings`. |
 | config.maintenance.gitRefAuditEnabled | bool | `false` | Whether to enable auditing the git ref lifecycle rule. Enabling this will cause docverse to make GitHub API calls to determine if the git ref associated with an edition still exists. |
-| config.maintenance.jobTimeoutSeconds | int | `3600` | Per-job timeout, in seconds, for maintenance-pool jobs (lifecycle evaluation and git ref audits). |
+| config.maintenance.jobTimeoutSeconds | int | `3600` | Per-job timeout, in seconds, for maintenance-pool jobs (lifecycle evaluation, git ref audits, and purgatory cleanup). |
+| config.maintenance.purgatoryCleanupCronHour | int | `3` | UTC hour at which the daily purgatory_cleanup dispatcher cron runs. |
+| config.maintenance.purgatoryCleanupCronMinute | int | `23` | UTC minute of `purgatoryCleanupCronHour` at which the daily purgatory_cleanup dispatcher cron runs. |
+| config.maintenance.purgatoryCleanupEnabled | bool | `true` | Whether to run the daily purgatory_cleanup sweep that permanently deletes the object-store content (unpacked tree and staging tarball) of soft-deleted builds once the organization's purgatory retention has elapsed and stamps `date_purged` on the row. The cron is registered either way, so flipping this does not require a worker restart. |
+| config.maintenance.purgatoryCleanupMaxBuildsPerJob | int | `500` | Cap on the builds a single per-org purgatory_cleanup job reclaims per daily tick, oldest deletion first; anything past the cap is picked up by the next tick. |
 | config.metrics.application | string | `"docverse"` | Name under which to log metrics. Generally there is no reason to change this. |
 | config.metrics.enabled | bool | `false` | Whether to enable sending application metrics events to Sasquatch over Kafka. When disabled, Docverse uses a no-op metrics manager. |
 | config.metrics.events.topicPrefix | string | `"lsst.square.metrics.events"` | Topic prefix for events. It may sometimes be useful to change this in development environments. |
@@ -40,6 +44,7 @@ Publish versioned docs
 | config.reaperThresholds.keeperSyncSeconds | int | `21600` | Stuck-run reaper threshold, in seconds, for keeper-sync jobs. |
 | config.reaperThresholds.lifecycleSeconds | int | `21600` | Stuck-run reaper threshold, in seconds, for lifecycle_eval and git_ref_audit jobs (maintenance pool). |
 | config.reaperThresholds.publishEditionSeconds | int | `14400` | Stuck-run reaper threshold, in seconds, for publish_edition jobs. |
+| config.reaperThresholds.purgatoryCleanupSeconds | int | `21600` | Stuck-run reaper threshold, in seconds, for purgatory_cleanup jobs (maintenance pool). |
 | config.sentry.enabled | bool | `false` | Whether to send error reports and tracing data to Sentry. Requires the sentry-dsn secret to be set in Vault. |
 | config.sentry.tracesSampleRate | float | `0` | The percentage of requests that should be traced. This should be a float between 0 and 1. |
 | config.slackAlerts | bool | `false` | Whether to send Slack alerts for unexpected failures |

--- a/applications/docverse/templates/configmap.yaml
+++ b/applications/docverse/templates/configmap.yaml
@@ -22,10 +22,15 @@ data:
   DOCVERSE_GITHUB_APP_ID: {{ .Values.config.githubAppId | quote }}
   {{- end }}
   DOCVERSE_GIT_REF_AUDIT_ENABLED: {{ .Values.config.maintenance.gitRefAuditEnabled | quote }}
+  DOCVERSE_PURGATORY_CLEANUP_ENABLED: {{ .Values.config.maintenance.purgatoryCleanupEnabled | quote }}
+  DOCVERSE_PURGATORY_CLEANUP_MAX_BUILDS_PER_JOB: {{ .Values.config.maintenance.purgatoryCleanupMaxBuildsPerJob | quote }}
+  DOCVERSE_PURGATORY_CLEANUP_CRON_HOUR: {{ .Values.config.maintenance.purgatoryCleanupCronHour | quote }}
+  DOCVERSE_PURGATORY_CLEANUP_CRON_MINUTE: {{ .Values.config.maintenance.purgatoryCleanupCronMinute | quote }}
   DOCVERSE_MAINTENANCE_JOB_TIMEOUT_SECONDS: {{ .Values.config.maintenance.jobTimeoutSeconds | quote }}
   DOCVERSE_KEEPER_SYNC_JOB_TIMEOUT_SECONDS: {{ .Values.config.keeperSync.jobTimeoutSeconds | quote }}
   DOCVERSE_KEEPER_SYNC_REAPER_THRESHOLD_SECONDS: {{ .Values.config.reaperThresholds.keeperSyncSeconds | quote }}
   DOCVERSE_LIFECYCLE_REAPER_THRESHOLD_SECONDS: {{ .Values.config.reaperThresholds.lifecycleSeconds | quote }}
+  DOCVERSE_PURGATORY_CLEANUP_REAPER_THRESHOLD_SECONDS: {{ .Values.config.reaperThresholds.purgatoryCleanupSeconds | quote }}
   DOCVERSE_DASHBOARD_BUILD_REAPER_THRESHOLD_SECONDS: {{ .Values.config.reaperThresholds.dashboardBuildSeconds | quote }}
   DOCVERSE_PUBLISH_EDITION_REAPER_THRESHOLD_SECONDS: {{ .Values.config.reaperThresholds.publishEditionSeconds | quote }}
   DOCVERSE_BUILD_PROCESSING_REAPER_THRESHOLD_SECONDS: {{ .Values.config.reaperThresholds.buildProcessingSeconds | quote }}

--- a/applications/docverse/values-roundtable-dev.yaml
+++ b/applications/docverse/values-roundtable-dev.yaml
@@ -1,6 +1,6 @@
 image:
   pullPolicy: "Always"
-  tag: "tickets-DM-56012"
+  tag: "tickets-DM-54691"
 
 config:
   logLevel: "DEBUG"

--- a/applications/docverse/values.yaml
+++ b/applications/docverse/values.yaml
@@ -101,13 +101,32 @@ config:
     enabled: false
 
     # -- Per-job timeout, in seconds, for maintenance-pool jobs (lifecycle
-    # evaluation and git ref audits).
+    # evaluation, git ref audits, and purgatory cleanup).
     jobTimeoutSeconds: 3600
 
     # -- Whether to enable auditing the git ref lifecycle rule.
     # Enabling this will cause docverse to make GitHub API calls to determine
     # if the git ref associated with an edition still exists.
     gitRefAuditEnabled: false
+
+    # -- Whether to run the daily purgatory_cleanup sweep that permanently
+    # deletes the object-store content (unpacked tree and staging tarball) of
+    # soft-deleted builds once the organization's purgatory retention has
+    # elapsed and stamps `date_purged` on the row. The cron is registered
+    # either way, so flipping this does not require a worker restart.
+    purgatoryCleanupEnabled: true
+
+    # -- Cap on the builds a single per-org purgatory_cleanup job reclaims per
+    # daily tick, oldest deletion first; anything past the cap is picked up by
+    # the next tick.
+    purgatoryCleanupMaxBuildsPerJob: 500
+
+    # -- UTC hour at which the daily purgatory_cleanup dispatcher cron runs.
+    purgatoryCleanupCronHour: 3
+
+    # -- UTC minute of `purgatoryCleanupCronHour` at which the daily
+    # purgatory_cleanup dispatcher cron runs.
+    purgatoryCleanupCronMinute: 23
 
   # -- Set true during a credential-encryption (Fernet) key rotation to deliver
   # the retired key (DOCVERSE_CREDENTIAL_ENCRYPTION_KEY_RETIRED) to all pods so
@@ -121,6 +140,9 @@ config:
     # -- Stuck-run reaper threshold, in seconds, for lifecycle_eval and
     # git_ref_audit jobs (maintenance pool).
     lifecycleSeconds: 21600
+    # -- Stuck-run reaper threshold, in seconds, for purgatory_cleanup jobs
+    # (maintenance pool).
+    purgatoryCleanupSeconds: 21600
     # -- Stuck-run reaper threshold, in seconds, for dashboard_build jobs.
     dashboardBuildSeconds: 1800
     # -- Stuck-run reaper threshold, in seconds, for publish_edition jobs.


### PR DESCRIPTION
## Summary

Plumbs the five `DOCVERSE_PURGATORY_CLEANUP_*` settings that [lsst-sqre/docverse#611](https://github.com/lsst-sqre/docverse/pull/611) (DM-54691) adds into the docverse configmap, and turns the sweep on by chart default.

The `purgatory_cleanup` sweep is a daily arq cron on the maintenance pool that permanently deletes the object-store content (unpacked tree and staging tarball) of soft-deleted builds once their organization's `purgatory_retention` has elapsed, then stamps `date_purged` on the build row. Builds a live edition still serves are held back, and a build can be restored through the admin restore endpoint until it is purged.

New values, all under `config`:

| Value | Default | Env var |
| --- | --- | --- |
| `maintenance.purgatoryCleanupEnabled` | `true` | `DOCVERSE_PURGATORY_CLEANUP_ENABLED` |
| `maintenance.purgatoryCleanupMaxBuildsPerJob` | `500` | `DOCVERSE_PURGATORY_CLEANUP_MAX_BUILDS_PER_JOB` |
| `maintenance.purgatoryCleanupCronHour` | `3` | `DOCVERSE_PURGATORY_CLEANUP_CRON_HOUR` |
| `maintenance.purgatoryCleanupCronMinute` | `23` | `DOCVERSE_PURGATORY_CLEANUP_CRON_MINUTE` |
| `reaperThresholds.purgatoryCleanupSeconds` | `21600` | `DOCVERSE_PURGATORY_CLEANUP_REAPER_THRESHOLD_SECONDS` |

The server-side default for the flag is `false`; the chart default of `true` is what enables the sweep, so both roundtable-dev and roundtable-prod pick it up once they run a docverse server release that includes #611. The cap, cron slot, and reaper threshold mirror the server defaults (03:23 UTC is staggered off every other maintenance-pool slot; the reaper fires at minutes 21 and 51).

This is safe to merge ahead of the server release: pydantic-settings only reads declared fields, so an image that predates the sweep ignores the new environment variables.

## Validation steps

1. `phalanx application lint docverse` passes for roundtable-dev and roundtable-prod, and `phalanx application template docverse roundtable-dev` renders the five `DOCVERSE_PURGATORY_CLEANUP_*` keys in the `docverse` ConfigMap.
2. After syncing roundtable-dev on a docverse image that includes #611, confirm the maintenance worker log registers the `purgatory_cleanup_dispatcher` cron at 03:23 UTC and the `purgatory_cleanup_reaper` at minutes 21 and 51.
3. Lower one org's `purgatory_retention` to 60 s, `DELETE` a completed build, wait past retention, and let the 03:23 tick run (or restart the worker with the hour/minute moved to the next minute). Confirm `GET /orgs/{org}/jobs?kind=purgatory_cleanup` shows a `completed` job with `builds_purged: 1`, the R2 bucket has no keys under the build's `storage_prefix`, and the build's `date_purged` is set.
4. Confirm a `purgatory_cleanup_completed` event and one `lifecycle_action` with `trigger = purgatory_cleanup` arrive in Sasquatch for that org.

## References

- Docverse PR: https://github.com/lsst-sqre/docverse/pull/611
- PRD: https://github.com/lsst-sqre/docverse/issues/596
- Jira: https://rubinobs.atlassian.net/browse/DM-54691
