### PR TITLE
DM-56038: Update qserv-kafka to 7.0.0

### DIFF
--- a/applications/bigquery-kafka/Chart.yaml
+++ b/applications/bigquery-kafka/Chart.yaml
@@ -5,7 +5,7 @@ version: 1.0.0
 description: "BigQuery Kafka bridge"
 sources:
   - "https://github.com/lsst-sqre/qserv-kafka"
-appVersion: 6.0.0
+appVersion: 7.0.0
 
 dependencies:
   - name: "redis"

--- a/applications/bigquery-kafka/README.md
+++ b/applications/bigquery-kafka/README.md
@@ -11,9 +11,9 @@ BigQuery Kafka bridge
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | config.arqFastMaxJobs | int | `50` | Maximum number of jobs each fast worker (used for I/O-intensive tasks) can process simultaneously |
-| config.arqSlowMaxJobs | int | `2` | Maximum number of jobs each slow worker (used for results processing) can process simultaneously |
+| config.arqSlowMaxJobs | int | `1` | Maximum number of jobs each slow worker (used for results processing) can process simultaneously |
 | config.backend | string | `"BigQuery"` | Database backend to use (Qserv or BigQuery) |
-| config.backendApiTimeout | string | `"30s"` | Timeout for backend API calls `parse_timedelta` format. Used for both QServ REST API and BigQuery API. |
+| config.backendApiTimeout | string | `"30s"` | Timeout for backend API calls in `parse_timedelta` format. |
 | config.backendPollInterval | string | `"1s"` | Interval at which the backend is polled for query status in Safir `parse_timedelta` format |
 | config.backendRetryCount | int | `3` | How many times to retry after a backend API network failure |
 | config.backendRetryDelay | string | `"1s"` | How long to wait between retries after a backend API network failure in Safir `parse_timedelta` format |
@@ -23,8 +23,8 @@ BigQuery Kafka bridge
 | config.consumerGroupId | string | `"bigquery"` | Kafka consumer group ID |
 | config.gcpServiceAccount | string | None, must be set | GCP service account email for Workload Identity. Format: {name}@{project-id}.iam.gserviceaccount.com |
 | config.jobCancelTopic | string | `"lsst.ppdbtap.job-delete"` | Kafka topic for query cancellation requests |
-| config.jobRunBatchSize | int | `10` | Maximum batch size for query execution requests. This should generally be the same as `redisMaxConnections` minus a few for overhead. |
-| config.jobRunMaxBytes | int | 10MiB | Maximum size of a batch read from Kafka in bytes. Wide queries can be up to 500KiB in size, so this should be at least 500KiB * 10. |
+| config.jobRunBatchSize | int | `50` | Maximum batch size for query execution requests. This should generally be the same as `redisMaxConnections` minus a few for overhead. |
+| config.jobRunMaxBytes | int | 25MiB | Maximum size of a batch read from Kafka in bytes. Wide queries can be up to 500KiB in size, so this should be at least 500KiB * 10. |
 | config.jobRunTopic | string | `"lsst.ppdbtap.job-run"` | Kafka topic for query execution requests |
 | config.jobStatusTopic | string | `"lsst.ppdbtap.job-status"` | Kafka topic for query status |
 | config.logLevel | string | `"INFO"` | Logging level |
@@ -35,7 +35,7 @@ BigQuery Kafka bridge
 | config.metrics.events.topicPrefix | string | `"lsst.square.metrics.events"` | Topic prefix for events. It may sometimes be useful to change this in development environments. |
 | config.metrics.schemaManager.registryUrl | string | Sasquatch in the local cluster | URL of the Confluent-compatible schema registry server |
 | config.metrics.schemaManager.suffix | string | `""` | Suffix to add to all registered subjects. This is sometimes useful for experimentation during development. |
-| config.redisMaxConnections | int | `15` | Size of the Redis connection pool. This should be set to `jobRunBatchSize` plus some extra connections for the monitor, cancel jobs. |
+| config.redisMaxConnections | int | `55` | Size of the Redis connection pool. This should be set to `jobRunBatchSize` plus some extra connections for the monitor, cancel jobs. |
 | config.resultTimeout | int | 3600 (1 hour) | How long to wait for result processing (retrieval and upload) before timing out, in seconds. This doubles as the timeout forcibly terminating result worker pods. |
 | config.sentry.enabled | bool | `false` | Set to true to enable the Sentry integration. |
 | config.sentry.tracesSampleRate | float | `0` | The percentage of requests that should be traced. This should be a float between 0 and 1 |
