### PR TITLE
DM-56050: *-kafka -  Fix bridge worker resource and autoscaling config

### DIFF
--- a/applications/bigquery-kafka/README.md
+++ b/applications/bigquery-kafka/README.md
@@ -46,7 +46,7 @@ BigQuery Kafka bridge
 | fastWorker.autoscaling.enabled | bool | `true` | Enable autoscaling of bigquery-kafka fast workers |
 | fastWorker.autoscaling.maxReplicas | int | `10` | Maximum number of bigquery-kafka fast worker pods. Each replica will open database connections up to the configured pool size and overflow limits, so make sure the combined connections are under the connection limit. |
 | fastWorker.autoscaling.minReplicas | int | `1` | Minimum number of bigquery-kafka fast worker pods |
-| fastWorker.autoscaling.targetCPUUtilizationPercentage | int | `75` | Target CPU utilization of bigquery-kafka fast worker pods. |
+| fastWorker.autoscaling.targetCPUQuantity | string | `"750m"` | Target absolute CPU usage value of bigquery-kafka fast worker pods. |
 | fastWorker.nodeSelector | object | `{}` | Node selection rules for the bigquery-kafka fast worker pods |
 | fastWorker.podAnnotations | object | `{}` | Annotations for the bigquery-kafka fast worker pods |
 | fastWorker.replicaCount | int | `1` | Number of fast worker pods to start |
@@ -87,7 +87,7 @@ BigQuery Kafka bridge
 | slowWorker.autoscaling.enabled | bool | `true` | Enable autoscaling of bigquery-kafka slow workers |
 | slowWorker.autoscaling.maxReplicas | int | `10` | Maximum number of bigquery-kafka slow worker pods. Each replica will open database connections up to the configured pool size and overflow limits, so make sure the combined connections are under the postgres connection limit. |
 | slowWorker.autoscaling.minReplicas | int | `1` | Minimum number of bigquery-kafka slow worker pods |
-| slowWorker.autoscaling.targetCPUUtilizationPercentage | int | `75` | Target CPU utilization of bigquery-kafka slow worker pods. |
+| slowWorker.autoscaling.targetCPUQuantity | string | `"750m"` | Target absolute CPU usage value of bigquery-kafka slow worker pods. |
 | slowWorker.nodeSelector | object | `{}` | Node selection rules for the bigquery-kafka slow worker pods |
 | slowWorker.podAnnotations | object | `{}` | Annotations for the bigquery-kafka slow worker pods |
 | slowWorker.replicaCount | int | `1` | Number of slow worker pods to start if autoscaling is disabled |

--- a/applications/bigquery-kafka/templates/fast-worker-hpa.yaml
+++ b/applications/bigquery-kafka/templates/fast-worker-hpa.yaml
@@ -14,14 +14,12 @@ spec:
   maxReplicas: {{ .Values.fastWorker.autoscaling.maxReplicas }}
   minReplicas: {{ .Values.fastWorker.autoscaling.minReplicas }}
   metrics:
