### PR TITLE
DM-54683: Add docverse edition reconcile knobs and deploy the branch image on roundtable-dev

### DIFF
--- a/applications/docverse/README.md
+++ b/applications/docverse/README.md
@@ -26,6 +26,8 @@ Publish versioned docs
 | config.keeperSync.jobTimeoutSeconds | int | `3600` | Per-job timeout, in seconds, for keeper-sync arq jobs. |
 | config.logLevel | string | `"INFO"` | Logging level |
 | config.logProfile | string | `"production"` | Logging profile (`production` for JSON, `development` for human-friendly) |
+| config.maintenance.editionReconcileEnabled | bool | `true` | Enable the edition reconcile loop that re-drives editions whose recorded publish state has drifted from what the CDN serves. The cron stays registered either way; disabling only makes each tick a no-op. |
+| config.maintenance.editionReconcileMaxActionsPerJob | int | `100` | Maximum number of republish plus unpublish actions one per-org `edition_reconcile` job applies per tick; the remainder is reported as capped and picked up on the next tick. |
 | config.maintenance.enabled | bool | `false` | Enable the maintenance worker that consumes the `docverse:maintenance-queue` arq queue. Requires the docverse image to provide `docverse.worker.main.MaintenanceWorkerSettings`. |
 | config.maintenance.gitRefAuditEnabled | bool | `false` | Whether to enable auditing the git ref lifecycle rule. Enabling this will cause docverse to make GitHub API calls to determine if the git ref associated with an edition still exists. |
 | config.maintenance.jobTimeoutSeconds | int | `3600` | Per-job timeout, in seconds, for maintenance-pool jobs (lifecycle evaluation, git ref audits, and purgatory cleanup). |
@@ -41,6 +43,7 @@ Publish versioned docs
 | config.reaperThresholds.buildProcessingSeconds | int | `28800` | Stuck-run reaper threshold, in seconds, for build_processing jobs. |
 | config.reaperThresholds.dashboardBuildSeconds | int | `1800` | Stuck-run reaper threshold, in seconds, for dashboard_build jobs. |
 | config.reaperThresholds.dashboardSyncSeconds | int | `21600` | Stuck-run reaper threshold, in seconds, for dashboard_sync jobs. |
+| config.reaperThresholds.editionReconcileSeconds | string | Derived by the server (`jobTimeoutSeconds` + 1800) | Stuck-run reaper threshold, in seconds, for edition_reconcile jobs. Leave unset to let the server derive it as `config.maintenance.jobTimeoutSeconds` plus a 1800 s margin; an explicit value must be strictly greater than that timeout or the server refuses to start. |
 | config.reaperThresholds.keeperSyncSeconds | int | `21600` | Stuck-run reaper threshold, in seconds, for keeper-sync jobs. |
 | config.reaperThresholds.lifecycleSeconds | int | `21600` | Stuck-run reaper threshold, in seconds, for lifecycle_eval and git_ref_audit jobs (maintenance pool). |
 | config.reaperThresholds.publishEditionSeconds | int | `14400` | Stuck-run reaper threshold, in seconds, for publish_edition jobs. |

--- a/applications/docverse/templates/configmap.yaml
+++ b/applications/docverse/templates/configmap.yaml
@@ -27,6 +27,8 @@ data:
   DOCVERSE_PURGATORY_CLEANUP_CRON_HOUR: {{ .Values.config.maintenance.purgatoryCleanupCronHour | quote }}
   DOCVERSE_PURGATORY_CLEANUP_CRON_MINUTE: {{ .Values.config.maintenance.purgatoryCleanupCronMinute | quote }}
   DOCVERSE_MAINTENANCE_JOB_TIMEOUT_SECONDS: {{ .Values.config.maintenance.jobTimeoutSeconds | quote }}
