### PR TITLE
DM-56052: Fix Sasquatch prompt processing topic names

### DIFF
--- a/applications/sasquatch/values-usdfdev.yaml
+++ b/applications/sasquatch/values-usdfdev.yaml
@@ -280,8 +280,8 @@ backup:
 prompt-processing:
   enabled: true
   topics:
-    - test.next-visit
-    - test.next-visit-job
+    - lsst.prompt.next-visit
+    - lsst.prompt.next-visit-job
 
 obsloctap:
   enabled: true

--- a/applications/sasquatch/values-usdfdev.yaml
+++ b/applications/sasquatch/values-usdfdev.yaml
@@ -228,7 +228,6 @@ rest-proxy:
     topics:
       - lsst.survey
     topicPrefixes:
-      - test
       - lsst.dm
       - lsst.debug
       - lsst.example

--- a/applications/sasquatch/values-usdfdev.yaml
+++ b/applications/sasquatch/values-usdfdev.yaml
@@ -280,7 +280,6 @@ prompt-processing:
   enabled: true
   topics:
     - lsst.prompt.next-visit
-    - lsst.prompt.next-visit-job
 
 obsloctap:
   enabled: true


### PR DESCRIPTION
All Sasquatch topics should start with the `lsst` prefix.