-    {{- if .Values.fastWorker.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
         name: "cpu"
         target:
-          type: Utilization
-          averageUtilization: {{ .Values.fastWorker.autoscaling.targetCPUUtilizationPercentage }}
-    {{- end }}
+          type: AverageValue
+          averageValue: {{ .Values.fastWorker.autoscaling.targetCPUQuantity }}
   scaleTargetRef:
     apiVersion: "apps/v1"
     kind: "Deployment"

--- a/applications/bigquery-kafka/templates/slow-worker-hpa.yaml
+++ b/applications/bigquery-kafka/templates/slow-worker-hpa.yaml
@@ -14,14 +14,12 @@ spec:
   maxReplicas: {{ .Values.slowWorker.autoscaling.maxReplicas }}
   minReplicas: {{ .Values.slowWorker.autoscaling.minReplicas }}
   metrics:
-    {{- if .Values.slowWorker.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
         name: "cpu"
         target:
-          type: Utilization
-          averageUtilization: {{ .Values.slowWorker.autoscaling.targetCPUUtilizationPercentage }}
-    {{- end }}
+          type: AverageValue
+          averageValue: {{ .Values.slowWorker.autoscaling.targetCPUQuantity }}
   scaleTargetRef:
     apiVersion: "apps/v1"
     kind: "Deployment"

--- a/applications/bigquery-kafka/values.yaml
+++ b/applications/bigquery-kafka/values.yaml
@@ -170,7 +170,7 @@ frontend:
   # @default -- See `values.yaml`
   resources:
     limits:
-      cpu: "2"
+      cpu: "1"
       memory: "1Gi"
     requests:
       cpu: "100m"
@@ -205,8 +205,8 @@ fastWorker:
     # limit.
     maxReplicas: 10
 
-    # -- Target CPU utilization of bigquery-kafka fast worker pods.
-    targetCPUUtilizationPercentage: 75
+    # -- Target absolute CPU usage value of bigquery-kafka fast worker pods.
+    targetCPUQuantity: 750m
 
   # -- Node selection rules for the bigquery-kafka fast worker pods
   nodeSelector: {}
@@ -221,10 +221,10 @@ fastWorker:
   # @default -- See `values.yaml`
   resources:
     limits:
-      cpu: "250m"
+      cpu: "1"
       memory: "300Mi"
     requests:
-      cpu: "50m"
+      cpu: "1"
       memory: "145Mi"
 
   # -- Tolerations for the bigquery-kafka fast worker pods
@@ -256,8 +256,8 @@ slowWorker:
     # connection limit.
     maxReplicas: 10
 
-    # -- Target CPU utilization of bigquery-kafka slow worker pods.
-    targetCPUUtilizationPercentage: 75
+    # -- Target absolute CPU usage value of bigquery-kafka slow worker pods.
+    targetCPUQuantity: 750m
 
   # -- Node selection rules for the bigquery-kafka slow worker pods
   nodeSelector: {}
@@ -272,7 +272,7 @@ slowWorker:
   # @default -- See `values.yaml`
   resources:
     limits:
-      cpu: "2"
+      cpu: "1"
       memory: "1Gi"
     requests:
       cpu: "1"

--- a/applications/qserv-kafka/README.md
+++ b/applications/qserv-kafka/README.md
@@ -49,7 +49,7 @@ Qserv Kafka bridge
 | fastWorker.autoscaling.enabled | bool | `true` | Enable autoscaling of qserv-kafka fast workers |
 | fastWorker.autoscaling.maxReplicas | int | `10` | Maximum number of qserv-kafka fast worker pods. Each replica will open database connections up to the configured pool size and overflow limits, so make sure the combined connections are under the connection limit. |
 | fastWorker.autoscaling.minReplicas | int | `1` | Minimum number of qserv-kafka fast worker pods |
-| fastWorker.autoscaling.targetCPUUtilizationPercentage | int | `75` | Target CPU utilization of qserv-kafka fast worker pods. |
+| fastWorker.autoscaling.targetCPUQuantity | string | `"750m"` | Target absolute CPU usage value of qserv-kafka fast worker pods. |
 | fastWorker.nodeSelector | object | `{}` | Node selection rules for the qserv-kafka fast worker pods |
 | fastWorker.podAnnotations | object | `{}` | Annotations for the qserv-kafka fast worker pods |
 | fastWorker.replicaCount | int | `1` | Number of fast worker pods to start |
@@ -90,7 +90,7 @@ Qserv Kafka bridge
 | slowWorker.autoscaling.enabled | bool | `true` | Enable autoscaling of qserv-kafka slow workers |
 | slowWorker.autoscaling.maxReplicas | int | `10` | Maximum number of qserv-kafka slow worker pods. Each replica will open database connections up to the configured pool size and overflow limits, so make sure the combined connections are under the connection limit. |
 | slowWorker.autoscaling.minReplicas | int | `1` | Minimum number of qserv-kafka slow worker pods |
-| slowWorker.autoscaling.targetCPUUtilizationPercentage | int | `50` | Target CPU utilization of qserv-kafka slow worker pods. |
+| slowWorker.autoscaling.targetCPUQuantity | string | `"500m"` | Target absolute CPU usage value of qserv-kafka slow worker pods. |
 | slowWorker.nodeSelector | object | `{}` | Node selection rules for the qserv-kafka worker pods |
 | slowWorker.podAnnotations | object | `{}` | Annotations for the qserv-kafka worker pods |
 | slowWorker.replicaCount | int | `1` | Number of slow worker pods to start if autoscaling is disabled |

--- a/applications/qserv-kafka/templates/fast-worker-hpa.yaml
+++ b/applications/qserv-kafka/templates/fast-worker-hpa.yaml
@@ -14,14 +14,12 @@ spec:
   maxReplicas: {{ .Values.fastWorker.autoscaling.maxReplicas }}
   minReplicas: {{ .Values.fastWorker.autoscaling.minReplicas }}
   metrics:
-    {{- if .Values.fastWorker.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
         name: "cpu"
         target:
-          type: Utilization
-          averageUtilization: {{ .Values.fastWorker.autoscaling.targetCPUUtilizationPercentage }}
-    {{- end }}
+          type: AverageValue
+          averageValue: {{ .Values.fastWorker.autoscaling.targetCPUQuantity }}
   scaleTargetRef:
     apiVersion: "apps/v1"
     kind: "Deployment"

--- a/applications/qserv-kafka/templates/slow-worker-hpa.yaml
+++ b/applications/qserv-kafka/templates/slow-worker-hpa.yaml
@@ -14,14 +14,12 @@ spec:
   maxReplicas: {{ .Values.slowWorker.autoscaling.maxReplicas }}
   minReplicas: {{ .Values.slowWorker.autoscaling.minReplicas }}
   metrics:
-    {{- if .Values.slowWorker.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
         name: "cpu"
         target:
-          type: Utilization
-          averageUtilization: {{ .Values.slowWorker.autoscaling.targetCPUUtilizationPercentage }}
-    {{- end }}
+          type: AverageValue
+          averageValue: {{ .Values.slowWorker.autoscaling.targetCPUQuantity }}
   scaleTargetRef:
     apiVersion: "apps/v1"
     kind: "Deployment"

--- a/applications/qserv-kafka/values.yaml
+++ b/applications/qserv-kafka/values.yaml
@@ -220,8 +220,8 @@ fastWorker:
     # limit.
     maxReplicas: 10
 
-    # -- Target CPU utilization of qserv-kafka fast worker pods.
-    targetCPUUtilizationPercentage: 75
+    # -- Target absolute CPU usage value of qserv-kafka fast worker pods.
+    targetCPUQuantity: 750m
 
   # -- Node selection rules for the qserv-kafka fast worker pods
   nodeSelector: {}
@@ -236,10 +236,10 @@ fastWorker:
   # @default -- See `values.yaml`
   resources:
     limits:
-      cpu: "250m"
+      cpu: "1"
       memory: "300Mi"
     requests:
-      cpu: "50m"
+      cpu: "1"
       memory: "145Mi"
 
   # -- Tolerations for the qserv-kafka fast worker pods
@@ -271,8 +271,8 @@ slowWorker:
     # limit.
     maxReplicas: 10
 
-    # -- Target CPU utilization of qserv-kafka slow worker pods.
-    targetCPUUtilizationPercentage: 50
+    # -- Target absolute CPU usage value of qserv-kafka slow worker pods.
+    targetCPUQuantity: 500m
 
   # -- Node selection rules for the qserv-kafka worker pods
   nodeSelector: {}


### PR DESCRIPTION
We want scale-up at 750m average CPU usage among all of the pods. We’re currently configured to scale up at 75% of 50m CPU usage.

There are a lot of other places in Phalanx where we should probably make this change (including the starter template), but we can do that in future PRs.