### PR TITLE
DM-55929: Deploy squareone 0.39.2

### DIFF
--- a/applications/squareone/Chart.yaml
+++ b/applications/squareone/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
     url: https://github.com/jonathansick
 
 # The default version tag of the squareone docker image
-appVersion: "0.39.0"
+appVersion: "0.39.2"


### PR DESCRIPTION
## Summary

Deploy squareone 0.39.2 to every environment.

**Release bump.** `Chart.yaml` `appVersion` moves from 0.39.0 to 0.39.2. This is a chart-only change: no runtime configuration keys were added or renamed between 0.39.0 and 0.39.2, so `values.yaml`, the per-environment values files, and the configmap template are untouched.

**What the release carries.** 0.39.1 changed only the squareone release machinery (Changesets CLI v3, `changesets/action@v2`) and has no user-facing effect. 0.39.2 refines the `/admin/oidc-clients` pages that shipped in 0.39.0 (deployed in #6924):

- The listing now leads each row with the client's description, linked to its detail page, instead of the opaque client ID. The return URI stays as the addendum beneath each row.
- On the detail page, the client ID sits in a read-only box that clips long IDs to the value column instead of wrapping, with the copy button pinned at its trailing edge. The box scrolls horizontally and carries the full ID in its tooltip.
- Dependency updates, including Next.js 16.3.3, sharp 0.35.4, and webpack 5.110.3.

See the [squareone 0.39.2 release notes](https://github.com/lsst-sqre/squareone/releases/tag/squareone%400.39.2) and the [0.39.1 release notes](https://github.com/lsst-sqre/squareone/releases/tag/squareone%400.39.1).

## Validation steps

- `phalanx application lint squareone` passes for all environments.
- `phalanx application template squareone idfdev` renders `ghcr.io/lsst-sqre/squareone:0.39.2`.
- The `0.39.2` image (with `-amd64` and `-arm64` variants) exists in GHCR, pushed by the squareone "Docker release" workflow run for the `squareone@0.39.2` tag.
- Pre-commit hooks (yamllint, helm-docs) pass on the commit; no README change since no values were touched.

After sync, on data-dev:

- Visit `/admin/oidc-clients` with an `admin:oidc` token and confirm each row leads with the client description linked to its detail page.
- Open a client with a long ID and confirm the ID box clips and scrolls horizontally with the copy button visible at the trailing edge.

## References

- squareone release: https://github.com/lsst-sqre/squareone/releases/tag/squareone%400.39.2
- squareone PRs: lsst-sqre/squareone#689, lsst-sqre/squareone#690, lsst-sqre/squareone#688, lsst-sqre/squareone#686
- Previous deploy: #6924
- Jira: https://rubinobs.atlassian.net/browse/DM-55929