@@ -87,7 +87,7 @@ BigQuery Kafka bridge
 | slowWorker.autoscaling.enabled | bool | `true` | Enable autoscaling of bigquery-kafka slow workers |
 | slowWorker.autoscaling.maxReplicas | int | `10` | Maximum number of bigquery-kafka slow worker pods. Each replica will open database connections up to the configured pool size and overflow limits, so make sure the combined connections are under the postgres connection limit. |
 | slowWorker.autoscaling.minReplicas | int | `1` | Minimum number of bigquery-kafka slow worker pods |
-| slowWorker.autoscaling.targetCPUQuantity | string | `"750m"` | Target absolute CPU usage value of bigquery-kafka slow worker pods. |
+| slowWorker.autoscaling.targetCPUQuantity | string | `"500m"` | Target absolute CPU usage value of bigquery-kafka slow worker pods. |
 | slowWorker.nodeSelector | object | `{}` | Node selection rules for the bigquery-kafka slow worker pods |
 | slowWorker.podAnnotations | object | `{}` | Annotations for the bigquery-kafka slow worker pods |
 | slowWorker.replicaCount | int | `1` | Number of slow worker pods to start if autoscaling is disabled |

--- a/applications/bigquery-kafka/README.md
+++ b/applications/bigquery-kafka/README.md
@@ -77,7 +77,7 @@ BigQuery Kafka bridge
 | redis.config.secretName | string | `"bigquery-kafka"` | Name of secret containing Redis password |
 | redis.persistence.accessMode | string | `"ReadWriteOnce"` | Access mode of storage to request |
 | redis.persistence.enabled | bool | `true` | Whether to persist Redis storage. Setting this to false will use `emptyDir` and lose track of all queries on restart. Only use this for a test deployment. |
-| redis.persistence.size | string | `"100Mi"` | Amount of persistent storage to request |
+| redis.persistence.size | string | `"1Gi"` | Amount of persistent storage to request |
 | redis.persistence.storageClass | string | `nil` | Class of storage to request |
 | redis.persistence.volumeClaimName | string | `nil` | Use an existing PVC, not dynamic provisioning. If this is set, the size, storageClass, and accessMode settings are ignored. |
 | redis.resources | object | See `values.yaml` | Resource limits and requests for the Redis pod |

--- a/applications/bigquery-kafka/templates/fast-worker-hpa.yaml
+++ b/applications/bigquery-kafka/templates/fast-worker-hpa.yaml
@@ -8,9 +8,9 @@ metadata:
 spec:
   behavior:
     scaleUp:
-      stabilizationWindowSeconds: 60
+      stabilizationWindowSeconds: 30
     scaleDown:
-      stabilizationWindowSeconds: 900
+      stabilizationWindowSeconds: 300
   maxReplicas: {{ .Values.fastWorker.autoscaling.maxReplicas }}
   minReplicas: {{ .Values.fastWorker.autoscaling.minReplicas }}
   metrics:

--- a/applications/bigquery-kafka/templates/slow-worker-hpa.yaml
+++ b/applications/bigquery-kafka/templates/slow-worker-hpa.yaml
@@ -8,9 +8,9 @@ metadata:
 spec:
   behavior:
     scaleUp:
-      stabilizationWindowSeconds: 60
+      stabilizationWindowSeconds: 30
     scaleDown:
-      stabilizationWindowSeconds: 900
+      stabilizationWindowSeconds: 300
   maxReplicas: {{ .Values.slowWorker.autoscaling.maxReplicas }}
   minReplicas: {{ .Values.slowWorker.autoscaling.minReplicas }}
   metrics:

--- a/applications/bigquery-kafka/values-idfdev.yaml
+++ b/applications/bigquery-kafka/values-idfdev.yaml
@@ -1,5 +1,3 @@
-vaultSecretsEnabled: true
-
 config:
   logLevel: "DEBUG"
   bigqueryProject: "ppdb-dev-5c07"
@@ -12,7 +10,3 @@ config:
   slack:
     enabled: false
   bigqueryMaxBytesBilled: 1000000000000
-
-redis:
-  persistence:
-    enabled: true

--- a/applications/bigquery-kafka/values-idfint.yaml
+++ b/applications/bigquery-kafka/values-idfint.yaml
@@ -1,5 +1,3 @@
-vaultSecretsEnabled: false
-
 config:
   logLevel: "DEBUG"
   bigqueryProject: "ppdb-int-6c62"
@@ -12,6 +10,3 @@ config:
   slack:
     enabled: false
   bigqueryMaxBytesBilled: 1000000000000