+  DOCVERSE_EDITION_RECONCILE_ENABLED: {{ .Values.config.maintenance.editionReconcileEnabled | quote }}
+  DOCVERSE_EDITION_RECONCILE_MAX_ACTIONS_PER_JOB: {{ .Values.config.maintenance.editionReconcileMaxActionsPerJob | quote }}
   DOCVERSE_KEEPER_SYNC_JOB_TIMEOUT_SECONDS: {{ .Values.config.keeperSync.jobTimeoutSeconds | quote }}
   DOCVERSE_KEEPER_SYNC_REAPER_THRESHOLD_SECONDS: {{ .Values.config.reaperThresholds.keeperSyncSeconds | quote }}
   DOCVERSE_LIFECYCLE_REAPER_THRESHOLD_SECONDS: {{ .Values.config.reaperThresholds.lifecycleSeconds | quote }}
@@ -35,6 +37,9 @@ data:
   DOCVERSE_PUBLISH_EDITION_REAPER_THRESHOLD_SECONDS: {{ .Values.config.reaperThresholds.publishEditionSeconds | quote }}
   DOCVERSE_BUILD_PROCESSING_REAPER_THRESHOLD_SECONDS: {{ .Values.config.reaperThresholds.buildProcessingSeconds | quote }}
   DOCVERSE_DASHBOARD_SYNC_REAPER_THRESHOLD_SECONDS: {{ .Values.config.reaperThresholds.dashboardSyncSeconds | quote }}
+  {{- if .Values.config.reaperThresholds.editionReconcileSeconds }}
+  DOCVERSE_EDITION_RECONCILE_REAPER_THRESHOLD_SECONDS: {{ .Values.config.reaperThresholds.editionReconcileSeconds | quote }}
+  {{- end }}
   {{- if .Values.config.metrics.enabled }}
   METRICS_ENABLED: "true"
   METRICS_APPLICATION: {{ .Values.config.metrics.application | quote }}

--- a/applications/docverse/values-roundtable-dev.yaml
+++ b/applications/docverse/values-roundtable-dev.yaml
@@ -1,6 +1,6 @@
 image:
   pullPolicy: "Always"
-  tag: "tickets-DM-54691"
+  tag: "tickets-DM-54683"
 
 config:
   logLevel: "DEBUG"

--- a/applications/docverse/values.yaml
+++ b/applications/docverse/values.yaml
@@ -109,6 +109,16 @@ config:
     # if the git ref associated with an edition still exists.
     gitRefAuditEnabled: false
 
+    # -- Enable the edition reconcile loop that re-drives editions whose
+    # recorded publish state has drifted from what the CDN serves. The cron
+    # stays registered either way; disabling only makes each tick a no-op.
+    editionReconcileEnabled: true
+
+    # -- Maximum number of republish plus unpublish actions one per-org
+    # `edition_reconcile` job applies per tick; the remainder is reported as
+    # capped and picked up on the next tick.
+    editionReconcileMaxActionsPerJob: 100
+
     # -- Whether to run the daily purgatory_cleanup sweep that permanently
     # deletes the object-store content (unpacked tree and staging tarball) of
     # soft-deleted builds once the organization's purgatory retention has
@@ -151,6 +161,13 @@ config:
     buildProcessingSeconds: 28800
     # -- Stuck-run reaper threshold, in seconds, for dashboard_sync jobs.
     dashboardSyncSeconds: 21600
+    # -- Stuck-run reaper threshold, in seconds, for edition_reconcile jobs.
+    # Leave unset to let the server derive it as
+    # `config.maintenance.jobTimeoutSeconds` plus a 1800 s margin; an explicit
+    # value must be strictly greater than that timeout or the server refuses
+    # to start.
+    # @default -- Derived by the server (`jobTimeoutSeconds` + 1800)
+    editionReconcileSeconds: null
 
 ingress:
   # -- Additional annotations for the ingress rule


