### PR TITLE
Add Guy Whittaker to USDF RSP Dev

### DIFF
--- a/applications/argocd/values-usdfdev.yaml
+++ b/applications/argocd/values-usdfdev.yaml
@@ -64,6 +64,7 @@ argo-cd:
         g, couger01@slac.stanford.edu, role:developer
         g, cyab05@slac.stanford.edu, role:developer
         g, dirving@slac.stanford.edu, role:developer
+        g, guymw@slac.stanford.edu, role:developer
         g, fritzm@slac.stanford.edu, role:developer
         g, gmegias@slac.stanford.edu, role:developer
         g, hchiang2@slac.stanford.edu, role:developer


### PR DESCRIPTION
Add Guy Whittaker to USDF RSP Dev.  Guy is developer for RubinTV.