-redis:
-  persistence:
-    enabled: true

--- a/applications/bigquery-kafka/values.yaml
+++ b/applications/bigquery-kafka/values.yaml
@@ -9,13 +9,12 @@ config:
 
   # -- Maximum number of jobs each slow worker (used for results processing)
   # can process simultaneously
-  arqSlowMaxJobs: 2
+  arqSlowMaxJobs: 1
 
   # -- Database backend to use (Qserv or BigQuery)
   backend: "BigQuery"
 
-  # -- Timeout for backend API calls
-  # `parse_timedelta` format. Used for both QServ REST API and BigQuery API.
+  # -- Timeout for backend API calls in `parse_timedelta` format.
   backendApiTimeout: "30s"
 
   # -- Interval at which the backend is polled for query status in Safir
@@ -54,12 +53,12 @@ config:
 
   # -- Maximum batch size for query execution requests. This should generally
   # be the same as `redisMaxConnections` minus a few for overhead.
-  jobRunBatchSize: 10
+  jobRunBatchSize: 50
 
   # -- Maximum size of a batch read from Kafka in bytes. Wide queries can be
   # up to 500KiB in size, so this should be at least 500KiB * 10.
-  # @default -- 10MiB
-  jobRunMaxBytes: 10485760
+  # @default -- 25MiB
+  jobRunMaxBytes: 26214400
 
   # -- Kafka topic for query execution requests
   jobRunTopic: "lsst.ppdbtap.job-run"
@@ -104,7 +103,7 @@ config:
   # -- Size of the Redis connection pool. This should be set to
   # `jobRunBatchSize` plus some extra connections for the monitor, cancel
   # jobs.
-  redisMaxConnections: 15
+  redisMaxConnections: 55
 
   # -- How long to wait for result processing (retrieval and upload) before
   # timing out, in seconds. This doubles as the timeout forcibly terminating
@@ -174,7 +173,7 @@ frontend:
       memory: "1Gi"
     requests:
       cpu: "100m"
-      memory: "145Mi"
+      memory: "300Mi"
 
   # -- Tolerations for the bigquery-kafka frontend pod
   # @default -- Tolerate GKE arm64 taint
@@ -206,7 +205,7 @@ fastWorker:
     maxReplicas: 10
 
     # -- Target absolute CPU usage value of bigquery-kafka fast worker pods.
-    targetCPUQuantity: 750m
+    targetCPUQuantity: "750m"
 
   # -- Node selection rules for the bigquery-kafka fast worker pods
   nodeSelector: {}
@@ -222,10 +221,10 @@ fastWorker:
   resources:
     limits:
       cpu: "1"
-      memory: "300Mi"
+      memory: "500Mi"
     requests:
       cpu: "1"
-      memory: "145Mi"
+      memory: "270Mi"
 
   # -- Tolerations for the bigquery-kafka fast worker pods
   # @default -- Tolerate GKE arm64 taint
@@ -257,7 +256,7 @@ slowWorker:
     maxReplicas: 10
 
     # -- Target absolute CPU usage value of bigquery-kafka slow worker pods.
-    targetCPUQuantity: 750m
+    targetCPUQuantity: "500m"
 
   # -- Node selection rules for the bigquery-kafka slow worker pods
   nodeSelector: {}
@@ -276,7 +275,7 @@ slowWorker:
       memory: "1Gi"
     requests:
       cpu: "1"
-      memory: "145Mi"
+      memory: "160Mi"
 
   # -- Tolerations for the bigquery-kafka slow worker pods
   # @default -- Tolerate GKE arm64 taint
@@ -319,10 +318,10 @@ redis:
   resources:
     limits:
       cpu: "1"
-      memory: "100Mi"
+      memory: "200Mi"
     requests:
       cpu: "10m"
-      memory: "20Mi"
+      memory: "50Mi"
 
   # -- Tolerations for the bigquery-kafka Redis pod
   # @default -- Tolerate GKE arm64 taint

--- a/applications/bigquery-kafka/values.yaml
+++ b/applications/bigquery-kafka/values.yaml
@@ -304,7 +304,7 @@ redis:
     accessMode: "ReadWriteOnce"
 
     # -- Amount of persistent storage to request
-    size: "100Mi"
+    size: "1Gi"
 
     # -- Class of storage to request
     storageClass: null
@@ -318,10 +318,10 @@ redis:
   resources:
     limits:
       cpu: "1"
-      memory: "200Mi"
+      memory: "500Mi"
     requests:
       cpu: "10m"