### PR DESCRIPTION
Plumbs the three edition reconcile settings that [lsst-sqre/docverse#621](https://github.com/lsst-sqre/docverse/pull/621) (DM-54683) adds into the docverse configmap, and points roundtable-dev at the `tickets-DM-54683` branch image so the loop can be validated before that PR merges.

## Summary

The edition reconcile loop is a per-org `edition_reconcile` job on the maintenance pool (dispatcher cron at minutes 9 and 39, reaper at 15 and 45). Each tick reads the org's editions, their newest publish-history rows, the live `publish_edition` jobs, and, for orgs with a CDN label, the Cloudflare KV pointers, then re-drives publishes whose recorded state has drifted from the edge and deletes lingering keys for tombstoned editions. `failed` pairs are left for operators.

New values, all under `config`:

| Value | Default | Env var |
| --- | --- | --- |
| `maintenance.editionReconcileEnabled` | `true` | `DOCVERSE_EDITION_RECONCILE_ENABLED` |
| `maintenance.editionReconcileMaxActionsPerJob` | `100` | `DOCVERSE_EDITION_RECONCILE_MAX_ACTIONS_PER_JOB` |
| `reaperThresholds.editionReconcileSeconds` | unset | `DOCVERSE_EDITION_RECONCILE_REAPER_THRESHOLD_SECONDS` |

The reaper threshold is rendered only when set. The server derives its default as `maintenance_job_timeout_seconds` plus 1800 s (5400 s at the stock timeout) and refuses to start if an explicit value does not strictly exceed the maintenance timeout, so leaving the chart value unset keeps the two knobs from drifting apart when `config.maintenance.jobTimeoutSeconds` changes.

The chart defaults match the server defaults, so this is safe to merge ahead of the server release: pydantic-settings only reads declared fields, and an image that predates the loop ignores the new variables.

**roundtable-dev image.** `image.tag` `tickets-DM-54691` → `tickets-DM-54683`; `pullPolicy` stays `Always`. The previous pin is superseded rather than dropped: DM-54691's code is on docverse `main` (docverse#611, 2026-09-10) and `tickets/DM-54683` is up to date with `main`, so this image is a strict superset of what `tickets-DM-54691` was testing.

**Schema migrations.** Two alembic revisions ride along: `d5e6f7a8b9c0` adds the `idx_queue_jobs_edition_reconcile_active_uq` per-org mutex index, and `e6f7a8b9c0d1` adds a deferrable `UNIQUE (edition_id, position)` on `edition_build_history` after renumbering any pre-existing ties. `config.updateSchema` is already `true` on roundtable-dev, so the PreSync schema-update hook applies them.

## Validation steps

- `phalanx application lint docverse` passes for roundtable-dev and roundtable-prod, and `phalanx application template docverse roundtable-dev` renders `DOCVERSE_EDITION_RECONCILE_ENABLED` and `DOCVERSE_EDITION_RECONCILE_MAX_ACTIONS_PER_JOB` in the `docverse` ConfigMap with no reaper-threshold key.
- `ghcr.io/lsst-sqre/docverse:tickets-DM-54683` is built and pushed (CI run `34645578341` on `b989ff7`, amd64 + arm64 manifest green).
- docverse#621 CI fully green on `b989ff7`: lint, typing, server, worker, deploy-worker, client tests, and client packaging.
- `pre-commit run` (helm-docs, yamllint) passes on the changed files.

After merge, sync docverse on roundtable-dev with a **full app sync** so the schema-update PreSync hook runs, then restart the maintenance worker and confirm its log registers the `edition_reconcile_dispatcher` cron at minutes 9 and 39 and the `edition_reconcile_reaper` at 15 and 45. Then run the PRD's manual QA:

1. Delete the KV key for a published edition of a client-upload project by hand. Within 30 minutes the pointer is restored, `GET /orgs/{org}/jobs?kind=edition_reconcile` shows `republished: 1`, Sentry has one warning message for the org, and an `edition_reconcile_completed` event reaches Sasquatch.
2. A steady-state tick on an org with no drift logs at debug, emits the event with zero actions, and sends no Sentry message.

## Teardown

Revert `image.tag` to a released version once docverse#621 merges and a server release is cut. Once this PR merges, drop the "Phalanx values pending #620" note from `docs/edition-reconcile.md` in docverse.

## References

- App PR: lsst-sqre/docverse#621
- PRD: lsst-sqre/docverse#612
- Chart task: lsst-sqre/docverse#620
- Jira: [DM-54683](https://rubinobs.atlassian.net/browse/DM-54683)
- Supersedes the branch pin from lsst-sqre/phalanx#6977

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DM-54683]: https://rubinobs.atlassian.net/browse/DM-54683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