### PR TITLE
DM-56066: Change the default advertised max execution duration for all TAP services to 12 hrs

### DIFF
--- a/charts/cadc-tap/README.md
+++ b/charts/cadc-tap/README.md
@@ -43,7 +43,7 @@ IVOA TAP service
 | config.kafka.topics.jobRun | string | `"lsst.tap.job-run"` | Job Run topic |
 | config.kafka.topics.jobStatus | string | `"lsst.tap.job-status"` | Job Status topic |
 | config.maxDestruction | string | `""` | Maximum UWS job destruction time in seconds. Leave empty to use the default (604800, 1 week). |
-| config.maxExecutionDuration | string | `""` | Maximum execution duration for TAP queries in seconds. Also used for sizing the signed result upload URL's expiration Leave empty to use the default (14400, 4 hours). |
+| config.maxExecutionDuration | string | `"43200"` | Maximum execution duration for TAP queries in seconds. Also used for sizing the signed result upload URL's expiration Leave empty to use the default (14400, 4 hours). |
 | config.maxQuote | string | `""` | Maximum UWS job quote in seconds. Leave empty to use the default (86400, 24 hours). |
 | config.maxRec | string | `""` | Maximum row limit (MAXREC) enforced server-side. Leave empty to use the default (100000000). |
 | config.outputLimit | string | `""` | Output limit value for TAP queries advertised in capabilities. Leave empty to use the default (100000000). |

--- a/charts/cadc-tap/values.yaml
+++ b/charts/cadc-tap/values.yaml
@@ -209,7 +209,7 @@ config:
   # -- Maximum execution duration for TAP queries in seconds.
   # Also used for sizing the signed result upload URL's expiration
   # Leave empty to use the default (14400, 4 hours).
-  maxExecutionDuration: ""
+  maxExecutionDuration: "43200"
 
   # -- Maximum UWS job destruction time in seconds.
   # Leave empty to use the default (604800, 1 week).


### PR DESCRIPTION
The new Qserv version introduces a 12hr lifetime on queries.
This PR accommodates that change by setting the configuration which determines the max execution duration value that users see via UWS. This also determines the maximum lifetime of signed URLs that are created for the query result files in GCS, which is set to maximum execution duration + a buffer.