-      memory: "50Mi"
+      memory: "100Mi"
 
   # -- Tolerations for the bigquery-kafka Redis pod
   # @default -- Tolerate GKE arm64 taint

--- a/applications/qserv-kafka/Chart.yaml
+++ b/applications/qserv-kafka/Chart.yaml
@@ -5,7 +5,7 @@ version: 1.0.0
 description: "Qserv Kafka bridge"
 sources:
   - "https://github.com/lsst-sqre/qserv-kafka"
-appVersion: 6.0.0
+appVersion: 7.0.0
 
 dependencies:
   - name: "redis"

--- a/applications/qserv-kafka/README.md
+++ b/applications/qserv-kafka/README.md
@@ -81,7 +81,7 @@ Qserv Kafka bridge
 | redis.config.secretName | string | `"qserv-kafka"` | Name of secret containing Redis password |
 | redis.persistence.accessMode | string | `"ReadWriteOnce"` | Access mode of storage to request |
 | redis.persistence.enabled | bool | `true` | Whether to persist Redis storage. Setting this to false will use `emptyDir` and lose track of all queries on restart. Only use this for a test deployment. |
-| redis.persistence.size | string | `"100Mi"` | Amount of persistent storage to request |
+| redis.persistence.size | string | `"1Gi"` | Amount of persistent storage to request |
 | redis.persistence.storageClass | string | `nil` | Class of storage to request |
 | redis.persistence.volumeClaimName | string | `nil` | Use an existing PVC, not dynamic provisioning. If this is set, the size, storageClass, and accessMode settings are ignored. |
 | redis.resources | object | See `values.yaml` | Resource limits and requests for the Redis pod |

--- a/applications/qserv-kafka/README.md
+++ b/applications/qserv-kafka/README.md
@@ -15,8 +15,8 @@ Qserv Kafka bridge
 | config.backendApiTimeout | string | `"30s"` | Timeout for REST API calls in Safir `parse_timedelta` format. This includes time spent waiting for a connection if the maximum number of connections has been reached. |
 | config.consumerGroupId | string | `"qserv"` | Kafka consumer group ID |
 | config.jobCancelTopic | string | `"lsst.tap.job-delete"` | Kafka topic for query cancellation requests |
-| config.jobRunBatchSize | int | `10` | Maximum batch size for query execution requests. This should generally be the same as `qservRestMaxConnections`. |
-| config.jobRunMaxBytes | int | 10MiB | Maximum size of a batch read from Kafka in bytes. Wide queries can be up to 500KiB in size, so this should be at least 500KiB * 10. |
+| config.jobRunBatchSize | int | `50` | Maximum batch size for query execution requests. This should generally be the same as `qservRestMaxConnections`. |
+| config.jobRunMaxBytes | int | 25MiB | Maximum size of a batch read from Kafka in bytes. Wide queries can be up to 500KiB in size, so this should be at least 500KiB * 10. |
 | config.jobRunTopic | string | `"lsst.tap.job-run"` | Kafka topic for query execution requests |
 | config.jobStatusTopic | string | `"lsst.tap.job-status"` | Kafka topic for query status |
 | config.logLevel | string | `"INFO"` | Logging level |
@@ -31,7 +31,7 @@ Qserv Kafka bridge
 | config.qservDatabaseUrl | string | None, must be set | URL to the Qserv MySQL interface (must use a scheme of `mysql+asyncmy`) |
 | config.qservDeleteQueries | bool | `true` | Whether to delete queries after they complete. If this is set to false, rely on Qserv's internal garbage collection of old queries. |
 | config.qservPollInterval | string | `"1s"` | Interval at which Qserv is polled for query status in Safir `parse_timedelta` format |
-| config.qservRestMaxConnections | int | `15` | Maximum simultaneous connections to open to the REST API. This should be set to `jobRunBatchSize` plus some extra connections for the monitor and cancel jobs. |
+| config.qservRestMaxConnections | int | `55` | Maximum simultaneous connections to open to the REST API. This should be set to `jobRunBatchSize` plus some extra connections for the monitor and cancel jobs. |
 | config.qservRestSendApiVersion | bool | `true` | Whether to send the expected API version in REST API calls to Qserv |
 | config.qservRestUrl | string | None, must be set | URL to the Qserv REST API |
 | config.qservRestUsername | string | `nil` | Username for HTTP Basic Authentication for the Qserv REST API. If not null, the password will be assumed to be the same as the database password. |

--- a/applications/qserv-kafka/README.md
+++ b/applications/qserv-kafka/README.md
@@ -12,7 +12,7 @@ Qserv Kafka bridge
 |-----|------|---------|-------------|
 | config.arqFastMaxJobs | int | `50` | Maximum number of jobs each fast worker (used for I/O-intensive tasks) can process simultaneously |
 | config.arqSlowMaxJobs | int | `1` | Maximum number of jobs each slow worker (used for results processing) can process simultaneously |
-| config.backendApiTimeout | string | `"60s"` | Timeout for REST API calls in Safir `parse_timedelta` format. This includes time spent waiting for a connection if the maximum number of connections has been reached. |
+| config.backendApiTimeout | string | `"30s"` | Timeout for REST API calls in Safir `parse_timedelta` format. This includes time spent waiting for a connection if the maximum number of connections has been reached. |
 | config.consumerGroupId | string | `"qserv"` | Kafka consumer group ID |
 | config.jobCancelTopic | string | `"lsst.tap.job-delete"` | Kafka topic for query cancellation requests |
 | config.jobRunBatchSize | int | `10` | Maximum batch size for query execution requests. This should generally be the same as `qservRestMaxConnections`. |
@@ -37,6 +37,7 @@ Qserv Kafka bridge
 | config.qservRestUsername | string | `nil` | Username for HTTP Basic Authentication for the Qserv REST API. If not null, the password will be assumed to be the same as the database password. |
 | config.qservRetryCount | int | `3` | How many times to retry after a Qserv API network failure |
 | config.qservRetryDelay | string | `"1s"` | How long to wait between retries after a Qserv API network failure in Safir `parse_timedelta` format |
+| config.qservUploadDeleteTimeout | string | `"5m"` | How long to allow for temporary user table deletion before timing out in Safir `parse_timedelta` format. |
 | config.qservUploadTimeout | string | `"30m"` | How long to allow for user table upload before timing out in Safir `parse_timedelta` format. |
 | config.redisMaxConnections | int | `15` | Size of the Redis connection pool. This should be set to `jobRunBatchSize` plus some extra connections for the monitor, cancel jobs. |
 | config.resultTimeout | int | 3600 (1 hour) | How long to wait for result processing (retrieval and upload) before timing out, in seconds. This doubles as the timeout forcibly terminating result worker pods. |

--- a/applications/qserv-kafka/README.md
+++ b/applications/qserv-kafka/README.md
@@ -91,7 +91,7 @@ Qserv Kafka bridge
 | slowWorker.autoscaling.enabled | bool | `true` | Enable autoscaling of qserv-kafka slow workers |
 | slowWorker.autoscaling.maxReplicas | int | `10` | Maximum number of qserv-kafka slow worker pods. Each replica will open database connections up to the configured pool size and overflow limits, so make sure the combined connections are under the connection limit. |
 | slowWorker.autoscaling.minReplicas | int | `1` | Minimum number of qserv-kafka slow worker pods |
-| slowWorker.autoscaling.targetCPUQuantity | string | `"500m"` | Target absolute CPU usage value of qserv-kafka slow worker pods. |
+| slowWorker.autoscaling.targetCPUQuantity | string | `"750m"` | Target absolute CPU usage value of qserv-kafka slow worker pods. |
 | slowWorker.nodeSelector | object | `{}` | Node selection rules for the qserv-kafka worker pods |
 | slowWorker.podAnnotations | object | `{}` | Annotations for the qserv-kafka worker pods |
 | slowWorker.replicaCount | int | `1` | Number of slow worker pods to start if autoscaling is disabled |

--- a/applications/qserv-kafka/README.md
+++ b/applications/qserv-kafka/README.md
@@ -32,7 +32,7 @@ Qserv Kafka bridge
 | config.qservDeleteQueries | bool | `true` | Whether to delete queries after they complete. If this is set to false, rely on Qserv's internal garbage collection of old queries. |
 | config.qservPollInterval | string | `"1s"` | Interval at which Qserv is polled for query status in Safir `parse_timedelta` format |
 | config.qservRestMaxConnections | int | `55` | Maximum simultaneous connections to open to the REST API. This should be set to `jobRunBatchSize` plus some extra connections for the monitor and cancel jobs. |
-| config.qservRestSendApiVersion | bool | `true` | Whether to send the expected API version in REST API calls to Qserv |
+| config.qservRestSendApiVersion | bool | `false` | Whether to send the expected API version in REST API calls to Qserv |
 | config.qservRestUrl | string | None, must be set | URL to the Qserv REST API |
 | config.qservRestUsername | string | `nil` | Username for HTTP Basic Authentication for the Qserv REST API. If not null, the password will be assumed to be the same as the database password. |
 | config.qservRetryCount | int | `3` | How many times to retry after a Qserv API network failure |

--- a/applications/qserv-kafka/templates/configmap.yaml
+++ b/applications/qserv-kafka/templates/configmap.yaml
@@ -36,6 +36,7 @@ data:
   {{- end }}
   QSERV_KAFKA_QSERV_RETRY_COUNT: {{ .Values.config.qservRetryCount | quote }}
   QSERV_KAFKA_QSERV_RETRY_DELAY: {{ .Values.config.qservRetryDelay | quote }}
+  QSERV_KAFKA_QSERV_UPLOAD_DELETE_TIMEOUT: {{ .Values.config.qservUploadDeleteTimeout | quote }}
   QSERV_KAFKA_QSERV_UPLOAD_TIMEOUT: {{ .Values.config.qservUploadTimeout | quote }}
   QSERV_KAFKA_REDIS_MAX_CONNECTIONS: {{ .Values.config.redisMaxConnections | quote }}
   QSERV_KAFKA_REDIS_URL: "redis://qserv-kafka-redis.{{ .Release.Namespace }}:6379/0"

--- a/applications/qserv-kafka/templates/fast-worker-hpa.yaml
+++ b/applications/qserv-kafka/templates/fast-worker-hpa.yaml
@@ -8,9 +8,9 @@ metadata:
 spec:
   behavior:
     scaleUp:
-      stabilizationWindowSeconds: 60
+      stabilizationWindowSeconds: 30
     scaleDown:
-      stabilizationWindowSeconds: 900
+      stabilizationWindowSeconds: 300
   maxReplicas: {{ .Values.fastWorker.autoscaling.maxReplicas }}
   minReplicas: {{ .Values.fastWorker.autoscaling.minReplicas }}
   metrics:

--- a/applications/qserv-kafka/templates/slow-worker-hpa.yaml
+++ b/applications/qserv-kafka/templates/slow-worker-hpa.yaml
@@ -8,9 +8,9 @@ metadata:
 spec:
   behavior:
     scaleUp:
-      stabilizationWindowSeconds: 60
+      stabilizationWindowSeconds: 30
     scaleDown:
-      stabilizationWindowSeconds: 900
+      stabilizationWindowSeconds: 300
   maxReplicas: {{ .Values.slowWorker.autoscaling.maxReplicas }}
   minReplicas: {{ .Values.slowWorker.autoscaling.minReplicas }}
   metrics:

--- a/applications/qserv-kafka/values-idfdev.yaml
+++ b/applications/qserv-kafka/values-idfdev.yaml
@@ -1,5 +1,4 @@
 config:
-  jobRunBatchSize: 50
   logLevel: "DEBUG"
   metrics:
     enabled: true
@@ -8,7 +7,5 @@ config:
   slack:
     enabled: true
   qservDatabaseUrl: "mysql+asyncmy://qsmaster@qserv-int.slac.stanford.edu:4040/"
-  qservRestMaxConnections: 55
-  qservRestSendApiVersion: false
   qservRestUrl: "https://qserv-int.slac.stanford.edu:4048/"
   qservRestUsername: "qsmaster"

--- a/applications/qserv-kafka/values-idfint.yaml
+++ b/applications/qserv-kafka/values-idfint.yaml
@@ -1,5 +1,4 @@
 config:
-  jobRunBatchSize: 50
   logLevel: "DEBUG"
   metrics:
     enabled: true
@@ -8,8 +7,6 @@ config:
   slack:
     enabled: true
   qservDatabaseUrl: "mysql+asyncmy://qsmaster@qserv-int.slac.stanford.edu:4040/"
-  qservRestMaxConnections: 55
-  qservRestSendApiVersion: false
   qservRestUrl: "https://qserv-int.slac.stanford.edu:4048/"
   qservRestUsername: "qsmaster"
 slowWorker:

--- a/applications/qserv-kafka/values-idfint.yaml
+++ b/applications/qserv-kafka/values-idfint.yaml
@@ -15,8 +15,3 @@ config:
 slowWorker:
   autoscaling:
     maxReplicas: 50
-redis:
-  resources:
-    limits:
-      cpu: "1"
-      memory: "200Mi"

--- a/applications/qserv-kafka/values-idfprod.yaml
+++ b/applications/qserv-kafka/values-idfprod.yaml
@@ -13,18 +13,3 @@ slowWorker:
   autoscaling:
     minReplicas: 4
     maxReplicas: 50
-  resources:
-    limits:
-      cpu: "1"
-      memory: "1000Mi"
-    requests:
-      cpu: "1"
-      memory: "290Mi"
-redis:
-  resources:
-    limits:
-      cpu: "1"
-      memory: "500Mi"
-    requests:
-      cpu: "10m"
-      memory: "200Mi"

--- a/applications/qserv-kafka/values-idfprod.yaml
+++ b/applications/qserv-kafka/values-idfprod.yaml
@@ -6,7 +6,6 @@ config:
   slack:
     enabled: true
   qservDatabaseUrl: "mysql+asyncmy://qsmaster@qserv-prod.slac.stanford.edu:4040/"
-  qservRestSendApiVersion: false
   qservRestUrl: "https://qserv-prod.slac.stanford.edu:4048/"
   qservRestUsername: "qsmaster"
 slowWorker:

--- a/applications/qserv-kafka/values-usdfdev.yaml
+++ b/applications/qserv-kafka/values-usdfdev.yaml
@@ -5,12 +5,5 @@ config:
   slack:
     enabled: true
   qservDatabaseUrl: "mysql+asyncmy://qsmaster@sdfqserv009.sdf.slac.stanford.edu:4090/"
-  qservRestSendApiVersion: false
   qservRestUrl: "https://sdfqserv009.sdf.slac.stanford.edu:4098"
   qservRestUsername: "qsmaster"
-frontend:
-  allowRootDebug: true
-resultWorker:
-  allowRootDebug: true
-  autoscaling:
-    maxReplicas: 50

--- a/applications/qserv-kafka/values-usdfint.yaml
+++ b/applications/qserv-kafka/values-usdfint.yaml
@@ -1,12 +1,4 @@
 config:
-  logLevel: "DEBUG"
   qservDatabaseUrl: "mysql+asyncmy://qsmaster@sdfqserv009.sdf.slac.stanford.edu:4090/"
-  qservRestSendApiVersion: false
   qservRestUrl: "https://sdfqserv009.sdf.slac.stanford.edu:4098/"
   qservRestUsername: "qsmaster"
-frontend:
-  allowRootDebug: true
-resultWorker:
-  allowRootDebug: true
-  autoscaling:
-    maxReplicas: 50

--- a/applications/qserv-kafka/values-usdfprod.yaml
+++ b/applications/qserv-kafka/values-usdfprod.yaml
@@ -1,13 +1,4 @@
 config:
   qservDatabaseUrl: "mysql+asyncmy://qsmaster@sdfqserv001.sdf.slac.stanford.edu:4040/"
-  qservRestSendApiVersion: false
   qservRestUrl: "https://sdfqserv001.sdf.slac.stanford.edu:4048/"
   qservRestUsername: "qsmaster"
-redis:
-  resources:
-    limits:
-      cpu: "1"
-      memory: "500Mi"
-    requests:
-      cpu: "10m"
-      memory: "200Mi"

--- a/applications/qserv-kafka/values.yaml
+++ b/applications/qserv-kafka/values.yaml
@@ -14,7 +14,7 @@ config:
   # -- Timeout for REST API calls in Safir `parse_timedelta` format. This
   # includes time spent waiting for a connection if the maximum number of
   # connections has been reached.
-  backendApiTimeout: "60s"
+  backendApiTimeout: "30s"
 
   # -- Kafka consumer group ID
   consumerGroupId: "qserv"
@@ -118,16 +118,20 @@ config:
   # password.
   qservRestUsername: null
 
-  # -- How long to allow for user table upload before timing out in Safir
-  # `parse_timedelta` format.
-  qservUploadTimeout: "30m"
-
   # -- How many times to retry after a Qserv API network failure
   qservRetryCount: 3
 
   # -- How long to wait between retries after a Qserv API network failure in
   # Safir `parse_timedelta` format
   qservRetryDelay: "1s"
+
+  # -- How long to allow for temporary user table deletion before timing out
+  # in Safir `parse_timedelta` format.
+  qservUploadDeleteTimeout: "5m"
+
+  # -- How long to allow for user table upload before timing out in Safir
+  # `parse_timedelta` format.
+  qservUploadTimeout: "30m"
 
   # -- Size of the Redis connection pool. This should be set to
   # `jobRunBatchSize` plus some extra connections for the monitor, cancel

--- a/applications/qserv-kafka/values.yaml
+++ b/applications/qserv-kafka/values.yaml
@@ -324,7 +324,7 @@ redis:
     accessMode: "ReadWriteOnce"
 
     # -- Amount of persistent storage to request
-    size: "100Mi"
+    size: "1Gi"
 
     # -- Class of storage to request
     storageClass: null
@@ -338,10 +338,10 @@ redis:
   resources:
     limits:
       cpu: "1"
-      memory: "200Mi"
+      memory: "500Mi"
     requests:
       cpu: "10m"
-      memory: "50Mi"
+      memory: "100Mi"
 
   # -- Tolerations for the qserv-kafka Redis pod
   # @default -- Tolerate GKE arm64 taint

--- a/applications/qserv-kafka/values.yaml
+++ b/applications/qserv-kafka/values.yaml
@@ -276,7 +276,7 @@ slowWorker:
     maxReplicas: 10
 
     # -- Target absolute CPU usage value of qserv-kafka slow worker pods.
-    targetCPUQuantity: "500m"
+    targetCPUQuantity: "750m"
 
   # -- Node selection rules for the qserv-kafka worker pods
   nodeSelector: {}

--- a/applications/qserv-kafka/values.yaml
+++ b/applications/qserv-kafka/values.yaml
@@ -107,7 +107,7 @@ config:
   qservRestMaxConnections: 55
 
   # -- Whether to send the expected API version in REST API calls to Qserv
-  qservRestSendApiVersion: true
+  qservRestSendApiVersion: false
 
   # -- URL to the Qserv REST API
   # @default -- None, must be set

--- a/applications/qserv-kafka/values.yaml
+++ b/applications/qserv-kafka/values.yaml
@@ -24,12 +24,12 @@ config:
 
   # -- Maximum batch size for query execution requests. This should generally
   # be the same as `qservRestMaxConnections`.
-  jobRunBatchSize: 10
+  jobRunBatchSize: 50
 
   # -- Maximum size of a batch read from Kafka in bytes. Wide queries can be
   # up to 500KiB in size, so this should be at least 500KiB * 10.
-  # @default -- 10MiB
-  jobRunMaxBytes: 10485760
+  # @default -- 25MiB
+  jobRunMaxBytes: 26214400
 
   # -- Kafka topic for query execution requests
   jobRunTopic: "lsst.tap.job-run"
@@ -104,7 +104,7 @@ config:
   # -- Maximum simultaneous connections to open to the REST API. This should
   # be set to `jobRunBatchSize` plus some extra connections for the monitor
   # and cancel jobs.
-  qservRestMaxConnections: 15
+  qservRestMaxConnections: 55
 
   # -- Whether to send the expected API version in REST API calls to Qserv
   qservRestSendApiVersion: true
@@ -193,7 +193,7 @@ frontend:
       memory: "450Mi"
     requests:
       cpu: "100m"
-      memory: "145Mi"
+      memory: "200Mi"
 
   # -- Tolerations for the qserv-kafka frontend pod
   # @default -- Tolerate GKE arm64 taint
@@ -225,7 +225,7 @@ fastWorker:
     maxReplicas: 10
 
     # -- Target absolute CPU usage value of qserv-kafka fast worker pods.
-    targetCPUQuantity: 750m
+    targetCPUQuantity: "750m"
 
   # -- Node selection rules for the qserv-kafka fast worker pods
   nodeSelector: {}
@@ -241,10 +241,10 @@ fastWorker:
   resources:
     limits:
       cpu: "1"
-      memory: "300Mi"
+      memory: "400Mi"
     requests:
       cpu: "1"
-      memory: "145Mi"
+      memory: "200Mi"
 
   # -- Tolerations for the qserv-kafka fast worker pods
   # @default -- Tolerate GKE arm64 taint
@@ -276,7 +276,7 @@ slowWorker:
     maxReplicas: 10
 
     # -- Target absolute CPU usage value of qserv-kafka slow worker pods.
-    targetCPUQuantity: 500m
+    targetCPUQuantity: "500m"
 
   # -- Node selection rules for the qserv-kafka worker pods
   nodeSelector: {}
@@ -295,7 +295,7 @@ slowWorker:
       memory: "500Mi"
     requests:
       cpu: "1"
-      memory: "145Mi"
+      memory: "200Mi"
 
   # -- Tolerations for the qserv-kafka slow worker pods
   # @default -- Tolerate GKE arm64 taint
@@ -338,10 +338,10 @@ redis:
   resources:
     limits:
       cpu: "1"
-      memory: "100Mi"
+      memory: "200Mi"
     requests:
       cpu: "10m"
-      memory: "20Mi"
+      memory: "50Mi"
 
   # -- Tolerations for the qserv-kafka Redis pod
   # @default -- Tolerate GKE arm64 taint


### PR DESCRIPTION
This release improves resource consumption when generating VOParquet output and streams user table uploads instead of downloading the entire user table into memory and then uploading it.